### PR TITLE
[codex] Fix WebGPU model progress and provider flows

### DIFF
--- a/src/services/browserPromptService.ts
+++ b/src/services/browserPromptService.ts
@@ -19,7 +19,11 @@ import {
 import { createMonotonicProgressReporter, mapProgressToRange } from './progress';
 import { buildSlideElementPrompt } from './prompts/slideElementPrompt';
 import { buildSlideTaskPrompt, extractImageUrls } from './prompts/slideTaskPrompt';
-import { TransformersTextGenerationRuntime, type TextGenerationRuntime } from './webGpuTextGenerationRuntime';
+import {
+  TransformersTextGenerationRuntime,
+  type TextGenerationInput,
+  type TextGenerationRuntime,
+} from './webGpuTextGenerationRuntime';
 
 export const CHROME_PROMPT_PROVIDER_ID = 'chrome-prompt-api';
 export const GEMMA_PROMPT_PROVIDER_ID = 'gemma-4-webgpu';
@@ -84,7 +88,67 @@ class ChromePromptProvider implements PromptProvider {
   }
 }
 
-class GemmaPromptProvider implements PromptProvider {
+const GEMMA_JSON_SYSTEM_PROMPT = [
+  'You are LocalStudio.ai structured JSON mode.',
+  'Return exactly one JSON value matching the requested schema.',
+  'Do not use markdown, comments, prose, code fences, or explanations.',
+  'The response must start with "{" and end with "}".',
+].join('\n');
+
+interface GemmaStructuredJsonOptions<T> {
+  prompt: string;
+  responseSchema: unknown;
+  parse: (value: string) => T;
+}
+
+export function createGemmaStructuredJsonMessages(prompt: string, responseSchema: unknown): TextGenerationInput {
+  return [
+    {
+      role: 'user',
+      content: [
+        GEMMA_JSON_SYSTEM_PROMPT,
+        '',
+        'JSON Schema:',
+        JSON.stringify(responseSchema),
+        '',
+        'Task:',
+        prompt,
+      ].join('\n'),
+    },
+  ];
+}
+
+function createGemmaJsonRepairMessages(options: {
+  prompt: string;
+  responseSchema: unknown;
+  invalidResponse: string;
+  errorMessage: string;
+}): TextGenerationInput {
+  return [
+    {
+      role: 'user',
+      content: [
+        GEMMA_JSON_SYSTEM_PROMPT,
+        '',
+        'The previous response was invalid for this schema.',
+        `Validation error: ${options.errorMessage}`,
+        '',
+        'JSON Schema:',
+        JSON.stringify(options.responseSchema),
+        '',
+        'Original task:',
+        options.prompt,
+        '',
+        'Invalid response to repair:',
+        options.invalidResponse,
+        '',
+        'Return only corrected JSON.',
+      ].join('\n'),
+    },
+  ];
+}
+
+export class GemmaPromptProvider implements PromptProvider {
   id = GEMMA_PROMPT_PROVIDER_ID;
   label = 'Gemma 4 WebGPU';
   description = 'Browser-local Gemma LLM for prompt-to-slides.';
@@ -107,7 +171,7 @@ class GemmaPromptProvider implements PromptProvider {
   ): Promise<void> {
     const reportProgress = createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
     await modelSetupService.downloadModel(GEMMA_LLM_MODEL_ID, {
-      onProgress: (progress) => reportProgress(mapProgressToRange(progress, 4, 92)),
+      onProgress: (progress) => reportProgress(progress),
     });
     await this.runtimeClient.preload(GEMMA_LLM_TRANSFORMERS_MODEL_ID, {
       onProgress: (progress) => reportProgress(mapProgressToRange(progress, 4, 99)),
@@ -119,15 +183,15 @@ class GemmaPromptProvider implements PromptProvider {
     prompt: string,
     options: { targetLanguageHint?: string } = {},
   ): Promise<GeneratedSlideTasksDocument> {
-    const response = await this.generateStrictJson(
-      buildSlideTaskPrompt({
+    return this.generateStructuredJson({
+      prompt: buildSlideTaskPrompt({
         userPrompt: prompt,
         targetLanguageHint: options.targetLanguageHint ?? 'same as user prompt',
         imageUrls: extractImageUrls(prompt),
       }),
-      GENERATED_SLIDE_TASKS_RESPONSE_SCHEMA,
-    );
-    return parseGeneratedSlideTasksJson(response);
+      responseSchema: GENERATED_SLIDE_TASKS_RESPONSE_SCHEMA,
+      parse: parseGeneratedSlideTasksJson,
+    });
   }
 
   async generateSlideElementFromTask(
@@ -139,29 +203,41 @@ class GemmaPromptProvider implements PromptProvider {
       existingElements: GeneratedSlideElement[];
     },
   ): Promise<GeneratedSlideElement> {
-    const response = await this.generateStrictJson(
-      buildSlideElementPrompt({
+    return this.generateStructuredJson({
+      prompt: buildSlideElementPrompt({
         userPrompt: context.userPrompt,
         task,
         allTasks: context.allTasks,
         page: context.page,
         existingElements: context.existingElements,
       }),
-      GENERATED_SLIDE_ELEMENT_RESPONSE_SCHEMA,
-    );
-    return parseGeneratedSlideElementJson(response);
+      responseSchema: GENERATED_SLIDE_ELEMENT_RESPONSE_SCHEMA,
+      parse: parseGeneratedSlideElementJson,
+    });
   }
 
-  private generateStrictJson(prompt: string, responseSchema: unknown) {
-    return this.runtimeClient.generate(
+  private async generateStructuredJson<T>(options: GemmaStructuredJsonOptions<T>) {
+    const response = await this.runtimeClient.generate(
       GEMMA_LLM_TRANSFORMERS_MODEL_ID,
-      [
-        prompt,
-        '',
-        'Return only valid JSON matching this JSON Schema.',
-        JSON.stringify(responseSchema),
-      ].join('\n'),
+      createGemmaStructuredJsonMessages(options.prompt, options.responseSchema),
+      { max_new_tokens: 3072 },
     );
+
+    try {
+      return options.parse(response);
+    } catch (error) {
+      const repairedResponse = await this.runtimeClient.generate(
+        GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+        createGemmaJsonRepairMessages({
+          prompt: options.prompt,
+          responseSchema: options.responseSchema,
+          invalidResponse: response,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }),
+        { max_new_tokens: 3072 },
+      );
+      return options.parse(repairedResponse);
+    }
   }
 }
 
@@ -221,8 +297,8 @@ export class BrowserPromptService implements PromptService {
                 : availability === 'unavailable'
                   ? 'unavailable'
                   : availability === 'downloading'
-                    ? 'downloading'
-                    : 'needs-download'
+                  ? 'downloading'
+                  : 'needs-download'
               : getModelReadiness(modelStates, provider.modelId),
           selected: false,
         } satisfies AiProviderState;

--- a/src/services/browserTranslatorService.ts
+++ b/src/services/browserTranslatorService.ts
@@ -199,7 +199,7 @@ class TranslateGemmaProvider implements TranslationProvider {
   ): Promise<void> {
     const reportProgress = createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
     await modelSetupService.downloadModel(TRANSLATEGEMMA_MODEL_ID, {
-      onProgress: (progress) => reportProgress(mapProgressToRange(progress, 4, 92)),
+      onProgress: (progress) => reportProgress(progress),
     });
     await this.runtimeClient.preload(TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID, {
       onProgress: (progress) => reportProgress(mapProgressToRange(progress, 4, 99)),

--- a/src/services/modelSetupService.ts
+++ b/src/services/modelSetupService.ts
@@ -37,6 +37,11 @@ export interface ImageGenerationModelLoader {
 
 export interface TextGenerationModelLoader {
   loadTextGenerationModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  removeTextGenerationModel?(modelId: string): Promise<void>;
+}
+
+export interface ModelCacheStorage {
+  deleteModelArtifacts(modelId: string): Promise<void>;
 }
 
 const initialStates: ModelState[] = [
@@ -131,6 +136,30 @@ export class TransformersTextGenerationModelLoader implements TextGenerationMode
       progress_callback: createTransformersProgressCallback(options?.onProgress),
     });
   }
+
+  async removeTextGenerationModel(): Promise<void> {
+    // Plain loader instances do not retain an in-memory pipeline. The shared runtime
+    // used by the app implements this hook to dispose WebGPU sessions.
+  }
+}
+
+export class BrowserTransformersModelCache implements ModelCacheStorage {
+  async deleteModelArtifacts(modelId: string): Promise<void> {
+    if (typeof caches === 'undefined') return;
+
+    const normalizedModelId = modelId.toLowerCase();
+    const encodedModelId = encodeURIComponent(modelId).toLowerCase();
+    const cache = await caches.open(TRANSFORMERS_CACHE_KEY);
+    const requests = await cache.keys();
+    await Promise.all(
+      requests
+        .filter((request) => {
+          const url = request.url.toLowerCase();
+          return url.includes(normalizedModelId) || url.includes(encodedModelId);
+        })
+        .map((request) => cache.delete(request)),
+    );
+  }
 }
 
 export class BrowserModelSetupService implements ModelSetupService {
@@ -141,6 +170,7 @@ export class BrowserModelSetupService implements ModelSetupService {
     private readonly storage: ModelStorage | undefined = getBrowserStorage(),
     private readonly imageGenerationModelLoader: ImageGenerationModelLoader = new TransformersImageGenerationModelLoader(),
     private readonly textGenerationModelLoader: TextGenerationModelLoader = new TransformersTextGenerationModelLoader(),
+    private readonly modelCacheStorage: ModelCacheStorage = new BrowserTransformersModelCache(),
   ) {
     const imageEditingModelReady = storage?.getItem(IMAGE_EDITING_READY_KEY) === 'true';
     const imageGenerationModelReady = storage?.getItem(IMAGE_GENERATION_READY_KEY) === 'true';
@@ -219,7 +249,7 @@ export class BrowserModelSetupService implements ModelSetupService {
     }
   }
 
-  removeModel(id: string): Promise<ModelState> {
+  async removeModel(id: string): Promise<ModelState> {
     const current = this.states.find((state) => state.id === id);
     if (!current) throw new Error(`Unknown model: ${id}`);
 
@@ -229,7 +259,22 @@ export class BrowserModelSetupService implements ModelSetupService {
       this.storage?.setItem(readyKey, 'false');
     }
 
-    return Promise.resolve(this.setModelState(id, { status: 'needs-download', progress: 0, error: undefined }));
+    if (id === GEMMA_LLM_MODEL_ID) {
+      await this.textGenerationModelLoader.removeTextGenerationModel?.(GEMMA_LLM_TRANSFORMERS_MODEL_ID);
+      await this.modelCacheStorage.deleteModelArtifacts(GEMMA_LLM_TRANSFORMERS_MODEL_ID);
+    }
+    if (id === TRANSLATEGEMMA_MODEL_ID) {
+      await this.textGenerationModelLoader.removeTextGenerationModel?.(TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID);
+      await this.modelCacheStorage.deleteModelArtifacts(TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID);
+    }
+    if (id === IMAGE_EDITING_MODEL_ID) {
+      await this.modelCacheStorage.deleteModelArtifacts(IMAGE_EDITING_TRANSFORMERS_MODEL_ID);
+    }
+    if (id === IMAGE_GENERATION_MODEL_ID) {
+      await this.modelCacheStorage.deleteModelArtifacts(IMAGE_GENERATION_TRANSFORMERS_MODEL_ID);
+    }
+
+    return this.setModelState(id, { status: 'needs-download', progress: 0, error: undefined });
   }
 
   private setModelState(id: string, patch: Partial<ModelState>) {

--- a/src/services/modelSetupService.ts
+++ b/src/services/modelSetupService.ts
@@ -14,7 +14,7 @@ import {
   TRANSFORMERS_CACHE_KEY,
 } from './imageGenerationModels';
 import { BrowserBonsaiImageRuntime } from './bonsaiImageRuntime';
-import { createMonotonicProgressReporter } from './progress';
+import { createMonotonicProgressReporter, createTransformersProgressCallback } from './progress';
 
 export const IMAGE_EDITING_MODEL_ID = 'image-editing-models';
 export const IMAGE_EDITING_TRANSFORMERS_MODEL_ID = 'Xenova/slimsam-77-uniform';
@@ -128,12 +128,7 @@ export class TransformersTextGenerationModelLoader implements TextGenerationMode
     await pipeline('text-generation', modelId, {
       dtype: 'q4',
       device: 'webgpu',
-      progress_callback: (progress) => {
-        const progressValue = 'progress' in progress ? progress.progress : undefined;
-        if (typeof progressValue === 'number') {
-          options?.onProgress?.(progressValue);
-        }
-      },
+      progress_callback: createTransformersProgressCallback(options?.onProgress),
     });
   }
 }

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -21,3 +21,59 @@ export function createMonotonicProgressReporter(
     return next;
   };
 }
+
+interface TransformersProgressEvent {
+  file?: string;
+  loaded?: number;
+  name?: string;
+  progress?: number;
+  status?: string;
+  total?: number;
+}
+
+function isTransformersProgressEvent(event: unknown): event is TransformersProgressEvent {
+  return Boolean(event && typeof event === 'object');
+}
+
+export function createTransformersProgressCallback(
+  onProgress: ((progress: number) => void) | undefined,
+  options: { initial?: number; min?: number; max?: number } = {},
+) {
+  const reportProgress = createMonotonicProgressReporter(onProgress, options);
+  const fileProgress = new Map<string, { loaded: number; total: number }>();
+  let receivedAggregateProgress = false;
+
+  return (event: unknown) => {
+    if (!isTransformersProgressEvent(event)) return;
+
+    if (event.status === 'progress_total' && typeof event.progress === 'number') {
+      receivedAggregateProgress = true;
+      reportProgress(event.progress);
+      return;
+    }
+
+    if (receivedAggregateProgress) return;
+
+    if (
+      event.status === 'progress' &&
+      event.file &&
+      typeof event.loaded === 'number' &&
+      typeof event.total === 'number' &&
+      event.total > 0
+    ) {
+      fileProgress.set(`${event.name ?? 'model'}:${event.file}`, {
+        loaded: Math.max(0, event.loaded),
+        total: Math.max(1, event.total),
+      });
+      const totals = Array.from(fileProgress.values());
+      const loaded = totals.reduce((sum, file) => sum + Math.min(file.loaded, file.total), 0);
+      const total = totals.reduce((sum, file) => sum + file.total, 0);
+      if (total > 0) reportProgress((loaded / total) * 100);
+      return;
+    }
+
+    if (event.status === 'progress' && typeof event.progress === 'number') {
+      reportProgress(event.progress);
+    }
+  };
+}

--- a/src/services/webGpuTextGenerationRuntime.ts
+++ b/src/services/webGpuTextGenerationRuntime.ts
@@ -1,4 +1,5 @@
 import { TRANSFORMERS_CACHE_KEY } from './imageGenerationModels';
+import { createTransformersProgressCallback } from './progress';
 
 export interface TextGenerationRuntime {
   preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
@@ -80,12 +81,7 @@ export class TransformersTextGenerationRuntime implements TextGenerationRuntime 
       return (await pipeline('text-generation', modelId, {
         dtype: 'q4',
         device: 'webgpu',
-        progress_callback: (progress) => {
-          const progressValue = 'progress' in progress ? progress.progress : undefined;
-          if (typeof progressValue === 'number') {
-            options?.onProgress?.(progressValue);
-          }
-        },
+        progress_callback: createTransformersProgressCallback(options?.onProgress),
       })) as unknown as TextGenerationPipeline;
     });
     this.pipelines.set(modelId, pipelinePromise);

--- a/src/services/webGpuTextGenerationRuntime.ts
+++ b/src/services/webGpuTextGenerationRuntime.ts
@@ -4,12 +4,15 @@ import { createTransformersProgressCallback } from './progress';
 export interface TextGenerationRuntime {
   preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
   generate(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string>;
+  removeTextGenerationModel?(modelId: string): Promise<void>;
 }
 
 export type TextGenerationInput = string | Array<{ role: string; content: unknown }>;
 export type TextGenerationOptions = Record<string, unknown>;
 
-type TextGenerationPipeline = (prompt: unknown, options?: TextGenerationOptions) => Promise<unknown>;
+type TextGenerationPipeline = ((prompt: unknown, options?: TextGenerationOptions) => Promise<unknown>) & {
+  dispose?: () => Promise<void> | void;
+};
 
 function extractTextFromGeneratedValue(value: unknown): string | undefined {
   if (typeof value === 'string') return value;
@@ -53,6 +56,13 @@ export class TransformersTextGenerationRuntime implements TextGenerationRuntime 
 
   async preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
     await this.loadPipeline(modelId, options);
+  }
+
+  async removeTextGenerationModel(modelId: string): Promise<void> {
+    const pipelinePromise = this.pipelines.get(modelId);
+    this.pipelines.delete(modelId);
+    const pipeline = await pipelinePromise?.catch(() => undefined);
+    await pipeline?.dispose?.();
   }
 
   async generate(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string> {

--- a/src/ui/editor/AiToolsPanel.tsx
+++ b/src/ui/editor/AiToolsPanel.tsx
@@ -8,6 +8,7 @@ import type { CreateImagePromptOptions } from './imagePromptOptions';
 import { defaultCreateImagePromptOptions, getImageSizeLabel, imageSizePresets } from './imagePromptOptions';
 
 interface AiToolsPanelProps {
+  activeSlideLanguage?: { code: string; displayCode: string; flag: string; label: string } | undefined;
   modelStates: ModelState[];
   attentionModelId?: string | undefined;
   createImageOptions?: CreateImagePromptOptions;
@@ -59,6 +60,12 @@ function getPreparationLabel(status: 'idle' | 'downloading' | 'ready' | 'failed'
   return 'Pending';
 }
 
+function getProgressText(status: 'idle' | 'downloading' | 'ready' | 'failed', progress: number) {
+  if (status === 'ready') return undefined;
+  if (status === 'downloading' && progress >= 98) return 'Finalizing...';
+  return `${progress}%`;
+}
+
 function getPreparationTone(status: 'idle' | 'downloading' | 'ready' | 'failed') {
   if (status === 'ready') return 'success';
   if (status === 'downloading') return 'warning';
@@ -79,6 +86,7 @@ function ToolHelp({ id, text }: { id: string; text: string }) {
 }
 
 export function AiToolsPanel({
+  activeSlideLanguage,
   modelStates,
   attentionModelId,
   createImageOptions = defaultCreateImagePromptOptions,
@@ -141,8 +149,11 @@ export function AiToolsPanel({
   const selectedTranslationProvider = translationProviders.find((provider) => provider.selected) ?? translationProviders[0];
   const promptStatus = getPreparationStatus(selectedPromptProvider, promptPreparation.status);
   const promptProgress = promptStatus === 'ready' ? 100 : promptPreparation.progress;
+  const promptProgressText = getProgressText(promptStatus, promptProgress);
   const translationProviderStatus = getPreparationStatus(selectedTranslationProvider, translationPreparation.status);
   const translationProviderProgress = translationProviderStatus === 'ready' ? 100 : translationPreparation.progress;
+  const translationProviderProgressText = getProgressText(translationProviderStatus, translationProviderProgress);
+  const displayedSourceLanguage = activeSlideLanguage?.code ?? translationPreparation.sourceLanguage;
   const selectedPromptNeedsDownload =
     selectedPromptProvider?.readiness === 'needs-download' || selectedPromptProvider?.readiness === 'failed';
   const selectedTranslationNeedsDownload =
@@ -222,7 +233,7 @@ export function AiToolsPanel({
                     label={getPreparationLabel(promptStatus)}
                     tone={getPreparationTone(promptStatus)}
                   />
-                  {promptStatus === 'ready' ? null : <span>{promptProgress}%</span>}
+                  {promptProgressText ? <span>{promptProgressText}</span> : null}
                 </div>
                 {promptStatus === 'ready' ? null : (
                   <>
@@ -327,16 +338,16 @@ export function AiToolsPanel({
                       label={getPreparationLabel(translationProviderStatus)}
                       tone={getPreparationTone(translationProviderStatus)}
                     />
-                    {translationProviderStatus === 'ready' ? null : <span>{translationProviderProgress}%</span>}
+                  {translationProviderProgressText ? <span>{translationProviderProgressText}</span> : null}
                   </div>
                   {translationProviderStatus === 'ready' ? null : (
                     <div className="model-progress">
                       <span style={{ width: `${translationProviderProgress}%` }} />
                     </div>
                   )}
-                  {translationPreparation.sourceLanguage ? (
+                  {displayedSourceLanguage ? (
                     <span className="translation-source-note">
-                      Pair: {translationPreparation.sourceLanguage} → {translationTargetLanguage}
+                      Pair: {displayedSourceLanguage} → {translationTargetLanguage}
                     </span>
                   ) : null}
                 </div>

--- a/src/ui/editor/EditorShell.tsx
+++ b/src/ui/editor/EditorShell.tsx
@@ -217,6 +217,7 @@ export function EditorShell({ services }: EditorShellProps) {
       <div className={vm.pagesPanelOpen ? 'editor-grid' : 'editor-grid editor-grid-pages-collapsed'}>
         <LeftToolPanel
           activeTab={vm.activeTab}
+          activeSlideLanguage={vm.activeSlideLanguage}
           onTabChange={vm.setActiveTab}
           open={leftPanelOpen}
           onOpenChange={setLeftPanelOpen}

--- a/src/ui/editor/LeftToolPanel.tsx
+++ b/src/ui/editor/LeftToolPanel.tsx
@@ -12,6 +12,7 @@ import type { RightPanelTab, TextPreset } from './useEditorViewModel';
 
 interface LeftToolPanelProps {
   activeTab: RightPanelTab;
+  activeSlideLanguage?: { code: string; displayCode: string; flag: string; label: string } | undefined;
   onTabChange: (tab: RightPanelTab) => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -59,6 +60,7 @@ const menuItems: Array<{ id: RightPanelTab; label: string; icon: typeof Layers3 
 
 export function LeftToolPanel({
   activeTab,
+  activeSlideLanguage,
   onTabChange,
   open = false,
   onOpenChange,
@@ -156,6 +158,7 @@ export function LeftToolPanel({
         ) : null}
         {panelOpen && activeTab === 'ai-tools' ? (
           <AiToolsPanel
+            activeSlideLanguage={activeSlideLanguage}
             modelStates={modelStates}
             attentionModelId={attentionModelId}
             translationLanguageOptions={translationLanguageOptions}

--- a/src/ui/editor/useEditorViewModel.ts
+++ b/src/ui/editor/useEditorViewModel.ts
@@ -773,6 +773,14 @@ export function useEditorViewModel(services: AppServices) {
       }
       setPromptApiNotice('Prompt API ready');
     } catch (error) {
+      const selectedProvider = promptProviderStates.find((provider) => provider.selected);
+      if (selectedProvider?.modelId) {
+        await services.modelSetupService.removeModel?.(selectedProvider.modelId);
+        setModelStates(await services.modelSetupService.getModelStates());
+        if (services.promptService.getProviderStates) {
+          setPromptProviderStates(await services.promptService.getProviderStates());
+        }
+      }
       setPromptPreparation({ availability: 'unavailable', progress: 0, status: 'failed' });
       setPromptApiAttention(true);
       setPromptApiNotice(error instanceof Error ? error.message : 'Chrome Prompt API could not be prepared.');
@@ -784,6 +792,14 @@ export function useEditorViewModel(services: AppServices) {
     const nextProviders = await services.promptService.setSelectedProvider(providerId);
     setPromptProviderStates(nextProviders);
     await refreshPromptApiAvailability();
+    const selectedProvider = nextProviders.find((provider) => provider.selected);
+    if (
+      selectedProvider?.modelId &&
+      selectedProvider.compatibility !== 'incompatible' &&
+      selectedProvider.readiness !== 'ready'
+    ) {
+      await preparePromptApi();
+    }
   }
 
   async function setTranslationProvider(providerId: string) {
@@ -795,10 +811,18 @@ export function useEditorViewModel(services: AppServices) {
       progress: current.status === 'ready' ? 0 : current.progress,
       status: current.status === 'ready' ? 'idle' : current.status,
     }));
+    const selectedProvider = nextProviders.find((provider) => provider.selected);
+    if (
+      selectedProvider?.modelId &&
+      selectedProvider.compatibility !== 'incompatible' &&
+      selectedProvider.readiness !== 'ready'
+    ) {
+      await prepareSelectedTranslationProvider(selectedProvider);
+    }
   }
 
-  async function prepareSelectedTranslationProvider() {
-    const selectedProvider = translationProviderStates.find((provider) => provider.selected);
+  async function prepareSelectedTranslationProvider(providerState?: AiProviderState) {
+    const selectedProvider = providerState ?? translationProviderStates.find((provider) => provider.selected);
     if (selectedProvider?.modelId && selectedProvider.readiness !== 'ready') {
       setTranslationPreparation({ progress: 4, status: 'downloading' });
       try {
@@ -816,6 +840,13 @@ export function useEditorViewModel(services: AppServices) {
           setTranslationProviderStates(await services.translatorService.getProviderStates());
         }
       } catch (error) {
+        if (selectedProvider?.modelId) {
+          await services.modelSetupService.removeModel?.(selectedProvider.modelId);
+          setModelStates(await services.modelSetupService.getModelStates());
+          if (services.translatorService.getProviderStates) {
+            setTranslationProviderStates(await services.translatorService.getProviderStates());
+          }
+        }
         setTranslationPreparation({ progress: 0, status: 'failed' });
         setTranslationNotice(error instanceof Error ? error.message : 'Translation model could not be prepared.');
       }

--- a/src/ui/editor/useEditorViewModel.ts
+++ b/src/ui/editor/useEditorViewModel.ts
@@ -702,15 +702,27 @@ export function useEditorViewModel(services: AppServices) {
   async function removeModel(id: string) {
     if (!services.modelSetupService.removeModel) return;
 
+    const selectedPromptProviderId = promptProviderStates.find((provider) => provider.modelId === id && provider.selected)?.id;
+    const selectedTranslationProviderId = translationProviderStates.find(
+      (provider) => provider.modelId === id && provider.selected,
+    )?.id;
     const next = await services.modelSetupService.removeModel(id);
     setModelStates((currentStates) =>
       currentStates.map((state) => (state.id === id ? next : state)),
     );
     if (services.promptService.getProviderStates) {
-      setPromptProviderStates(await services.promptService.getProviderStates());
+      const nextPromptProviders =
+        selectedPromptProviderId && services.promptService.setSelectedProvider
+          ? await services.promptService.setSelectedProvider(selectedPromptProviderId)
+          : await services.promptService.getProviderStates();
+      setPromptProviderStates(nextPromptProviders);
     }
     if (services.translatorService.getProviderStates) {
-      setTranslationProviderStates(await services.translatorService.getProviderStates());
+      const nextTranslationProviders =
+        selectedTranslationProviderId && services.translatorService.setSelectedProvider
+          ? await services.translatorService.setSelectedProvider(selectedTranslationProviderId)
+          : await services.translatorService.getProviderStates();
+      setTranslationProviderStates(nextTranslationProviders);
     }
     if (id === GEMMA_LLM_MODEL_ID) {
       setPromptPreparation({ availability: 'downloadable', progress: 0, status: 'idle' });

--- a/tests/unit/services/browserPromptService.gemma.test.ts
+++ b/tests/unit/services/browserPromptService.gemma.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GEMMA_LLM_TRANSFORMERS_MODEL_ID } from '../../../src/services/aiModelIds';
+import {
+  createGemmaStructuredJsonMessages,
+  GemmaPromptProvider,
+} from '../../../src/services/browserPromptService';
+import type {
+  TextGenerationInput,
+  TextGenerationOptions,
+  TextGenerationRuntime,
+} from '../../../src/services/webGpuTextGenerationRuntime';
+
+class TestTextGenerationRuntime implements TextGenerationRuntime {
+  preload = vi.fn<() => Promise<void>>(() => Promise.resolve());
+  generate = vi.fn<
+    (modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions) => Promise<string>
+  >();
+}
+
+class ProgressModelSetupService {
+  downloadModel = vi.fn((_id: string, options?: { onProgress?: (progress: number) => void }) => {
+    options?.onProgress?.(99);
+    return Promise.resolve({
+      id: 'gemma-4-webgpu-llm',
+      label: 'Gemma',
+      provider: 'transformers' as const,
+      status: 'ready' as const,
+      progress: 100,
+      required: false,
+    });
+  });
+
+  getModelStates = vi.fn(() => Promise.resolve([]));
+  downloadRequiredModels = vi.fn(() => Promise.resolve([]));
+}
+
+describe('GemmaPromptProvider structured JSON generation', () => {
+  it('builds chat-style JSON instructions for Gemma', () => {
+    const messages = createGemmaStructuredJsonMessages('Create a Web AI slide', { type: 'object' });
+
+    expect(Array.isArray(messages)).toBe(true);
+    const [message] = messages as Array<{ role: string; content: string }>;
+    expect(message?.role).toBe('user');
+    expect(message?.content).toContain('Return exactly one JSON value');
+    expect(JSON.stringify(messages)).toContain('Create a Web AI slide');
+    expect(JSON.stringify(messages)).toContain('\\"type\\":\\"object\\"');
+  });
+
+  it('generates slide tasks using structured chat messages', async () => {
+    const runtime = new TestTextGenerationRuntime();
+    runtime.generate.mockResolvedValue(JSON.stringify({
+      language: 'en',
+      page: {
+        name: 'Why Web AI Matters',
+        width: 1920,
+        height: 1080,
+        background: { type: 'color', color: '#050D10' },
+      },
+      tasks: [
+        { type: 'set-background', color: '#050D10' },
+        { type: 'add-title', id: 'title', text: 'Why Web AI Matters', placementHint: 'top center' },
+      ],
+    }));
+    const provider = new GemmaPromptProvider(runtime);
+
+    const tasks = await provider.generateSlideTasksFromPrompt('A slide about Web AI');
+
+    expect(tasks.tasks).toHaveLength(2);
+    const [modelId, promptInput, generationOptions] = runtime.generate.mock.calls[0]!;
+    expect(modelId).toBe(GEMMA_LLM_TRANSFORMERS_MODEL_ID);
+    expect(generationOptions).toEqual({ max_new_tokens: 3072 });
+    expect(Array.isArray(promptInput)).toBe(true);
+    const [message] = promptInput as Array<{ role: string; content: string }>;
+    expect(message?.role).toBe('user');
+    expect(message?.content).toContain('JSON Schema:');
+  });
+
+  it('repairs invalid Gemma JSON once before returning slide tasks', async () => {
+    const runtime = new TestTextGenerationRuntime();
+    runtime.generate
+      .mockResolvedValueOnce('Sure, here is the layout: not json')
+      .mockResolvedValueOnce(JSON.stringify({
+        language: 'en',
+        page: {
+          name: 'Why Web AI Matters',
+          width: 1920,
+          height: 1080,
+          background: { type: 'color', color: '#050D10' },
+        },
+        tasks: [{ type: 'add-title', id: 'title', text: 'Why Web AI Matters', placementHint: 'center' }],
+      }));
+    const provider = new GemmaPromptProvider(runtime);
+
+    const tasks = await provider.generateSlideTasksFromPrompt('A slide about Web AI');
+
+    expect(tasks.tasks).toHaveLength(1);
+    expect(runtime.generate).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(runtime.generate.mock.calls[1]?.[1])).toContain('Invalid response to repair');
+  });
+
+  it('does not double-map Gemma model setup progress near completion', async () => {
+    const runtime = new TestTextGenerationRuntime();
+    const provider = new GemmaPromptProvider(runtime);
+    const modelSetupService = new ProgressModelSetupService();
+    const progress: number[] = [];
+
+    await provider.prepare(modelSetupService, {
+      onProgress: (value) => progress.push(value),
+    });
+
+    expect(progress).toContain(99);
+    expect(progress.at(-1)).toBe(100);
+  });
+});

--- a/tests/unit/services/modelSetupService.test.ts
+++ b/tests/unit/services/modelSetupService.test.ts
@@ -2,12 +2,14 @@ import { vi } from 'vitest';
 import { GEMMA_LLM_MODEL_ID, TRANSLATEGEMMA_MODEL_ID } from '../../../src/services/aiModelIds';
 import {
   BrowserModelSetupService,
+  BrowserTransformersModelCache,
   InMemoryModelSetupService,
   type ImageEditingModelLoader,
   type ImageGenerationModelLoader,
+  type ModelCacheStorage,
   type TextGenerationModelLoader,
 } from '../../../src/services/modelSetupService';
-import { IMAGE_GENERATION_MODEL_ID } from '../../../src/services/imageGenerationModels';
+import { IMAGE_GENERATION_MODEL_ID, TRANSFORMERS_CACHE_KEY } from '../../../src/services/imageGenerationModels';
 
 describe('InMemoryModelSetupService', () => {
   it('downloads required models in parallel and exposes progress', async () => {
@@ -175,7 +177,22 @@ describe('BrowserModelSetupService', () => {
   it('removes cached model readiness metadata and marks the model downloadable again', async () => {
     const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
     const storage = createStorage({ 'localstudio.ai.model.translategemma-webgpu.ready': 'true' });
-    const service = new BrowserModelSetupService({ loadImageEditingModel }, storage);
+    const removeTextGenerationModel = vi.fn().mockResolvedValue(undefined);
+    const deleteModelArtifacts = vi.fn().mockResolvedValue(undefined);
+    const textGenerationLoader: TextGenerationModelLoader = {
+      loadTextGenerationModel: vi.fn().mockResolvedValue(undefined),
+      removeTextGenerationModel,
+    };
+    const modelCacheStorage: ModelCacheStorage = {
+      deleteModelArtifacts,
+    };
+    const service = new BrowserModelSetupService(
+      { loadImageEditingModel },
+      storage,
+      undefined,
+      textGenerationLoader,
+      modelCacheStorage,
+    );
 
     const state = await service.removeModel(TRANSLATEGEMMA_MODEL_ID);
 
@@ -185,5 +202,37 @@ describe('BrowserModelSetupService', () => {
       progress: 0,
     });
     expect(storage.getItem('localstudio.ai.model.translategemma-webgpu.ready')).toBe('false');
+    expect(removeTextGenerationModel).toHaveBeenCalledWith('onnx-community/translategemma-text-4b-it-ONNX');
+    expect(deleteModelArtifacts).toHaveBeenCalledWith('onnx-community/translategemma-text-4b-it-ONNX');
+  });
+
+  it('removes matching Transformers.js cache entries for a model id', async () => {
+    const deletedRequests: string[] = [];
+    const cache = {
+      keys: vi.fn(() =>
+        Promise.resolve([
+          new Request('https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/config.json'),
+          new Request('https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/onnx/model_q4.onnx'),
+          new Request('https://huggingface.co/onnx-community/translategemma-text-4b-it-ONNX/resolve/main/config.json'),
+        ]),
+      ),
+      delete: vi.fn((request: Request) => {
+        deletedRequests.push(request.url);
+        return Promise.resolve(true);
+      }),
+    };
+    vi.stubGlobal('caches', {
+      open: vi.fn((cacheName: string) => {
+        expect(cacheName).toBe(TRANSFORMERS_CACHE_KEY);
+        return Promise.resolve(cache);
+      }),
+    });
+
+    await new BrowserTransformersModelCache().deleteModelArtifacts('onnx-community/gemma-4-E2B-it-ONNX');
+
+    expect(deletedRequests).toEqual([
+      'https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/config.json',
+      'https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/onnx/model_q4.onnx',
+    ]);
   });
 });

--- a/tests/unit/services/progress.test.ts
+++ b/tests/unit/services/progress.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { createTransformersProgressCallback } from '../../../src/services/progress';
+
+describe('createTransformersProgressCallback', () => {
+  it('prefers Transformers.js aggregate progress over raw per-file progress', () => {
+    const progress: number[] = [];
+    const onProgress = createTransformersProgressCallback((value) => progress.push(value));
+
+    onProgress({
+      file: 'model_q4.onnx',
+      loaded: 18,
+      name: 'onnx-community/gemma',
+      progress: 18,
+      status: 'progress_total',
+      total: 100,
+    });
+    onProgress({
+      file: 'tokenizer.json',
+      loaded: 100,
+      name: 'onnx-community/gemma',
+      progress: 100,
+      status: 'progress',
+      total: 100,
+    });
+
+    expect(progress).toEqual([18]);
+  });
+
+  it('aggregates per-file progress when aggregate progress is unavailable', () => {
+    const progress: number[] = [];
+    const onProgress = createTransformersProgressCallback((value) => progress.push(value));
+
+    onProgress({
+      file: 'a.onnx',
+      loaded: 50,
+      name: 'model',
+      status: 'progress',
+      total: 100,
+    });
+    onProgress({
+      file: 'b.onnx',
+      loaded: 25,
+      name: 'model',
+      status: 'progress',
+      total: 100,
+    });
+
+    expect(progress).toEqual([50, 50]);
+  });
+});

--- a/tests/unit/ui/editor/AiToolsPanel.test.tsx
+++ b/tests/unit/ui/editor/AiToolsPanel.test.tsx
@@ -78,4 +78,19 @@ describe('AiToolsPanel', () => {
     expect(screen.queryByRole('button', { name: 'Download LLM Model' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Download Translation Model' })).not.toBeInTheDocument();
   });
+
+  it('shows finalizing copy instead of a stuck high percentage during model preparation', () => {
+    render(
+      <AiToolsPanel
+        modelStates={[]}
+        promptProviderStates={[gemmaProvider]}
+        promptPreparation={{ availability: 'downloading', progress: 99, status: 'downloading' }}
+      />,
+    );
+
+    const llmCard = screen.getByRole('article', { name: 'LLM Model' });
+
+    expect(within(llmCard).getByText('Finalizing...')).toBeInTheDocument();
+    expect(within(llmCard).queryByText('99%')).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/tests/unit/ui/editor/EditorShell.test.tsx
@@ -699,6 +699,7 @@ describe('EditorShell', () => {
     await user.click(screen.getAllByRole('button', { name: 'Translate Slide 1' })[0]!);
 
     expect(await screen.findByRole('button', { name: 'Current slide language Portuguese' })).toBeInTheDocument();
+    expect(screen.getByText('Pair: pt → pt')).toBeInTheDocument();
   });
 
   it('ignores repeated translate clicks while a translation is running', async () => {

--- a/tests/unit/ui/editor/aiFlows.test.tsx
+++ b/tests/unit/ui/editor/aiFlows.test.tsx
@@ -148,6 +148,10 @@ class PromptProviderSelectionService extends TestPromptService {
     return this.selectedProviderId;
   }
 
+  markGemmaNeedsDownload() {
+    this.availability = 'downloadable';
+  }
+
   setSelectedProvider(providerId: string) {
     this.selectedProviderId = providerId;
     return this.getProviderStates();
@@ -155,6 +159,10 @@ class PromptProviderSelectionService extends TestPromptService {
 }
 
 class PromptModelSetupService extends InMemoryModelSetupService implements ModelSetupService {
+  constructor(private readonly onGemmaRemoved?: () => void) {
+    super();
+  }
+
   private gemmaState: ModelState = {
     id: GEMMA_LLM_MODEL_ID,
     label: 'Gemma 4 WebGPU LLM',
@@ -174,6 +182,13 @@ class PromptModelSetupService extends InMemoryModelSetupService implements Model
     options?.onProgress?.(40);
     options?.onProgress?.(100);
     this.gemmaState = { ...this.gemmaState, status: 'ready', progress: 100 };
+    return { ...this.gemmaState };
+  }
+
+  override async removeModel(id: string): Promise<ModelState> {
+    if (id !== GEMMA_LLM_MODEL_ID) return super.removeModel(id);
+    this.onGemmaRemoved?.();
+    this.gemmaState = { ...this.gemmaState, status: 'needs-download', progress: 0 };
     return { ...this.gemmaState };
   }
 }
@@ -227,9 +242,27 @@ class TranslationProviderSelectionService extends PreparingTranslatorService {
     return this.selectedProviderId;
   }
 
+  markTranslateGemmaNeedsDownload() {
+    this.translateGemmaReady = false;
+  }
+
   setSelectedProvider(providerId: string) {
     this.selectedProviderId = providerId;
     return this.getProviderStates();
+  }
+}
+
+class TranslationModelSetupService extends InMemoryModelSetupService implements ModelSetupService {
+  constructor(private readonly onTranslateGemmaRemoved?: () => void) {
+    super();
+  }
+
+  override async removeModel(id: string): Promise<ModelState> {
+    const next = await super.removeModel(id);
+    if (id === TRANSLATEGEMMA_MODEL_ID) {
+      this.onTranslateGemmaRemoved?.();
+    }
+    return next;
   }
 }
 
@@ -361,7 +394,7 @@ describe('mocked AI flows', () => {
     const services = createAppServices();
     const promptService = new PromptProviderSelectionService('downloadable');
     services.promptService = promptService;
-    services.modelSetupService = new PromptModelSetupService();
+    services.modelSetupService = new PromptModelSetupService(() => promptService.markGemmaNeedsDownload());
     render(<EditorShell services={services} />);
 
     await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
@@ -374,11 +407,33 @@ describe('mocked AI flows', () => {
     expect(within(llmCard).getByText('Ready')).toBeInTheDocument();
   });
 
+  it('keeps Gemma selected after removing its cached model', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const promptService = new PromptProviderSelectionService('downloadable');
+    services.promptService = promptService;
+    services.modelSetupService = new PromptModelSetupService(() => promptService.markGemmaNeedsDownload());
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.selectOptions(screen.getAllByLabelText('LLM Model')[1]!, 'gemma-4-webgpu');
+    await waitFor(() => {
+      expect(promptService.preparePromptApi).toHaveBeenCalled();
+    });
+    await user.click(screen.getByRole('button', { name: 'Remove LLM Model' }));
+
+    expect(screen.getAllByLabelText('LLM Model')[1]).toHaveValue('gemma-4-webgpu');
+    expect(screen.getByRole('button', { name: 'Download LLM Model' })).toBeInTheDocument();
+  });
+
   it('prepares TranslateGemma automatically when selected as the translation model', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
     const translatorService = new TranslationProviderSelectionService();
     services.translatorService = translatorService;
+    services.modelSetupService = new TranslationModelSetupService(() =>
+      translatorService.markTranslateGemmaNeedsDownload(),
+    );
     render(<EditorShell services={services} />);
 
     await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
@@ -389,6 +444,27 @@ describe('mocked AI flows', () => {
     });
     const translationCard = screen.getByRole('article', { name: 'Translate Design' });
     expect(within(translationCard).getByRole('button', { name: 'Remove Translation Model' })).toBeInTheDocument();
+  });
+
+  it('keeps TranslateGemma selected after removing its cached model', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const translatorService = new TranslationProviderSelectionService();
+    services.translatorService = translatorService;
+    services.modelSetupService = new TranslationModelSetupService(() =>
+      translatorService.markTranslateGemmaNeedsDownload(),
+    );
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.selectOptions(screen.getByLabelText('Translation Model'), 'translategemma-webgpu');
+    await waitFor(() => {
+      expect(translatorService.prepareTranslation).toHaveBeenCalled();
+    });
+    await user.click(screen.getByRole('button', { name: 'Remove Translation Model' }));
+
+    expect(screen.getByLabelText('Translation Model')).toHaveValue('translategemma-webgpu');
+    expect(screen.getByRole('button', { name: 'Download Translation Model' })).toBeInTheDocument();
   });
 
   it('generates an image from create image mode and inserts it into the active slide', async () => {

--- a/tests/unit/ui/editor/aiFlows.test.tsx
+++ b/tests/unit/ui/editor/aiFlows.test.tsx
@@ -8,12 +8,16 @@ import type {
 } from '../../../../src/domain/generatedSlide';
 import type { Asset } from '../../../../src/domain/model';
 import type {
+  AiProviderState,
   ImageGenerationService,
   ImageGenerationOptions,
+  ModelSetupService,
+  ModelState,
   PromptApiAvailability,
   PromptService,
   TranslatorService,
 } from '../../../../src/services/interfaces';
+import { GEMMA_LLM_MODEL_ID, TRANSLATEGEMMA_MODEL_ID } from '../../../../src/services/aiModelIds';
 import { MockImageGenerationService } from '../../../../src/services/inMemoryAiServices';
 import { InMemoryModelSetupService } from '../../../../src/services/modelSetupService';
 import { EditorShell } from '../../../../src/ui/editor/EditorShell';
@@ -43,7 +47,7 @@ class PreparingTranslatorService implements TranslatorService {
 }
 
 class TestPromptService implements PromptService {
-  constructor(private availability: PromptApiAvailability = 'unavailable') {}
+  constructor(protected availability: PromptApiAvailability = 'unavailable') {}
 
   checkAvailability = vi.fn(() => Promise.resolve(this.availability));
 
@@ -109,6 +113,124 @@ class SlowImageGenerationService implements ImageGenerationService {
         }, 250);
       }),
   );
+}
+
+class PromptProviderSelectionService extends TestPromptService {
+  private selectedProviderId = 'chrome-prompt-api';
+
+  getProviderStates = vi.fn((): Promise<AiProviderState[]> =>
+    Promise.resolve([
+      {
+        id: 'chrome-prompt-api',
+        label: 'Chrome Built-in Prompt API',
+        description: 'Prompt to slides using Chrome Built-in AI.',
+        capability: 'prompt',
+        runtime: 'chrome-built-in',
+        compatibility: 'compatible',
+        readiness: 'ready',
+        selected: this.selectedProviderId === 'chrome-prompt-api',
+      },
+      {
+        id: 'gemma-4-webgpu',
+        label: 'Gemma 4 WebGPU',
+        description: 'Browser-local Gemma LLM for prompt-to-slides.',
+        capability: 'prompt',
+        runtime: 'webgpu-huggingface',
+        compatibility: 'compatible',
+        modelId: GEMMA_LLM_MODEL_ID,
+        readiness: this.availability === 'ready' ? 'ready' : 'needs-download',
+        selected: this.selectedProviderId === 'gemma-4-webgpu',
+      },
+    ]),
+  );
+
+  getSelectedProviderId() {
+    return this.selectedProviderId;
+  }
+
+  setSelectedProvider(providerId: string) {
+    this.selectedProviderId = providerId;
+    return this.getProviderStates();
+  }
+}
+
+class PromptModelSetupService extends InMemoryModelSetupService implements ModelSetupService {
+  private gemmaState: ModelState = {
+    id: GEMMA_LLM_MODEL_ID,
+    label: 'Gemma 4 WebGPU LLM',
+    provider: 'transformers',
+    status: 'needs-download',
+    progress: 0,
+    required: false,
+  };
+
+  override async getModelStates(): Promise<ModelState[]> {
+    const states = await super.getModelStates();
+    return [...states.filter((state) => state.id !== GEMMA_LLM_MODEL_ID), { ...this.gemmaState }];
+  }
+
+  override async downloadModel(id: string, options?: { onProgress?: (progress: number) => void }): Promise<ModelState> {
+    if (id !== GEMMA_LLM_MODEL_ID) return super.downloadModel(id, options);
+    options?.onProgress?.(40);
+    options?.onProgress?.(100);
+    this.gemmaState = { ...this.gemmaState, status: 'ready', progress: 100 };
+    return { ...this.gemmaState };
+  }
+}
+
+class TranslationProviderSelectionService extends PreparingTranslatorService {
+  private selectedProviderId = 'chrome-translator-api';
+  private translateGemmaReady = false;
+
+  override prepareTranslation = vi.fn(
+    (
+      sourceLanguage: string,
+      targetLanguage: string,
+      options?: { onProgress?: (progress: number) => void },
+    ) => {
+      void sourceLanguage;
+      void targetLanguage;
+      options?.onProgress?.(45);
+      options?.onProgress?.(100);
+      this.translateGemmaReady = true;
+      return Promise.resolve();
+    },
+  );
+
+  getProviderStates = vi.fn((): Promise<AiProviderState[]> =>
+    Promise.resolve([
+      {
+        id: 'chrome-translator-api',
+        label: 'Chrome Built-in Translator',
+        description: 'Translate visible text using Chrome Built-in AI.',
+        capability: 'translation',
+        runtime: 'chrome-built-in',
+        compatibility: 'compatible',
+        readiness: 'ready',
+        selected: this.selectedProviderId === 'chrome-translator-api',
+      },
+      {
+        id: 'translategemma-webgpu',
+        label: 'TranslateGemma WebGPU',
+        description: 'Browser-local translation model.',
+        capability: 'translation',
+        runtime: 'webgpu-huggingface',
+        compatibility: 'compatible',
+        modelId: TRANSLATEGEMMA_MODEL_ID,
+        readiness: this.translateGemmaReady ? 'ready' : 'needs-download',
+        selected: this.selectedProviderId === 'translategemma-webgpu',
+      },
+    ]),
+  );
+
+  getSelectedProviderId() {
+    return this.selectedProviderId;
+  }
+
+  setSelectedProvider(providerId: string) {
+    this.selectedProviderId = providerId;
+    return this.getProviderStates();
+  }
 }
 
 describe('mocked AI flows', () => {
@@ -232,6 +354,41 @@ describe('mocked AI flows', () => {
 
     expect(screen.getByRole('tab', { name: 'Layout' })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByLabelText('Create image prompt')).toHaveValue('neon cover');
+  });
+
+  it('prepares Gemma automatically when selected as the LLM model', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const promptService = new PromptProviderSelectionService('downloadable');
+    services.promptService = promptService;
+    services.modelSetupService = new PromptModelSetupService();
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.selectOptions(screen.getAllByLabelText('LLM Model')[1]!, 'gemma-4-webgpu');
+
+    await waitFor(() => {
+      expect(promptService.preparePromptApi).toHaveBeenCalled();
+    });
+    const llmCard = screen.getByRole('article', { name: 'LLM Model' });
+    expect(within(llmCard).getByText('Ready')).toBeInTheDocument();
+  });
+
+  it('prepares TranslateGemma automatically when selected as the translation model', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const translatorService = new TranslationProviderSelectionService();
+    services.translatorService = translatorService;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.selectOptions(screen.getByLabelText('Translation Model'), 'translategemma-webgpu');
+
+    await waitFor(() => {
+      expect(translatorService.prepareTranslation).toHaveBeenCalled();
+    });
+    const translationCard = screen.getByRole('article', { name: 'Translate Design' });
+    expect(within(translationCard).getByRole('button', { name: 'Remove Translation Model' })).toBeInTheDocument();
   });
 
   it('generates an image from create image mode and inserts it into the active slide', async () => {


### PR DESCRIPTION
## Summary
- Use Transformers.js aggregate progress events for WebGPU text model downloads, with per-file aggregation fallback.
- Add structured JSON Gemma prompt generation and repair retry coverage.
- Keep model provider state checks passive on refresh, while selection/download flows explicitly prepare Gemma and TranslateGemma.
- Update the Translate Design pair label to use the active slide language from the header and the selected target language.

## Why
The previous progress handling treated per-file download progress as global model progress, which caused jumps, stalls near completion, and confusing UI. A cache verification path also caused heavy model loads during refresh. This PR keeps refresh passive and moves model loading back to explicit user actions.

## Validation
- npm run lint
- npm run typecheck
- npm run test