### PR TITLE
Add language detection provider fallback

### DIFF
--- a/src/app/composition.ts
+++ b/src/app/composition.ts
@@ -27,6 +27,7 @@ import { BrowserFileSystemProjectRepository } from '../services/browserFileSyste
 import { DisabledProjectRepository } from '../services/disabledProjectRepository';
 import { BrowserLocalSetupService } from '../services/localSetupService';
 import { BrowserModelSetupService } from '../services/modelSetupService';
+import { TransformersLanguageDetectionRuntime } from '../services/webGpuLanguageDetectionRuntime';
 import { TransformersTextGenerationRuntime } from '../services/webGpuTextGenerationRuntime';
 
 export interface AppServices {
@@ -54,11 +55,14 @@ interface CreateAppServicesOptions {
 
 export function createAppServices(options: CreateAppServicesOptions = {}): AppServices {
   const textGenerationRuntime = new TransformersTextGenerationRuntime();
+  const languageDetectionRuntime = new TransformersLanguageDetectionRuntime();
   const modelSetupService = new BrowserModelSetupService(
     undefined,
     undefined,
     undefined,
     textGenerationRuntime,
+    undefined,
+    languageDetectionRuntime,
   );
   return {
     initialProject: options.initialProject ?? createSampleProject(),
@@ -68,7 +72,13 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
     exportService: new BrowserExportService(),
     localSetupService: new BrowserLocalSetupService(),
     modelSetupService,
-    translatorService: new BrowserTranslatorService(modelSetupService, undefined, undefined, textGenerationRuntime),
+    translatorService: new BrowserTranslatorService(
+      modelSetupService,
+      undefined,
+      undefined,
+      textGenerationRuntime,
+      languageDetectionRuntime,
+    ),
     promptService: new BrowserPromptService(modelSetupService, undefined, undefined, textGenerationRuntime),
     imageGenerationService: new BrowserImageGenerationService(),
     paletteService: new MockPaletteService(),

--- a/src/services/aiModelIds.ts
+++ b/src/services/aiModelIds.ts
@@ -1,7 +1,14 @@
 export const GEMMA_LLM_MODEL_ID = 'gemma-4-webgpu-llm';
 export const GEMMA_LLM_TRANSFORMERS_MODEL_ID = 'onnx-community/gemma-4-E2B-it-ONNX';
+export const GEMMA_LLM_DISPLAY_NAME = 'Gemma 4 E2B';
 export const GEMMA_LLM_READY_KEY = 'localstudio.ai.model.gemma-4-webgpu-llm.ready';
 
 export const TRANSLATEGEMMA_MODEL_ID = 'translategemma-webgpu';
 export const TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID = 'onnx-community/translategemma-text-4b-it-ONNX';
+export const TRANSLATEGEMMA_DISPLAY_NAME = 'TranslateGemma 4B';
 export const TRANSLATEGEMMA_READY_KEY = 'localstudio.ai.model.translategemma-webgpu.ready';
+
+export const LANGUAGE_DETECTION_MODEL_ID = 'language-detection-webgpu';
+export const LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID = 'onnx-community/xlm-roberta-base-language-detection-ONNX';
+export const LANGUAGE_DETECTION_DISPLAY_NAME = 'XLM-RoBERTa Base 270M';
+export const LANGUAGE_DETECTION_READY_KEY = 'localstudio.ai.model.language-detection-webgpu.ready';

--- a/src/services/browserPromptService.ts
+++ b/src/services/browserPromptService.ts
@@ -7,7 +7,7 @@ import {
   type GeneratedSlideTask,
   type GeneratedSlideTasksDocument,
 } from '../domain/generatedSlide';
-import { GEMMA_LLM_MODEL_ID, GEMMA_LLM_TRANSFORMERS_MODEL_ID } from './aiModelIds';
+import { GEMMA_LLM_DISPLAY_NAME, GEMMA_LLM_MODEL_ID, GEMMA_LLM_TRANSFORMERS_MODEL_ID } from './aiModelIds';
 import { ChromePromptService } from './chromePromptService';
 import type { AiProviderState, ModelSetupService, PromptApiAvailability, PromptService } from './interfaces';
 import {
@@ -151,7 +151,7 @@ function createGemmaJsonRepairMessages(options: {
 
 export class GemmaPromptProvider implements PromptProvider {
   id = GEMMA_PROMPT_PROVIDER_ID;
-  label = 'Gemma 4 WebGPU';
+  label = GEMMA_LLM_DISPLAY_NAME;
   description = 'Browser-local Gemma LLM for prompt-to-slides.';
   runtime = 'webgpu-huggingface' as const;
   modelId = GEMMA_LLM_MODEL_ID;
@@ -172,9 +172,6 @@ export class GemmaPromptProvider implements PromptProvider {
   ): Promise<void> {
     const reportProgress = createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
     await modelSetupService.downloadModel(GEMMA_LLM_MODEL_ID, {
-      onProgress: (progress) => reportProgress(progress),
-    });
-    await this.runtimeClient.preload(GEMMA_LLM_TRANSFORMERS_MODEL_ID, {
       onProgress: (progress) => reportProgress(mapProgressToRange(progress, 4, 99)),
     });
     reportProgress(100);

--- a/src/services/browserTranslatorService.ts
+++ b/src/services/browserTranslatorService.ts
@@ -1,5 +1,16 @@
-import { TRANSLATEGEMMA_MODEL_ID, TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID } from './aiModelIds';
-import { ChromeTranslatorService } from './chromeTranslatorService';
+import {
+  LANGUAGE_DETECTION_MODEL_ID,
+  LANGUAGE_DETECTION_DISPLAY_NAME,
+  LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID,
+  TRANSLATEGEMMA_DISPLAY_NAME,
+  TRANSLATEGEMMA_MODEL_ID,
+  TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID,
+} from './aiModelIds';
+import {
+  ChromeTranslatorService,
+  hasChromeLanguageDetector,
+  normalizeDetectedLanguageCode,
+} from './chromeTranslatorService';
 import type { AiProviderState, ModelSetupService, TranslatorService } from './interfaces';
 import {
   getBrowserProviderStorage,
@@ -8,11 +19,18 @@ import {
   selectDefaultProvider,
 } from './providerSelection';
 import { createMonotonicProgressReporter, mapProgressToRange } from './progress';
+import {
+  TransformersLanguageDetectionRuntime,
+  type LanguageDetectionRuntime,
+} from './webGpuLanguageDetectionRuntime';
 import { TransformersTextGenerationRuntime, type TextGenerationRuntime } from './webGpuTextGenerationRuntime';
 
 export const CHROME_TRANSLATION_PROVIDER_ID = 'chrome-translator-api';
 export const TRANSLATEGEMMA_PROVIDER_ID = 'translategemma-webgpu';
 export const TRANSLATION_PROVIDER_STORAGE_KEY = 'localstudio.ai.translation-provider';
+export const CHROME_LANGUAGE_DETECTION_PROVIDER_ID = 'chrome-language-detector-api';
+export const WEBGPU_LANGUAGE_DETECTION_PROVIDER_ID = 'language-detection-webgpu';
+export const LANGUAGE_DETECTION_PROVIDER_STORAGE_KEY = 'localstudio.ai.language-detection-provider';
 
 interface TranslationProvider {
   id: string;
@@ -29,6 +47,17 @@ interface TranslationProvider {
   ): Promise<void>;
   translate(text: string, targetLanguage: string, options?: { sourceLanguage?: string }): Promise<string>;
   detectLanguage?(text: string): Promise<string>;
+}
+
+interface LanguageDetectionProvider {
+  id: string;
+  label: string;
+  description: string;
+  runtime: AiProviderState['runtime'];
+  modelId?: string | undefined;
+  checkCompatibility(): { compatible: boolean; disabledReason?: string | undefined };
+  prepare(modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  detectLanguage(text: string): Promise<string>;
 }
 
 type ChromeTranslatorApi = {
@@ -178,7 +207,7 @@ class ChromeTranslationProvider implements TranslationProvider {
 
 class TranslateGemmaProvider implements TranslationProvider {
   id = TRANSLATEGEMMA_PROVIDER_ID;
-  label = 'TranslateGemma WebGPU';
+  label = TRANSLATEGEMMA_DISPLAY_NAME;
   description = 'Browser-local WebGPU translation model.';
   runtime = 'webgpu-huggingface' as const;
   modelId = TRANSLATEGEMMA_MODEL_ID;
@@ -199,9 +228,6 @@ class TranslateGemmaProvider implements TranslationProvider {
   ): Promise<void> {
     const reportProgress = createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
     await modelSetupService.downloadModel(TRANSLATEGEMMA_MODEL_ID, {
-      onProgress: (progress) => reportProgress(progress),
-    });
-    await this.runtimeClient.preload(TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID, {
       onProgress: (progress) => reportProgress(mapProgressToRange(progress, 4, 99)),
     });
     reportProgress(100);
@@ -219,19 +245,82 @@ class TranslateGemmaProvider implements TranslationProvider {
   }
 }
 
+class ChromeLanguageDetectionProvider implements LanguageDetectionProvider {
+  id = CHROME_LANGUAGE_DETECTION_PROVIDER_ID;
+  label = 'Chrome Built-in Language Detector';
+  description = 'Detect slide text language using Chrome Built-in AI.';
+  runtime = 'chrome-built-in' as const;
+
+  constructor(private readonly chromeTranslatorService = new ChromeTranslatorService()) {}
+
+  checkCompatibility() {
+    return hasChromeLanguageDetector()
+      ? { compatible: true }
+      : { compatible: false, disabledReason: 'Chrome Built-in LanguageDetector is unavailable in this browser.' };
+  }
+
+  prepare(_modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }) {
+    options?.onProgress?.(100);
+    return Promise.resolve();
+  }
+
+  detectLanguage(text: string) {
+    return this.chromeTranslatorService.detectLanguage(text);
+  }
+}
+
+class WebGpuLanguageDetectionProvider implements LanguageDetectionProvider {
+  id = WEBGPU_LANGUAGE_DETECTION_PROVIDER_ID;
+  label = LANGUAGE_DETECTION_DISPLAY_NAME;
+  description = 'Browser-local XLM-RoBERTa language detection fallback.';
+  runtime = 'webgpu-huggingface' as const;
+  modelId = LANGUAGE_DETECTION_MODEL_ID;
+
+  constructor(private readonly runtimeClient: LanguageDetectionRuntime = new TransformersLanguageDetectionRuntime()) {}
+
+  checkCompatibility() {
+    return isWebGpuCompatible()
+      ? { compatible: true }
+      : { compatible: false, disabledReason: 'WebGPU is required for external language detection.' };
+  }
+
+  async prepare(modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }) {
+    const reportProgress = createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
+    await modelSetupService.downloadModel(LANGUAGE_DETECTION_MODEL_ID, {
+      onProgress: (progress) => reportProgress(mapProgressToRange(progress, 4, 99)),
+    });
+    reportProgress(100);
+  }
+
+  async detectLanguage(text: string) {
+    const result = await this.runtimeClient.detectLanguage(LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID, text);
+    return normalizeDetectedLanguageCode(result.language);
+  }
+}
+
 export class BrowserTranslatorService implements TranslatorService {
   private selectedProviderId: string | undefined;
+  private selectedLanguageDetectionProviderId: string | undefined;
   private forceSelectedProvider = false;
+  private forceSelectedLanguageDetectionProvider = false;
   private readonly providers: TranslationProvider[];
+  private readonly languageDetectionProviders: LanguageDetectionProvider[];
 
   constructor(
     private readonly modelSetupService: ModelSetupService,
     providers?: TranslationProvider[],
     private readonly storage = getBrowserProviderStorage(),
     textGenerationRuntime: TextGenerationRuntime = new TransformersTextGenerationRuntime(),
+    private readonly languageDetectionRuntime: LanguageDetectionRuntime = new TransformersLanguageDetectionRuntime(),
   ) {
     this.providers = providers ?? [new ChromeTranslationProvider(), new TranslateGemmaProvider(textGenerationRuntime)];
+    this.languageDetectionProviders = [
+      new ChromeLanguageDetectionProvider(),
+      new WebGpuLanguageDetectionProvider(languageDetectionRuntime),
+    ];
     this.selectedProviderId = storage?.getItem(TRANSLATION_PROVIDER_STORAGE_KEY) ?? undefined;
+    this.selectedLanguageDetectionProviderId =
+      storage?.getItem(LANGUAGE_DETECTION_PROVIDER_STORAGE_KEY) ?? undefined;
   }
 
   getSelectedProviderId() {
@@ -245,6 +334,44 @@ export class BrowserTranslatorService implements TranslatorService {
     this.forceSelectedProvider = true;
     this.storage?.setItem(TRANSLATION_PROVIDER_STORAGE_KEY, provider.id);
     return this.getProviderStates();
+  }
+
+  async getLanguageDetectionProviderStates(): Promise<AiProviderState[]> {
+    const modelStates = await this.modelSetupService.getModelStates();
+    const states = this.languageDetectionProviders.map((provider) => {
+      const compatibility = provider.checkCompatibility();
+      return {
+        id: provider.id,
+        label: provider.label,
+        description: provider.description,
+        capability: 'language-detection' as const,
+        runtime: provider.runtime,
+        compatibility: compatibility.compatible ? 'compatible' as const : 'incompatible' as const,
+        disabledReason: compatibility.disabledReason,
+        modelId: provider.modelId,
+        readiness:
+          provider.runtime === 'chrome-built-in'
+            ? compatibility.compatible
+              ? 'ready' as const
+              : 'unavailable' as const
+            : getModelReadiness(modelStates, provider.modelId),
+        selected: false,
+      } satisfies AiProviderState;
+    });
+    const selected = selectDefaultProvider(states, this.selectedLanguageDetectionProviderId, {
+      forcePreferred: this.forceSelectedLanguageDetectionProvider,
+    });
+    this.selectedLanguageDetectionProviderId = selected?.id;
+    return states.map((state) => ({ ...state, selected: state.id === selected?.id }));
+  }
+
+  async setLanguageDetectionProvider(providerId: string) {
+    const provider = this.languageDetectionProviders.find((item) => item.id === providerId);
+    if (!provider) throw new Error(`Unknown language detection provider: ${providerId}`);
+    this.selectedLanguageDetectionProviderId = provider.id;
+    this.forceSelectedLanguageDetectionProvider = true;
+    this.storage?.setItem(LANGUAGE_DETECTION_PROVIDER_STORAGE_KEY, provider.id);
+    return this.getLanguageDetectionProviderStates();
   }
 
   async getProviderStates(): Promise<AiProviderState[]> {
@@ -278,10 +405,24 @@ export class BrowserTranslatorService implements TranslatorService {
     return states.map((state) => ({ ...state, selected: state.id === selected?.id }));
   }
 
-  async detectLanguage(text: string): Promise<string> {
-    const provider = this.getSelectedProvider();
-    if (provider.detectLanguage) return provider.detectLanguage(text);
-    return navigator.language || 'en';
+  async prepareLanguageDetection(options?: { onProgress?: (progress: number) => void }) {
+    await this.getSelectedLanguageDetectionProvider().prepare(this.modelSetupService, options);
+  }
+
+  async detectLanguage(
+    text: string,
+    options?: { allowModelPreparation?: boolean; onProgress?: (progress: number) => void },
+  ): Promise<string> {
+    const provider = this.getSelectedLanguageDetectionProvider();
+    if (options?.allowModelPreparation === false && provider.runtime !== 'chrome-built-in') {
+      return normalizeDetectedLanguageCode(navigator.language || 'en');
+    }
+    try {
+      await provider.prepare(this.modelSetupService, options);
+      return normalizeDetectedLanguageCode(await provider.detectLanguage(text));
+    } catch {
+      return normalizeDetectedLanguageCode(navigator.language || 'en');
+    }
   }
 
   async prepareTranslation(
@@ -301,6 +442,23 @@ export class BrowserTranslatorService implements TranslatorService {
       this.providers.find((provider) => provider.id === this.selectedProviderId) ??
       this.providers.find((provider) => provider.id === CHROME_TRANSLATION_PROVIDER_ID) ??
       this.providers[0]!
+    );
+  }
+
+  private getSelectedLanguageDetectionProvider() {
+    const selectedProvider = this.languageDetectionProviders.find(
+      (provider) => provider.id === this.selectedLanguageDetectionProviderId,
+    );
+    if (selectedProvider) return selectedProvider;
+
+    return (
+      this.languageDetectionProviders.find(
+        (provider) => provider.id === CHROME_LANGUAGE_DETECTION_PROVIDER_ID && provider.checkCompatibility().compatible,
+      ) ??
+      this.languageDetectionProviders.find(
+        (provider) => provider.id === WEBGPU_LANGUAGE_DETECTION_PROVIDER_ID && provider.checkCompatibility().compatible,
+      ) ??
+      this.languageDetectionProviders[0]!
     );
   }
 }

--- a/src/services/chromeTranslatorService.ts
+++ b/src/services/chromeTranslatorService.ts
@@ -59,14 +59,23 @@ function getTranslationKey(sourceLanguage: string, targetLanguage: string) {
   return `${sourceLanguage}:${targetLanguage}`;
 }
 
+export function hasChromeLanguageDetector() {
+  return typeof window !== 'undefined' && Boolean((window as ChromeAiWindow).LanguageDetector?.create);
+}
+
+export function normalizeDetectedLanguageCode(language: string) {
+  return normalizeLanguageCode(language);
+}
+
 export class ChromeTranslatorService implements TranslatorService {
   private readonly translators = new Map<string, Promise<ChromeTranslationInstance>>();
 
   async detectLanguage(text: string): Promise<string> {
-    const languageDetector = (window as ChromeAiWindow).LanguageDetector;
-    if (!languageDetector?.create) return navigator.language || 'en';
+    if (!hasChromeLanguageDetector()) return navigator.language || 'en';
+    const createLanguageDetector = (window as ChromeAiWindow).LanguageDetector?.create;
+    if (!createLanguageDetector) return navigator.language || 'en';
 
-    const detector = await languageDetector.create();
+    const detector = await createLanguageDetector();
     const results = await detector.detect(text);
     return normalizeLanguageCode(results[0]?.detectedLanguage ?? navigator.language ?? 'en');
   }

--- a/src/services/imageGenerationModels.ts
+++ b/src/services/imageGenerationModels.ts
@@ -1,5 +1,6 @@
 export const IMAGE_GENERATION_MODEL_ID = 'image-generation-models';
 export const IMAGE_GENERATION_TRANSFORMERS_MODEL_ID = 'prism-ml/bonsai-image-ternary-4B-mlx-2bit';
+export const IMAGE_GENERATION_DISPLAY_NAME = 'Bonsai Image 4B';
 export const IMAGE_GENERATION_READY_KEY = 'ew-canvas-ai.model.image-generation-models.runtime-v1.ready';
 export const DEFAULT_IMAGE_GENERATION_SIZE = 512;
 export const DEFAULT_IMAGE_GENERATION_STEPS = 4;

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -6,7 +6,7 @@ import type {
 } from '../domain/generatedSlide';
 
 export type ModelStatus = 'unavailable' | 'needs-download' | 'downloading' | 'ready' | 'failed';
-export type AiCapability = 'prompt' | 'translation' | 'image-generation' | 'image-editing';
+export type AiCapability = 'prompt' | 'translation' | 'language-detection' | 'image-generation' | 'image-editing';
 export type AiProviderRuntime = 'chrome-built-in' | 'webgpu-huggingface';
 export type AiProviderCompatibility = 'compatible' | 'incompatible' | 'unknown';
 
@@ -25,7 +25,7 @@ export interface AiProviderState {
   id: string;
   label: string;
   description: string;
-  capability: Extract<AiCapability, 'prompt' | 'translation'>;
+  capability: Extract<AiCapability, 'prompt' | 'translation' | 'language-detection'>;
   runtime: AiProviderRuntime;
   compatibility: AiProviderCompatibility;
   disabledReason?: string | undefined;
@@ -103,7 +103,13 @@ export interface TranslatorService {
   getProviderStates?(): Promise<AiProviderState[]>;
   getSelectedProviderId?(): string;
   setSelectedProvider?(providerId: string): Promise<AiProviderState[]>;
-  detectLanguage(text: string): Promise<string>;
+  getLanguageDetectionProviderStates?(): Promise<AiProviderState[]>;
+  setLanguageDetectionProvider?(providerId: string): Promise<AiProviderState[]>;
+  prepareLanguageDetection?(options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  detectLanguage(
+    text: string,
+    options?: { allowModelPreparation?: boolean; onProgress?: (progress: number) => void },
+  ): Promise<string>;
   prepareTranslation(
     sourceLanguage: string,
     targetLanguage: string,

--- a/src/services/modelSetupService.ts
+++ b/src/services/modelSetupService.ts
@@ -1,8 +1,14 @@
 import type { ModelSetupService, ModelState } from './interfaces';
 import {
+  GEMMA_LLM_DISPLAY_NAME,
   GEMMA_LLM_MODEL_ID,
   GEMMA_LLM_READY_KEY,
   GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+  LANGUAGE_DETECTION_DISPLAY_NAME,
+  LANGUAGE_DETECTION_MODEL_ID,
+  LANGUAGE_DETECTION_READY_KEY,
+  LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID,
+  TRANSLATEGEMMA_DISPLAY_NAME,
   TRANSLATEGEMMA_MODEL_ID,
   TRANSLATEGEMMA_READY_KEY,
   TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID,
@@ -18,6 +24,7 @@ import { createMonotonicProgressReporter, createTransformersProgressCallback } f
 
 export const IMAGE_EDITING_MODEL_ID = 'image-editing-models';
 export const IMAGE_EDITING_TRANSFORMERS_MODEL_ID = 'Xenova/slimsam-77-uniform';
+export const IMAGE_EDITING_DISPLAY_NAME = 'SlimSAM 77M';
 
 const IMAGE_EDITING_READY_KEY = 'ew-canvas-ai.model.image-editing-models.ready';
 
@@ -38,6 +45,11 @@ export interface ImageGenerationModelLoader {
 export interface TextGenerationModelLoader {
   loadTextGenerationModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
   removeTextGenerationModel?(modelId: string): Promise<void>;
+  releaseTextGenerationModel?(modelId: string): Promise<void> | void;
+}
+
+export interface LanguageDetectionModelLoader {
+  loadLanguageDetectionModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
 }
 
 export interface ModelCacheStorage {
@@ -47,7 +59,7 @@ export interface ModelCacheStorage {
 const initialStates: ModelState[] = [
   {
     id: GEMMA_LLM_MODEL_ID,
-    label: 'Gemma 4 WebGPU LLM',
+    label: GEMMA_LLM_DISPLAY_NAME,
     description: 'Browser-local LLM model for prompt-to-slides.',
     provider: 'transformers',
     status: 'needs-download',
@@ -56,8 +68,17 @@ const initialStates: ModelState[] = [
   },
   {
     id: TRANSLATEGEMMA_MODEL_ID,
-    label: 'TranslateGemma WebGPU',
+    label: TRANSLATEGEMMA_DISPLAY_NAME,
     description: 'Browser-local translation model.',
+    provider: 'transformers',
+    status: 'needs-download',
+    progress: 0,
+    required: false,
+  },
+  {
+    id: LANGUAGE_DETECTION_MODEL_ID,
+    label: LANGUAGE_DETECTION_DISPLAY_NAME,
+    description: 'Browser-local fallback detector for slide text language.',
     provider: 'transformers',
     status: 'needs-download',
     progress: 0,
@@ -75,7 +96,7 @@ const initialStates: ModelState[] = [
   {
     id: IMAGE_GENERATION_MODEL_ID,
     label: 'Image Generation Models',
-    description: 'Bonsai Image WebGPU text-to-image model.',
+    description: 'Text-to-image model for generated slide assets.',
     provider: 'transformers',
     status: 'needs-download',
     progress: 0,
@@ -97,6 +118,7 @@ function getReadyKey(id: string) {
   if (id === IMAGE_GENERATION_MODEL_ID) return IMAGE_GENERATION_READY_KEY;
   if (id === GEMMA_LLM_MODEL_ID) return GEMMA_LLM_READY_KEY;
   if (id === TRANSLATEGEMMA_MODEL_ID) return TRANSLATEGEMMA_READY_KEY;
+  if (id === LANGUAGE_DETECTION_MODEL_ID) return LANGUAGE_DETECTION_READY_KEY;
   return undefined;
 }
 
@@ -130,16 +152,30 @@ export class TransformersTextGenerationModelLoader implements TextGenerationMode
     env.useBrowserCache = true;
     env.cacheKey = TRANSFORMERS_CACHE_KEY;
 
-    await pipeline('text-generation', modelId, {
+    const textGeneration = await pipeline('text-generation', modelId, {
       dtype: 'q4',
       device: 'webgpu',
       progress_callback: createTransformersProgressCallback(options?.onProgress),
     });
+    await (textGeneration as { dispose?: () => Promise<void> | void }).dispose?.();
   }
+}
 
-  async removeTextGenerationModel(): Promise<void> {
-    // Plain loader instances do not retain an in-memory pipeline. The shared runtime
-    // used by the app implements this hook to dispose WebGPU sessions.
+export class TransformersLanguageDetectionModelLoader implements LanguageDetectionModelLoader {
+  async loadLanguageDetectionModel(
+    modelId: string,
+    options?: { onProgress?: (progress: number) => void },
+  ): Promise<void> {
+    const { pipeline, env } = await import('@huggingface/transformers');
+
+    env.useBrowserCache = true;
+    env.cacheKey = TRANSFORMERS_CACHE_KEY;
+
+    const detector = await pipeline('text-classification', modelId, {
+      device: 'webgpu',
+      progress_callback: createTransformersProgressCallback(options?.onProgress),
+    });
+    await (detector as { dispose?: () => Promise<void> | void }).dispose?.();
   }
 }
 
@@ -171,15 +207,19 @@ export class BrowserModelSetupService implements ModelSetupService {
     private readonly imageGenerationModelLoader: ImageGenerationModelLoader = new TransformersImageGenerationModelLoader(),
     private readonly textGenerationModelLoader: TextGenerationModelLoader = new TransformersTextGenerationModelLoader(),
     private readonly modelCacheStorage: ModelCacheStorage = new BrowserTransformersModelCache(),
+    private readonly languageDetectionModelLoader: LanguageDetectionModelLoader = new TransformersLanguageDetectionModelLoader(),
   ) {
     const imageEditingModelReady = storage?.getItem(IMAGE_EDITING_READY_KEY) === 'true';
     const imageGenerationModelReady = storage?.getItem(IMAGE_GENERATION_READY_KEY) === 'true';
     const gemmaLlmReady = storage?.getItem(GEMMA_LLM_READY_KEY) === 'true';
     const translateGemmaReady = storage?.getItem(TRANSLATEGEMMA_READY_KEY) === 'true';
+    const languageDetectionReady = storage?.getItem(LANGUAGE_DETECTION_READY_KEY) === 'true';
     this.states = initialStates.map((state) =>
       state.id === GEMMA_LLM_MODEL_ID && gemmaLlmReady
         ? { ...state, status: 'ready', progress: 100 }
         : state.id === TRANSLATEGEMMA_MODEL_ID && translateGemmaReady
+          ? { ...state, status: 'ready', progress: 100 }
+        : state.id === LANGUAGE_DETECTION_MODEL_ID && languageDetectionReady
           ? { ...state, status: 'ready', progress: 100 }
         : state.id === IMAGE_EDITING_MODEL_ID && imageEditingModelReady
         ? { ...state, status: 'ready', progress: 100 }
@@ -229,13 +269,21 @@ export class BrowserModelSetupService implements ModelSetupService {
         await this.textGenerationModelLoader.loadTextGenerationModel(GEMMA_LLM_TRANSFORMERS_MODEL_ID, {
           onProgress: reportProgress,
         });
+        await this.textGenerationModelLoader.releaseTextGenerationModel?.(GEMMA_LLM_TRANSFORMERS_MODEL_ID);
         this.storage?.setItem(GEMMA_LLM_READY_KEY, 'true');
       }
       if (id === TRANSLATEGEMMA_MODEL_ID) {
         await this.textGenerationModelLoader.loadTextGenerationModel(TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID, {
           onProgress: reportProgress,
         });
+        await this.textGenerationModelLoader.releaseTextGenerationModel?.(TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID);
         this.storage?.setItem(TRANSLATEGEMMA_READY_KEY, 'true');
+      }
+      if (id === LANGUAGE_DETECTION_MODEL_ID) {
+        await this.languageDetectionModelLoader.loadLanguageDetectionModel(LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID, {
+          onProgress: reportProgress,
+        });
+        this.storage?.setItem(LANGUAGE_DETECTION_READY_KEY, 'true');
       }
       options?.onProgress?.(100);
       return this.setModelState(id, { status: 'ready', progress: 100, error: undefined });
@@ -244,6 +292,7 @@ export class BrowserModelSetupService implements ModelSetupService {
       if (id === IMAGE_GENERATION_MODEL_ID) this.storage?.setItem(IMAGE_GENERATION_READY_KEY, 'false');
       if (id === GEMMA_LLM_MODEL_ID) this.storage?.setItem(GEMMA_LLM_READY_KEY, 'false');
       if (id === TRANSLATEGEMMA_MODEL_ID) this.storage?.setItem(TRANSLATEGEMMA_READY_KEY, 'false');
+      if (id === LANGUAGE_DETECTION_MODEL_ID) this.storage?.setItem(LANGUAGE_DETECTION_READY_KEY, 'false');
       const message = error instanceof Error ? error.message : 'Model download failed.';
       return this.setModelState(id, { status: 'failed', progress: 0, error: message });
     }

--- a/src/services/progress.ts
+++ b/src/services/progress.ts
@@ -77,3 +77,20 @@ export function createTransformersProgressCallback(
     }
   };
 }
+export function createEstimatedProgressTicker(
+  onProgress: (progress: number) => void,
+  options: { intervalMs?: number; max: number; start: number; step?: number },
+) {
+  let latest = options.start;
+  const intervalMs = options.intervalMs ?? 1_500;
+  const step = options.step ?? 1;
+  const timer = setInterval(() => {
+    if (latest >= options.max) return;
+    latest = Math.min(options.max, latest + step);
+    onProgress(latest);
+  }, intervalMs);
+
+  return () => {
+    clearInterval(timer);
+  };
+}

--- a/src/services/webGpuLanguageDetectionRuntime.ts
+++ b/src/services/webGpuLanguageDetectionRuntime.ts
@@ -1,0 +1,76 @@
+import { TRANSFORMERS_CACHE_KEY } from './imageGenerationModels';
+import { createTransformersProgressCallback } from './progress';
+
+export interface LanguageDetectionRuntime {
+  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  detectLanguage(modelId: string, text: string): Promise<{ language: string; score?: number | undefined }>;
+}
+
+type TextClassificationResult = { label?: unknown; score?: unknown };
+type TextClassificationPipeline = ((text: string, options?: Record<string, unknown>) => Promise<unknown>) & {
+  dispose?: () => Promise<void> | void;
+};
+
+function isTextClassificationResult(value: unknown): value is TextClassificationResult {
+  return Boolean(value && typeof value === 'object');
+}
+
+function getTopClassificationResult(result: unknown): TextClassificationResult | undefined {
+  if (Array.isArray(result)) {
+    const values: unknown[] = result;
+    const first = values[0];
+    if (Array.isArray(first)) return getTopClassificationResult(first);
+    return isTextClassificationResult(first) ? first : undefined;
+  }
+  return isTextClassificationResult(result) ? result : undefined;
+}
+
+export function extractDetectedLanguage(result: unknown) {
+  const topResult = getTopClassificationResult(result);
+  const label = topResult?.label;
+  if (typeof label !== 'string' || !label.trim()) {
+    throw new Error('Language detection model did not return a language label.');
+  }
+
+  return {
+    language: label,
+    ...(typeof topResult?.score === 'number' ? { score: topResult.score } : {}),
+  };
+}
+
+export class TransformersLanguageDetectionRuntime implements LanguageDetectionRuntime {
+  private pipelines = new Map<string, Promise<TextClassificationPipeline>>();
+
+  loadLanguageDetectionModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+    return this.preload(modelId, options);
+  }
+
+  async preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+    await this.loadPipeline(modelId, options);
+  }
+
+  async detectLanguage(modelId: string, text: string) {
+    const detector = await this.loadPipeline(modelId);
+    const result = await detector(text, {
+      topk: 1,
+      truncation: true,
+    });
+    return extractDetectedLanguage(result);
+  }
+
+  private loadPipeline(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+    const existingPipeline = this.pipelines.get(modelId);
+    if (existingPipeline) return existingPipeline;
+
+    const pipelinePromise = import('@huggingface/transformers').then(async ({ env, pipeline }) => {
+      env.useBrowserCache = true;
+      env.cacheKey = TRANSFORMERS_CACHE_KEY;
+      return (await pipeline('text-classification', modelId, {
+        device: 'webgpu',
+        progress_callback: createTransformersProgressCallback(options?.onProgress),
+      }));
+    });
+    this.pipelines.set(modelId, pipelinePromise);
+    return pipelinePromise;
+  }
+}

--- a/src/services/webGpuTextGenerationRuntime.ts
+++ b/src/services/webGpuTextGenerationRuntime.ts
@@ -54,6 +54,13 @@ export class TransformersTextGenerationRuntime implements TextGenerationRuntime 
     return this.preload(modelId, options);
   }
 
+  async releaseTextGenerationModel(modelId: string): Promise<void> {
+    const pipelinePromise = this.pipelines.get(modelId);
+    this.pipelines.delete(modelId);
+    const pipeline = await pipelinePromise;
+    await pipeline?.dispose?.();
+  }
+
   async preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
     await this.loadPipeline(modelId, options);
   }

--- a/src/ui/editor/AiToolsPanel.tsx
+++ b/src/ui/editor/AiToolsPanel.tsx
@@ -1,7 +1,12 @@
 import { Download, ImagePlus, Languages, ScanSearch, X } from 'lucide-react';
-import { GEMMA_LLM_MODEL_ID, TRANSLATEGEMMA_MODEL_ID } from '../../services/aiModelIds';
-import { IMAGE_GENERATION_MODEL_ID } from '../../services/imageGenerationModels';
+import {
+  GEMMA_LLM_MODEL_ID,
+  LANGUAGE_DETECTION_MODEL_ID,
+  TRANSLATEGEMMA_MODEL_ID,
+} from '../../services/aiModelIds';
+import { IMAGE_GENERATION_DISPLAY_NAME, IMAGE_GENERATION_MODEL_ID } from '../../services/imageGenerationModels';
 import type { AiProviderState, ModelState } from '../../services/interfaces';
+import { IMAGE_EDITING_DISPLAY_NAME, IMAGE_EDITING_MODEL_ID } from '../../services/modelSetupService';
 import { IconButton } from '../components/IconButton';
 import { StatusPill } from '../components/StatusPill';
 import type { CreateImagePromptOptions } from './imagePromptOptions';
@@ -14,7 +19,9 @@ interface AiToolsPanelProps {
   createImageOptions?: CreateImagePromptOptions;
   promptProviderStates?: AiProviderState[] | undefined;
   translationProviderStates?: AiProviderState[] | undefined;
+  languageDetectionProviderStates?: AiProviderState[] | undefined;
   translationLanguageOptions?: Array<{ code: string; flag: string; label: string }> | undefined;
+  languageDetectionPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' } | undefined;
   translationPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' } | undefined;
   translationTargetAttention?: boolean | undefined;
   translationTargetLanguage?: string | undefined;
@@ -25,8 +32,10 @@ interface AiToolsPanelProps {
   onRemoveModel?: ((id: string) => Promise<void>) | undefined;
   onCreateImageOptionsChange?: ((options: CreateImagePromptOptions) => void) | undefined;
   onPreparePromptApi?: (() => Promise<void>) | undefined;
+  onPrepareLanguageDetectionProvider?: (() => Promise<void>) | undefined;
   onPrepareTranslationProvider?: (() => Promise<void>) | undefined;
   onPromptProviderChange?: ((providerId: string) => void) | undefined;
+  onLanguageDetectionProviderChange?: ((providerId: string) => void) | undefined;
   onTranslationTargetLanguageChange?: ((languageCode: string) => void) | undefined;
   onTranslationProviderChange?: ((providerId: string) => void) | undefined;
 }
@@ -62,6 +71,7 @@ function getPreparationLabel(status: 'idle' | 'downloading' | 'ready' | 'failed'
 
 function getProgressText(status: 'idle' | 'downloading' | 'ready' | 'failed', progress: number) {
   if (status === 'ready') return undefined;
+  if (status === 'idle') return undefined;
   if (status === 'downloading' && progress >= 98) return 'Finalizing...';
   return `${progress}%`;
 }
@@ -70,6 +80,12 @@ function getPreparationTone(status: 'idle' | 'downloading' | 'ready' | 'failed')
   if (status === 'ready') return 'success';
   if (status === 'downloading') return 'warning';
   return 'neutral';
+}
+
+function getFixedModelDisplayName(modelId: string, fallback: string) {
+  if (modelId === IMAGE_EDITING_MODEL_ID) return IMAGE_EDITING_DISPLAY_NAME;
+  if (modelId === IMAGE_GENERATION_MODEL_ID) return IMAGE_GENERATION_DISPLAY_NAME;
+  return fallback;
 }
 
 function ToolHelp({ id, text }: { id: string; text: string }) {
@@ -92,7 +108,9 @@ export function AiToolsPanel({
   createImageOptions = defaultCreateImagePromptOptions,
   promptProviderStates = [],
   translationProviderStates = [],
+  languageDetectionProviderStates = [],
   translationLanguageOptions = [],
+  languageDetectionPreparation = { progress: 0, status: 'idle' },
   translationPreparation = { progress: 0, status: 'idle' },
   translationTargetAttention = false,
   translationTargetLanguage = '',
@@ -103,8 +121,10 @@ export function AiToolsPanel({
   onRemoveModel,
   onCreateImageOptionsChange,
   onPreparePromptApi,
+  onPrepareLanguageDetectionProvider,
   onPrepareTranslationProvider,
   onPromptProviderChange,
+  onLanguageDetectionProviderChange,
   onTranslationTargetLanguageChange,
   onTranslationProviderChange,
 }: AiToolsPanelProps) {
@@ -145,11 +165,34 @@ export function AiToolsPanel({
             selected: true,
           },
         ];
+  const languageDetectionProviders =
+    languageDetectionProviderStates.length > 0
+      ? languageDetectionProviderStates
+      : [
+          {
+            id: 'chrome-language-detector-api',
+            label: 'Chrome Built-in Language Detector',
+            description: 'Detect slide language using Chrome Built-in AI.',
+            capability: 'language-detection' as const,
+            runtime: 'chrome-built-in' as const,
+            compatibility: 'compatible' as const,
+            readiness: 'ready' as const,
+            selected: true,
+          },
+        ];
   const selectedPromptProvider = promptProviders.find((provider) => provider.selected) ?? promptProviders[0];
   const selectedTranslationProvider = translationProviders.find((provider) => provider.selected) ?? translationProviders[0];
+  const selectedLanguageDetectionProvider =
+    languageDetectionProviders.find((provider) => provider.selected) ?? languageDetectionProviders[0];
   const promptStatus = getPreparationStatus(selectedPromptProvider, promptPreparation.status);
   const promptProgress = promptStatus === 'ready' ? 100 : promptPreparation.progress;
   const promptProgressText = getProgressText(promptStatus, promptProgress);
+  const languageDetectionStatus = getPreparationStatus(
+    selectedLanguageDetectionProvider,
+    languageDetectionPreparation.status,
+  );
+  const languageDetectionProgress =
+    languageDetectionStatus === 'ready' ? 100 : languageDetectionPreparation.progress;
   const translationProviderStatus = getPreparationStatus(selectedTranslationProvider, translationPreparation.status);
   const translationProviderProgress = translationProviderStatus === 'ready' ? 100 : translationPreparation.progress;
   const translationProviderProgressText = getProgressText(translationProviderStatus, translationProviderProgress);
@@ -158,11 +201,19 @@ export function AiToolsPanel({
     selectedPromptProvider?.readiness === 'needs-download' || selectedPromptProvider?.readiness === 'failed';
   const selectedTranslationNeedsDownload =
     selectedTranslationProvider?.readiness === 'needs-download' || selectedTranslationProvider?.readiness === 'failed';
+  const selectedLanguageDetectionNeedsDownload =
+    selectedLanguageDetectionProvider?.readiness === 'needs-download' ||
+    selectedLanguageDetectionProvider?.readiness === 'failed';
   const selectedPromptCanRemove = selectedPromptProvider?.modelId && selectedPromptProvider.readiness === 'ready';
+  const selectedLanguageDetectionCanRemove =
+    selectedLanguageDetectionProvider?.modelId && selectedLanguageDetectionProvider.readiness === 'ready';
   const selectedTranslationCanRemove =
     selectedTranslationProvider?.modelId && selectedTranslationProvider.readiness === 'ready';
   const visibleModelStates = modelStates.filter(
-    (model) => model.id !== GEMMA_LLM_MODEL_ID && model.id !== TRANSLATEGEMMA_MODEL_ID,
+    (model) =>
+      model.id !== GEMMA_LLM_MODEL_ID &&
+      model.id !== TRANSLATEGEMMA_MODEL_ID &&
+      model.id !== LANGUAGE_DETECTION_MODEL_ID,
   );
 
   return (
@@ -235,7 +286,7 @@ export function AiToolsPanel({
                   />
                   {promptProgressText ? <span>{promptProgressText}</span> : null}
                 </div>
-                {promptStatus === 'ready' ? null : (
+                {promptStatus === 'downloading' ? (
                   <>
                     <div className="model-progress">
                       <span style={{ width: `${promptProgress}%` }} />
@@ -244,7 +295,80 @@ export function AiToolsPanel({
                       {promptApiNotice ?? `Availability: ${promptPreparation.availability}`}
                     </span>
                   </>
-                )}
+                ) : null}
+              </div>
+            </div>
+          </article>
+
+          <article className="tool-card" aria-label="Language Detection">
+            <div className="tool-card-heading">
+              <ScanSearch size={18} />
+              <strong>Language Detection</strong>
+              <StatusPill
+                label={selectedLanguageDetectionProvider?.runtime === 'chrome-built-in' ? 'CHROME' : 'EXTERNAL'}
+                tone={selectedLanguageDetectionProvider?.compatibility === 'compatible' ? 'success' : 'neutral'}
+              />
+              {languageDetectionStatus === 'downloading' ? null : selectedLanguageDetectionNeedsDownload ? (
+                <IconButton
+                  label="Download Language Detection Model"
+                  attention
+                  disabled={selectedLanguageDetectionProvider?.compatibility === 'incompatible'}
+                  onClick={() => {
+                    void onPrepareLanguageDetectionProvider?.();
+                  }}
+                >
+                  <Download size={14} />
+                </IconButton>
+              ) : selectedLanguageDetectionCanRemove ? (
+                <IconButton
+                  label="Remove Language Detection Model"
+                  tone="danger"
+                  onClick={() => {
+                    void onRemoveModel?.(selectedLanguageDetectionProvider.modelId!);
+                  }}
+                >
+                  <X size={14} />
+                </IconButton>
+              ) : null}
+            </div>
+            <p>Choose how LocalStudio.ai detects source text language before translation.</p>
+            <label className="translation-target-control">
+              <span className="translation-target-label">Detection Model</span>
+              <select
+                aria-label="Language Detection Model"
+                disabled={languageDetectionPreparation.status === 'downloading'}
+                value={selectedLanguageDetectionProvider?.id ?? ''}
+                onChange={(event) => onLanguageDetectionProviderChange?.(event.target.value)}
+              >
+                {languageDetectionProviders.map((provider) => (
+                  <option
+                    key={provider.id}
+                    value={provider.id}
+                    disabled={provider.compatibility === 'incompatible'}
+                  >
+                    {provider.label}
+                    {provider.compatibility === 'incompatible' ? ' - unavailable' : ''}
+                  </option>
+                ))}
+              </select>
+              {selectedLanguageDetectionProvider?.disabledReason ? (
+                <span className="translation-source-note">{selectedLanguageDetectionProvider.disabledReason}</span>
+              ) : null}
+            </label>
+            <div className="translation-target-control">
+              <div className="translation-preparation" aria-label="Language detection preparation">
+                <div className="translation-preparation-meta">
+                  <StatusPill
+                    label={getPreparationLabel(languageDetectionStatus)}
+                    tone={getPreparationTone(languageDetectionStatus)}
+                  />
+                  {languageDetectionStatus === 'downloading' ? <span>{languageDetectionProgress}%</span> : null}
+                </div>
+                {languageDetectionStatus === 'downloading' ? (
+                  <div className="model-progress">
+                    <span style={{ width: `${languageDetectionProgress}%` }} />
+                  </div>
+                ) : null}
               </div>
             </div>
           </article>
@@ -307,6 +431,24 @@ export function AiToolsPanel({
                 <span className="translation-source-note">{selectedTranslationProvider.disabledReason}</span>
               ) : null}
             </label>
+            {selectedTranslationProvider?.modelId ? (
+              <div className="translation-target-control">
+                <div className="translation-preparation" aria-label="Translation model preparation">
+                  <div className="translation-preparation-meta">
+                    <StatusPill
+                      label={getPreparationLabel(translationProviderStatus)}
+                      tone={getPreparationTone(translationProviderStatus)}
+                    />
+                    {translationProviderStatus === 'downloading' ? <span>{translationProviderProgress}%</span> : null}
+                  </div>
+                  {translationProviderStatus === 'downloading' ? (
+                    <div className="model-progress">
+                      <span style={{ width: `${translationProviderProgress}%` }} />
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
             <label className="translation-target-control">
               <span className="translation-target-label">
                 Translate to:
@@ -338,13 +480,13 @@ export function AiToolsPanel({
                       label={getPreparationLabel(translationProviderStatus)}
                       tone={getPreparationTone(translationProviderStatus)}
                     />
-                  {translationProviderProgressText ? <span>{translationProviderProgressText}</span> : null}
+                    {translationProviderProgressText ? <span>{translationProviderProgressText}</span> : null}
                   </div>
-                  {translationProviderStatus === 'ready' ? null : (
+                  {translationProviderStatus === 'downloading' ? (
                     <div className="model-progress">
                       <span style={{ width: `${translationProviderProgress}%` }} />
                     </div>
-                  )}
+                  ) : null}
                   {displayedSourceLanguage ? (
                     <span className="translation-source-note">
                       Pair: {displayedSourceLanguage} → {translationTargetLanguage}
@@ -392,6 +534,12 @@ export function AiToolsPanel({
                     </IconButton>
                   )}
                 </div>
+                <label className="translation-target-control model-row-selector">
+                  <span className="translation-target-label">Model</span>
+                  <select aria-label={`${model.label} model`} value={model.id} onChange={() => undefined}>
+                    <option value={model.id}>{getFixedModelDisplayName(model.id, model.label)}</option>
+                  </select>
+                </label>
                 <div className="model-row-meta">
                   <StatusPill label={formatStatus(model.status)} tone={statusTone(model.status)} />
                   {model.status === 'ready' ? null : <span>{model.progress}%</span>}

--- a/src/ui/editor/EditorShell.tsx
+++ b/src/ui/editor/EditorShell.tsx
@@ -241,6 +241,8 @@ export function EditorShell({ services }: EditorShellProps) {
           translationLanguageOptions={vm.translationLanguageOptions}
           promptProviderStates={vm.promptProviderStates}
           translationProviderStates={vm.translationProviderStates}
+          languageDetectionProviderStates={vm.languageDetectionProviderStates}
+          languageDetectionPreparation={vm.languageDetectionPreparation}
           translationPreparation={vm.translationPreparation}
           translationTargetAttention={vm.translationTargetAttention}
           translationTargetLanguage={vm.translationTargetLanguage}
@@ -251,9 +253,13 @@ export function EditorShell({ services }: EditorShellProps) {
           onRemoveModel={vm.removeModel}
           onCreateImageOptionsChange={vm.setCreateImageOptions}
           onPreparePromptApi={vm.preparePromptApi}
+          onPrepareLanguageDetectionProvider={vm.prepareSelectedLanguageDetectionProvider}
           onPrepareTranslationProvider={vm.prepareSelectedTranslationProvider}
           onPromptProviderChange={(providerId) => {
             void vm.setPromptProvider(providerId);
+          }}
+          onLanguageDetectionProviderChange={(providerId) => {
+            void vm.setLanguageDetectionProvider(providerId);
           }}
           onTranslationTargetLanguageChange={(languageCode) => {
             void vm.setTranslationTargetLanguage(languageCode);

--- a/src/ui/editor/LeftToolPanel.tsx
+++ b/src/ui/editor/LeftToolPanel.tsx
@@ -21,7 +21,9 @@ interface LeftToolPanelProps {
   createImageOptions?: CreateImagePromptOptions;
   promptProviderStates?: AiProviderState[];
   translationProviderStates?: AiProviderState[];
+  languageDetectionProviderStates?: AiProviderState[];
   translationLanguageOptions?: Array<{ code: string; flag: string; label: string }>;
+  languageDetectionPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' };
   translationPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' };
   translationTargetAttention?: boolean;
   translationTargetLanguage?: string;
@@ -34,8 +36,10 @@ interface LeftToolPanelProps {
   onImportImage?: ((file: File) => void) | undefined;
   onInsertText?: ((preset: TextPreset) => void) | undefined;
   onPreparePromptApi?: (() => Promise<void>) | undefined;
+  onPrepareLanguageDetectionProvider?: (() => Promise<void>) | undefined;
   onPrepareTranslationProvider?: (() => Promise<void>) | undefined;
   onPromptProviderChange?: ((providerId: string) => void) | undefined;
+  onLanguageDetectionProviderChange?: ((providerId: string) => void) | undefined;
   onTranslationTargetLanguageChange?: ((languageCode: string) => void) | undefined;
   onTranslationProviderChange?: ((providerId: string) => void) | undefined;
   project: ProjectDocument;
@@ -69,7 +73,9 @@ export function LeftToolPanel({
   createImageOptions,
   promptProviderStates,
   translationProviderStates,
+  languageDetectionProviderStates,
   translationLanguageOptions,
+  languageDetectionPreparation,
   translationPreparation,
   translationTargetAttention,
   translationTargetLanguage,
@@ -82,8 +88,10 @@ export function LeftToolPanel({
   onImportImage,
   onInsertText,
   onPreparePromptApi,
+  onPrepareLanguageDetectionProvider,
   onPrepareTranslationProvider,
   onPromptProviderChange,
+  onLanguageDetectionProviderChange,
   onTranslationTargetLanguageChange,
   onTranslationProviderChange,
   project,
@@ -164,6 +172,8 @@ export function LeftToolPanel({
             translationLanguageOptions={translationLanguageOptions}
             promptProviderStates={promptProviderStates}
             translationProviderStates={translationProviderStates}
+            languageDetectionProviderStates={languageDetectionProviderStates}
+            languageDetectionPreparation={languageDetectionPreparation}
             translationPreparation={translationPreparation}
             translationTargetAttention={translationTargetAttention}
             translationTargetLanguage={translationTargetLanguage}
@@ -174,8 +184,10 @@ export function LeftToolPanel({
             onRemoveModel={onRemoveModel}
             onCreateImageOptionsChange={onCreateImageOptionsChange}
             onPreparePromptApi={onPreparePromptApi}
+            onPrepareLanguageDetectionProvider={onPrepareLanguageDetectionProvider}
             onPrepareTranslationProvider={onPrepareTranslationProvider}
             onPromptProviderChange={onPromptProviderChange}
+            onLanguageDetectionProviderChange={onLanguageDetectionProviderChange}
             onTranslationTargetLanguageChange={onTranslationTargetLanguageChange}
             onTranslationProviderChange={onTranslationProviderChange}
             {...(createImageOptions ? { createImageOptions } : {})}

--- a/src/ui/editor/useEditorViewModel.ts
+++ b/src/ui/editor/useEditorViewModel.ts
@@ -36,7 +36,11 @@ import { fitImageWithinPage } from '../../domain/imageSizing';
 import type { DesignElement, Page, PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
 import { SAMPLE_HERO_IMAGE_SIZE, SAMPLE_HERO_IMAGE_URL } from '../../domain/sampleProject';
 import type { AiProviderState, ModelState, PromptApiAvailability, VersionHistoryEntry } from '../../services/interfaces';
-import { GEMMA_LLM_MODEL_ID, TRANSLATEGEMMA_MODEL_ID } from '../../services/aiModelIds';
+import {
+  GEMMA_LLM_MODEL_ID,
+  LANGUAGE_DETECTION_MODEL_ID,
+  TRANSLATEGEMMA_MODEL_ID,
+} from '../../services/aiModelIds';
 import {
   DEFAULT_IMAGE_GENERATION_SIZE,
   IMAGE_GENERATION_MODEL_ID,
@@ -414,10 +418,15 @@ export function useEditorViewModel(services: AppServices) {
   const [translationTargetLanguage, setTranslationTargetLanguageState] = useState(readTranslationTargetLanguage);
   const [promptProviderStates, setPromptProviderStates] = useState<AiProviderState[]>([]);
   const [translationProviderStates, setTranslationProviderStates] = useState<AiProviderState[]>([]);
+  const [languageDetectionProviderStates, setLanguageDetectionProviderStates] = useState<AiProviderState[]>([]);
   const [translationTargetAttention, setTranslationTargetAttention] = useState(false);
   const [translationPreparation, setTranslationPreparation] = useState<TranslationPreparationState>({
     progress: 0,
     status: readTranslationTargetLanguage() ? 'ready' : 'idle',
+  });
+  const [languageDetectionPreparation, setLanguageDetectionPreparation] = useState<TranslationPreparationState>({
+    progress: 0,
+    status: 'idle',
   });
   const [promptPreparation, setPromptPreparation] = useState<PromptPreparationState>({
     availability: 'unavailable',
@@ -482,6 +491,9 @@ export function useEditorViewModel(services: AppServices) {
       }
       if (services.translatorService.getProviderStates) {
         setTranslationProviderStates(await services.translatorService.getProviderStates());
+      }
+      if (services.translatorService.getLanguageDetectionProviderStates) {
+        setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
       }
     }
 
@@ -594,7 +606,7 @@ export function useEditorViewModel(services: AppServices) {
     languageDetectionSequenceRef.current = sequence;
 
     void services.translatorService
-      .detectLanguage(sampleText)
+      .detectLanguage(sampleText, { allowModelPreparation: false })
       .then((languageCode) => {
         if (languageDetectionSequenceRef.current !== sequence) return;
         setPageLanguageCodes((current) => ({
@@ -658,6 +670,9 @@ export function useEditorViewModel(services: AppServices) {
     if (services.translatorService.getProviderStates) {
       setTranslationProviderStates(await services.translatorService.getProviderStates());
     }
+    if (services.translatorService.getLanguageDetectionProviderStates) {
+      setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
+    }
     if (next.some((state) => state.id === IMAGE_EDITING_MODEL_ID && state.status === 'ready')) {
       setBackgroundSelectionNotice(undefined);
     }
@@ -690,6 +705,9 @@ export function useEditorViewModel(services: AppServices) {
     }
     if (services.translatorService.getProviderStates) {
       setTranslationProviderStates(await services.translatorService.getProviderStates());
+    }
+    if (services.translatorService.getLanguageDetectionProviderStates) {
+      setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
     }
     if (id === IMAGE_EDITING_MODEL_ID && next.status === 'ready') {
       setBackgroundSelectionNotice(undefined);
@@ -730,6 +748,9 @@ export function useEditorViewModel(services: AppServices) {
     }
     if (id === TRANSLATEGEMMA_MODEL_ID) {
       setTranslationPreparation({ progress: 0, status: 'idle' });
+    }
+    if (id === LANGUAGE_DETECTION_MODEL_ID) {
+      setLanguageDetectionPreparation({ progress: 0, status: 'idle' });
     }
   }
 
@@ -804,7 +825,6 @@ export function useEditorViewModel(services: AppServices) {
     if (!services.promptService.setSelectedProvider) return;
     const nextProviders = await services.promptService.setSelectedProvider(providerId);
     setPromptProviderStates(nextProviders);
-    await refreshPromptApiAvailability();
     const selectedProvider = nextProviders.find((provider) => provider.selected);
     if (
       selectedProvider?.modelId &&
@@ -812,7 +832,9 @@ export function useEditorViewModel(services: AppServices) {
       selectedProvider.readiness !== 'ready'
     ) {
       await preparePromptApi();
+      return;
     }
+    await refreshPromptApiAvailability();
   }
 
   async function setTranslationProvider(providerId: string) {
@@ -831,6 +853,50 @@ export function useEditorViewModel(services: AppServices) {
       selectedProvider.readiness !== 'ready'
     ) {
       await prepareSelectedTranslationProvider(selectedProvider);
+    }
+  }
+
+  async function setLanguageDetectionProvider(providerId: string) {
+    if (!services.translatorService.setLanguageDetectionProvider) return;
+    const nextProviders = await services.translatorService.setLanguageDetectionProvider(providerId);
+    setLanguageDetectionProviderStates(nextProviders);
+    setLanguageDetectionPreparation((current) => ({
+      ...current,
+      progress: current.status === 'ready' ? 0 : current.progress,
+      status: current.status === 'ready' ? 'idle' : current.status,
+    }));
+    const selectedProvider = nextProviders.find((provider) => provider.selected);
+    if (
+      selectedProvider?.modelId &&
+      selectedProvider.compatibility !== 'incompatible' &&
+      selectedProvider.readiness !== 'ready'
+    ) {
+      await prepareSelectedLanguageDetectionProvider(selectedProvider);
+    }
+  }
+
+  async function prepareSelectedLanguageDetectionProvider(providerState?: AiProviderState) {
+    const selectedProvider = providerState ?? languageDetectionProviderStates.find((provider) => provider.selected);
+    if (!selectedProvider?.modelId || selectedProvider.readiness === 'ready') return;
+
+    setLanguageDetectionPreparation({ progress: 4, status: 'downloading' });
+    try {
+      await services.translatorService.prepareLanguageDetection?.({
+        onProgress: (progress) => {
+          setLanguageDetectionPreparation((current) => ({
+            progress: Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+            status: progress >= 100 ? 'ready' : 'downloading',
+          }));
+        },
+      });
+      setLanguageDetectionPreparation({ progress: 100, status: 'ready' });
+      setModelStates(await services.modelSetupService.getModelStates());
+      if (services.translatorService.getLanguageDetectionProviderStates) {
+        setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
+      }
+    } catch (error) {
+      setLanguageDetectionPreparation({ progress: 0, status: 'failed' });
+      setTranslationNotice(error instanceof Error ? error.message : 'Language detection model could not be prepared.');
     }
   }
 
@@ -1410,17 +1476,31 @@ export function useEditorViewModel(services: AppServices) {
 
     setTranslationPreparation({ progress: 4, status: 'downloading' });
     try {
-      const sourceLanguage = normalizeLanguageCode(await services.translatorService.detectLanguage(sampleText));
-      setTranslationPreparation({ progress: 8, sourceLanguage, status: 'downloading' });
-      await services.translatorService.prepareTranslation(sourceLanguage, nextLanguage, {
-        onProgress: (progress) => {
-          setTranslationPreparation((current) => ({
-            progress: Math.max(current.progress, 8, Math.min(100, Math.round(progress))),
-            sourceLanguage,
-            status: progress >= 100 ? 'ready' : 'downloading',
-          }));
-        },
-      });
+      const sourceLanguage = normalizeLanguageCode(
+        await services.translatorService.detectLanguage(sampleText, {
+          onProgress: (progress) => {
+            setTranslationPreparation((current) => ({
+              progress: Math.max(current.progress, 4, Math.min(45, Math.round(progress * 0.45))),
+              status: 'downloading',
+            }));
+          },
+        }),
+      );
+      const selectedTranslationProvider = translationProviderStates.find((provider) => provider.selected);
+      const shouldPrepareLanguagePair =
+        !selectedTranslationProvider?.modelId || selectedTranslationProvider.runtime === 'chrome-built-in';
+      if (shouldPrepareLanguagePair) {
+        setTranslationPreparation({ progress: 8, sourceLanguage, status: 'downloading' });
+        await services.translatorService.prepareTranslation(sourceLanguage, nextLanguage, {
+          onProgress: (progress) => {
+            setTranslationPreparation((current) => ({
+              progress: Math.max(current.progress, 8, Math.min(100, Math.round(progress))),
+              sourceLanguage,
+              status: progress >= 100 ? 'ready' : 'downloading',
+            }));
+          },
+        });
+      }
       setTranslationPreparation({ progress: 100, sourceLanguage, status: 'ready' });
     } catch (error) {
       setTranslationPreparation({ progress: 0, status: 'failed' });
@@ -2151,8 +2231,10 @@ export function useEditorViewModel(services: AppServices) {
     translationTargetLanguage,
     promptProviderStates,
     translationProviderStates,
+    languageDetectionProviderStates,
     translationTargetAttention,
     translationPreparation,
+    languageDetectionPreparation,
     isTranslating,
     translationNotice,
     promptPreparation,
@@ -2168,6 +2250,7 @@ export function useEditorViewModel(services: AppServices) {
     aiToolsAttentionModelId,
     preparePromptApi,
     prepareSelectedTranslationProvider,
+    prepareSelectedLanguageDetectionProvider,
     ensurePromptApiReadyForPrompt,
     ensureImageGenerationReadyForPrompt,
     generateSlideFromPrompt,
@@ -2176,6 +2259,7 @@ export function useEditorViewModel(services: AppServices) {
     setCreateImageOptions,
     setPromptProvider,
     setTranslationProvider,
+    setLanguageDetectionProvider,
     setTranslationTargetLanguage,
     canTranslateSelection: !isTranslating && getTranslatableTextElementIds('selection').length > 0,
     canTranslateCurrentSlide: !isTranslating && getTranslatableTextElementIds('slide').length > 0,

--- a/tests/unit/services/browserTranslatorService.test.ts
+++ b/tests/unit/services/browserTranslatorService.test.ts
@@ -1,10 +1,128 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  LANGUAGE_DETECTION_PROVIDER_STORAGE_KEY,
   createTranslateGemmaMessages,
   toTranslateGemmaLanguageCode,
 } from '../../../src/services/browserTranslatorService';
+import {
+  LANGUAGE_DETECTION_MODEL_ID,
+  LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID,
+  TRANSLATEGEMMA_MODEL_ID,
+} from '../../../src/services/aiModelIds';
+import type { ModelSetupService, ModelState } from '../../../src/services/interfaces';
+import { BrowserTranslatorService } from '../../../src/services/browserTranslatorService';
+import { InMemoryModelSetupService } from '../../../src/services/modelSetupService';
+import { createEstimatedProgressTicker } from '../../../src/services/progress';
+import type { LanguageDetectionRuntime } from '../../../src/services/webGpuLanguageDetectionRuntime';
+
+class RecordingModelSetupService extends InMemoryModelSetupService implements ModelSetupService {
+  override downloadModel = vi.fn((id: string, options?: { onProgress?: (progress: number) => void }): Promise<ModelState> => {
+    options?.onProgress?.(50);
+    return super.downloadModel(id, options);
+  });
+}
+
+class TestLanguageDetectionRuntime implements LanguageDetectionRuntime {
+  preload = vi.fn((_modelId: string, options?: { onProgress?: (progress: number) => void }) => {
+    options?.onProgress?.(80);
+    return Promise.resolve();
+  });
+
+  detectLanguage = vi.fn(() => Promise.resolve({ language: 'fr', score: 0.99 }));
+}
+
+class DeferredModelSetupService extends InMemoryModelSetupService implements ModelSetupService {
+  resolveDownload: (() => void) | undefined;
+
+  override downloadModel = vi.fn((id: string, options?: { onProgress?: (progress: number) => void }): Promise<ModelState> => {
+    options?.onProgress?.(99);
+    return new Promise<ModelState>((resolve) => {
+      this.resolveDownload = () => {
+        resolve({
+          id,
+          label: id,
+          provider: 'transformers',
+          required: false,
+          status: 'ready',
+          progress: 100,
+        });
+      };
+    });
+  });
+}
+
+function createStorage(seed: Record<string, string> = {}) {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+}
 
 describe('TranslateGemma helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('can keep progress moving during silent WebGPU finalization', () => {
+    vi.useFakeTimers();
+    const progress: number[] = [];
+
+    const stop = createEstimatedProgressTicker((value) => progress.push(value), {
+      intervalMs: 100,
+      max: 98,
+      start: 92,
+      step: 2,
+    });
+
+    vi.advanceTimersByTime(350);
+    stop();
+    vi.advanceTimersByTime(350);
+
+    expect(progress).toEqual([94, 96, 98]);
+    vi.useRealTimers();
+  });
+
+  it('advances TranslateGemma progress while model setup is finalizing silently', async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: {},
+    });
+    const modelSetupService = new DeferredModelSetupService();
+    const progress: number[] = [];
+    const textRuntime = {
+      generate: vi.fn(),
+      preload: vi.fn(() => Promise.resolve()),
+    };
+    const service = new BrowserTranslatorService(
+      modelSetupService,
+      undefined,
+      undefined,
+      textRuntime,
+    );
+
+    await service.setSelectedProvider?.('translategemma-webgpu');
+    const preparePromise = service.prepareTranslation('en', 'es', {
+      onProgress: (value) => progress.push(value),
+    });
+    await Promise.resolve();
+    vi.advanceTimersByTime(3_100);
+
+    expect(modelSetupService.downloadModel).toHaveBeenCalledWith(
+      TRANSLATEGEMMA_MODEL_ID,
+      expect.any(Object),
+    );
+    expect(progress.some((value) => value > 92 && value < 100)).toBe(true);
+
+    modelSetupService.resolveDownload?.();
+    await preparePromise;
+    expect(progress.at(-1)).toBe(100);
+    vi.useRealTimers();
+  });
+
   it('maps browser language codes to TranslateGemma codes', () => {
     expect(toTranslateGemmaLanguageCode('pt')).toBe('pt_BR');
     expect(toTranslateGemmaLanguageCode('pt-BR')).toBe('pt_BR');
@@ -32,5 +150,147 @@ describe('TranslateGemma helpers', () => {
         ],
       },
     ]);
+  });
+
+  it('uses Chrome native language detection when available', async () => {
+    const detect = vi.fn(() => Promise.resolve([{ detectedLanguage: 'es' }]));
+    vi.stubGlobal('LanguageDetector', {
+      create: vi.fn(() => Promise.resolve({ detect })),
+    });
+    const modelSetupService = new RecordingModelSetupService();
+    const languageRuntime = new TestLanguageDetectionRuntime();
+    const service = new BrowserTranslatorService(
+      modelSetupService,
+      undefined,
+      undefined,
+      undefined,
+      languageRuntime,
+    );
+
+    await expect(service.detectLanguage('Hola mundo')).resolves.toBe('es');
+
+    expect(modelSetupService.downloadModel).not.toHaveBeenCalled();
+    expect(languageRuntime.detectLanguage).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the WebGPU language detection model when native detection is unavailable', async () => {
+    vi.stubGlobal('LanguageDetector', undefined);
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: {},
+    });
+    const modelSetupService = new RecordingModelSetupService();
+    const languageRuntime = new TestLanguageDetectionRuntime();
+    const progress: number[] = [];
+    const service = new BrowserTranslatorService(
+      modelSetupService,
+      undefined,
+      undefined,
+      undefined,
+      languageRuntime,
+    );
+
+    await expect(
+      service.detectLanguage('Bonjour tout le monde', {
+        onProgress: (value) => progress.push(value),
+      }),
+    ).resolves.toBe('fr');
+
+    expect(modelSetupService.downloadModel).toHaveBeenCalledWith(
+      LANGUAGE_DETECTION_MODEL_ID,
+      expect.any(Object),
+    );
+    expect(languageRuntime.preload).not.toHaveBeenCalled();
+    expect(languageRuntime.detectLanguage).toHaveBeenCalledWith(
+      LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID,
+      'Bonjour tout le monde',
+    );
+    expect(progress.at(-1)).toBe(100);
+  });
+
+  it('does not prepare the WebGPU language detector when model preparation is disabled', async () => {
+    vi.stubGlobal('LanguageDetector', undefined);
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: {},
+    });
+    const modelSetupService = new RecordingModelSetupService();
+    const languageRuntime = new TestLanguageDetectionRuntime();
+    const service = new BrowserTranslatorService(
+      modelSetupService,
+      undefined,
+      createStorage({ 'localstudio.ai.language-detection-provider': 'language-detection-webgpu' }),
+      undefined,
+      languageRuntime,
+    );
+
+    await expect(
+      service.detectLanguage('Bonjour tout le monde', {
+        allowModelPreparation: false,
+      }),
+    ).resolves.toBe('en');
+
+    expect(modelSetupService.downloadModel).not.toHaveBeenCalled();
+    expect(languageRuntime.preload).not.toHaveBeenCalled();
+    expect(languageRuntime.detectLanguage).not.toHaveBeenCalled();
+  });
+
+  it('exposes configurable language detection provider states', async () => {
+    vi.stubGlobal('LanguageDetector', undefined);
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: {},
+    });
+    const service = new BrowserTranslatorService(
+      new RecordingModelSetupService(),
+      undefined,
+      createStorage(),
+      undefined,
+      new TestLanguageDetectionRuntime(),
+    );
+
+    const states = await service.getLanguageDetectionProviderStates();
+
+    expect(states).toEqual([
+      expect.objectContaining({
+        id: 'chrome-language-detector-api',
+        compatibility: 'incompatible',
+        readiness: 'unavailable',
+        selected: false,
+      }),
+      expect.objectContaining({
+        id: 'language-detection-webgpu',
+        compatibility: 'compatible',
+        modelId: LANGUAGE_DETECTION_MODEL_ID,
+        readiness: 'needs-download',
+        selected: true,
+      }),
+    ]);
+  });
+
+  it('persists explicit language detection provider selection', async () => {
+    vi.stubGlobal('LanguageDetector', {
+      create: vi.fn(() => Promise.resolve({ detect: vi.fn() })),
+    });
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: {},
+    });
+    const storage = createStorage();
+    const service = new BrowserTranslatorService(
+      new RecordingModelSetupService(),
+      undefined,
+      storage,
+      undefined,
+      new TestLanguageDetectionRuntime(),
+    );
+
+    const states = await service.setLanguageDetectionProvider('language-detection-webgpu');
+
+    expect(storage.getItem(LANGUAGE_DETECTION_PROVIDER_STORAGE_KEY)).toBe('language-detection-webgpu');
+    expect(states.find((state) => state.id === 'language-detection-webgpu')).toMatchObject({
+      selected: true,
+      readiness: 'needs-download',
+    });
   });
 });

--- a/tests/unit/services/modelSetupService.test.ts
+++ b/tests/unit/services/modelSetupService.test.ts
@@ -1,11 +1,20 @@
 import { vi } from 'vitest';
-import { GEMMA_LLM_MODEL_ID, TRANSLATEGEMMA_MODEL_ID } from '../../../src/services/aiModelIds';
+import {
+  GEMMA_LLM_DISPLAY_NAME,
+  GEMMA_LLM_MODEL_ID,
+  GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+  LANGUAGE_DETECTION_DISPLAY_NAME,
+  LANGUAGE_DETECTION_MODEL_ID,
+  TRANSLATEGEMMA_DISPLAY_NAME,
+  TRANSLATEGEMMA_MODEL_ID,
+} from '../../../src/services/aiModelIds';
 import {
   BrowserModelSetupService,
   BrowserTransformersModelCache,
   InMemoryModelSetupService,
   type ImageEditingModelLoader,
   type ImageGenerationModelLoader,
+  type LanguageDetectionModelLoader,
   type ModelCacheStorage,
   type TextGenerationModelLoader,
 } from '../../../src/services/modelSetupService';
@@ -18,14 +27,19 @@ describe('InMemoryModelSetupService', () => {
 
     const states = await service.getModelStates();
     expect(states.filter((state) => state.required).every((state) => state.status === 'ready')).toBe(true);
-    expect(states).toHaveLength(4);
+    expect(states).toHaveLength(5);
     expect(states.find((state) => state.id === GEMMA_LLM_MODEL_ID)).toMatchObject({
-      label: 'Gemma 4 WebGPU LLM',
+      label: GEMMA_LLM_DISPLAY_NAME,
       required: false,
       status: 'needs-download',
     });
     expect(states.find((state) => state.id === TRANSLATEGEMMA_MODEL_ID)).toMatchObject({
-      label: 'TranslateGemma WebGPU',
+      label: TRANSLATEGEMMA_DISPLAY_NAME,
+      required: false,
+      status: 'needs-download',
+    });
+    expect(states.find((state) => state.id === LANGUAGE_DETECTION_MODEL_ID)).toMatchObject({
+      label: LANGUAGE_DETECTION_DISPLAY_NAME,
       required: false,
       status: 'needs-download',
     });
@@ -37,7 +51,7 @@ describe('InMemoryModelSetupService', () => {
     expect(states.find((state) => state.id === IMAGE_GENERATION_MODEL_ID)).toMatchObject({
       id: IMAGE_GENERATION_MODEL_ID,
       label: 'Image Generation Models',
-      description: 'Bonsai Image WebGPU text-to-image model.',
+      description: 'Text-to-image model for generated slide assets.',
       status: 'needs-download',
       required: false,
     });
@@ -130,6 +144,61 @@ describe('BrowserModelSetupService', () => {
 
     expect(state).toMatchObject({ id: GEMMA_LLM_MODEL_ID, status: 'ready', progress: 100 });
     expect(progress).toEqual([10, 18, 18, 55, 100]);
+  });
+
+  it('releases text generation pipelines after warming the browser cache', async () => {
+    const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
+    const loadImageGenerationModel = vi.fn().mockResolvedValue(undefined);
+    const loadTextGenerationModel = vi.fn().mockResolvedValue(undefined);
+    const releaseTextGenerationModel = vi.fn().mockResolvedValue(undefined);
+    const textGenerationLoader: TextGenerationModelLoader & {
+      releaseTextGenerationModel: (modelId: string) => Promise<void>;
+    } = {
+      loadTextGenerationModel,
+      releaseTextGenerationModel,
+    };
+    const service = new BrowserModelSetupService(
+      { loadImageEditingModel },
+      createStorage(),
+      { loadImageGenerationModel },
+      textGenerationLoader,
+    );
+
+    await service.downloadModel(GEMMA_LLM_MODEL_ID);
+
+    expect(loadTextGenerationModel).toHaveBeenCalledWith(GEMMA_LLM_TRANSFORMERS_MODEL_ID, expect.any(Object));
+    expect(releaseTextGenerationModel).toHaveBeenCalledWith(GEMMA_LLM_TRANSFORMERS_MODEL_ID);
+  });
+
+  it('downloads the language detection model independently', async () => {
+    const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
+    const loadImageGenerationModel = vi.fn().mockResolvedValue(undefined);
+    const loadTextGenerationModel = vi.fn().mockResolvedValue(undefined);
+    const loadLanguageDetectionModel = vi.fn((_, options?: { onProgress?: (progress: number) => void }) => {
+      options?.onProgress?.(42);
+      return Promise.resolve();
+    });
+    const languageDetectionLoader: LanguageDetectionModelLoader = {
+      loadLanguageDetectionModel,
+    };
+    const service = new BrowserModelSetupService(
+      { loadImageEditingModel },
+      createStorage(),
+      { loadImageGenerationModel },
+      { loadTextGenerationModel },
+      undefined,
+      languageDetectionLoader,
+    );
+
+    const progress: number[] = [];
+    const state = await service.downloadModel(LANGUAGE_DETECTION_MODEL_ID, {
+      onProgress: (value) => progress.push(value),
+    });
+
+    expect(state).toMatchObject({ id: LANGUAGE_DETECTION_MODEL_ID, status: 'ready', progress: 100 });
+    expect(progress).toEqual([42, 100]);
+    expect(loadLanguageDetectionModel).toHaveBeenCalledTimes(1);
+    expect(loadTextGenerationModel).not.toHaveBeenCalled();
   });
 
   it('restores ready state from browser cache metadata', async () => {
@@ -234,5 +303,20 @@ describe('BrowserModelSetupService', () => {
       'https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/config.json',
       'https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/onnx/model_q4.onnx',
     ]);
+  });
+
+  it('restores language detection ready state from browser cache metadata', async () => {
+    const service = new BrowserModelSetupService(
+      { loadImageEditingModel: vi.fn().mockResolvedValue(undefined) },
+      createStorage({ 'localstudio.ai.model.language-detection-webgpu.ready': 'true' }),
+    );
+
+    const states = await service.getModelStates();
+
+    expect(states.find((state) => state.id === LANGUAGE_DETECTION_MODEL_ID)).toMatchObject({
+      id: LANGUAGE_DETECTION_MODEL_ID,
+      status: 'ready',
+      progress: 100,
+    });
   });
 });

--- a/tests/unit/services/webGpuLanguageDetectionRuntime.test.ts
+++ b/tests/unit/services/webGpuLanguageDetectionRuntime.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { extractDetectedLanguage } from '../../../src/services/webGpuLanguageDetectionRuntime';
+
+describe('extractDetectedLanguage', () => {
+  it('extracts the top language from text-classification output', () => {
+    expect(extractDetectedLanguage([{ label: 'fr', score: 0.998 }])).toEqual({
+      language: 'fr',
+      score: 0.998,
+    });
+  });
+
+  it('extracts the top language from nested top-k output', () => {
+    expect(extractDetectedLanguage([[{ label: 'pt', score: 0.991 }]])).toEqual({
+      language: 'pt',
+      score: 0.991,
+    });
+  });
+});

--- a/tests/unit/ui/editor/AiToolsPanel.test.tsx
+++ b/tests/unit/ui/editor/AiToolsPanel.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen, within } from '@testing-library/react';
+import {
+  GEMMA_LLM_DISPLAY_NAME,
+  LANGUAGE_DETECTION_DISPLAY_NAME,
+  TRANSLATEGEMMA_DISPLAY_NAME,
+} from '../../../../src/services/aiModelIds';
 import type { AiProviderState } from '../../../../src/services/interfaces';
 import { AiToolsPanel } from '../../../../src/ui/editor/AiToolsPanel';
 
 const gemmaProvider: AiProviderState = {
   id: 'gemma-4-webgpu',
-  label: 'Gemma 4 WebGPU',
+  label: GEMMA_LLM_DISPLAY_NAME,
   description: 'Browser-local Gemma LLM for prompt-to-slides.',
   capability: 'prompt',
   runtime: 'webgpu-huggingface',
@@ -16,12 +21,24 @@ const gemmaProvider: AiProviderState = {
 
 const translateGemmaProvider: AiProviderState = {
   id: 'translategemma-webgpu',
-  label: 'TranslateGemma WebGPU',
+  label: TRANSLATEGEMMA_DISPLAY_NAME,
   description: 'Browser-local WebGPU translation model.',
   capability: 'translation',
   runtime: 'webgpu-huggingface',
   compatibility: 'compatible',
   modelId: 'translategemma-webgpu',
+  readiness: 'needs-download',
+  selected: true,
+};
+
+const languageDetectionProvider: AiProviderState = {
+  id: 'language-detection-webgpu',
+  label: LANGUAGE_DETECTION_DISPLAY_NAME,
+  description: 'Browser-local XLM-RoBERTa language detection fallback.',
+  capability: 'language-detection',
+  runtime: 'webgpu-huggingface',
+  compatibility: 'compatible',
+  modelId: 'language-detection-webgpu',
   readiness: 'needs-download',
   selected: true,
 };
@@ -57,8 +74,26 @@ describe('AiToolsPanel', () => {
     const translationCard = screen.getByRole('article', { name: 'Translate Design' });
 
     expect(within(translationCard).queryByText('Ready')).not.toBeInTheDocument();
-    expect(within(translationCard).getByText('Pending')).toBeInTheDocument();
+    expect(within(translationCard).getAllByText('Pending').length).toBeGreaterThanOrEqual(1);
+    expect(within(translationCard).queryByText('100%')).not.toBeInTheDocument();
     expect(within(translationCard).getByRole('button', { name: 'Download Translation Model' })).toBeInTheDocument();
+  });
+
+  it('shows translation model download progress even before a target language is selected', () => {
+    render(
+      <AiToolsPanel
+        modelStates={[]}
+        translationProviderStates={[translateGemmaProvider]}
+        translationLanguageOptions={[{ code: 'pt', flag: '🇧🇷', label: 'Portuguese' }]}
+        translationPreparation={{ progress: 64, status: 'downloading' }}
+      />,
+    );
+
+    const translationCard = screen.getByRole('article', { name: 'Translate Design' });
+
+    expect(within(translationCard).getByLabelText('Translation Model')).toBeDisabled();
+    expect(within(translationCard).getByLabelText('Translation model preparation')).toHaveTextContent('Downloading');
+    expect(within(translationCard).getByText('64%')).toBeInTheDocument();
   });
 
   it('shows remove actions for cached external providers', () => {
@@ -92,5 +127,23 @@ describe('AiToolsPanel', () => {
 
     expect(within(llmCard).getByText('Finalizing...')).toBeInTheDocument();
     expect(within(llmCard).queryByText('99%')).not.toBeInTheDocument();
+  });
+
+  it('shows the same configurable model controls for language detection', () => {
+    render(
+      <AiToolsPanel
+        modelStates={[]}
+        languageDetectionProviderStates={[languageDetectionProvider]}
+        languageDetectionPreparation={{ progress: 0, status: 'idle' }}
+      />,
+    );
+
+    const detectionCard = screen.getByRole('article', { name: 'Language Detection' });
+
+    expect(within(detectionCard).getByLabelText('Language Detection Model')).toHaveValue(
+      'language-detection-webgpu',
+    );
+    expect(within(detectionCard).getByText('Pending')).toBeInTheDocument();
+    expect(within(detectionCard).getByRole('button', { name: 'Download Language Detection Model' })).toBeInTheDocument();
   });
 });

--- a/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/tests/unit/ui/editor/EditorShell.test.tsx
@@ -81,9 +81,9 @@ class RecordingTranslatorService implements TranslatorService {
     Promise.resolve(`${targetLanguage}:${text}`),
   );
 
-  detectLanguage(): Promise<string> {
+  detectLanguage = vi.fn(() => {
     return Promise.resolve('en');
-  }
+  });
 }
 
 class ImportingProjectRepository implements ProjectRepository {
@@ -692,6 +692,10 @@ describe('EditorShell', () => {
     render(<EditorShell services={services} />);
 
     expect(await screen.findByRole('button', { name: 'Current slide language English' })).toBeInTheDocument();
+    expect((services.translatorService as RecordingTranslatorService).detectLanguage).toHaveBeenCalledWith(
+      expect.any(String),
+      { allowModelPreparation: false },
+    );
 
     await openLeftTab(user, 'AI Tools');
     await user.selectOptions(screen.getByLabelText('Translate to'), 'pt');

--- a/tests/unit/ui/editor/aiFlows.test.tsx
+++ b/tests/unit/ui/editor/aiFlows.test.tsx
@@ -46,6 +46,146 @@ class PreparingTranslatorService implements TranslatorService {
   }
 }
 
+class ConfigurableTranslatorService extends PreparingTranslatorService {
+  private selectedProviderId = 'chrome-translator-api';
+  private translateGemmaReady: boolean;
+
+  constructor(options: { translateGemmaReady?: boolean } = {}) {
+    super();
+    this.translateGemmaReady = options.translateGemmaReady ?? false;
+  }
+
+  getProviderStates = vi.fn((): Promise<AiProviderState[]> => Promise.resolve(this.createProviderStates()));
+
+  setSelectedProvider = vi.fn((providerId: string): Promise<AiProviderState[]> => {
+    this.selectedProviderId = providerId;
+    return Promise.resolve(this.createProviderStates());
+  });
+
+  override prepareTranslation = vi.fn(
+    (
+      sourceLanguage: string,
+      targetLanguage: string,
+      options?: { onProgress?: (progress: number) => void },
+    ) => {
+      void sourceLanguage;
+      void targetLanguage;
+      options?.onProgress?.(91);
+      options?.onProgress?.(100);
+      this.translateGemmaReady = true;
+      return Promise.resolve();
+    },
+  );
+
+  private createProviderStates(): AiProviderState[] {
+    return [
+      {
+        id: 'chrome-translator-api',
+        label: 'Chrome Built-in Translator',
+        description: 'Uses Chrome built-in local translation support.',
+        capability: 'translation',
+        runtime: 'chrome-built-in',
+        compatibility: 'compatible',
+        readiness: 'ready',
+        selected: this.selectedProviderId === 'chrome-translator-api',
+      },
+      {
+        id: 'translategemma-webgpu',
+        label: 'TranslateGemma 4B',
+        description: 'Browser-local WebGPU translation model.',
+        capability: 'translation',
+        runtime: 'webgpu-huggingface',
+        compatibility: 'compatible',
+        modelId: 'translategemma-webgpu',
+        readiness: this.translateGemmaReady ? 'ready' : 'needs-download',
+        selected: this.selectedProviderId === 'translategemma-webgpu',
+      },
+    ];
+  }
+}
+
+class ConfigurablePromptService implements PromptService {
+  private selectedProviderId = 'chrome-prompt-api';
+  private availability: PromptApiAvailability = 'downloadable';
+  private gemmaReady = false;
+
+  checkAvailability = vi.fn(() => Promise.resolve(this.gemmaReady ? 'ready' : this.availability));
+
+  getProviderStates = vi.fn((): Promise<AiProviderState[]> => Promise.resolve(this.createProviderStates()));
+
+  setSelectedProvider = vi.fn((providerId: string): Promise<AiProviderState[]> => {
+    this.selectedProviderId = providerId;
+    return Promise.resolve(this.createProviderStates());
+  });
+
+  preparePromptApi = vi.fn((options?: { onProgress?: (progress: number) => void }) => {
+    options?.onProgress?.(91);
+    options?.onProgress?.(100);
+    this.gemmaReady = true;
+    this.availability = 'ready';
+    return Promise.resolve();
+  });
+
+  generateSlideTasksFromPrompt = vi.fn((): Promise<GeneratedSlideTasksDocument> =>
+    Promise.resolve({
+      language: 'en',
+      page: {
+        name: 'Generated Web AI Slide',
+        width: 1920,
+        height: 1080,
+        background: { type: 'color', color: '#050D10' },
+      },
+      tasks: [{ type: 'add-title', id: 'title', text: 'Why Web AI Matters', placementHint: 'center' }],
+    }),
+  );
+
+  generateSlideElementFromTask = vi.fn(
+    (task: Exclude<GeneratedSlideTask, { type: 'set-background' }>): Promise<GeneratedSlideElement> =>
+      Promise.resolve({
+        type: 'text',
+        id: task.id,
+        text: 'text' in task ? task.text : 'Why Web AI Matters',
+        x: 720,
+        y: 280,
+        width: 800,
+        height: 180,
+        rotation: 0,
+        opacity: 1,
+        fontFamily: 'Orbitron',
+        fontSize: 76,
+        fontWeight: 800,
+        fill: '#37FD76',
+        align: 'center',
+      }),
+  );
+
+  private createProviderStates(): AiProviderState[] {
+    return [
+      {
+        id: 'chrome-prompt-api',
+        label: 'Chrome Built-in Prompt API',
+        description: 'Prompt to slides using Chrome Built-in AI.',
+        capability: 'prompt',
+        runtime: 'chrome-built-in',
+        compatibility: 'compatible',
+        readiness: 'ready',
+        selected: this.selectedProviderId === 'chrome-prompt-api',
+      },
+      {
+        id: 'gemma-4-webgpu',
+        label: 'Gemma 4 E2B',
+        description: 'Browser-local Gemma LLM for prompt-to-slides.',
+        capability: 'prompt',
+        runtime: 'webgpu-huggingface',
+        compatibility: 'compatible',
+        modelId: 'gemma-4-webgpu-llm',
+        readiness: this.gemmaReady ? 'ready' : 'needs-download',
+        selected: this.selectedProviderId === 'gemma-4-webgpu',
+      },
+    ];
+  }
+}
+
 class TestPromptService implements PromptService {
   constructor(protected availability: PromptApiAvailability = 'unavailable') {}
 
@@ -683,13 +823,70 @@ describe('mocked AI flows', () => {
 
     expect(screen.getByLabelText('Translate to')).toHaveValue('es');
     expect(translator.prepareTranslation).toHaveBeenCalledWith('en', 'es', expect.any(Object));
-    expect(await screen.findByText('Ready')).toBeInTheDocument();
+    expect((await screen.findAllByText('Ready')).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByLabelText('Translation language preparation').querySelector('.model-progress')).toBeNull();
     expect(screen.getByText('Pair: en → es')).toBeInTheDocument();
     expect(window.localStorage.getItem('localstudio.ai.translation-target-language')).toBe('es');
     expect(
       screen.getByText('Choose the language that will be used for all translations in this deck.'),
     ).toBeInTheDocument();
+  });
+
+  it('prepares an uncached translation model when selected from the dropdown', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const translator = new ConfigurableTranslatorService();
+    services.translatorService = translator;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.selectOptions(screen.getByLabelText('Translation Model'), 'translategemma-webgpu');
+
+    await waitFor(() => {
+      expect(translator.prepareTranslation).toHaveBeenCalledWith('en', 'en', expect.any(Object));
+    });
+    expect(screen.getByLabelText('Translation Model')).toHaveValue('translategemma-webgpu');
+    await waitFor(() => {
+      expect(screen.getByLabelText('Translation model preparation')).toHaveTextContent('Ready');
+    });
+  });
+
+  it('does not reprepare a cached external translation model when the target language changes', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const translator = new ConfigurableTranslatorService({ translateGemmaReady: true });
+    services.translatorService = translator;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.selectOptions(screen.getByLabelText('Translation Model'), 'translategemma-webgpu');
+    await waitFor(() => {
+      expect(screen.getByLabelText('Translation Model')).toHaveValue('translategemma-webgpu');
+    });
+    translator.prepareTranslation.mockClear();
+
+    await user.selectOptions(screen.getByLabelText('Translate to'), 'es');
+
+    expect(screen.getByLabelText('Translate to')).toHaveValue('es');
+    expect(translator.prepareTranslation).not.toHaveBeenCalled();
+    expect(await screen.findByText('Pair: en → es')).toBeInTheDocument();
+  });
+
+  it('prepares an uncached LLM model when selected from the dropdown', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const promptService = new ConfigurablePromptService();
+    services.promptService = promptService;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.selectOptions(screen.getByRole('combobox', { name: 'LLM Model' }), 'gemma-4-webgpu');
+
+    await waitFor(() => {
+      expect(promptService.preparePromptApi).toHaveBeenCalledWith(expect.any(Object));
+    });
+    expect(screen.getByRole('combobox', { name: 'LLM Model' })).toHaveValue('gemma-4-webgpu');
+    expect(screen.getByLabelText('LLM preparation')).toHaveTextContent('Ready');
   });
 
   it('lists Chrome-supported translation target languages', async () => {


### PR DESCRIPTION
## Summary
- Add configurable language detection providers with Chrome Built-in and WebGPU fallback options.
- Add browser-cache model setup for the external language detector and expose it in AI Tools.
- Fix model preparation so Gemma/TranslateGemma/language detection warm cache without keeping large WebGPU pipelines pinned at idle.
- Prevent external TranslateGemma from re-preparing on target language changes and auto-prepare Gemma when selected.

## Validation
- npm run lint
- npm run typecheck
- npm run test -- tests/unit/services/browserTranslatorService.test.ts tests/unit/services/modelSetupService.test.ts tests/unit/services/webGpuLanguageDetectionRuntime.test.ts tests/unit/ui/editor/aiFlows.test.tsx tests/unit/ui/editor/AiToolsPanel.test.tsx tests/unit/ui/editor/EditorShell.test.tsx