### PR TITLE
[codex] Add selected image prompt replacement

### DIFF
--- a/apps/editor/src/domain/commands/aiCommands.ts
+++ b/apps/editor/src/domain/commands/aiCommands.ts
@@ -1,4 +1,4 @@
-import type { ImageElement, ProjectDocument, TextElement } from '../model';
+import type { ProjectDocument, TextElement } from '../model';
 import type { EditorCommand } from './types';
 
 export class TranslateTextCommand implements EditorCommand {
@@ -14,26 +14,6 @@ export class TranslateTextCommand implements EditorCommand {
     if (!element || element.type !== 'text') return project;
 
     const nextElement: TextElement = { ...element, text: this.translatedText };
-    return {
-      ...project,
-      elements: { ...project.elements, [this.elementId]: nextElement },
-    };
-  }
-}
-
-export class ReplaceImageAssetCommand implements EditorCommand {
-  readonly description = 'Replace image asset';
-
-  constructor(
-    private readonly elementId: string,
-    private readonly assetId: string,
-  ) {}
-
-  execute(project: ProjectDocument): ProjectDocument {
-    const element = project.elements[this.elementId];
-    if (!element || element.type !== 'image') return project;
-
-    const nextElement: ImageElement = { ...element, assetId: this.assetId };
     return {
       ...project,
       elements: { ...project.elements, [this.elementId]: nextElement },

--- a/apps/editor/src/domain/commands/basicCommands.ts
+++ b/apps/editor/src/domain/commands/basicCommands.ts
@@ -415,6 +415,36 @@ export class AddImageElementCommand implements EditorCommand {
   }
 }
 
+export class ReplaceImageAssetCommand implements EditorCommand {
+  readonly description = 'Replace image asset';
+
+  constructor(
+    private readonly elementId: string,
+    private readonly asset: Asset,
+  ) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    const element = project.elements[this.elementId];
+    if (!element || element.type !== 'image' || element.locked) return project;
+
+    return removeUnreferencedAssets({
+      ...project,
+      assets: {
+        ...project.assets,
+        [this.asset.id]: this.asset,
+      },
+      elements: {
+        ...project.elements,
+        [this.elementId]: {
+          ...element,
+          assetId: this.asset.id,
+        },
+      },
+      updatedAt: new Date().toISOString(),
+    });
+  }
+}
+
 export class AddElementsCommand implements EditorCommand {
   readonly description = 'Add elements';
 

--- a/apps/editor/src/ui/editor/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/EditorShell.tsx
@@ -363,6 +363,7 @@ export function EditorShell({ services }: EditorShellProps) {
             generationStatus={vm.promptGenerationStatus}
             isGeneratingImage={vm.isGeneratingImage}
             isGeneratingSlide={vm.isGeneratingSlide}
+            selectedImageElementId={vm.selectedImagePromptElementId}
             onCreateImagePromptIntent={() => vm.ensureImageGenerationReadyForPrompt()}
             onCreateImageSubmit={(prompt, options) => vm.generateImageFromPrompt(prompt, options)}
             onSlidePromptSubmit={(prompt) => vm.generateSlideFromPrompt(prompt)}

--- a/apps/editor/src/ui/editor/PromptBar.tsx
+++ b/apps/editor/src/ui/editor/PromptBar.tsx
@@ -10,6 +10,7 @@ interface PromptBarProps {
   generationStatus?: string | undefined;
   isGeneratingImage?: boolean;
   isGeneratingSlide?: boolean;
+  selectedImageElementId?: string | undefined;
   createImageOptions: CreateImagePromptOptions;
   onCreateImagePromptIntent?: () => boolean | Promise<boolean>;
   onCreateImageSubmit?: (prompt: string, options: CreateImagePromptOptions) => Promise<void>;
@@ -40,6 +41,7 @@ export function PromptBar({
   generationStatus,
   isGeneratingImage = false,
   isGeneratingSlide,
+  selectedImageElementId,
   createImageOptions,
   onCreateImagePromptIntent,
   onCreateImageSubmit,
@@ -51,7 +53,8 @@ export function PromptBar({
   const [mode, setMode] = useState<'create-image' | null>('create-image');
   const [localSubmissionActive, setLocalSubmissionActive] = useState(false);
   const [value, setValue] = useState('');
-  const examples = mode === 'create-image' ? imagePromptExamples : slidePromptExamples;
+  const activeMode = selectedImageElementId ? 'create-image' : mode;
+  const examples = activeMode === 'create-image' ? imagePromptExamples : slidePromptExamples;
   const isProcessing = isGeneratingSlide || isGeneratingImage || localSubmissionActive;
 
   function activateCreateImageMode() {
@@ -61,7 +64,7 @@ export function PromptBar({
   }
 
   async function guardPromptIntent() {
-    if (mode !== 'create-image') return true;
+    if (activeMode !== 'create-image') return true;
     return onCreateImagePromptIntent?.() ?? true;
   }
 
@@ -69,7 +72,7 @@ export function PromptBar({
     const trimmedValue = value.trim();
     if (!trimmedValue || isProcessing) return;
     setLocalSubmissionActive(true);
-    if (mode === 'create-image') {
+    if (activeMode === 'create-image') {
       try {
         const canCreateImage = await guardPromptIntent();
         if (!canCreateImage) return;
@@ -90,7 +93,7 @@ export function PromptBar({
 
   return (
     <div className="prompt-stack">
-      <div className="prompt-examples" aria-label={mode === 'create-image' ? 'Image prompt examples' : 'Slide prompt examples'}>
+      <div className="prompt-examples" aria-label={activeMode === 'create-image' ? 'Image prompt examples' : 'Slide prompt examples'}>
         {examples.map((example) => (
           <button
             key={example}
@@ -107,18 +110,18 @@ export function PromptBar({
           </button>
         ))}
       </div>
-      {mode === 'create-image' && createImageStatus ? (
+      {activeMode === 'create-image' && createImageStatus ? (
         <div className="prompt-generation-status">{createImageStatus}</div>
       ) : null}
-      {mode !== 'create-image' && generationStatus ? (
+      {activeMode !== 'create-image' && generationStatus ? (
         <div className="prompt-generation-status">{generationStatus}</div>
       ) : null}
-      {mode === 'create-image' && createImageNotice ? (
+      {activeMode === 'create-image' && createImageNotice ? (
         <div className="prompt-generation-notice" role="tooltip">
           {createImageNotice}
         </div>
       ) : null}
-      {mode !== 'create-image' && generationNotice ? (
+      {activeMode !== 'create-image' && generationNotice ? (
         <div className="prompt-generation-notice" role="tooltip">
           {generationNotice}
         </div>
@@ -160,11 +163,11 @@ export function PromptBar({
             </div>
           ) : null}
         </div>
-        {mode === 'create-image' ? (
+        {activeMode === 'create-image' ? (
           <button
             aria-label="Remove Create image mode"
             className="prompt-mode-token"
-            disabled={isProcessing}
+            disabled={isProcessing || Boolean(selectedImageElementId)}
             type="button"
             onClick={() => {
               setMode(null);
@@ -179,8 +182,8 @@ export function PromptBar({
         <input
           ref={inputRef}
           type="text"
-          placeholder={mode === 'create-image' ? '' : 'Describe slide structure or organize current content...'}
-          aria-label={mode === 'create-image' ? 'Create image prompt' : 'Slide structure prompt'}
+          placeholder={activeMode === 'create-image' ? '' : 'Describe slide structure or organize current content...'}
+          aria-label={activeMode === 'create-image' ? 'Create image prompt' : 'Slide structure prompt'}
           disabled={isProcessing}
           value={value}
           onFocus={() => {
@@ -188,7 +191,7 @@ export function PromptBar({
           }}
           onChange={(event) => {
             const nextValue = event.target.value;
-            if (mode === 'create-image' && value.length > 0 && nextValue.length === 0) {
+            if (activeMode === 'create-image' && !selectedImageElementId && value.length > 0 && nextValue.length === 0) {
               setMode(null);
               setValue('');
               return;

--- a/apps/editor/src/ui/editor/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/useEditorViewModel.ts
@@ -13,6 +13,7 @@ import {
   RenamePageCommand,
   ReorderPageCommand,
   ReorderElementCommand,
+  ReplaceImageAssetCommand,
   SetElementLockCommand,
   SetElementVisibilityCommand,
   SetPageVisibilityCommand,
@@ -33,7 +34,7 @@ import {
 } from '../../domain/commands/basicCommands';
 import type { GeneratedSlideElement } from '../../domain/generatedSlide';
 import { fitImageWithinPage } from '../../domain/imageSizing';
-import type { DesignElement, Page, PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
+import type { DesignElement, ImageElement, Page, PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
 import { SAMPLE_HERO_IMAGE_SIZE, SAMPLE_HERO_IMAGE_URL } from '../../domain/sampleProject';
 import type { AiProviderState, ModelState, PromptApiAvailability, VersionHistoryEntry } from '../../services/interfaces';
 import {
@@ -99,6 +100,7 @@ const IMAGE_EDITING_MODEL_REQUIRED_MESSAGE = 'You must download the image editin
 const PROMPT_API_REQUIRED_MESSAGE = 'LLM model must be prepared before using prompt-to-slides.';
 const IMAGE_GENERATION_MODEL_REQUIRED_MESSAGE = 'Download image generation models before creating images.';
 const IMAGE_PROMPT_MODE_REQUIRED_MESSAGE = 'Use Create image from the + menu to generate images.';
+const IMAGE_GENERATION_DIMENSION_MULTIPLE = 16;
 const BACKGROUND_PREVIEW_DEBOUNCE_MS = 120;
 const DEFAULT_SLIDE_LANGUAGE_CODE = 'pt';
 const PASTED_ELEMENT_OFFSET = 32;
@@ -175,6 +177,13 @@ function getLanguageOption(languageCode: string | undefined) {
   return (
     TRANSLATION_LANGUAGE_OPTIONS.find((option) => option.code === code) ??
     TRANSLATION_LANGUAGE_OPTIONS.find((option) => option.code === DEFAULT_SLIDE_LANGUAGE_CODE)!
+  );
+}
+
+function normalizeImageGenerationDimension(value: number) {
+  return Math.max(
+    IMAGE_GENERATION_DIMENSION_MULTIPLE,
+    Math.round(value / IMAGE_GENERATION_DIMENSION_MULTIPLE) * IMAGE_GENERATION_DIMENSION_MULTIPLE,
   );
 }
 
@@ -472,6 +481,11 @@ export function useEditorViewModel(services: AppServices) {
     activePageId,
     selectedElementIds,
   ]);
+  const selectedImageElement = useMemo<ImageElement | undefined>(() => {
+    if (selectedElementIds.length !== 1) return undefined;
+    const element = project.elements[selectedElementIds[0] ?? ''];
+    return element?.type === 'image' ? element : undefined;
+  }, [project.elements, selectedElementIds]);
   const activeSlideLanguage = useMemo(() => {
     const option = getLanguageOption(pageLanguageCodes[activePageId]);
     return {
@@ -1027,6 +1041,7 @@ export function useEditorViewModel(services: AppServices) {
   async function generateImageFromPrompt(prompt: string, options?: CreateImagePromptOptions) {
     const trimmedPrompt = prompt.trim();
     if (!trimmedPrompt || isGeneratingImage || isGeneratingSlide) return;
+    const imageToReplace = selectedImageElement;
     const runId = promptGenerationRunIdRef.current + 1;
     promptGenerationRunIdRef.current = runId;
     const isCurrentRun = () => promptGenerationRunIdRef.current === runId;
@@ -1038,14 +1053,18 @@ export function useEditorViewModel(services: AppServices) {
     if (!page) return;
 
     setCreateImageNotice(undefined);
-    setCreateImageStatus('Generating image...');
+    setCreateImageStatus(imageToReplace ? 'Generating replacement...' : 'Generating image...');
     setIsGeneratingImage(true);
     try {
       const generationOptions = {
-        ...(options?.height !== undefined ? { height: options.height } : {}),
+        height: normalizeImageGenerationDimension(
+          imageToReplace?.height ?? options?.height ?? DEFAULT_IMAGE_GENERATION_SIZE,
+        ),
         ...(options?.seed !== undefined ? { seed: options.seed } : {}),
         ...(options?.steps !== undefined ? { steps: options.steps } : {}),
-        ...(options?.width !== undefined ? { width: options.width } : {}),
+        width: normalizeImageGenerationDimension(
+          imageToReplace?.width ?? options?.width ?? DEFAULT_IMAGE_GENERATION_SIZE,
+        ),
       };
       const asset = await services.imageGenerationService.generateImage(trimmedPrompt, {
         ...generationOptions,
@@ -1055,10 +1074,18 @@ export function useEditorViewModel(services: AppServices) {
         },
       });
       if (!isCurrentRun()) return;
+      if (imageToReplace) {
+        commitProject(
+          (currentProject) => new ReplaceImageAssetCommand(imageToReplace.id, asset).execute(currentProject),
+          { selectedElementIds: [imageToReplace.id] },
+        );
+        return;
+      }
+
       const elementId = createId('image-generated');
       const fittedImage = fitImageWithinPage({
-        imageWidth: options?.width ?? DEFAULT_IMAGE_GENERATION_SIZE,
-        imageHeight: options?.height ?? DEFAULT_IMAGE_GENERATION_SIZE,
+        imageWidth: generationOptions.width,
+        imageHeight: generationOptions.height,
         pageWidth: page.width,
         pageHeight: page.height,
       });
@@ -2245,6 +2272,7 @@ export function useEditorViewModel(services: AppServices) {
     createImageNotice,
     createImageStatus,
     createImageOptions,
+    selectedImagePromptElementId: selectedImageElement?.id,
     isGeneratingImage,
     isGeneratingSlide,
     aiToolsAttentionModelId,

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -9,6 +9,7 @@ import {
   RenamePageCommand,
   ReorderPageCommand,
   ReorderElementCommand,
+  ReplaceImageAssetCommand,
   SetPageVisibilityCommand,
   SetZOrderCommand,
   SetElementLockCommand,
@@ -78,6 +79,34 @@ describe('editor commands', () => {
     expect(next.elements['image-hero']).toBeUndefined();
     expect(next.assets['asset-hero']).toBeUndefined();
     expect(next.pages[0]?.elementIds).not.toContain('image-hero');
+  });
+
+  it('replaces an image asset while preserving its frame and z-order', () => {
+    const project = createSampleProject();
+    const command = new ReplaceImageAssetCommand('image-hero', {
+      id: 'asset-generated-replacement',
+      type: 'image',
+      name: 'replacement.png',
+      mimeType: 'image/png',
+      objectUrl: 'blob:replacement',
+    });
+    const next = command.execute(project);
+
+    expect(next).not.toBe(project);
+    expect(next.elements['image-hero']).toMatchObject({
+      id: 'image-hero',
+      type: 'image',
+      assetId: 'asset-generated-replacement',
+      x: 55,
+      y: 200,
+      width: 980,
+      height: 735,
+      rotation: 0,
+    });
+    expect(next.pages[0]?.elementIds).toEqual(project.pages[0]?.elementIds);
+    expect(next.assets['asset-generated-replacement']).toBeDefined();
+    expect(next.assets['asset-hero']).toBeUndefined();
+    expect(project.elements['image-hero']).toMatchObject({ type: 'image', assetId: 'asset-hero' });
   });
 
   it('toggles image horizontal flip immutably', () => {

--- a/apps/editor/tests/unit/ui/editor/aiFlows.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/aiFlows.test.tsx
@@ -706,6 +706,45 @@ describe('mocked AI flows', () => {
     });
   });
 
+  it('replaces the selected image using the selected image frame as generation size', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const generateImage = vi.fn((_prompt: string, options?: ImageGenerationOptions): Promise<Asset> => {
+      options?.onProgress?.({ label: 'Generating replacement 1/4', progress: 25 });
+      return Promise.resolve({
+        id: 'asset-generated-replacement',
+        type: 'image',
+        name: 'replacement.png',
+        mimeType: 'image/png',
+        objectUrl:
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lMFeWAAAAABJRU5ErkJggg==',
+      });
+    });
+    services.modelSetupService = new InMemoryModelSetupService();
+    services.imageGenerationService = { generateImage };
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('tab', { name: 'AI Tools' }));
+    await user.click(screen.getByRole('button', { name: 'Download Image Generation Models' }));
+    await user.click(screen.getByRole('button', { name: '16:9' }));
+    await user.click(screen.getByRole('tab', { name: 'Layout' }));
+    await user.click(screen.getByRole('button', { name: 'Selected Image' }));
+    await user.type(screen.getByLabelText('Create image prompt'), 'Replace with a neon studio');
+    await user.click(screen.getByRole('button', { name: 'Submit prompt' }));
+
+    await waitFor(() => {
+      expect(generateImage).toHaveBeenCalledWith(
+        'Replace with a neon studio',
+        expect.objectContaining({
+          height: 736,
+          width: 976,
+        }),
+      );
+    });
+    expect(screen.getByRole('button', { name: 'Selected Image' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Undo' })).not.toBeDisabled();
+  });
+
   it('shows a stop action instead of allowing duplicate create image submissions', async () => {
     const user = userEvent.setup();
     const services = createAppServices();


### PR DESCRIPTION
## Summary

- Switch the prompt bar into create-image mode when a single image element is selected.
- Replace the selected image asset after generation while preserving the element frame, z-order, and selection.
- Normalize selected image generation dimensions to multiples of 16 for the Bonsai image model while keeping the canvas element size unchanged.
- Add command and UI flow tests for selected-image replacement.

## Root Cause

The previous create-image flow always inserted a new image and used the global image generation size preset. When the selected image frame was used directly, arbitrary canvas dimensions such as 980x735 could violate the model requirement that width and height be divisible by 16.

## Validation

- `npm run lint`
- `npm run test`
- `npm run build --workspace @localstudio/editor`