### PR TITLE
Add WebMCP workflow planning UI and automation adapter

### DIFF
--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -2,8 +2,17 @@ import { useMemo } from 'react';
 import { createAppServices } from './app/composition';
 import { createBlankProject } from './domain/sampleProject';
 import { EditorShell } from './ui/editor/EditorShell';
+import { WebMcpShowcasePage } from './ui/webmcp/WebMcpShowcasePage';
 
 export function App() {
+  if (window.location.pathname === '/webmcp' || window.location.pathname === '/editor/webmcp') {
+    return <WebMcpShowcasePage />;
+  }
+
+  return <EditorApp />;
+}
+
+function EditorApp() {
   const services = useMemo(() => {
     const url = new URL(window.location.href);
     const shouldStartBlankProject = url.searchParams.get('newProject') === '1';

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -177,6 +177,340 @@ button {
   color: inherit;
 }
 
+.webmcp-page {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(380px, 520px) minmax(720px, 1fr);
+  background:
+    linear-gradient(90deg, rgba(46, 167, 255, 0.14), transparent 42%),
+    linear-gradient(180deg, rgba(55, 253, 118, 0.08), transparent 36%),
+    #05090a;
+  color: #eefaf5;
+}
+
+.webmcp-control-plane {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  min-width: 0;
+  padding: 28px;
+  border-right: 1px solid rgba(122, 255, 199, 0.18);
+  background: rgba(5, 12, 13, 0.9);
+}
+
+.webmcp-brand-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #9fffd2;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  line-height: 18px;
+  text-transform: uppercase;
+}
+
+.webmcp-signal {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(159, 255, 210, 0.34);
+  border-radius: 6px;
+  color: #9fffd2;
+  background: rgba(159, 255, 210, 0.08);
+}
+
+.webmcp-hero {
+  display: grid;
+  gap: 10px;
+}
+
+.webmcp-kicker {
+  margin: 0;
+  color: #64b7ff;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
+.webmcp-hero h1 {
+  margin: 0;
+  max-width: 420px;
+  color: #ffffff;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 42px;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 48px;
+}
+
+.webmcp-hero p {
+  margin: 0;
+  max-width: 460px;
+  color: rgba(238, 250, 245, 0.72);
+  font-size: 14px;
+  line-height: 22px;
+}
+
+.webmcp-action-row {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+
+.webmcp-primary-action,
+.webmcp-step-button {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  border: 1px solid rgba(159, 255, 210, 0.36);
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease,
+    opacity 140ms ease;
+}
+
+.webmcp-primary-action {
+  padding: 0 14px;
+  background: #37fd76;
+  color: #07100b;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.webmcp-primary-action:hover:not(:disabled) {
+  background: #9fffd2;
+  border-color: #9fffd2;
+}
+
+.webmcp-primary-action:disabled,
+.webmcp-step-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.webmcp-status {
+  min-width: 0;
+  color: rgba(238, 250, 245, 0.72);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.webmcp-tool-list {
+  min-height: 74px;
+  display: flex;
+  align-content: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid rgba(122, 255, 199, 0.16);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.webmcp-tool-pill,
+.webmcp-empty-tools {
+  min-height: 26px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 9px;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 16px;
+}
+
+.webmcp-tool-pill {
+  border: 1px solid rgba(100, 183, 255, 0.28);
+  color: #bfe5ff;
+  background: rgba(100, 183, 255, 0.1);
+}
+
+.webmcp-empty-tools {
+  color: rgba(238, 250, 245, 0.52);
+}
+
+.webmcp-workflow {
+  display: grid;
+  gap: 9px;
+}
+
+.webmcp-step {
+  display: grid;
+  gap: 7px;
+}
+
+.webmcp-step-button {
+  justify-content: flex-start;
+  width: 100%;
+  padding: 0 12px;
+  background: rgba(255, 255, 255, 0.045);
+  color: #eefaf5;
+  font-size: 13px;
+  font-weight: 750;
+  text-align: left;
+}
+
+.webmcp-step-button:hover:not(:disabled),
+.webmcp-step-button-active {
+  border-color: rgba(159, 255, 210, 0.62);
+  background: rgba(159, 255, 210, 0.1);
+}
+
+.webmcp-step-button-focused {
+  animation: webmcp-step-pulse 900ms ease-in-out 3;
+  border-color: #9fffd2;
+  box-shadow: 0 0 0 2px rgba(159, 255, 210, 0.14);
+}
+
+.webmcp-step-index {
+  width: 22px;
+  height: 22px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 4px;
+  background: rgba(100, 183, 255, 0.16);
+  color: #bfe5ff;
+  font-size: 11px;
+  font-weight: 900;
+}
+
+.webmcp-step-command {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  gap: 8px;
+  padding-left: 30px;
+}
+
+.webmcp-step-command input,
+.webmcp-step-command select {
+  min-width: 0;
+  height: 38px;
+  padding: 0 11px;
+  border: 1px solid rgba(122, 255, 199, 0.2);
+  border-radius: 6px;
+  outline: none;
+  background: rgba(0, 0, 0, 0.24);
+  color: #eefaf5;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.webmcp-step-command select {
+  cursor: pointer;
+}
+
+.webmcp-step-command input:focus,
+.webmcp-step-command select:focus {
+  border-color: rgba(159, 255, 210, 0.66);
+  box-shadow: 0 0 0 2px rgba(159, 255, 210, 0.12);
+}
+
+.webmcp-step-command button {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(159, 255, 210, 0.42);
+  border-radius: 6px;
+  cursor: pointer;
+  background: rgba(55, 253, 118, 0.12);
+  color: #9fffd2;
+}
+
+.webmcp-step-command button:hover:not(:disabled) {
+  background: rgba(55, 253, 118, 0.2);
+}
+
+.webmcp-step-command button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+@keyframes webmcp-step-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(159, 255, 210, 0);
+  }
+
+  50% {
+    box-shadow: 0 0 0 4px rgba(159, 255, 210, 0.22);
+  }
+}
+
+.webmcp-result-panel {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: 34px minmax(160px, 1fr);
+  border: 1px solid rgba(122, 255, 199, 0.16);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.26);
+  overflow: hidden;
+}
+
+.webmcp-result-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border-bottom: 1px solid rgba(122, 255, 199, 0.12);
+  color: #9fffd2;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.webmcp-result-panel pre {
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  color: rgba(238, 250, 245, 0.82);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: pre-wrap;
+}
+
+.webmcp-editor-frame {
+  min-width: 0;
+  min-height: 100vh;
+  padding: 18px;
+  background:
+    linear-gradient(135deg, rgba(159, 255, 210, 0.08), transparent 30%),
+    rgba(3, 5, 6, 0.88);
+}
+
+.webmcp-editor-frame iframe {
+  width: 100%;
+  height: calc(100vh - 36px);
+  display: block;
+  border: 1px solid rgba(159, 255, 210, 0.2);
+  border-radius: 8px;
+  background: #050d10;
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.45);
+}
+
+@media (max-width: 1180px) {
+  .webmcp-page {
+    grid-template-columns: 420px minmax(620px, 1fr);
+  }
+
+  .webmcp-control-plane {
+    padding: 22px;
+  }
+}
+
 .font-orbitron {
   font-family: 'Orbitron', sans-serif;
 }

--- a/apps/editor/src/services/editorAutomationController.ts
+++ b/apps/editor/src/services/editorAutomationController.ts
@@ -1,0 +1,207 @@
+import type { Asset, DesignElement, Page, ProjectDocument, SelectionState } from '../domain/model';
+import type { CreateImagePromptOptions } from '../ui/editor/imagePromptOptions';
+import { imageSizePresets } from '../ui/editor/imagePromptOptions';
+
+export type AutomationResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; errorCode: string; message: string };
+
+export type TranslationScope = 'selection' | 'slide' | 'deck';
+
+export interface EditorAutomationState {
+  project: ProjectDocument;
+  selection: SelectionState;
+}
+
+export interface TranslateTextAutomationInput {
+  pageId?: string;
+  scope: string;
+  targetLanguage: string;
+}
+
+export interface GenerateImageAutomationInput extends Partial<CreateImagePromptOptions> {
+  prompt: string;
+}
+
+export interface EditorAutomationDelegate {
+  createProject(input: { name?: string }): Promise<ProjectDocument>;
+  generateSlides(input: { prompt: string }): Promise<ProjectDocument>;
+  generateImage(input: GenerateImageAutomationInput): Promise<ProjectDocument>;
+  translateText(input: TranslateTextAutomationInput & { scope: TranslationScope }): Promise<{
+    project: ProjectDocument;
+    translatedPageIds: string[];
+  }>;
+  getState(): EditorAutomationState;
+}
+
+export interface ProjectSnapshot {
+  projectId: string;
+  name: string;
+  pages: Array<{
+    id: string;
+    name: string;
+    width: number;
+    height: number;
+    background: Page['background'];
+    elementCount: number;
+    elements: SnapshotElement[];
+  }>;
+  assets: Array<Omit<Asset, 'objectUrl'>>;
+  selection: SelectionState;
+}
+
+type SnapshotElement = Pick<
+  DesignElement,
+  'height' | 'id' | 'locked' | 'opacity' | 'rotation' | 'type' | 'visible' | 'width' | 'x' | 'y'
+> & {
+  assetId?: string;
+  fill?: string;
+  text?: string;
+};
+
+const VALID_TRANSLATION_SCOPES: TranslationScope[] = ['selection', 'slide', 'deck'];
+const VALID_IMAGE_DIMENSIONS = new Set(imageSizePresets.flatMap((preset) => [preset.width, preset.height]));
+
+function success<T>(data: T): AutomationResult<T> {
+  return { ok: true, data };
+}
+
+function failure<T>(errorCode: string, message: string): AutomationResult<T> {
+  return { ok: false, errorCode, message };
+}
+
+function compactAsset(asset: Asset): Omit<Asset, 'objectUrl'> {
+  return {
+    id: asset.id,
+    type: asset.type,
+    name: asset.name,
+    mimeType: asset.mimeType,
+    ...(asset.fileName ? { fileName: asset.fileName } : {}),
+    ...(asset.storage ? { storage: asset.storage } : {}),
+  };
+}
+
+function compactElement(element: DesignElement): SnapshotElement {
+  const base = {
+    height: element.height,
+    id: element.id,
+    locked: element.locked,
+    opacity: element.opacity,
+    rotation: element.rotation,
+    type: element.type,
+    visible: element.visible,
+    width: element.width,
+    x: element.x,
+    y: element.y,
+  };
+
+  if (element.type === 'text') {
+    return { ...base, fill: element.fill, text: element.text };
+  }
+  if (element.type === 'image') {
+    return { ...base, assetId: element.assetId };
+  }
+  return { ...base, fill: element.fill };
+}
+
+export function createProjectSnapshot(state: EditorAutomationState): ProjectSnapshot {
+  return {
+    projectId: state.project.id,
+    name: state.project.name,
+    pages: state.project.pages.map((page) => ({
+      id: page.id,
+      name: page.name,
+      width: page.width,
+      height: page.height,
+      background: page.background,
+      elementCount: page.elementIds.length,
+      elements: page.elementIds
+        .map((elementId) => state.project.elements[elementId])
+        .filter((element): element is DesignElement => Boolean(element))
+        .map(compactElement),
+    })),
+    assets: Object.values(state.project.assets).map(compactAsset),
+    selection: state.selection,
+  };
+}
+
+export class EditorAutomationController {
+  private activeAction: string | undefined;
+
+  constructor(private readonly delegate: EditorAutomationDelegate) {}
+
+  async createProject(input: { name?: string } = {}): Promise<
+    AutomationResult<{ name: string; pageCount: number; projectId: string }>
+  > {
+    const trimmedName = input.name?.trim();
+    const project = await this.delegate.createProject(trimmedName ? { name: trimmedName } : {});
+    return success({
+      projectId: project.id,
+      name: project.name,
+      pageCount: project.pages.length,
+    });
+  }
+
+  async generateSlides(input: { prompt: string }): Promise<AutomationResult<{ snapshot: ProjectSnapshot }>> {
+    const prompt = input.prompt.trim();
+    if (!prompt) return failure('empty_prompt', 'Enter a prompt before generating slides.');
+    return this.runExclusive('generate_slides', async () => {
+      const project = await this.delegate.generateSlides({ prompt });
+      return success({ snapshot: createProjectSnapshot({ ...this.delegate.getState(), project }) });
+    });
+  }
+
+  async generateImage(input: GenerateImageAutomationInput): Promise<AutomationResult<{ snapshot: ProjectSnapshot }>> {
+    const prompt = input.prompt.trim();
+    if (!prompt) return failure('empty_prompt', 'Enter a prompt before generating an image.');
+    if (input.width !== undefined && !VALID_IMAGE_DIMENSIONS.has(input.width)) {
+      return failure('invalid_image_dimensions', 'Image width must match one of the supported prompt presets.');
+    }
+    if (input.height !== undefined && !VALID_IMAGE_DIMENSIONS.has(input.height)) {
+      return failure('invalid_image_dimensions', 'Image height must match one of the supported prompt presets.');
+    }
+    return this.runExclusive('generate_image', async () => {
+      const project = await this.delegate.generateImage({ ...input, prompt });
+      return success({ snapshot: createProjectSnapshot({ ...this.delegate.getState(), project }) });
+    });
+  }
+
+  async translateText(input: TranslateTextAutomationInput): Promise<
+    AutomationResult<{ snapshot: ProjectSnapshot; translatedPageIds: string[] }>
+  > {
+    if (!VALID_TRANSLATION_SCOPES.includes(input.scope as TranslationScope)) {
+      return failure('invalid_translation_scope', 'Translation scope must be selection, slide, or deck.');
+    }
+    const targetLanguage = input.targetLanguage.trim();
+    if (!targetLanguage) return failure('empty_target_language', 'Choose a target language before translating.');
+    return this.runExclusive('translate_text', async () => {
+      const result = await this.delegate.translateText({
+        ...input,
+        scope: input.scope as TranslationScope,
+        targetLanguage,
+      });
+      return success({
+        translatedPageIds: result.translatedPageIds,
+        snapshot: createProjectSnapshot({ ...this.delegate.getState(), project: result.project }),
+      });
+    });
+  }
+
+  getProjectSnapshot(): AutomationResult<{ snapshot: ProjectSnapshot }> {
+    return success({ snapshot: createProjectSnapshot(this.delegate.getState()) });
+  }
+
+  private async runExclusive<T>(action: string, run: () => Promise<AutomationResult<T>>): Promise<AutomationResult<T>> {
+    if (this.activeAction) {
+      return failure('busy', 'Another automation action is already running.');
+    }
+    this.activeAction = action;
+    try {
+      return await run();
+    } catch (error) {
+      return failure(action, error instanceof Error ? error.message : 'Automation action failed.');
+    } finally {
+      this.activeAction = undefined;
+    }
+  }
+}

--- a/apps/editor/src/services/webMcpToolAdapter.ts
+++ b/apps/editor/src/services/webMcpToolAdapter.ts
@@ -1,0 +1,147 @@
+import type {
+  AutomationResult,
+  EditorAutomationController,
+  GenerateImageAutomationInput,
+  TranslateTextAutomationInput,
+} from './editorAutomationController';
+import { imagePromptExamples, slidePromptExamples } from '../ui/editor/promptRecipes';
+
+type ToolInput = Record<string, unknown>;
+
+export interface WebMcpTool {
+  description: string;
+  execute(input: ToolInput): Promise<AutomationResult<unknown>> | AutomationResult<unknown>;
+  inputSchema: Record<string, unknown>;
+  name: string;
+}
+
+export interface WebMcpModelContext {
+  registerTool?: (tool: WebMcpTool) => unknown;
+  registerTools?: (tools: WebMcpTool[]) => unknown;
+}
+
+export interface WebMcpDemoWindow extends Window {
+  localStudioWebMcpTools?: WebMcpTool[];
+}
+
+type ControllerLike = Pick<
+  EditorAutomationController,
+  'createProject' | 'generateSlides' | 'generateImage' | 'translateText' | 'getProjectSnapshot'
+>;
+
+function promptExamplesList(examples: readonly string[]) {
+  return examples.map((example) => `- ${example}`).join('\n');
+}
+
+function stringInput(input: ToolInput, key: string) {
+  const value = input[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function optionalNumberInput(input: ToolInput, key: string) {
+  const value = input[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function imageInput(input: ToolInput): GenerateImageAutomationInput {
+  const height = optionalNumberInput(input, 'height');
+  const seed = optionalNumberInput(input, 'seed');
+  const steps = optionalNumberInput(input, 'steps');
+  const width = optionalNumberInput(input, 'width');
+  return {
+    prompt: stringInput(input, 'prompt'),
+    ...(height !== undefined ? { height } : {}),
+    ...(seed !== undefined ? { seed } : {}),
+    ...(steps !== undefined ? { steps } : {}),
+    ...(width !== undefined ? { width } : {}),
+  };
+}
+
+function translateInput(input: ToolInput): TranslateTextAutomationInput {
+  return {
+    scope: stringInput(input, 'scope'),
+    targetLanguage: stringInput(input, 'targetLanguage'),
+    ...(stringInput(input, 'pageId') ? { pageId: stringInput(input, 'pageId') } : {}),
+  };
+}
+
+export class WebMcpToolAdapter {
+  constructor(private readonly controller: ControllerLike) {}
+
+  createTools(): WebMcpTool[] {
+    return [
+      {
+        name: 'create_project',
+        description: 'Create a new blank LocalStudio AI project in the active editor tab.',
+        inputSchema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+        execute: (input) => {
+          const name = stringInput(input, 'name');
+          return this.controller.createProject(name ? { name } : {});
+        },
+      },
+      {
+        name: 'generate_slides',
+        description: `Generate slide content on the active page from a prompt. Good prompt examples:\n${promptExamplesList(slidePromptExamples)}`,
+        inputSchema: {
+          type: 'object',
+          required: ['prompt'],
+          properties: { prompt: { type: 'string' } },
+        },
+        execute: (input) => this.controller.generateSlides({ prompt: stringInput(input, 'prompt') }),
+      },
+      {
+        name: 'generate_image',
+        description: `Generate an image for the active slide. If an image is selected, replace it; otherwise insert a fitted image. Good prompt examples:\n${promptExamplesList(imagePromptExamples)}`,
+        inputSchema: {
+          type: 'object',
+          required: ['prompt'],
+          properties: {
+            height: { type: 'number' },
+            prompt: { type: 'string' },
+            seed: { type: 'number' },
+            steps: { type: 'number' },
+            width: { type: 'number' },
+          },
+        },
+        execute: (input) => this.controller.generateImage(imageInput(input)),
+      },
+      {
+        name: 'translate_text',
+        description: 'Translate visible text in the active LocalStudio AI project. Scope must be selection, slide, or deck.',
+        inputSchema: {
+          type: 'object',
+          required: ['scope', 'targetLanguage'],
+          properties: {
+            pageId: { type: 'string' },
+            scope: { type: 'string', enum: ['selection', 'slide', 'deck'] },
+            targetLanguage: { type: 'string' },
+          },
+        },
+        execute: (input) => this.controller.translateText(translateInput(input)),
+      },
+      {
+        name: 'get_project_snapshot',
+        description: 'Return a compact JSON snapshot of the active LocalStudio AI project without large image payloads.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        execute: () => this.controller.getProjectSnapshot(),
+      },
+    ];
+  }
+
+  register(modelContext: WebMcpModelContext): () => void {
+    const tools = this.createTools();
+    if (modelContext.registerTools) {
+      modelContext.registerTools(tools);
+    } else {
+      tools.forEach((tool) => modelContext.registerTool?.(tool));
+    }
+
+    return () => undefined;
+  }
+}

--- a/apps/editor/src/ui/editor/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/EditorShell.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import type Konva from 'konva';
 import type { AppServices } from '../../app/composition';
+import { EditorAutomationController, type EditorAutomationDelegate } from '../../services/editorAutomationController';
 import { IMAGE_EDITING_MODEL_ID } from '../../services/modelSetupService';
+import {
+  WebMcpToolAdapter,
+  type WebMcpDemoWindow,
+  type WebMcpModelContext,
+} from '../../services/webMcpToolAdapter';
 import { EditorFooter } from './EditorFooter';
 import { LeftToolPanel } from './LeftToolPanel';
 import { PagesPanel } from './PagesPanel';
@@ -65,8 +71,19 @@ function writeEditorObjectClipboardMarker(clipboardData: DataTransfer | null) {
   clipboardData.setData('text/plain', 'LocalStudio.ai editor elements');
 }
 
+function isWebMcpEnabled() {
+  if (typeof window === 'undefined') return false;
+  return new URL(window.location.href).searchParams.get('webmcp') === '1';
+}
+
+function getWebMcpModelContext() {
+  if (typeof document === 'undefined') return undefined;
+  return (document as Document & { modelContext?: WebMcpModelContext }).modelContext;
+}
+
 export function EditorShell({ services }: EditorShellProps) {
   const vm = useEditorViewModel(services);
+  const automationDelegateRef = useRef(vm.automation);
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);
   const stageRef = useRef<Konva.Stage>(null);
   const workspaceRef = useRef<HTMLElement>(null);
@@ -138,6 +155,10 @@ export function EditorShell({ services }: EditorShellProps) {
   }, [hasSelection, isHistoryReadOnly, vm]);
 
   useEffect(() => {
+    automationDelegateRef.current = vm.automation;
+  }, [vm.automation]);
+
+  useEffect(() => {
     function handleCopy(event: ClipboardEvent) {
       if (isHistoryReadOnly) return;
       if (isEditableInteractionTarget(event.target) || hasBrowserTextSelection() || !hasSelection) return;
@@ -176,6 +197,27 @@ export function EditorShell({ services }: EditorShellProps) {
       window.removeEventListener('paste', handlePaste);
     };
   }, [hasSelection, isHistoryReadOnly, vm]);
+
+  useEffect(() => {
+    if (!isWebMcpEnabled()) return undefined;
+    const delegate: EditorAutomationDelegate = {
+      createProject: (input) => automationDelegateRef.current.createProject(input),
+      generateSlides: (input) => automationDelegateRef.current.generateSlides(input),
+      generateImage: (input) => automationDelegateRef.current.generateImage(input),
+      translateText: (input) => automationDelegateRef.current.translateText(input),
+      getState: () => automationDelegateRef.current.getState(),
+    };
+    const adapter = new WebMcpToolAdapter(new EditorAutomationController(delegate));
+    const demoWindow = window as WebMcpDemoWindow;
+    const modelContext = getWebMcpModelContext();
+    demoWindow.localStudioWebMcpTools = adapter.createTools();
+    const unregister = modelContext ? adapter.register(modelContext) : undefined;
+
+    return () => {
+      unregister?.();
+      delete demoWindow.localStudioWebMcpTools;
+    };
+  }, []);
 
   return (
     <div className="app-shell">

--- a/apps/editor/src/ui/editor/PromptBar.tsx
+++ b/apps/editor/src/ui/editor/PromptBar.tsx
@@ -2,6 +2,7 @@ import { ImagePlus, Mic, Plus, SendHorizontal, Square, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { IconButton } from '../components/IconButton';
 import type { CreateImagePromptOptions } from './imagePromptOptions';
+import { imagePromptExamples, slidePromptExamples } from './promptRecipes';
 
 interface PromptBarProps {
   createImageNotice?: string | undefined;
@@ -17,22 +18,6 @@ interface PromptBarProps {
   onSlidePromptSubmit?: (prompt: string) => Promise<void>;
   onStopGeneration?: () => void;
 }
-
-const slidePromptExamples = [
-  'Slide with the placeholder image expanded large on the left, the neon green title “AI Design Revolution” on the right, and the subtitle “Browser-native creative” below it.',
-  'Three-image grid about Web AI, with matching captions.',
-  'Top title and three body bullets about why Web AI is useful.',
-  'Slide using https://img-c.udemycdn.com/course/480x270/5625134_794c.jpg as the main image, with a short title and caption.',
-  'Slide with a deep purple background, gold title "Web AI Advantage", and white subtitle "Fast local intelligence".',
-];
-
-const imagePromptExamples = [
-  'Create an icy Bonsai tree in a rainy forest with snowy mountains in the background, photo realistic',
-  'Create a neon green browser-native design studio floating inside a dark futuristic workspace',
-  'Create a cinematic close-up of a laptop editing slides with glowing green UI reflections',
-  'Create a realistic product hero image for a local-first AI creative editor on a dark background',
-  'Create a cyberpunk classroom with holographic slide canvases and black-and-green lighting',
-];
 
 export function PromptBar({
   createImageNotice,

--- a/apps/editor/src/ui/editor/promptRecipes.ts
+++ b/apps/editor/src/ui/editor/promptRecipes.ts
@@ -1,0 +1,26 @@
+export const slidePromptExamples = [
+  'Slide with the placeholder image expanded large on the left, the neon green title “AI Design Revolution” on the right, and the subtitle “Browser-native creative” below it.',
+  'Three-image grid about Web AI, with matching captions.',
+  'Top title and three body bullets about why Web AI is useful.',
+  'Slide using https://img-c.udemycdn.com/course/480x270/5625134_794c.jpg as the main image, with a short title and caption.',
+  'Slide with a deep purple background, gold title "Web AI Advantage", and white subtitle "Fast local intelligence".',
+] as const;
+
+export const imagePromptExamples = [
+  'Create an icy Bonsai tree in a rainy forest with snowy mountains in the background, photo realistic',
+  'Create a neon green browser-native design studio floating inside a dark futuristic workspace',
+  'Create a cinematic close-up of a laptop editing slides with glowing green UI reflections',
+  'Create a realistic product hero image for a local-first AI creative editor on a dark background',
+  'Create a cyberpunk classroom with holographic slide canvases and black-and-green lighting',
+] as const;
+
+export const promptRecipeCatalog = {
+  slide: {
+    label: 'Slide prompt examples',
+    examples: slidePromptExamples,
+  },
+  image: {
+    label: 'Image prompt examples',
+    examples: imagePromptExamples,
+  },
+} as const;

--- a/apps/editor/src/ui/editor/translationLanguages.ts
+++ b/apps/editor/src/ui/editor/translationLanguages.ts
@@ -1,0 +1,47 @@
+export interface TranslationLanguageOption {
+  code: string;
+  flag: string;
+  label: string;
+}
+
+export const TRANSLATION_LANGUAGE_OPTIONS: TranslationLanguageOption[] = [
+  { code: 'ar', flag: '🇸🇦', label: 'Arabic' },
+  { code: 'bn', flag: '🇧🇩', label: 'Bengali' },
+  { code: 'bg', flag: '🇧🇬', label: 'Bulgarian' },
+  { code: 'zh', flag: '🇨🇳', label: 'Chinese' },
+  { code: 'zh-Hant', flag: '🇹🇼', label: 'Chinese (Traditional)' },
+  { code: 'hr', flag: '🇭🇷', label: 'Croatian' },
+  { code: 'cs', flag: '🇨🇿', label: 'Czech' },
+  { code: 'da', flag: '🇩🇰', label: 'Danish' },
+  { code: 'nl', flag: '🇳🇱', label: 'Dutch' },
+  { code: 'en', flag: '🇺🇸', label: 'English' },
+  { code: 'fi', flag: '🇫🇮', label: 'Finnish' },
+  { code: 'fr', flag: '🇫🇷', label: 'French' },
+  { code: 'de', flag: '🇩🇪', label: 'German' },
+  { code: 'el', flag: '🇬🇷', label: 'Greek' },
+  { code: 'iw', flag: '🇮🇱', label: 'Hebrew' },
+  { code: 'hi', flag: '🇮🇳', label: 'Hindi' },
+  { code: 'hu', flag: '🇭🇺', label: 'Hungarian' },
+  { code: 'id', flag: '🇮🇩', label: 'Indonesian' },
+  { code: 'it', flag: '🇮🇹', label: 'Italian' },
+  { code: 'ja', flag: '🇯🇵', label: 'Japanese' },
+  { code: 'kn', flag: '🇮🇳', label: 'Kannada' },
+  { code: 'ko', flag: '🇰🇷', label: 'Korean' },
+  { code: 'lt', flag: '🇱🇹', label: 'Lithuanian' },
+  { code: 'mr', flag: '🇮🇳', label: 'Marathi' },
+  { code: 'no', flag: '🇳🇴', label: 'Norwegian' },
+  { code: 'pl', flag: '🇵🇱', label: 'Polish' },
+  { code: 'pt', flag: '🇧🇷', label: 'Portuguese' },
+  { code: 'ro', flag: '🇷🇴', label: 'Romanian' },
+  { code: 'ru', flag: '🇷🇺', label: 'Russian' },
+  { code: 'sk', flag: '🇸🇰', label: 'Slovak' },
+  { code: 'sl', flag: '🇸🇮', label: 'Slovenian' },
+  { code: 'es', flag: '🇪🇸', label: 'Spanish' },
+  { code: 'sv', flag: '🇸🇪', label: 'Swedish' },
+  { code: 'ta', flag: '🇮🇳', label: 'Tamil' },
+  { code: 'te', flag: '🇮🇳', label: 'Telugu' },
+  { code: 'th', flag: '🇹🇭', label: 'Thai' },
+  { code: 'tr', flag: '🇹🇷', label: 'Turkish' },
+  { code: 'uk', flag: '🇺🇦', label: 'Ukrainian' },
+  { code: 'vi', flag: '🇻🇳', label: 'Vietnamese' },
+];

--- a/apps/editor/src/ui/editor/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/useEditorViewModel.ts
@@ -35,7 +35,8 @@ import {
 import type { GeneratedSlideElement } from '../../domain/generatedSlide';
 import { fitImageWithinPage } from '../../domain/imageSizing';
 import type { DesignElement, ImageElement, Page, PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
-import { SAMPLE_HERO_IMAGE_SIZE, SAMPLE_HERO_IMAGE_URL } from '../../domain/sampleProject';
+import { createBlankProject, SAMPLE_HERO_IMAGE_SIZE, SAMPLE_HERO_IMAGE_URL } from '../../domain/sampleProject';
+import type { EditorAutomationDelegate } from '../../services/editorAutomationController';
 import type { AiProviderState, ModelState, PromptApiAvailability, VersionHistoryEntry } from '../../services/interfaces';
 import {
   GEMMA_LLM_MODEL_ID,
@@ -49,6 +50,7 @@ import {
 import { IMAGE_EDITING_MODEL_ID } from '../../services/modelSetupService';
 import { looksLikeImageGenerationRequest } from '../../services/prompts/slideTaskPrompt';
 import { defaultCreateImagePromptOptions, type CreateImagePromptOptions } from './imagePromptOptions';
+import { TRANSLATION_LANGUAGE_OPTIONS } from './translationLanguages';
 
 export type RightPanelTab = 'layout' | 'text' | 'design' | 'ai-tools' | 'assets';
 export type TextPreset = 'title' | 'subtitle' | 'body';
@@ -104,48 +106,6 @@ const IMAGE_GENERATION_DIMENSION_MULTIPLE = 16;
 const BACKGROUND_PREVIEW_DEBOUNCE_MS = 120;
 const DEFAULT_SLIDE_LANGUAGE_CODE = 'pt';
 const PASTED_ELEMENT_OFFSET = 32;
-export const TRANSLATION_LANGUAGE_OPTIONS = [
-  { code: 'ar', flag: '🇸🇦', label: 'Arabic' },
-  { code: 'bn', flag: '🇧🇩', label: 'Bengali' },
-  { code: 'bg', flag: '🇧🇬', label: 'Bulgarian' },
-  { code: 'zh', flag: '🇨🇳', label: 'Chinese' },
-  { code: 'zh-Hant', flag: '🇹🇼', label: 'Chinese (Traditional)' },
-  { code: 'hr', flag: '🇭🇷', label: 'Croatian' },
-  { code: 'cs', flag: '🇨🇿', label: 'Czech' },
-  { code: 'da', flag: '🇩🇰', label: 'Danish' },
-  { code: 'nl', flag: '🇳🇱', label: 'Dutch' },
-  { code: 'en', flag: '🇺🇸', label: 'English' },
-  { code: 'fi', flag: '🇫🇮', label: 'Finnish' },
-  { code: 'fr', flag: '🇫🇷', label: 'French' },
-  { code: 'de', flag: '🇩🇪', label: 'German' },
-  { code: 'el', flag: '🇬🇷', label: 'Greek' },
-  { code: 'iw', flag: '🇮🇱', label: 'Hebrew' },
-  { code: 'hi', flag: '🇮🇳', label: 'Hindi' },
-  { code: 'hu', flag: '🇭🇺', label: 'Hungarian' },
-  { code: 'id', flag: '🇮🇩', label: 'Indonesian' },
-  { code: 'it', flag: '🇮🇹', label: 'Italian' },
-  { code: 'ja', flag: '🇯🇵', label: 'Japanese' },
-  { code: 'kn', flag: '🇮🇳', label: 'Kannada' },
-  { code: 'ko', flag: '🇰🇷', label: 'Korean' },
-  { code: 'lt', flag: '🇱🇹', label: 'Lithuanian' },
-  { code: 'mr', flag: '🇮🇳', label: 'Marathi' },
-  { code: 'no', flag: '🇳🇴', label: 'Norwegian' },
-  { code: 'pl', flag: '🇵🇱', label: 'Polish' },
-  { code: 'pt', flag: '🇧🇷', label: 'Portuguese' },
-  { code: 'ro', flag: '🇷🇴', label: 'Romanian' },
-  { code: 'ru', flag: '🇷🇺', label: 'Russian' },
-  { code: 'sk', flag: '🇸🇰', label: 'Slovak' },
-  { code: 'sl', flag: '🇸🇮', label: 'Slovenian' },
-  { code: 'es', flag: '🇪🇸', label: 'Spanish' },
-  { code: 'sv', flag: '🇸🇪', label: 'Swedish' },
-  { code: 'ta', flag: '🇮🇳', label: 'Tamil' },
-  { code: 'te', flag: '🇮🇳', label: 'Telugu' },
-  { code: 'th', flag: '🇹🇭', label: 'Thai' },
-  { code: 'tr', flag: '🇹🇷', label: 'Turkish' },
-  { code: 'uk', flag: '🇺🇦', label: 'Ukrainian' },
-  { code: 'vi', flag: '🇻🇳', label: 'Vietnamese' },
-];
-
 function normalizeLanguageCode(languageCode: string | undefined) {
   const normalized = languageCode?.trim();
   if (!normalized) return DEFAULT_SLIDE_LANGUAGE_CODE;
@@ -409,12 +369,15 @@ export function useEditorViewModel(services: AppServices) {
     [services.skipStoredProjectLoad],
   );
   const [project, setProject] = useState<ProjectDocument>(initialProject);
+  const projectRef = useRef(project);
   const [activeTab, setActiveTab] = useState<RightPanelTab>('layout');
   const [modelStates, setModelStates] = useState<ModelState[]>([]);
   const [hasLoadedProject, setHasLoadedProject] = useState(!shouldRestoreStoredProject);
   const [persistenceEnabled, setPersistenceEnabled] = useState(shouldRestoreStoredProject);
   const [activePageId, setActivePageId] = useState(initialProject.pages[0]?.id ?? '');
+  const activePageIdRef = useRef(activePageId);
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
+  const selectedElementIdsRef = useRef(selectedElementIds);
   const [history, setHistory] = useState<EditorHistory>({ past: [], future: [] });
   const [zoomPercent, setZoomPercent] = useState(100);
   const [pagesPanelOpen, setPagesPanelOpen] = useState(false);
@@ -470,6 +433,9 @@ export function useEditorViewModel(services: AppServices) {
   const [, setBackgroundSelectionPoints] = useState<Record<string, BackgroundSelectionPoint[]>>(
     {},
   );
+  projectRef.current = project;
+  activePageIdRef.current = activePageId;
+  selectedElementIdsRef.current = selectedElementIds;
   const backgroundSelectionPointsRef = useRef<Record<string, BackgroundSelectionPoint[]>>({});
   const backgroundPreviewTimeoutRef = useRef<number | undefined>(undefined);
   const backgroundPreviewSequenceRef = useRef(0);
@@ -664,6 +630,29 @@ export function useEditorViewModel(services: AppServices) {
     void removed;
     backgroundSelectionPointsRef.current = remainingPoints;
     setBackgroundSelectionPoints(remainingPoints);
+  }
+
+  function replaceProjectForAutomation(nextProject: ProjectDocument) {
+    const nextActivePageId = nextProject.pages[0]?.id ?? '';
+    projectRef.current = nextProject;
+    activePageIdRef.current = nextActivePageId;
+    selectedElementIdsRef.current = [];
+    setProject(nextProject);
+    setActivePageId(nextActivePageId);
+    setSelectedElementIds([]);
+    setHistory({ past: [], future: [] });
+    setPageLanguageCodes({});
+    setBackgroundSelectionMode(false);
+    setBackgroundSelectionNotice(undefined);
+    clearBackgroundPreview();
+    clearBackgroundPreparation();
+    clearBackgroundSelectionPoints();
+    setPreviewProject(undefined);
+    setSelectedVersionId(undefined);
+    setVersionHistoryOpen(false);
+    skipNextProjectSaveRef.current = true;
+    lastVersionProjectRef.current = nextProject;
+    setLastEditedAt(nextProject.updatedAt);
   }
 
   function isBackgroundPreparationReady(elementId: string) {
@@ -1143,14 +1132,21 @@ export function useEditorViewModel(services: AppServices) {
     setProject((currentProject) => {
       const nextProject = updater(currentProject);
       if (nextProject === currentProject) return currentProject;
+      projectRef.current = nextProject;
 
       setHistory((currentHistory) => ({
         past: [...currentHistory.past, currentProject].slice(-50),
         future: [],
       }));
 
-      if (options?.activePageId !== undefined) setActivePageId(options.activePageId);
-      if (options?.selectedElementIds !== undefined) setSelectedElementIds(options.selectedElementIds);
+      if (options?.activePageId !== undefined) {
+        activePageIdRef.current = options.activePageId;
+        setActivePageId(options.activePageId);
+      }
+      if (options?.selectedElementIds !== undefined) {
+        selectedElementIdsRef.current = options.selectedElementIds;
+        setSelectedElementIds(options.selectedElementIds);
+      }
       return nextProject;
     });
   }
@@ -1582,6 +1578,75 @@ export function useEditorViewModel(services: AppServices) {
       setIsTranslating(false);
     }
   }
+
+  function createProjectForAutomation(input: { name?: string }) {
+    const blankProject = createBlankProject();
+    const nextProject = normalizeProjectDocument({
+      ...blankProject,
+      name: input.name?.trim() || blankProject.name,
+      updatedAt: new Date().toISOString(),
+    });
+    replaceProjectForAutomation(nextProject);
+    return Promise.resolve(nextProject);
+  }
+
+  async function generateSlidesForAutomation(input: { prompt: string }) {
+    await generateSlideFromPrompt(input.prompt);
+    return projectRef.current;
+  }
+
+  async function generateImageForAutomation(input: { height?: number; prompt: string; seed?: number; steps?: number; width?: number }) {
+    const options =
+      input.height !== undefined ||
+      input.seed !== undefined ||
+      input.steps !== undefined ||
+      input.width !== undefined
+        ? {
+            ...createImageOptions,
+            ...(input.height !== undefined ? { height: input.height } : {}),
+            ...(input.seed !== undefined ? { seed: input.seed } : {}),
+            ...(input.steps !== undefined ? { steps: input.steps } : {}),
+            ...(input.width !== undefined ? { width: input.width } : {}),
+          }
+        : undefined;
+    await generateImageFromPrompt(input.prompt, options);
+    return projectRef.current;
+  }
+
+  async function translateTextForAutomation(input: { pageId?: string; scope: TranslationScope; targetLanguage: string }) {
+    await setTranslationTargetLanguage(input.targetLanguage);
+    const translationOptions = input.pageId ? { pageId: input.pageId } : undefined;
+    const translatedPageIds = await translateTextScope(input.scope, input.targetLanguage, translationOptions);
+    if (translatedPageIds.length > 0) {
+      const normalizedTargetLanguage = normalizeLanguageCode(input.targetLanguage);
+      setPageLanguageCodes((current) => ({
+        ...current,
+        ...Object.fromEntries(translatedPageIds.map((pageId) => [pageId, normalizedTargetLanguage])),
+      }));
+    }
+    return {
+      project: projectRef.current,
+      translatedPageIds,
+    };
+  }
+
+  function getAutomationState() {
+    return {
+      project: projectRef.current,
+      selection: {
+        pageId: activePageIdRef.current,
+        elementIds: selectedElementIdsRef.current,
+      },
+    };
+  }
+
+  const automation: EditorAutomationDelegate = {
+    createProject: createProjectForAutomation,
+    generateSlides: generateSlidesForAutomation,
+    generateImage: generateImageForAutomation,
+    translateText: translateTextForAutomation,
+    getState: getAutomationState,
+  };
 
   function setElementVisibility(elementId: string, visible: boolean) {
     commitProject((currentProject) =>
@@ -2222,6 +2287,7 @@ export function useEditorViewModel(services: AppServices) {
 
   return {
     project: previewProject ?? project,
+    automation,
     activePageId,
     zoomPercent,
     pagesPanelOpen,

--- a/apps/editor/src/ui/webmcp/WebMcpShowcasePage.tsx
+++ b/apps/editor/src/ui/webmcp/WebMcpShowcasePage.tsx
@@ -1,0 +1,322 @@
+import { Bot, FileJson, ImagePlus, Languages, Play, Radar, SendHorizontal } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+import { imagePromptExamples, slidePromptExamples } from '../editor/promptRecipes';
+import { TRANSLATION_LANGUAGE_OPTIONS } from '../editor/translationLanguages';
+
+interface WebMcpToolLike {
+  call?: (input: Record<string, unknown>) => unknown;
+  description?: string;
+  execute?: (input: Record<string, unknown>) => unknown;
+  invoke?: (input: Record<string, unknown>) => unknown;
+  name: string;
+}
+
+interface BrowserModelContext {
+  getTools(options: { fromOrigins: string[] }): Promise<WebMcpToolLike[]>;
+}
+
+interface DemoStep {
+  input: Record<string, unknown>;
+  label: string;
+  toolName: string;
+}
+
+const demoSteps: DemoStep[] = [
+  {
+    label: 'Create project',
+    toolName: 'create_project',
+    input: { name: 'WebMCP Demo Deck' },
+  },
+  {
+    label: 'Generate slide',
+    toolName: 'generate_slides',
+    input: { prompt: slidePromptExamples[1] },
+  },
+  {
+    label: 'Generate image',
+    toolName: 'generate_image',
+    input: {
+      prompt: imagePromptExamples[1],
+      width: 512,
+      height: 512,
+      steps: 4,
+    },
+  },
+  {
+    label: 'Translate deck',
+    toolName: 'translate_text',
+    input: { scope: 'deck', targetLanguage: 'pt' },
+  },
+  {
+    label: 'Read snapshot',
+    toolName: 'get_project_snapshot',
+    input: {},
+  },
+];
+
+function getBrowserModelContext() {
+  if (typeof document === 'undefined') return undefined;
+  return (document as Document & { modelContext?: BrowserModelContext }).modelContext;
+}
+
+function isWebMcpToolLikeArray(value: unknown): value is WebMcpToolLike[] {
+  return Array.isArray(value) && value.every((item) => {
+    if (!item || typeof item !== 'object') return false;
+    return typeof (item as { name?: unknown }).name === 'string';
+  });
+}
+
+function getLocalDemoTools(iframe: HTMLIFrameElement) {
+  const frameWindow = iframe.contentWindow;
+  if (!frameWindow || !('localStudioWebMcpTools' in frameWindow)) return undefined;
+  const tools = frameWindow.localStudioWebMcpTools;
+  return isWebMcpToolLikeArray(tools) ? tools : undefined;
+}
+
+function callTool(tool: WebMcpToolLike, input: Record<string, unknown>) {
+  const callable = tool.call ?? tool.execute ?? tool.invoke;
+  if (!callable) throw new Error(`${tool.name} is not callable in this WebMCP runtime.`);
+  return Promise.resolve(callable(input));
+}
+
+function formatPayload(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+function getDefaultCommandValue(step: DemoStep) {
+  const primaryValue = step.input.name ?? step.input.prompt ?? step.input.targetLanguage;
+  return typeof primaryValue === 'string' ? primaryValue : formatPayload(step.input);
+}
+
+function getCommandInput(step: DemoStep, value: string) {
+  if (step.toolName === 'create_project') return { name: value };
+  if (step.toolName === 'generate_slides') return { prompt: value };
+  if (step.toolName === 'generate_image') return { ...step.input, prompt: value };
+  if (step.toolName === 'translate_text') return { ...step.input, targetLanguage: value };
+  return step.input;
+}
+
+function hasCommandInput(step: DemoStep) {
+  return step.toolName !== 'get_project_snapshot';
+}
+
+export function WebMcpShowcasePage() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const stepButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const [tools, setTools] = useState<WebMcpToolLike[]>([]);
+  const [status, setStatus] = useState('Ready to discover page tools.');
+  const [lastResult, setLastResult] = useState<string>('{}');
+  const [isRunning, setIsRunning] = useState(false);
+  const [activeStepName, setActiveStepName] = useState<string | undefined>();
+  const [focusedStepName, setFocusedStepName] = useState<string | undefined>();
+  const [commandValues, setCommandValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(demoSteps.map((step) => [step.toolName, getDefaultCommandValue(step)])),
+  );
+  const editorSrc = '/editor/?webmcp=1&newProject=1';
+  const toolsByName = useMemo(() => new Map(tools.map((tool) => [tool.name, tool])), [tools]);
+
+  function openStep(step: DemoStep) {
+    setActiveStepName(step.toolName);
+    setFocusedStepName(step.toolName);
+    if (!hasCommandInput(step)) void runStep(step);
+  }
+
+  function focusStep(toolName: string) {
+    setActiveStepName(toolName);
+    setFocusedStepName(toolName);
+    stepButtonRefs.current[toolName]?.focus();
+    window.requestAnimationFrame(() => {
+      const stepButton = stepButtonRefs.current[toolName];
+      stepButton?.focus();
+      stepButton?.scrollIntoView?.({ block: 'nearest' });
+    });
+  }
+
+  async function discoverTools() {
+    const iframe = iframeRef.current;
+    if (!iframe) {
+      setStatus('Editor iframe is not ready yet.');
+      setTools([]);
+      return;
+    }
+
+    setStatus('Discovering tools from LocalStudio...');
+    const modelContext = getBrowserModelContext();
+    const iframeOrigin = new URL(iframe.src).origin;
+    const fallbackTools = getLocalDemoTools(iframe);
+    const discoveredTools = modelContext
+      ? await modelContext.getTools({ fromOrigins: [iframeOrigin] })
+      : fallbackTools;
+    if (!discoveredTools) {
+      setStatus('No WebMCP runtime or same-origin demo tools found. Wait for the editor frame, then try again.');
+      setTools([]);
+      return;
+    }
+    setTools(discoveredTools);
+    setStatus(
+      modelContext
+        ? `Discovered ${discoveredTools.length} tools through WebMCP.`
+        : `Discovered ${discoveredTools.length} tools through the local demo bridge.`,
+    );
+    setLastResult(formatPayload(discoveredTools.map((tool) => ({ name: tool.name, description: tool.description }))));
+  }
+
+  async function runStep(step: DemoStep, input = step.input) {
+    const tool = toolsByName.get(step.toolName);
+    if (!tool) {
+      setStatus(`${step.toolName} has not been discovered yet.`);
+      return;
+    }
+
+    setIsRunning(true);
+    setStatus(`Running ${step.label}...`);
+    try {
+      const result = await callTool(tool, input);
+      setStatus(`${step.label} completed.`);
+      setLastResult(formatPayload(result));
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : `${step.label} failed.`);
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  return (
+    <main className="webmcp-page">
+      <section className="webmcp-control-plane" aria-label="WebMCP control plane">
+        <div className="webmcp-brand-row">
+          <span className="webmcp-signal" aria-hidden="true">
+            <Radar size={18} />
+          </span>
+          <span>LocalStudio.ai</span>
+        </div>
+        <div className="webmcp-hero">
+          <p className="webmcp-kicker">Browser agent surface</p>
+          <h1>WebMCP showcase</h1>
+          <p>
+            A host page discovers semantic tools from the editor iframe and calls the same automation layer
+            used by the LocalStudio interface.
+          </p>
+        </div>
+
+        <div className="webmcp-action-row">
+          <button
+            className="webmcp-primary-action"
+            disabled={isRunning}
+            type="button"
+            onClick={() => {
+              void discoverTools();
+            }}
+          >
+            <Radar size={16} />
+            <span>Discover tools</span>
+          </button>
+          <span className="webmcp-status">{status}</span>
+        </div>
+
+        <div className="webmcp-tool-list" aria-label="Discovered tools">
+          {tools.length > 0 ? (
+            tools.map((tool) => (
+              <button
+                className="webmcp-tool-pill"
+                key={tool.name}
+                type="button"
+                onClick={() => {
+                  focusStep(tool.name);
+                }}
+              >
+                {tool.name}
+              </button>
+            ))
+          ) : (
+            <span className="webmcp-empty-tools">No tools discovered</span>
+          )}
+        </div>
+
+        <div className="webmcp-workflow" aria-label="Demo workflow">
+          {demoSteps.map((step, index) => (
+            <div className="webmcp-step" key={step.toolName}>
+              <button
+                ref={(element) => {
+                  stepButtonRefs.current[step.toolName] = element;
+                }}
+                aria-label={step.label}
+                className={[
+                  'webmcp-step-button',
+                  activeStepName === step.toolName ? 'webmcp-step-button-active' : '',
+                  focusedStepName === step.toolName ? 'webmcp-step-button-focused' : '',
+                ].filter(Boolean).join(' ')}
+                disabled={isRunning}
+                type="button"
+                onClick={() => {
+                  openStep(step);
+                }}
+              >
+                <span className="webmcp-step-index">{index + 1}</span>
+                {step.toolName === 'generate_image' ? <ImagePlus size={16} /> : null}
+                {step.toolName === 'translate_text' ? <Languages size={16} /> : null}
+                {step.toolName === 'get_project_snapshot' ? <FileJson size={16} /> : null}
+                {step.toolName === 'generate_slides' || step.toolName === 'create_project' ? <Play size={16} /> : null}
+                <span>{step.label}</span>
+              </button>
+              {activeStepName === step.toolName && hasCommandInput(step) ? (
+                <form
+                  className="webmcp-step-command"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void runStep(step, getCommandInput(step, commandValues[step.toolName] ?? ''));
+                  }}
+                >
+                  {step.toolName === 'translate_text' ? (
+                    <select
+                      aria-label={`${step.label} command input`}
+                      value={commandValues[step.toolName] ?? ''}
+                      onChange={(event) => {
+                        setCommandValues((current) => ({
+                          ...current,
+                          [step.toolName]: event.target.value,
+                        }));
+                      }}
+                    >
+                      {TRANSLATION_LANGUAGE_OPTIONS.map((language) => (
+                        <option key={language.code} value={language.code}>
+                          {language.label} ({language.code}) {language.flag}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      aria-label={`${step.label} command input`}
+                      value={commandValues[step.toolName] ?? ''}
+                      onChange={(event) => {
+                        setCommandValues((current) => ({
+                          ...current,
+                          [step.toolName]: event.target.value,
+                        }));
+                      }}
+                    />
+                  )}
+                  <button aria-label={`Send ${step.label}`} disabled={isRunning} type="submit">
+                    <SendHorizontal size={15} />
+                  </button>
+                </form>
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <section className="webmcp-result-panel" aria-label="Last WebMCP result">
+          <div className="webmcp-result-heading">
+            <Bot size={16} />
+            <span>Last result</span>
+          </div>
+          <pre>{lastResult}</pre>
+        </section>
+      </section>
+
+      <section className="webmcp-editor-frame" aria-label="LocalStudio editor frame">
+        <iframe ref={iframeRef} src={editorSrc} title="LocalStudio editor WebMCP demo" />
+      </section>
+    </main>
+  );
+}

--- a/apps/editor/tests/unit/app/App.test.tsx
+++ b/apps/editor/tests/unit/app/App.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { App } from '../../../src/App';
+import { TRANSLATION_LANGUAGE_OPTIONS } from '../../../src/ui/editor/translationLanguages';
 
 describe('App', () => {
   beforeEach(() => {
@@ -14,6 +15,10 @@ describe('App', () => {
   afterEach(() => {
     window.history.replaceState({}, '', '/');
     window.localStorage.clear();
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: undefined,
+    });
     vi.unstubAllGlobals();
   });
 
@@ -75,5 +80,104 @@ describe('App', () => {
 
     expect(await screen.findByText('Untitled Project')).toBeInTheDocument();
     expect(screen.queryByText('LocalStudio.ai runs locally in this browser.')).not.toBeInTheDocument();
+  });
+
+  it('renders the WebMCP showcase page at /webmcp', () => {
+    window.history.replaceState({}, '', '/webmcp');
+
+    render(<App />);
+
+    expect(screen.getByRole('heading', { name: 'WebMCP showcase' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Discover tools' })).toBeInTheDocument();
+    expect(screen.getByTitle('LocalStudio editor WebMCP demo')).toHaveAttribute(
+      'src',
+      '/editor/?webmcp=1&newProject=1',
+    );
+  });
+
+  it('renders the WebMCP showcase page under the editor base path', () => {
+    window.history.replaceState({}, '', '/editor/webmcp');
+
+    render(<App />);
+
+    expect(screen.getByRole('heading', { name: 'WebMCP showcase' })).toBeInTheDocument();
+  });
+
+  it('opens editable command input for a WebMCP workflow step', async () => {
+    const user = userEvent.setup();
+    window.history.replaceState({}, '', '/webmcp');
+
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Create project' }));
+
+    expect(screen.getByLabelText('Create project command input')).toHaveValue('WebMCP Demo Deck');
+    expect(screen.getByRole('button', { name: 'Send Create project' })).toBeInTheDocument();
+  });
+
+  it('shows the AI tools translation options for the WebMCP translate step', async () => {
+    const user = userEvent.setup();
+    window.history.replaceState({}, '', '/webmcp');
+
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Translate deck' }));
+
+    const languageSelect = screen.getByLabelText('Translate deck command input');
+    const options = within(languageSelect).getAllByRole<HTMLOptionElement>('option');
+    expect(options).toHaveLength(TRANSLATION_LANGUAGE_OPTIONS.length);
+    expect(options.map((option) => option.value)).toEqual(
+      TRANSLATION_LANGUAGE_OPTIONS.map((language) => language.code),
+    );
+    expect(screen.getByRole('option', { name: 'Hebrew (iw) 🇮🇱' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Chinese (Traditional) (zh-Hant) 🇹🇼' })).toBeInTheDocument();
+  });
+
+  it('runs the WebMCP snapshot step without showing a command input', async () => {
+    const user = userEvent.setup();
+    const executeSnapshot = vi.fn().mockResolvedValue({ project: { name: 'Demo' } });
+    window.history.replaceState({}, '', '/webmcp');
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: {
+        getTools: vi.fn().mockResolvedValue([
+          { name: 'get_project_snapshot', description: 'Read snapshot', execute: executeSnapshot },
+        ]),
+      },
+    });
+
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Discover tools' }));
+    await user.click(screen.getByRole('button', { name: 'Read snapshot' }));
+
+    await waitFor(() => {
+      expect(executeSnapshot).toHaveBeenCalledWith({});
+    });
+    expect(screen.queryByLabelText('Read snapshot command input')).not.toBeInTheDocument();
+    expect(screen.getByText('Read snapshot completed.')).toBeInTheDocument();
+  });
+
+  it('focuses the matching workflow step when a discovered tool is selected', async () => {
+    const user = userEvent.setup();
+    window.history.replaceState({}, '', '/webmcp');
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: {
+        getTools: vi.fn().mockResolvedValue([
+          { name: 'create_project', description: 'Create project', execute: vi.fn() },
+          { name: 'generate_slides', description: 'Generate slides', execute: vi.fn() },
+        ]),
+      },
+    });
+
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Discover tools' }));
+    await user.click(await screen.findByRole('button', { name: 'generate_slides' }));
+
+    const stepButton = screen.getByRole('button', { name: 'Generate slide' });
+    expect(stepButton).toHaveFocus();
+    expect(stepButton).toHaveClass('webmcp-step-button-focused');
   });
 });

--- a/apps/editor/tests/unit/services/editorAutomationController.test.ts
+++ b/apps/editor/tests/unit/services/editorAutomationController.test.ts
@@ -1,0 +1,104 @@
+import { EditorAutomationController } from '../../../src/services/editorAutomationController';
+import type { ProjectDocument } from '../../../src/domain/model';
+import { createSampleProject } from '../../../src/domain/sampleProject';
+
+function projectWithName(name: string): ProjectDocument {
+  return {
+    ...createSampleProject(),
+    name,
+  };
+}
+
+describe('EditorAutomationController', () => {
+  it('creates a project through the automation delegate', async () => {
+    const controller = new EditorAutomationController({
+      createProject: vi.fn(() => Promise.resolve(projectWithName('Agent Deck'))),
+      generateSlides: vi.fn(),
+      generateImage: vi.fn(),
+      translateText: vi.fn(),
+      getState: () => ({ project: projectWithName('Agent Deck'), selection: { pageId: 'page-1', elementIds: [] } }),
+    });
+
+    await expect(controller.createProject({ name: 'Agent Deck' })).resolves.toMatchObject({
+      ok: true,
+      data: {
+        projectId: 'project-1',
+        name: 'Agent Deck',
+        pageCount: 1,
+      },
+    });
+  });
+
+  it('generates slides and returns a compact project snapshot', async () => {
+    const nextProject = projectWithName('Generated Deck');
+    const controller = new EditorAutomationController({
+      createProject: vi.fn(),
+      generateSlides: vi.fn(() => Promise.resolve(nextProject)),
+      generateImage: vi.fn(),
+      translateText: vi.fn(),
+      getState: () => ({ project: nextProject, selection: { pageId: 'page-1', elementIds: ['text-title'] } }),
+    });
+
+    const result = await controller.generateSlides({ prompt: 'Three-image grid about Web AI, with matching captions.' });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        snapshot: {
+          projectId: 'project-1',
+          name: 'Generated Deck',
+          pages: [{ id: 'page-1', elementCount: 3 }],
+          selection: { pageId: 'page-1', elementIds: ['text-title'] },
+        },
+      },
+    });
+  });
+
+  it('rejects concurrent long-running work with a busy error', async () => {
+    let resolveGeneration: ((project: ProjectDocument) => void) | undefined;
+    const controller = new EditorAutomationController({
+      createProject: vi.fn(),
+      generateSlides: vi.fn(
+        () =>
+          new Promise<ProjectDocument>((resolve) => {
+            resolveGeneration = resolve;
+          }),
+      ),
+      generateImage: vi.fn(),
+      translateText: vi.fn(),
+      getState: () => ({ project: createSampleProject(), selection: { pageId: 'page-1', elementIds: [] } }),
+    });
+
+    const firstRun = controller.generateSlides({ prompt: 'Top title and three body bullets about why Web AI is useful.' });
+    await expect(controller.generateImage({ prompt: 'Create a local Web AI hero image' })).resolves.toEqual({
+      ok: false,
+      errorCode: 'busy',
+      message: 'Another automation action is already running.',
+    });
+    resolveGeneration?.(createSampleProject());
+    await firstRun;
+  });
+
+  it('validates translation scope and image dimensions before calling the delegate', async () => {
+    const generateImage = vi.fn();
+    const translateText = vi.fn();
+    const controller = new EditorAutomationController({
+      createProject: vi.fn(),
+      generateSlides: vi.fn(),
+      generateImage,
+      translateText,
+      getState: () => ({ project: createSampleProject(), selection: { pageId: 'page-1', elementIds: [] } }),
+    });
+
+    await expect(controller.generateImage({ prompt: 'Create an image', width: 15 })).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'invalid_image_dimensions',
+    });
+    await expect(controller.translateText({ scope: 'page', targetLanguage: 'pt' })).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'invalid_translation_scope',
+    });
+    expect(generateImage).not.toHaveBeenCalled();
+    expect(translateText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/editor/tests/unit/services/webMcpToolAdapter.test.ts
+++ b/apps/editor/tests/unit/services/webMcpToolAdapter.test.ts
@@ -1,0 +1,57 @@
+import { imagePromptExamples, slidePromptExamples } from '../../../src/ui/editor/promptRecipes';
+import { WebMcpToolAdapter, type WebMcpTool } from '../../../src/services/webMcpToolAdapter';
+
+describe('WebMcpToolAdapter', () => {
+  it('registers discoverable WebMCP tools with prompt examples in metadata', () => {
+    const registerTools = vi.fn<(tools: WebMcpTool[]) => void>();
+    const adapter = new WebMcpToolAdapter({
+      createProject: vi.fn(),
+      generateSlides: vi.fn(),
+      generateImage: vi.fn(),
+      translateText: vi.fn(),
+      getProjectSnapshot: vi.fn(),
+    });
+
+    adapter.register({ registerTools });
+
+    const tools = registerTools.mock.calls[0]?.[0] ?? [];
+    expect(tools).toHaveLength(5);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'create_project',
+      'generate_slides',
+      'generate_image',
+      'translate_text',
+      'get_project_snapshot',
+    ]);
+    const generateSlidesTool = tools.find((tool) => tool.name === 'generate_slides');
+    const generateImageTool = tools.find((tool) => tool.name === 'generate_image');
+    expect(generateSlidesTool?.description).toContain(slidePromptExamples[0]);
+    expect(generateImageTool?.description).toContain(imagePromptExamples[0]);
+  });
+
+  it('forwards tool calls to the automation controller', async () => {
+    const generateSlides = vi.fn(() =>
+      Promise.resolve({ ok: true as const, data: { snapshot: { projectId: 'project-1' } as never } }),
+    );
+    const registerTools = vi.fn<(tools: WebMcpTool[]) => void>();
+    const adapter = new WebMcpToolAdapter({
+      createProject: vi.fn(),
+      generateSlides,
+      generateImage: vi.fn(),
+      translateText: vi.fn(),
+      getProjectSnapshot: vi.fn(),
+    });
+
+    adapter.register({ registerTools });
+    const tools = registerTools.mock.calls[0]?.[0] ?? [];
+    const generateSlidesTool = tools.find((tool) => tool.name === 'generate_slides');
+
+    await expect(generateSlidesTool?.execute({ prompt: 'Three-image grid about Web AI, with matching captions.' })).resolves.toEqual({
+      ok: true,
+      data: { snapshot: { projectId: 'project-1' } },
+    });
+    expect(generateSlides).toHaveBeenCalledWith({
+      prompt: 'Three-image grid about Web AI, with matching captions.',
+    });
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -9,6 +9,7 @@ import type {
   ProjectRepository,
   TranslatorService,
 } from '../../../../src/services/interfaces';
+import type { WebMcpDemoWindow, WebMcpTool } from '../../../../src/services/webMcpToolAdapter';
 import { InMemoryModelSetupService } from '../../../../src/services/modelSetupService';
 import { EditorShell } from '../../../../src/ui/editor/EditorShell';
 
@@ -192,6 +193,55 @@ async function selectImageLayer(user: ReturnType<typeof userEvent.setup>) {
 }
 
 describe('EditorShell', () => {
+  afterEach(() => {
+    window.history.pushState({}, '', '/editor/');
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: undefined,
+    });
+    delete (window as WebMcpDemoWindow).localStudioWebMcpTools;
+  });
+
+  it('registers WebMCP tools when explicitly enabled', async () => {
+    const registerTools = vi.fn<(tools: WebMcpTool[]) => void>();
+    window.history.pushState({}, '', '/editor/?webmcp=1');
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTools },
+    });
+
+    render(<EditorShell services={createAppServices()} />);
+
+    await waitFor(() => {
+      expect(registerTools).toHaveBeenCalled();
+    });
+    const tools = registerTools.mock.calls[0]?.[0] ?? [];
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'create_project',
+      'generate_slides',
+      'generate_image',
+      'translate_text',
+      'get_project_snapshot',
+    ]);
+  });
+
+  it('exposes same-origin demo tools when WebMCP runtime is unavailable', async () => {
+    window.history.pushState({}, '', '/editor/?webmcp=1');
+
+    render(<EditorShell services={createAppServices()} />);
+
+    await waitFor(() => {
+      expect((window as WebMcpDemoWindow).localStudioWebMcpTools).toHaveLength(5);
+    });
+    expect((window as WebMcpDemoWindow).localStudioWebMcpTools?.map((tool) => tool.name)).toEqual([
+      'create_project',
+      'generate_slides',
+      'generate_image',
+      'translate_text',
+      'get_project_snapshot',
+    ]);
+  });
+
   it('renders the approved editor shell landmarks', async () => {
     render(<EditorShell services={createAppServices()} />);
 

--- a/apps/editor/tests/unit/ui/editor/promptRecipes.test.ts
+++ b/apps/editor/tests/unit/ui/editor/promptRecipes.test.ts
@@ -1,0 +1,16 @@
+import {
+  imagePromptExamples,
+  promptRecipeCatalog,
+  slidePromptExamples,
+} from '../../../../src/ui/editor/promptRecipes';
+
+describe('promptRecipes', () => {
+  it('shares the prompt examples used by UI and WebMCP metadata', () => {
+    expect(slidePromptExamples).toContain('Three-image grid about Web AI, with matching captions.');
+    expect(imagePromptExamples).toContain(
+      'Create a neon green browser-native design studio floating inside a dark futuristic workspace',
+    );
+    expect(promptRecipeCatalog.slide.examples).toBe(slidePromptExamples);
+    expect(promptRecipeCatalog.image.examples).toBe(imagePromptExamples);
+  });
+});

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -1,9 +1,38 @@
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, type Connect } from 'vite';
+
+function rewriteWebMcpRoute(req: Connect.IncomingMessage) {
+  if (!req.url) return;
+  if (req.url === '/webmcp') {
+    req.url = '/editor/';
+    return;
+  }
+  if (req.url.startsWith('/webmcp?')) {
+    req.url = `/editor/${req.url.slice('/webmcp'.length)}`;
+  }
+}
+
+function webMcpRouteAlias() {
+  return {
+    name: 'webmcp-route-alias',
+    configureServer(server: { middlewares: Connect.Server }) {
+      server.middlewares.use((req, _res, next) => {
+        rewriteWebMcpRoute(req);
+        next();
+      });
+    },
+    configurePreviewServer(server: { middlewares: Connect.Server }) {
+      server.middlewares.use((req, _res, next) => {
+        rewriteWebMcpRoute(req);
+        next();
+      });
+    },
+  };
+}
 
 export default defineConfig({
   base: '/editor/',
-  plugins: [react()],
+  plugins: [webMcpRouteAlias(), react()],
   build: {
     emptyOutDir: false,
     outDir: '../../dist/editor',


### PR DESCRIPTION
## Summary
- Adds a WebMCP showcase page and wires it into the editor app shell.
- Introduces editor automation controller and WebMCP tool adapter to support workflow planning interactions.
- Updates prompt bar, prompt recipes, translation language handling, and editor view model to fit the new workflow.
- Refreshes app styles and expands unit coverage across the new editor flow.

## Testing
- Added and updated unit tests for the app, editor shell, prompt recipes, editor automation controller, and WebMCP tool adapter.
- Validated the editor UI flow locally at a high level with the updated component and service wiring.
- Not run (not requested)