### PR TITLE
Replace image prompt examples with contrasted AI-focused variants

### DIFF
--- a/apps/editor/src/ui/editor/promptRecipes.ts
+++ b/apps/editor/src/ui/editor/promptRecipes.ts
@@ -7,11 +7,11 @@ export const slidePromptExamples = [
 ] as const;
 
 export const imagePromptExamples = [
-  'Create an icy Bonsai tree in a rainy forest with snowy mountains in the background, photo realistic',
-  'Create a neon green browser-native design studio floating inside a dark futuristic workspace',
-  'Create a cinematic close-up of a laptop editing slides with glowing green UI reflections',
-  'Create a realistic product hero image for a local-first AI creative editor on a dark background',
-  'Create a cyberpunk classroom with holographic slide canvases and black-and-green lighting',
+  'A realistic photo of a person using an AI-powered web app on a tablet in a modern city environment, glass buildings and people blurred in the background, subject positioned on the left, camera at eye level, natural daylight, urban innovation and technology atmosphere',
+  'A stunning futuristic AI background featuring glowing neural network structures floating in a dark digital space, abstract data particles flowing between nodes, deep perspective, layered depth, cinematic blue and purple lighting, highly detailed, realistic, professional technology aesthetic, no people, no logos, no readable text',
+  'A beautiful abstract machine learning landscape with mountains made of glowing data points, neural network pathways forming rivers of light, dark futuristic sky, deep depth of field, cinematic atmosphere, elegant blue and cyan color palette, realistic 3D technology background, no people, no logos, no readable text',
+  'A macro cinematic background of an advanced AI chip on a circuit board, glowing neural network patterns flowing across the surface, shallow depth of field, futuristic blue and gold lighting, extremely detailed hardware texture, premium technology photography style, no logos, no readable text',
+  'A cinematic AI agent background showing multiple autonomous digital agents as glowing abstract orbs moving through a connected web of tasks, browser panels, APIs, and data pipelines, futuristic dark environment, strong sense of motion, deep perspective, premium technology style, no people, no logos, no readable text',
 ] as const;
 
 export const promptRecipeCatalog = {

--- a/apps/editor/tests/unit/ui/editor/promptRecipes.test.ts
+++ b/apps/editor/tests/unit/ui/editor/promptRecipes.test.ts
@@ -6,10 +6,16 @@ import {
 
 describe('promptRecipes', () => {
   it('shares the prompt examples used by UI and WebMCP metadata', () => {
+    const contrastedImagePrompts = [
+      'A realistic photo of a person using an AI-powered web app on a tablet in a modern city environment, glass buildings and people blurred in the background, subject positioned on the left, camera at eye level, natural daylight, urban innovation and technology atmosphere',
+      'A stunning futuristic AI background featuring glowing neural network structures floating in a dark digital space, abstract data particles flowing between nodes, deep perspective, layered depth, cinematic blue and purple lighting, highly detailed, realistic, professional technology aesthetic, no people, no logos, no readable text',
+      'A beautiful abstract machine learning landscape with mountains made of glowing data points, neural network pathways forming rivers of light, dark futuristic sky, deep depth of field, cinematic atmosphere, elegant blue and cyan color palette, realistic 3D technology background, no people, no logos, no readable text',
+      'A macro cinematic background of an advanced AI chip on a circuit board, glowing neural network patterns flowing across the surface, shallow depth of field, futuristic blue and gold lighting, extremely detailed hardware texture, premium technology photography style, no logos, no readable text',
+      'A cinematic AI agent background showing multiple autonomous digital agents as glowing abstract orbs moving through a connected web of tasks, browser panels, APIs, and data pipelines, futuristic dark environment, strong sense of motion, deep perspective, premium technology style, no people, no logos, no readable text',
+    ];
+
     expect(slidePromptExamples).toContain('Three-image grid about Web AI, with matching captions.');
-    expect(imagePromptExamples).toContain(
-      'Create a neon green browser-native design studio floating inside a dark futuristic workspace',
-    );
+    expect(imagePromptExamples).toEqual(contrastedImagePrompts);
     expect(promptRecipeCatalog.slide.examples).toBe(slidePromptExamples);
     expect(promptRecipeCatalog.image.examples).toBe(imagePromptExamples);
   });


### PR DESCRIPTION
## Summary
- Replaced the image prompt examples with a new set of high-contrast, AI-themed prompts covering product usage, abstract neural networks, machine learning landscapes, chip closeups, and autonomous agents.
- Updated the unit test to assert the full image prompt list, keeping UI examples and WebMCP metadata in sync.

## Testing
- Not run (not requested)