### PR TITLE
Wrap prompt input into a responsive multiline composer

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -941,11 +941,11 @@ button {
 .editor-grid {
   min-height: 0;
   display: grid;
-  grid-template-columns: max-content minmax(640px, 1fr) 300px;
+  grid-template-columns: max-content minmax(0, 1fr) minmax(260px, 300px);
 }
 
 .editor-grid-pages-collapsed {
-  grid-template-columns: max-content minmax(640px, 1fr);
+  grid-template-columns: max-content minmax(0, 1fr);
 }
 
 .left-tool-panel {
@@ -1159,8 +1159,8 @@ button {
   display: grid;
   grid-template-rows: minmax(0, 1fr) auto;
   overflow: hidden;
-  gap: 14px;
-  padding: 14px 18px 16px;
+  gap: 12px;
+  padding: 14px 18px 18px;
   background: #050d10;
   box-shadow: inset 0 0 60px rgba(0, 0, 0, 0.28);
 }
@@ -1267,8 +1267,9 @@ button {
   flex-direction: column;
   align-items: center;
   gap: 20px;
+  overflow-x: hidden;
   overflow-y: auto;
-  padding: 12px 0 18px;
+  padding: 12px 0 10px;
   scroll-snap-type: y proximity;
 }
 
@@ -1968,7 +1969,9 @@ button {
 .prompt-stack {
   position: relative;
   z-index: 1;
-  width: min(860px, 82%);
+  box-sizing: border-box;
+  width: min(860px, 100%);
+  min-width: 0;
   margin-inline: auto;
   align-self: center;
   justify-self: center;
@@ -2193,10 +2196,13 @@ button {
   flex-wrap: wrap;
   justify-content: center;
   gap: 8px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .prompt-example-chip {
   max-width: min(100%, 280px);
+  min-width: 0;
   min-height: 30px;
   border: 1px solid rgba(55, 253, 118, 0.2);
   border-radius: 999px;
@@ -2275,14 +2281,18 @@ button {
 }
 
 .prompt-bar {
-  display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
-  height: 48px;
+  min-height: 48px;
   border: 1px solid var(--ew-border);
-  border-radius: 999px;
+  border-radius: 24px;
   background: var(--ew-panel-low);
-  padding: 0 8px 0 16px;
+  padding: 8px 8px 8px 16px;
   color: var(--ew-green);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
   transition:
@@ -2305,23 +2315,44 @@ button {
     0 0 20px rgba(55, 253, 118, 0.16);
 }
 
-.prompt-bar input {
+.prompt-input-cluster {
   min-width: 0;
-  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.prompt-bar textarea {
+  min-width: 0;
+  flex: 1 1 220px;
+  width: 100%;
+  max-height: 112px;
   border: 0;
   outline: 0;
   background: transparent;
   color: var(--ew-text);
   font-size: 13px;
+  line-height: 1.35;
+  overflow-y: auto;
+  resize: none;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
-.prompt-bar input:disabled {
+.prompt-submit-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.prompt-bar textarea:disabled {
   color: rgba(236, 255, 233, 0.72);
   opacity: 1;
   -webkit-text-fill-color: rgba(236, 255, 233, 0.72);
 }
 
-.prompt-bar input::placeholder {
+.prompt-bar textarea::placeholder {
   color: rgba(145, 153, 157, 0.74);
 }
 
@@ -2387,6 +2418,8 @@ button {
 }
 
 .prompt-mode-token {
+  flex: 0 1 auto;
+  max-width: min(178px, 42%);
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2404,6 +2437,12 @@ button {
     border-color 140ms ease,
     color 140ms ease,
     transform 140ms ease;
+}
+
+.prompt-mode-token span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .prompt-mode-token:hover,
@@ -2429,6 +2468,46 @@ button {
   width: 13px;
   opacity: 1;
   transform: scale(1);
+}
+
+@media (max-width: 760px) {
+  .workspace-column {
+    padding-inline: 10px;
+  }
+
+  .prompt-stack {
+    width: 100%;
+  }
+
+  .prompt-examples {
+    justify-content: flex-start;
+  }
+
+  .prompt-bar {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    border-radius: 18px;
+    padding: 8px;
+  }
+
+  .prompt-input-cluster {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .prompt-input-cluster textarea {
+    flex-basis: 100%;
+  }
+
+  .prompt-submit-actions {
+    justify-self: end;
+  }
+
+  .prompt-mode-token {
+    max-width: 100%;
+  }
 }
 
 .right-panel {

--- a/apps/editor/src/ui/editor/PromptBar.tsx
+++ b/apps/editor/src/ui/editor/PromptBar.tsx
@@ -1,5 +1,5 @@
 import { ImagePlus, Mic, Plus, SendHorizontal, Square, X } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { IconButton } from '../components/IconButton';
 import type { CreateImagePromptOptions } from './imagePromptOptions';
 import { imagePromptExamples, slidePromptExamples } from './promptRecipes';
@@ -33,7 +33,7 @@ export function PromptBar({
   onSlidePromptSubmit,
   onStopGeneration,
 }: PromptBarProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [mode, setMode] = useState<'create-image' | null>('create-image');
   const [localSubmissionActive, setLocalSubmissionActive] = useState(false);
@@ -41,6 +41,14 @@ export function PromptBar({
   const activeMode = selectedImageElementId ? 'create-image' : mode;
   const examples = activeMode === 'create-image' ? imagePromptExamples : slidePromptExamples;
   const isProcessing = isGeneratingSlide || isGeneratingImage || localSubmissionActive;
+
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    input.style.height = '0px';
+    input.style.height = `${Math.min(Math.max(input.scrollHeight, 18), 112)}px`;
+  }, [value]);
 
   function activateCreateImageMode() {
     setMode('create-image');
@@ -148,69 +156,79 @@ export function PromptBar({
             </div>
           ) : null}
         </div>
-        {activeMode === 'create-image' ? (
-          <button
-            aria-label="Remove Create image mode"
-            className="prompt-mode-token"
-            disabled={isProcessing || Boolean(selectedImageElementId)}
-            type="button"
-            onClick={() => {
-              setMode(null);
-              inputRef.current?.focus();
+        <div className="prompt-input-cluster">
+          {activeMode === 'create-image' ? (
+            <button
+              aria-label="Remove Create image mode"
+              className="prompt-mode-token"
+              disabled={isProcessing || Boolean(selectedImageElementId)}
+              type="button"
+              onClick={() => {
+                setMode(null);
+                inputRef.current?.focus();
+              }}
+            >
+              <ImagePlus size={15} />
+              <span>Create image</span>
+              <X className="prompt-mode-token-close" size={13} />
+            </button>
+          ) : null}
+          <textarea
+            ref={inputRef}
+            placeholder={activeMode === 'create-image' ? '' : 'Describe slide structure or organize current content...'}
+            aria-label={activeMode === 'create-image' ? 'Create image prompt' : 'Slide structure prompt'}
+            disabled={isProcessing}
+            rows={1}
+            value={value}
+            onFocus={() => {
+              void guardPromptIntent();
             }}
-          >
-            <ImagePlus size={15} />
-            <span>Create image</span>
-            <X className="prompt-mode-token-close" size={13} />
-          </button>
-        ) : null}
-        <input
-          ref={inputRef}
-          type="text"
-          placeholder={activeMode === 'create-image' ? '' : 'Describe slide structure or organize current content...'}
-          aria-label={activeMode === 'create-image' ? 'Create image prompt' : 'Slide structure prompt'}
-          disabled={isProcessing}
-          value={value}
-          onFocus={() => {
-            void guardPromptIntent();
-          }}
-          onChange={(event) => {
-            const nextValue = event.target.value;
-            if (activeMode === 'create-image' && !selectedImageElementId && value.length > 0 && nextValue.length === 0) {
-              setMode(null);
-              setValue('');
-              return;
-            }
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                void submitPrompt();
+              }
+            }}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              if (activeMode === 'create-image' && !selectedImageElementId && value.length > 0 && nextValue.length === 0) {
+                setMode(null);
+                setValue('');
+                return;
+              }
 
-            setValue(nextValue);
-            void guardPromptIntent();
-          }}
-        />
-        <IconButton disabled={isProcessing} label="Record voice prompt">
-          <Mic size={16} />
-        </IconButton>
-        {isProcessing ? (
-          <IconButton
-            label="Stop generation"
-            tone="danger"
-            onClick={() => {
-              setLocalSubmissionActive(false);
-              setValue('');
-              onStopGeneration?.();
+              setValue(nextValue);
+              void guardPromptIntent();
             }}
-          >
-            <Square size={16} />
+          />
+        </div>
+        <div className="prompt-submit-actions">
+          <IconButton disabled={isProcessing} label="Record voice prompt">
+            <Mic size={16} />
           </IconButton>
-        ) : (
-          <IconButton
-            label="Submit prompt"
-            onClick={() => {
-              void submitPrompt();
-            }}
-          >
-            <SendHorizontal size={16} />
-          </IconButton>
-        )}
+          {isProcessing ? (
+            <IconButton
+              label="Stop generation"
+              tone="danger"
+              onClick={() => {
+                setLocalSubmissionActive(false);
+                setValue('');
+                onStopGeneration?.();
+              }}
+            >
+              <Square size={16} />
+            </IconButton>
+          ) : (
+            <IconButton
+              label="Submit prompt"
+              onClick={() => {
+                void submitPrompt();
+              }}
+            >
+              <SendHorizontal size={16} />
+            </IconButton>
+          )}
+        </div>
       </form>
     </div>
   );

--- a/apps/editor/tests/unit/ui/editor/PromptBar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/PromptBar.test.tsx
@@ -5,6 +5,15 @@ import { defaultCreateImagePromptOptions } from '../../../../src/ui/editor/image
 import { PromptBar } from '../../../../src/ui/editor/PromptBar';
 
 describe('PromptBar', () => {
+  it('uses a multiline prompt field so long image prompts can wrap', () => {
+    render(<PromptBar createImageOptions={defaultCreateImagePromptOptions} />);
+
+    const promptField = screen.getByLabelText('Create image prompt');
+
+    expect(promptField.tagName).toBe('TEXTAREA');
+    expect(promptField).not.toHaveStyle({ height: '0px' });
+  });
+
   it('shows the stop action immediately while create image readiness is still checking', async () => {
     const user = userEvent.setup();
     let resolveReadiness: ((ready: boolean) => void) | undefined;


### PR DESCRIPTION
## Summary
- Replace the prompt field with an auto-sizing textarea so long prompts can wrap instead of overflowing
- Rework the prompt bar layout to better fit the mode chip, input, and actions on desktop and mobile
- Tighten grid and panel spacing to reduce clipping in constrained editor widths
- Add a unit test covering the new multiline prompt field behavior

## Testing
- Added/updated unit coverage for the prompt bar textarea behavior
- Not run (not requested)