### PR TITLE
Add GIF and video slide support in the editor

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -1429,6 +1429,21 @@ button {
   background: #050d10;
 }
 
+.canvas-media-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.canvas-media-element {
+  position: absolute;
+  display: block;
+  border-radius: 6px;
+  object-fit: fill;
+  transform-origin: top left;
+}
+
 .background-selection-hint {
   position: absolute;
   left: 50%;

--- a/apps/editor/src/domain/commands/basicCommands.ts
+++ b/apps/editor/src/domain/commands/basicCommands.ts
@@ -2,10 +2,12 @@ import type {
   Asset,
   BaseElement,
   DesignElement,
+  GifElement,
   ImageElement,
   Page,
   PageBackground,
   ProjectDocument,
+  VideoElement,
 } from '../model';
 import type { EditorCommand } from './types';
 
@@ -18,6 +20,13 @@ export type AlignMode = 'horizontal-center' | 'vertical-center' | 'page-center';
 export type ZOrderMode = 'front' | 'back' | 'forward' | 'backward';
 export type ElementFramePatch = Partial<Pick<BaseElement, 'height' | 'rotation' | 'width' | 'x' | 'y'>>;
 export type ImageCropPatch = ElementFramePatch & { crop: NonNullable<ImageElement['crop']> };
+export type GifPlaybackPatch = Partial<Pick<GifElement, 'playing'>>;
+export type VideoPlaybackPatch = Partial<
+  Pick<VideoElement, 'autoplayInPreview' | 'controls' | 'loop' | 'muted' | 'trimStartSeconds'>
+> & {
+  trimEndSeconds?: number | undefined;
+};
+export type MediaPlaybackPatch = GifPlaybackPatch | VideoPlaybackPatch;
 export type ElementStylePatch = Partial<{
   align: 'left' | 'center' | 'right';
   fill: string;
@@ -42,7 +51,9 @@ type TextTranslationValue = string | TextTranslationPatch;
 function collectReferencedAssetIds(project: ProjectDocument): Set<string> {
   const referencedAssetIds = new Set<string>();
   for (const element of Object.values(project.elements)) {
-    if (element.type === 'image') referencedAssetIds.add(element.assetId);
+    if (element.type === 'image' || element.type === 'gif' || element.type === 'video') {
+      referencedAssetIds.add(element.assetId);
+    }
   }
   for (const page of project.pages) {
     if (page.background.type === 'asset') referencedAssetIds.add(page.background.assetId);
@@ -410,6 +421,72 @@ export class AddImageElementCommand implements EditorCommand {
           ? { ...page, elementIds: [...page.elementIds, this.payload.element.id] }
           : page,
       ),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+}
+
+export class AddMediaElementCommand implements EditorCommand {
+  readonly description = 'Add media element';
+
+  constructor(
+    private readonly pageId: string,
+    private readonly payload: { asset: Asset; element: GifElement | VideoElement },
+  ) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    return {
+      ...project,
+      assets: {
+        ...project.assets,
+        [this.payload.asset.id]: this.payload.asset,
+      },
+      elements: {
+        ...project.elements,
+        [this.payload.element.id]: this.payload.element,
+      },
+      pages: project.pages.map((page) =>
+        page.id === this.pageId
+          ? { ...page, elementIds: [...page.elementIds, this.payload.element.id] }
+          : page,
+      ),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+}
+
+export class UpdateMediaPlaybackCommand implements EditorCommand {
+  readonly description = 'Update media playback';
+
+  constructor(
+    private readonly elementId: string,
+    private readonly patch: MediaPlaybackPatch,
+  ) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    const element = project.elements[this.elementId];
+    if (!element || element.locked) return project;
+    if (element.type !== 'gif' && element.type !== 'video') return project;
+    const nextElement: DesignElement =
+      element.type === 'gif'
+        ? { ...element, ...(this.patch as GifPlaybackPatch) }
+        : (() => {
+            const { trimEndSeconds, ...patch } = this.patch as VideoPlaybackPatch;
+            const next: VideoElement = { ...element, ...patch };
+            if (trimEndSeconds !== undefined) {
+              next.trimEndSeconds = trimEndSeconds;
+            } else if ('trimEndSeconds' in this.patch) {
+              delete next.trimEndSeconds;
+            }
+            return next;
+          })();
+
+    return {
+      ...project,
+      elements: {
+        ...project.elements,
+        [this.elementId]: nextElement,
+      },
       updatedAt: new Date().toISOString(),
     };
   }

--- a/apps/editor/src/domain/model.ts
+++ b/apps/editor/src/domain/model.ts
@@ -1,4 +1,4 @@
-export type ElementType = 'text' | 'image' | 'shape';
+export type ElementType = 'text' | 'image' | 'gif' | 'video' | 'shape';
 
 export interface ProjectDocument {
   id: string;
@@ -26,7 +26,7 @@ export type PageBackground =
 
 export interface Asset {
   id: string;
-  type: 'image';
+  type: 'image' | 'gif' | 'video';
   name: string;
   mimeType: string;
   objectUrl?: string;
@@ -34,7 +34,7 @@ export interface Asset {
   storage?: 'inline' | 'file' | 'remote';
 }
 
-export type DesignElement = TextElement | ImageElement | ShapeElement;
+export type DesignElement = TextElement | ImageElement | GifElement | VideoElement | ShapeElement;
 
 export interface BaseElement {
   id: string;
@@ -64,6 +64,23 @@ export interface ImageElement extends BaseElement {
   assetId: string;
   crop?: CropRect;
   flipX?: boolean;
+}
+
+export interface GifElement extends BaseElement {
+  type: 'gif';
+  assetId: string;
+  playing: boolean;
+}
+
+export interface VideoElement extends BaseElement {
+  type: 'video';
+  assetId: string;
+  loop: boolean;
+  controls: boolean;
+  muted: boolean;
+  autoplayInPreview: boolean;
+  trimStartSeconds: number;
+  trimEndSeconds?: number;
 }
 
 export interface ShapeElement extends BaseElement {

--- a/apps/editor/src/services/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/browserFileSystemProjectRepository.ts
@@ -33,7 +33,11 @@ const VERSION_HISTORY_LIMIT = 100;
 
 function getAssetFileExtension(mimeType: string) {
   if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/gif') return 'gif';
   if (mimeType === 'image/webp') return 'webp';
+  if (mimeType === 'video/mp4') return 'mp4';
+  if (mimeType === 'video/webm') return 'webm';
+  if (mimeType === 'video/quicktime') return 'mov';
   return 'png';
 }
 
@@ -61,7 +65,9 @@ async function objectUrlToBlob(objectUrl: string) {
 function collectReferencedAssetIds(project: ProjectDocument) {
   const referencedAssetIds = new Set<string>();
   for (const element of Object.values(project.elements)) {
-    if (element.type === 'image') referencedAssetIds.add(element.assetId);
+    if (element.type === 'image' || element.type === 'gif' || element.type === 'video') {
+      referencedAssetIds.add(element.assetId);
+    }
   }
   for (const page of project.pages) {
     if (page.background.type === 'asset') referencedAssetIds.add(page.background.assetId);

--- a/apps/editor/src/services/editorAutomationController.ts
+++ b/apps/editor/src/services/editorAutomationController.ts
@@ -55,8 +55,15 @@ type SnapshotElement = Pick<
   'height' | 'id' | 'locked' | 'opacity' | 'rotation' | 'type' | 'visible' | 'width' | 'x' | 'y'
 > & {
   assetId?: string;
+  autoplayInPreview?: boolean;
+  controls?: boolean;
   fill?: string;
+  loop?: boolean;
+  muted?: boolean;
+  playing?: boolean;
   text?: string;
+  trimEndSeconds?: number | undefined;
+  trimStartSeconds?: number;
 };
 
 const VALID_TRANSLATION_SCOPES: TranslationScope[] = ['selection', 'slide', 'deck'];
@@ -100,6 +107,21 @@ function compactElement(element: DesignElement): SnapshotElement {
   }
   if (element.type === 'image') {
     return { ...base, assetId: element.assetId };
+  }
+  if (element.type === 'gif') {
+    return { ...base, assetId: element.assetId, playing: element.playing };
+  }
+  if (element.type === 'video') {
+    return {
+      ...base,
+      assetId: element.assetId,
+      autoplayInPreview: element.autoplayInPreview,
+      controls: element.controls,
+      loop: element.loop,
+      muted: element.muted,
+      trimEndSeconds: element.trimEndSeconds,
+      trimStartSeconds: element.trimStartSeconds,
+    };
   }
   return { ...base, fill: element.fill };
 }

--- a/apps/editor/src/ui/editor/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/CanvasWorkspace.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, ty
 import type Konva from 'konva';
 import { Circle, Image as KonvaImage, Layer, Line, Rect, Stage, Text, Transformer } from 'react-konva';
 import type { ElementFramePatch, ImageCropPatch } from '../../domain/commands/basicCommands';
-import type { CropRect, DesignElement, ImageElement, ProjectDocument, SelectionState } from '../../domain/model';
+import type { CropRect, DesignElement, GifElement, ImageElement, ProjectDocument, SelectionState, VideoElement } from '../../domain/model';
 import { getNormalizedElementPoint } from './backgroundSelection';
 import { FloatingSelectionToolbar } from './FloatingSelectionToolbar';
 import { calculateImageCropPatch, type ImageCropHandle } from './imageCrop';
@@ -39,7 +39,7 @@ interface CanvasWorkspaceProps {
   onDeleteSelectedElement?: (() => void) | undefined;
   onDuplicateSelectedElement?: (() => void) | undefined;
   onFlipSelectedImage?: (() => void) | undefined;
-  onInsertImage?: (() => void) | undefined;
+  onInsertMedia?: (() => void) | undefined;
   onInsertText?: (() => void) | undefined;
   onSelectElement?: ((elementId: string, options?: { additive?: boolean }) => void) | undefined;
   onSendSelectedElementBackward?: (() => void) | undefined;
@@ -128,7 +128,7 @@ export function CanvasWorkspace({
   onDeleteSelectedElement,
   onDuplicateSelectedElement,
   onFlipSelectedImage,
-  onInsertImage,
+  onInsertMedia,
   onInsertText,
   onSelectElement,
   onSendSelectedElementBackward,
@@ -171,6 +171,9 @@ export function CanvasWorkspace({
   const visibleElements = sourceVisibleElements
     .map((element) => getDraftedElement(element))
     .filter(isDesignElement);
+  const visibleMediaElements = visibleElements.filter(
+    (element): element is GifElement | VideoElement => element.type === 'gif' || element.type === 'video',
+  );
   const hasSelection = selection.elementIds.length > 0;
   const showEditorOverlays = !presentationMode && !readOnly;
   const selectedElement = getDraftedElement(project.elements[selection.elementIds[0] ?? '']);
@@ -649,6 +652,20 @@ export function CanvasWorkspace({
                   );
                 }
 
+                if (element.type === 'gif' || element.type === 'video') {
+                  const selected = selection.elementIds.includes(element.id);
+                  return (
+                    <Rect
+                      {...commonProps}
+                      key={element.id}
+                      fill="rgba(0,0,0,0.01)"
+                      stroke={selected ? '#37FD76' : 'rgba(55,253,118,0.28)'}
+                      strokeWidth={selected ? 2 : 1}
+                      {...(!selected ? { dash: [6, 5] } : {})}
+                    />
+                  );
+                }
+
                 return (
                   <Text
                     {...commonProps}
@@ -749,6 +766,26 @@ export function CanvasWorkspace({
               ) : null}
             </Layer>
           </Stage>
+          <div className="canvas-media-layer" aria-hidden={visibleMediaElements.length === 0 ? true : undefined}>
+            {visibleMediaElements.map((element) => {
+              const asset = project.assets[element.assetId];
+              return (
+                <CanvasMediaElement
+                  key={element.id}
+                  assetName={asset?.name ?? (element.type === 'video' ? 'Imported video' : 'Imported GIF')}
+                  assetUrl={asset?.objectUrl}
+                  element={element}
+                  interactive={
+                    presentationMode ||
+                    readOnly ||
+                    (element.type === 'video' && selection.elementIds.includes(element.id))
+                  }
+                  previewMode={presentationMode || readOnly}
+                  scale={{ x: scaleX, y: scaleY }}
+                />
+              );
+            })}
+          </div>
           {showEditorOverlays && selectedElement?.type === 'image' && isCropModeActive ? (
             <CropFrameOverlay
               element={selectedElement}
@@ -803,12 +840,12 @@ export function CanvasWorkspace({
             <button type="button" aria-label="Insert Text" title="Insert Text" onClick={onInsertText}>
               <span className="material-symbols-outlined">title</span>
             </button>
-            <button type="button" aria-label="Insert Image" title="Insert Image" onClick={onInsertImage}>
+            <button type="button" aria-label="Insert Media" title="Insert Media" onClick={onInsertMedia}>
               <span className="material-symbols-outlined">add_photo_alternate</span>
             </button>
           </div>
         ) : null}
-        {showEditorOverlays && hasSelection && selectedElement?.type !== 'text' ? (
+        {showEditorOverlays && hasSelection && (selectedElement?.type === 'image' || selectedElement?.type === 'shape') ? (
           <FloatingSelectionToolbar
             elementType={selectedElement?.type === 'image' ? 'image' : 'shape'}
             onAlignCenter={onAlignSelectedElement}
@@ -912,6 +949,118 @@ interface CanvasImageElementProps {
   assetUrl: string | undefined;
   commonProps: CommonElementProps;
   element: Extract<DesignElement, { type: 'image' }>;
+}
+
+interface CanvasMediaElementProps {
+  assetName: string;
+  assetUrl: string | undefined;
+  element: GifElement | VideoElement;
+  interactive: boolean;
+  previewMode: boolean;
+  scale: { x: number; y: number };
+}
+
+function getMediaStyle(element: GifElement | VideoElement, scale: { x: number; y: number }, interactive: boolean) {
+  return {
+    height: `${element.height * scale.y}px`,
+    left: `${element.x * scale.x}px`,
+    opacity: element.opacity,
+    pointerEvents: interactive ? 'auto' : 'none',
+    top: `${element.y * scale.y}px`,
+    transform: `rotate(${element.rotation}deg)`,
+    width: `${element.width * scale.x}px`,
+  } as const;
+}
+
+function CanvasMediaElement({ assetName, assetUrl, element, interactive, previewMode, scale }: CanvasMediaElementProps) {
+  if (element.type === 'gif') {
+    return (
+      <img
+        aria-label={assetName}
+        className="canvas-media-element"
+        src={element.playing ? assetUrl : undefined}
+        style={getMediaStyle(element, scale, interactive)}
+      />
+    );
+  }
+
+  return (
+    <CanvasVideoElement
+      assetName={assetName}
+      assetUrl={assetUrl}
+      element={element}
+      interactive={interactive}
+      previewMode={previewMode}
+      scale={scale}
+    />
+  );
+}
+
+interface CanvasVideoElementProps {
+  assetName: string;
+  assetUrl: string | undefined;
+  element: VideoElement;
+  interactive: boolean;
+  previewMode: boolean;
+  scale: { x: number; y: number };
+}
+
+function CanvasVideoElement({ assetName, assetUrl, element, interactive, previewMode, scale }: CanvasVideoElementProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const previousTrimRef = useRef<{ assetUrl: string | undefined; end: number | undefined; start: number } | undefined>(undefined);
+  const autoplay = previewMode && element.autoplayInPreview;
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const start = Math.max(0, element.trimStartSeconds);
+    const end = element.trimEndSeconds !== undefined && element.trimEndSeconds > 0
+      ? Math.max(0, element.trimEndSeconds)
+      : undefined;
+    const previousTrim = previousTrimRef.current;
+    const assetChanged = previousTrim?.assetUrl !== assetUrl;
+    if (assetChanged || previousTrim?.start !== start) {
+      video.currentTime = start;
+    } else if (previousTrim?.end !== end && end !== undefined) {
+      video.currentTime = end;
+    }
+    previousTrimRef.current = { assetUrl, end, start };
+  }, [assetUrl, element.trimEndSeconds, element.trimStartSeconds]);
+
+  function enforceTrimWindow(video: HTMLVideoElement) {
+    const trimEnd = element.trimEndSeconds;
+    if (trimEnd === undefined || trimEnd <= 0) return;
+    if (video.currentTime < trimEnd) return;
+    if (element.loop) {
+      video.currentTime = Math.max(0, element.trimStartSeconds);
+      return;
+    }
+    video.pause();
+  }
+
+  return (
+    <video
+      aria-label={assetName}
+      autoPlay={autoplay}
+      className="canvas-media-element"
+      controls={element.controls}
+      data-trim-end={element.trimEndSeconds ?? ''}
+      data-trim-start={element.trimStartSeconds}
+      loop={element.loop}
+      muted={element.muted}
+      playsInline
+      preload="metadata"
+      ref={videoRef}
+      src={assetUrl}
+      style={getMediaStyle(element, scale, interactive)}
+      onLoadedMetadata={(event) => {
+        event.currentTarget.currentTime = Math.max(0, element.trimStartSeconds);
+      }}
+      onTimeUpdate={(event) => {
+        enforceTrimWindow(event.currentTarget);
+      }}
+    />
+  );
 }
 
 function CanvasImageElement({ assetUrl, commonProps, element }: CanvasImageElementProps) {

--- a/apps/editor/src/ui/editor/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/DesignPanel.tsx
@@ -1,10 +1,12 @@
-import { AlignCenter, CaseSensitive, Image, Square, Type } from 'lucide-react';
+import { AlignCenter, CaseSensitive, Film, Image, Square, Type, Video } from 'lucide-react';
 import type {
   DesignElement,
   PageBackground,
   ProjectDocument,
   SelectionState,
+  VideoElement,
 } from '../../domain/model';
+import type { MediaPlaybackPatch } from '../../domain/commands/basicCommands';
 import { PanelSection } from '../components/PanelSection';
 import { TEXT_FONT_FAMILIES, TEXT_FONT_WEIGHTS } from './textStyleOptions';
 
@@ -27,6 +29,7 @@ interface DesignPanelProps {
       strokeWidth: number;
     }>,
   ) => void;
+  onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
 }
 
@@ -43,6 +46,7 @@ export function DesignPanel({
   activePageId,
   selection,
   onUpdateElementStyle,
+  onUpdateMediaPlayback,
   onUpdatePageBackground,
 }: DesignPanelProps) {
   const page = project.pages.find((item) => item.id === activePageId);
@@ -52,6 +56,12 @@ export function DesignPanel({
   function updateSelectedStyle(patch: Parameters<NonNullable<typeof onUpdateElementStyle>>[1]) {
     if (!selectedElement || selectedElement.locked) return;
     onUpdateElementStyle?.(selectedElement.id, patch);
+  }
+
+  function updateSelectedMediaPlayback(patch: MediaPlaybackPatch) {
+    if (!selectedElement || selectedElement.locked) return;
+    if (selectedElement.type !== 'gif' && selectedElement.type !== 'video') return;
+    onUpdateMediaPlayback?.(selectedElement.id, patch);
   }
 
   function applyColor(color: string) {
@@ -103,6 +113,8 @@ export function DesignPanel({
         <div className="compact-action design-selection-summary">
           {selectedElement?.type === 'text' ? <Type size={16} /> : null}
           {selectedElement?.type === 'image' ? <Image size={16} /> : null}
+          {selectedElement?.type === 'gif' ? <Film size={16} /> : null}
+          {selectedElement?.type === 'video' ? <Video size={16} /> : null}
           {selectedElement?.type === 'shape' ? <Square size={16} /> : null}
           {!selectedElement ? <CaseSensitive size={16} /> : null}
           <span>{selectedElement ? `Selected ${selectedElement.type}` : 'No selected element'}</span>
@@ -202,6 +214,10 @@ export function DesignPanel({
         </PanelSection>
       ) : null}
 
+      {selectedElement?.type === 'video' ? (
+        <VideoPlaybackPanel element={selectedElement} onUpdate={updateSelectedMediaPlayback} />
+      ) : null}
+
       {selectedElement?.type === 'shape' ? (
         <PanelSection title="Shape">
           <label className="design-control">
@@ -241,5 +257,100 @@ export function DesignPanel({
         </PanelSection>
       ) : null}
     </div>
+  );
+}
+
+interface VideoPlaybackPanelProps {
+  element: VideoElement;
+  onUpdate: (patch: MediaPlaybackPatch) => void;
+}
+
+function toTrimSeconds(value: string) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+function getTrimSliderMax(element: VideoElement) {
+  return Math.max(60, Math.ceil(element.trimStartSeconds), Math.ceil(element.trimEndSeconds ?? 0));
+}
+
+function VideoPlaybackPanel({ element, onUpdate }: VideoPlaybackPanelProps) {
+  const trimSliderMax = getTrimSliderMax(element);
+
+  return (
+    <PanelSection title="Playback">
+      <label className="design-control">
+        <span>Loop</span>
+        <input
+          aria-label="Loop selected video"
+          type="checkbox"
+          checked={element.loop}
+          onChange={(event) => {
+            onUpdate({ loop: event.target.checked });
+          }}
+        />
+      </label>
+      <label className="design-control">
+        <span>Controls</span>
+        <input
+          aria-label="Show selected video controls"
+          type="checkbox"
+          checked={element.controls}
+          onChange={(event) => {
+            onUpdate({ controls: event.target.checked });
+          }}
+        />
+      </label>
+      <label className="design-control">
+        <span>Muted</span>
+        <input
+          aria-label="Mute selected video"
+          type="checkbox"
+          checked={element.muted}
+          onChange={(event) => {
+            onUpdate({ muted: event.target.checked });
+          }}
+        />
+      </label>
+      <label className="design-control">
+        <span>Preview autoplay</span>
+        <input
+          aria-label="Autoplay selected video in preview"
+          type="checkbox"
+          checked={element.autoplayInPreview}
+          onChange={(event) => {
+            onUpdate({ autoplayInPreview: event.target.checked });
+          }}
+        />
+      </label>
+      <label className="design-control">
+        <span>Trim start {element.trimStartSeconds.toFixed(1)}s</span>
+        <input
+          aria-label="Selected video trim start"
+          max={trimSliderMax}
+          min="0"
+          step="0.1"
+          type="range"
+          value={element.trimStartSeconds}
+          onChange={(event) => {
+            onUpdate({ trimStartSeconds: toTrimSeconds(event.target.value) });
+          }}
+        />
+      </label>
+      <label className="design-control">
+        <span>Trim end {(element.trimEndSeconds ?? 0).toFixed(1)}s</span>
+        <input
+          aria-label="Selected video trim end"
+          max={trimSliderMax}
+          min="0"
+          step="0.1"
+          type="range"
+          value={element.trimEndSeconds ?? 0}
+          onChange={(event) => {
+            onUpdate({ trimEndSeconds: toTrimSeconds(event.target.value) });
+          }}
+        />
+      </label>
+    </PanelSection>
   );
 }

--- a/apps/editor/src/ui/editor/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/EditorShell.tsx
@@ -109,6 +109,30 @@ export function EditorShell({ services }: EditorShellProps) {
     window.open(url.toString(), '_blank', 'noopener,noreferrer');
   }
 
+  function isAnimatedMediaFile(file: File) {
+    return file.type === 'image/gif' || file.type.startsWith('video/');
+  }
+
+  function revealMediaSettingsForElement(elementId: string) {
+    const selectedElement = vm.project.elements[elementId];
+    if (selectedElement?.type !== 'gif' && selectedElement?.type !== 'video') return;
+    vm.setActiveTab('design');
+    setLeftPanelOpen(true);
+  }
+
+  function selectElement(elementId: string, options?: { additive?: boolean }) {
+    vm.selectElement(elementId, options);
+    if (!options?.additive) revealMediaSettingsForElement(elementId);
+  }
+
+  function importMediaFile(file: File) {
+    if (isAnimatedMediaFile(file)) {
+      vm.setActiveTab('design');
+      setLeftPanelOpen(true);
+    }
+    void vm.importMediaFile(file);
+  }
+
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (isHistoryReadOnly) return;
@@ -271,16 +295,18 @@ export function EditorShell({ services }: EditorShellProps) {
           project={vm.project}
           activePageId={vm.activePageId}
           selection={vm.selection}
-          onSelectElement={isHistoryReadOnly ? undefined : vm.selectElement}
+          onSelectElement={isHistoryReadOnly ? undefined : selectElement}
           onSetElementVisibility={isHistoryReadOnly ? undefined : vm.setElementVisibility}
           onSetElementLock={isHistoryReadOnly ? undefined : vm.setElementLock}
           onDeleteElement={isHistoryReadOnly ? undefined : vm.deleteElement}
           onReorderElement={isHistoryReadOnly ? undefined : vm.reorderElement}
           onUpdateElementStyle={isHistoryReadOnly ? undefined : vm.updateElementStyle}
+          onUpdateMediaPlayback={isHistoryReadOnly ? undefined : vm.updateMediaPlayback}
           onUpdatePageBackground={isHistoryReadOnly ? undefined : vm.updatePageBackground}
           onImportImage={isHistoryReadOnly ? undefined : (file) => {
             void vm.importImageFile(file);
           }}
+          onImportMedia={isHistoryReadOnly ? undefined : importMediaFile}
           onInsertText={isHistoryReadOnly ? undefined : vm.insertTextElement}
           modelStates={vm.modelStates}
           attentionModelId={vm.aiToolsAttentionModelId ?? (vm.backgroundSelectionNotice ? IMAGE_EDITING_MODEL_ID : undefined)}
@@ -355,13 +381,13 @@ export function EditorShell({ services }: EditorShellProps) {
             onDeleteSelectedElement={isHistoryReadOnly ? undefined : vm.deleteSelectedElement}
             onDuplicateSelectedElement={isHistoryReadOnly ? undefined : vm.duplicateSelectedElement}
             onFlipSelectedImage={isHistoryReadOnly ? undefined : vm.flipSelectedImage}
-            onInsertImage={isHistoryReadOnly ? undefined : () => {
+            onInsertMedia={isHistoryReadOnly ? undefined : () => {
               toolbarImageInputRef.current?.click();
             }}
             onInsertText={isHistoryReadOnly ? undefined : () => {
               vm.insertTextElement();
             }}
-            onSelectElement={isHistoryReadOnly ? undefined : vm.selectElement}
+            onSelectElement={isHistoryReadOnly ? undefined : selectElement}
             onSendSelectedElementBackward={isHistoryReadOnly ? undefined : () => {
               vm.setSelectedElementZOrder('backward');
             }}
@@ -386,14 +412,14 @@ export function EditorShell({ services }: EditorShellProps) {
           />
           <input
             ref={toolbarImageInputRef}
-            aria-label="Insert image file"
+            aria-label="Insert media file"
             className="visually-hidden-input"
             type="file"
-            accept="image/*"
+            accept="image/*,video/*"
             onChange={(event) => {
               const file = event.target.files?.[0];
               if (!file || isHistoryReadOnly) return;
-              void vm.importImageFile(file);
+              importMediaFile(file);
               event.target.value = '';
             }}
           />

--- a/apps/editor/src/ui/editor/LayersPanel.tsx
+++ b/apps/editor/src/ui/editor/LayersPanel.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, GripVertical, Image, Lock, Search, Square, Trash2, Type, Unlock } from 'lucide-react';
+import { Eye, EyeOff, Film, GripVertical, Image, Lock, Search, Square, Trash2, Type, Unlock, Video } from 'lucide-react';
 import type { DesignElement, ProjectDocument, SelectionState } from '../../domain/model';
 import { IconButton } from '../components/IconButton';
 import { PanelSection } from '../components/PanelSection';
@@ -29,6 +29,8 @@ function getLayerLabel(element: DesignElement, project: ProjectDocument) {
     return `${project.assets[element.assetId]?.name ?? 'Imported Image'} copy`;
   }
   if (element.type === 'image') return project.assets[element.assetId]?.name ?? 'Imported Image';
+  if (element.type === 'gif') return project.assets[element.assetId]?.name ?? 'Imported GIF';
+  if (element.type === 'video') return project.assets[element.assetId]?.name ?? 'Imported Video';
   if (element.type === 'shape') return 'Background Shape';
   return element.id;
 }
@@ -36,6 +38,8 @@ function getLayerLabel(element: DesignElement, project: ProjectDocument) {
 function getLayerIcon(element: DesignElement) {
   if (element.type === 'text') return Type;
   if (element.type === 'image') return Image;
+  if (element.type === 'gif') return Film;
+  if (element.type === 'video') return Video;
   return Square;
 }
 

--- a/apps/editor/src/ui/editor/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/LeftToolPanel.tsx
@@ -1,7 +1,7 @@
 import { Brush, ImagePlus, Layers3, Sparkles, Type } from 'lucide-react';
 import { useRef } from 'react';
 import type { PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
-import type { ElementStylePatch } from '../../domain/commands/basicCommands';
+import type { ElementStylePatch, MediaPlaybackPatch } from '../../domain/commands/basicCommands';
 import type { AiProviderState, ModelState } from '../../services/interfaces';
 import { AiToolsPanel } from './AiToolsPanel';
 import { DesignPanel } from './DesignPanel';
@@ -34,6 +34,7 @@ interface LeftToolPanelProps {
   onRemoveModel?: ((id: string) => Promise<void>) | undefined;
   onCreateImageOptionsChange?: ((options: CreateImagePromptOptions) => void) | undefined;
   onImportImage?: ((file: File) => void) | undefined;
+  onImportMedia?: ((file: File) => void) | undefined;
   onInsertText?: ((preset: TextPreset) => void) | undefined;
   onPreparePromptApi?: (() => Promise<void>) | undefined;
   onPrepareLanguageDetectionProvider?: (() => Promise<void>) | undefined;
@@ -51,6 +52,7 @@ interface LeftToolPanelProps {
   onDeleteElement?: ((elementId: string) => void) | undefined;
   onReorderElement?: ((elementId: string, targetElementId: string) => void) | undefined;
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
+  onUpdateMediaPlayback?: ((elementId: string, patch: MediaPlaybackPatch) => void) | undefined;
   onUpdatePageBackground?: ((background: PageBackground) => void) | undefined;
 }
 
@@ -86,6 +88,7 @@ export function LeftToolPanel({
   onRemoveModel,
   onCreateImageOptionsChange,
   onImportImage,
+  onImportMedia,
   onInsertText,
   onPreparePromptApi,
   onPrepareLanguageDetectionProvider,
@@ -103,6 +106,7 @@ export function LeftToolPanel({
   onDeleteElement,
   onReorderElement,
   onUpdateElementStyle,
+  onUpdateMediaPlayback,
   onUpdatePageBackground,
 }: LeftToolPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -158,6 +162,7 @@ export function LeftToolPanel({
             activePageId={activePageId}
             selection={selection}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
+            {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
           />
         ) : null}
@@ -197,7 +202,7 @@ export function LeftToolPanel({
           <section className="panel-stack">
             <div className="panel-section">
               <h2 className="panel-heading">Assets</h2>
-              <p className="panel-muted">Import images from disk into the active page.</p>
+              <p className="panel-muted">Import images, GIFs, or videos from disk into the active page.</p>
             </div>
             <button
               className="compact-action compact-action-full"
@@ -209,18 +214,22 @@ export function LeftToolPanel({
               <span className="material-symbols-outlined" aria-hidden="true">
                 add_photo_alternate
               </span>
-              Import Image
+              Import Media
             </button>
             <input
               ref={fileInputRef}
-              aria-label="Import image file"
+              aria-label="Import media file"
               className="visually-hidden-input"
               type="file"
-              accept="image/*"
+              accept="image/*,video/*"
               onChange={(event) => {
                 const file = event.target.files?.[0];
                 if (!file) return;
-                onImportImage?.(file);
+                if (onImportMedia) {
+                  onImportMedia(file);
+                } else {
+                  onImportImage?.(file);
+                }
                 event.target.value = '';
               }}
             />

--- a/apps/editor/src/ui/editor/PageRail.tsx
+++ b/apps/editor/src/ui/editor/PageRail.tsx
@@ -6,10 +6,11 @@ interface PageRailProps {
   activePageId: string;
   onAddPage?: () => void;
   onImportImage?: (file: File) => void;
+  onImportMedia?: (file: File) => void;
   onSelectPage?: (pageId: string) => void;
 }
 
-export function PageRail({ project, activePageId, onAddPage, onImportImage, onSelectPage }: PageRailProps) {
+export function PageRail({ project, activePageId, onAddPage, onImportImage, onImportMedia, onSelectPage }: PageRailProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   return (
@@ -65,14 +66,18 @@ export function PageRail({ project, activePageId, onAddPage, onImportImage, onSe
         </button>
         <input
           ref={fileInputRef}
-          aria-label="Import image file"
+          aria-label="Import media file"
           className="visually-hidden-input"
           type="file"
-          accept="image/*"
+          accept="image/*,video/*"
           onChange={(event) => {
             const file = event.target.files?.[0];
             if (!file) return;
-            onImportImage?.(file);
+            if (onImportMedia) {
+              onImportMedia(file);
+            } else {
+              onImportImage?.(file);
+            }
             event.target.value = '';
           }}
         />

--- a/apps/editor/src/ui/editor/PagesPanel.tsx
+++ b/apps/editor/src/ui/editor/PagesPanel.tsx
@@ -310,6 +310,24 @@ function MiniElement({
     );
   }
 
+  if (element.type === 'gif') {
+    const asset = project.assets[element.assetId];
+    return asset?.objectUrl ? (
+      <img alt="" className="page-card-mini-element" src={asset.objectUrl} style={style} />
+    ) : (
+      <span className="page-card-mini-element page-card-mini-placeholder" style={style} />
+    );
+  }
+
+  if (element.type === 'video') {
+    const asset = project.assets[element.assetId];
+    return asset?.objectUrl ? (
+      <video className="page-card-mini-element" muted playsInline preload="metadata" src={asset.objectUrl} style={style} />
+    ) : (
+      <span className="page-card-mini-element page-card-mini-placeholder" style={style} />
+    );
+  }
+
   return (
     <span
       className="page-card-mini-element"

--- a/apps/editor/src/ui/editor/RightPanel.tsx
+++ b/apps/editor/src/ui/editor/RightPanel.tsx
@@ -1,6 +1,6 @@
 import { Brush, Layers3, Sparkles } from 'lucide-react';
 import type { PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
-import type { ElementStylePatch } from '../../domain/commands/basicCommands';
+import type { ElementStylePatch, MediaPlaybackPatch } from '../../domain/commands/basicCommands';
 import type { AiProviderState, ModelState } from '../../services/interfaces';
 import { SegmentedTabs, type SegmentedTab } from '../components/SegmentedTabs';
 import { AiToolsPanel } from './AiToolsPanel';
@@ -43,6 +43,7 @@ interface RightPanelProps {
   onDeleteElement?: (elementId: string) => void;
   onReorderElement?: (elementId: string, targetElementId: string) => void;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
+  onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
 }
 
@@ -84,6 +85,7 @@ export function RightPanel({
   onDeleteElement,
   onReorderElement,
   onUpdateElementStyle,
+  onUpdateMediaPlayback,
   onUpdatePageBackground,
 }: RightPanelProps) {
   return (
@@ -132,6 +134,7 @@ export function RightPanel({
             activePageId={activePageId}
             selection={selection}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
+            {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
           />
         ) : null}

--- a/apps/editor/src/ui/editor/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/useEditorViewModel.ts
@@ -4,6 +4,7 @@ import {
   AddGeneratedSlideElementCommand,
   AddElementsCommand,
   AddImageElementCommand,
+  AddMediaElementCommand,
   AlignElementCommand,
   DeleteElementCommand,
   DeletePageCommand,
@@ -24,12 +25,14 @@ import {
   UpdateElementFramesCommand,
   UpdateElementStyleCommand,
   UpdateElementFrameCommand,
+  UpdateMediaPlaybackCommand,
   UpdatePageBackgroundCommand,
   UpdateTextContentCommand,
   type AlignMode,
   type ElementFramePatch,
   type ImageCropPatch,
   type ElementStylePatch,
+  type MediaPlaybackPatch,
   type ZOrderMode,
 } from '../../domain/commands/basicCommands';
 import type { GeneratedSlideElement } from '../../domain/generatedSlide';
@@ -268,6 +271,26 @@ function readImageSize(src: string) {
     });
     image.src = src;
   });
+}
+
+function readVideoSize(src: string) {
+  return new Promise<{ width: number; height: number }>((resolve, reject) => {
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    video.addEventListener('loadedmetadata', () => {
+      resolve({ width: video.videoWidth || 16, height: video.videoHeight || 9 });
+    });
+    video.addEventListener('error', () => {
+      reject(new Error('Video dimensions could not be read.'));
+    });
+    video.src = src;
+  });
+}
+
+function getMediaAssetType(file: File): 'image' | 'gif' | 'video' {
+  if (file.type === 'image/gif') return 'gif';
+  if (file.type.startsWith('video/')) return 'video';
+  return 'image';
 }
 
 function createId(prefix: string) {
@@ -1672,7 +1695,7 @@ export function useEditorViewModel(services: AppServices) {
     if (selectedElements.length === 0) return;
     const copiedAssets: ProjectDocument['assets'] = {};
     for (const element of selectedElements) {
-      if (element.type !== 'image') continue;
+      if (element.type !== 'image' && element.type !== 'gif' && element.type !== 'video') continue;
       const asset = project.assets[element.assetId];
       if (asset) copiedAssets[element.assetId] = asset;
     }
@@ -2243,19 +2266,86 @@ export function useEditorViewModel(services: AppServices) {
 
   async function importImageFile(file: File) {
     const dataUrl = await readImageFileAsDataUrl(file);
-    const imageSize = await readImageSize(dataUrl);
+    const assetType = getMediaAssetType(file);
+    const mediaSize = assetType === 'video' ? await readVideoSize(dataUrl) : await readImageSize(dataUrl);
     const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
     if (!page) return;
 
     const assetId = createId('asset');
-    const elementId = createId('image');
-    const imageName = file.name.trim() || 'Pasted image';
-    const fittedImage = fitImageWithinPage({
-      imageWidth: imageSize.width,
-      imageHeight: imageSize.height,
+    const elementId = createId(assetType);
+    const mediaName = file.name.trim() || (assetType === 'video' ? 'Pasted video' : assetType === 'gif' ? 'Pasted GIF' : 'Pasted image');
+    const fittedMedia = fitImageWithinPage({
+      imageWidth: mediaSize.width,
+      imageHeight: mediaSize.height,
       pageWidth: page.width,
       pageHeight: page.height,
     });
+
+    if (assetType === 'gif') {
+      commitProject(
+        (currentProject) =>
+          new AddMediaElementCommand(activePageId, {
+            asset: {
+              id: assetId,
+              type: 'gif',
+              name: mediaName,
+              mimeType: file.type || 'image/gif',
+              objectUrl: dataUrl,
+            },
+            element: {
+              id: elementId,
+              type: 'gif',
+              assetId,
+              x: fittedMedia.x,
+              y: fittedMedia.y,
+              width: fittedMedia.width,
+              height: fittedMedia.height,
+              rotation: 0,
+              locked: false,
+              visible: true,
+              opacity: 1,
+              playing: true,
+            },
+          }).execute(currentProject),
+        { selectedElementIds: [elementId] },
+      );
+      return;
+    }
+
+    if (assetType === 'video') {
+      commitProject(
+        (currentProject) =>
+          new AddMediaElementCommand(activePageId, {
+            asset: {
+              id: assetId,
+              type: 'video',
+              name: mediaName,
+              mimeType: file.type || 'video/mp4',
+              objectUrl: dataUrl,
+            },
+            element: {
+              id: elementId,
+              type: 'video',
+              assetId,
+              x: fittedMedia.x,
+              y: fittedMedia.y,
+              width: fittedMedia.width,
+              height: fittedMedia.height,
+              rotation: 0,
+              locked: false,
+              visible: true,
+              opacity: 1,
+              loop: false,
+              controls: true,
+              muted: true,
+              autoplayInPreview: true,
+              trimStartSeconds: 0,
+            },
+          }).execute(currentProject),
+        { selectedElementIds: [elementId] },
+      );
+      return;
+    }
 
     commitProject(
       (currentProject) =>
@@ -2263,7 +2353,7 @@ export function useEditorViewModel(services: AppServices) {
         asset: {
           id: assetId,
           type: 'image',
-          name: imageName,
+          name: mediaName,
           mimeType: file.type || 'image/*',
           objectUrl: dataUrl,
         },
@@ -2271,10 +2361,10 @@ export function useEditorViewModel(services: AppServices) {
           id: elementId,
           type: 'image',
           assetId,
-          x: fittedImage.x,
-          y: fittedImage.y,
-          width: fittedImage.width,
-          height: fittedImage.height,
+          x: fittedMedia.x,
+          y: fittedMedia.y,
+          width: fittedMedia.width,
+          height: fittedMedia.height,
           rotation: 0,
           locked: false,
           visible: true,
@@ -2283,6 +2373,10 @@ export function useEditorViewModel(services: AppServices) {
       }).execute(currentProject),
       { selectedElementIds: [elementId] },
     );
+  }
+
+  function updateMediaPlayback(elementId: string, patch: MediaPlaybackPatch) {
+    commitProject((currentProject) => new UpdateMediaPlaybackCommand(elementId, patch).execute(currentProject));
   }
 
   return {
@@ -2402,6 +2496,7 @@ export function useEditorViewModel(services: AppServices) {
     updateElementFrame,
     updateElementFrames,
     updateElementStyle,
+    updateMediaPlayback,
     updatePageBackground,
     updateTextContent,
     setElementVisibility,
@@ -2409,5 +2504,6 @@ export function useEditorViewModel(services: AppServices) {
     deleteElement,
     reorderElement,
     importImageFile,
+    importMediaFile: importImageFile,
   };
 }

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -2,6 +2,7 @@ import {
   AddElementsCommand,
   AlignElementCommand,
   AddImageElementCommand,
+  AddMediaElementCommand,
   DeleteElementCommand,
   DeletePageCommand,
   DuplicatePageCommand,
@@ -19,6 +20,7 @@ import {
   UpdateElementFrameCommand,
   UpdateElementFramesCommand,
   UpdateElementStyleCommand,
+  UpdateMediaPlaybackCommand,
   UpdatePageBackgroundCommand,
   UpdateTextContentCommand,
   TranslateTextElementsCommand,
@@ -365,6 +367,132 @@ describe('editor commands', () => {
     expect(next.elements['image-imported']).toMatchObject({ assetId: 'asset-imported' });
     expect(next.pages[0]?.elementIds.at(-1)).toBe('image-imported');
     expect(project.assets['asset-imported']).toBeUndefined();
+  });
+
+  it('adds imported GIF and video elements as topmost animated media layers', () => {
+    const project = createSampleProject();
+    const withGif = new AddMediaElementCommand('page-1', {
+      asset: {
+        id: 'asset-gif',
+        type: 'gif',
+        name: 'Looping animation',
+        mimeType: 'image/gif',
+        objectUrl: 'data:image/gif;base64,abc',
+      },
+      element: {
+        id: 'gif-imported',
+        type: 'gif',
+        assetId: 'asset-gif',
+        x: 480,
+        y: 240,
+        width: 640,
+        height: 360,
+        rotation: 0,
+        locked: false,
+        opacity: 1,
+        visible: true,
+        playing: true,
+      },
+    }).execute(project);
+    const next = new AddMediaElementCommand('page-1', {
+      asset: {
+        id: 'asset-video',
+        type: 'video',
+        name: 'Demo clip',
+        mimeType: 'video/mp4',
+        objectUrl: 'data:video/mp4;base64,abc',
+      },
+      element: {
+        id: 'video-imported',
+        type: 'video',
+        assetId: 'asset-video',
+        x: 500,
+        y: 260,
+        width: 800,
+        height: 450,
+        rotation: 0,
+        locked: false,
+        opacity: 1,
+        visible: true,
+        loop: true,
+        controls: true,
+        muted: true,
+        autoplayInPreview: true,
+        trimStartSeconds: 2,
+        trimEndSeconds: 8,
+      },
+    }).execute(withGif);
+
+    expect(next.assets['asset-gif']).toMatchObject({ type: 'gif', mimeType: 'image/gif' });
+    expect(next.assets['asset-video']).toMatchObject({ type: 'video', mimeType: 'video/mp4' });
+    expect(next.elements['gif-imported']).toMatchObject({ type: 'gif', playing: true });
+    expect(next.elements['video-imported']).toMatchObject({
+      type: 'video',
+      loop: true,
+      controls: true,
+      muted: true,
+      autoplayInPreview: true,
+      trimStartSeconds: 2,
+      trimEndSeconds: 8,
+    });
+    expect(next.pages[0]?.elementIds.slice(-2)).toEqual(['gif-imported', 'video-imported']);
+  });
+
+  it('updates animated media playback settings immutably', () => {
+    const project = new AddMediaElementCommand('page-1', {
+      asset: {
+        id: 'asset-video',
+        type: 'video',
+        name: 'Demo clip',
+        mimeType: 'video/mp4',
+        objectUrl: 'blob:video',
+      },
+      element: {
+        id: 'video-imported',
+        type: 'video',
+        assetId: 'asset-video',
+        x: 0,
+        y: 0,
+        width: 640,
+        height: 360,
+        rotation: 0,
+        locked: false,
+        opacity: 1,
+        visible: true,
+        loop: false,
+        controls: false,
+        muted: false,
+        autoplayInPreview: false,
+        trimStartSeconds: 0,
+      },
+    }).execute(createSampleProject());
+
+    const next = new UpdateMediaPlaybackCommand('video-imported', {
+      loop: true,
+      controls: true,
+      muted: true,
+      autoplayInPreview: true,
+      trimStartSeconds: 1.5,
+      trimEndSeconds: 9.25,
+    }).execute(project);
+
+    expect(next.elements['video-imported']).toMatchObject({
+      type: 'video',
+      loop: true,
+      controls: true,
+      muted: true,
+      autoplayInPreview: true,
+      trimStartSeconds: 1.5,
+      trimEndSeconds: 9.25,
+    });
+    expect(project.elements['video-imported']).toMatchObject({
+      type: 'video',
+      loop: false,
+      controls: false,
+      muted: false,
+      autoplayInPreview: false,
+      trimStartSeconds: 0,
+    });
   });
 
   it('adds multiple pasted elements as topmost layers', () => {

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
@@ -261,6 +261,82 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     expect(savedAsset.objectUrl).toBeUndefined();
   });
 
+  it('moves GIF and video assets into assets/ with media file extensions', async () => {
+    const directory = new MockDirectoryHandle();
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory: () => Promise.resolve(directory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+    const project = createSampleProject();
+    project.assets['asset-gif'] = {
+      id: 'asset-gif',
+      type: 'gif',
+      name: 'Animation',
+      mimeType: 'image/gif',
+      objectUrl: 'data:image/gif;base64,Z2lm',
+    };
+    project.assets['asset-video'] = {
+      id: 'asset-video',
+      type: 'video',
+      name: 'Clip',
+      mimeType: 'video/mp4',
+      objectUrl: 'data:video/mp4;base64,bXA0',
+    };
+    project.elements['gif-imported'] = {
+      id: 'gif-imported',
+      type: 'gif',
+      assetId: 'asset-gif',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      playing: true,
+    };
+    project.elements['video-imported'] = {
+      id: 'video-imported',
+      type: 'video',
+      assetId: 'asset-video',
+      x: 0,
+      y: 0,
+      width: 160,
+      height: 90,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      loop: true,
+      controls: true,
+      muted: true,
+      autoplayInPreview: true,
+      trimStartSeconds: 1,
+      trimEndSeconds: 4,
+    };
+    project.pages[0]?.elementIds.push('gif-imported', 'video-imported');
+
+    await repository.saveProject(project);
+
+    const assetsDirectory = directory.directories.get('assets')!;
+    expect(assetsDirectory.files.has('asset-gif.gif')).toBe(true);
+    expect(assetsDirectory.files.has('asset-video.mp4')).toBe(true);
+    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    expect(savedProject.assets['asset-gif']).toMatchObject({
+      type: 'gif',
+      fileName: 'asset-gif.gif',
+      storage: 'file',
+    });
+    expect(savedProject.assets['asset-video']).toMatchObject({
+      type: 'video',
+      fileName: 'asset-video.mp4',
+      storage: 'file',
+    });
+    expect(savedProject.assets['asset-gif']?.objectUrl).toBeUndefined();
+    expect(savedProject.assets['asset-video']?.objectUrl).toBeUndefined();
+  });
+
   it('removes stale file-backed assets from project metadata and assets folder on save', async () => {
     const directory = new MockDirectoryHandle();
     const assetsDirectory = new MockDirectoryHandle();

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -2,9 +2,80 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { createSampleProject } from '../../../../src/domain/sampleProject';
+import type { ProjectDocument, VideoElement } from '../../../../src/domain/model';
 import { CanvasWorkspace } from '../../../../src/ui/editor/CanvasWorkspace';
 
 describe('CanvasWorkspace', () => {
+  function createMediaProject(): ProjectDocument {
+    const project = createSampleProject();
+    project.assets['asset-video'] = {
+      id: 'asset-video',
+      type: 'video',
+      name: 'Demo clip',
+      mimeType: 'video/mp4',
+      objectUrl: 'blob:video',
+    };
+    project.assets['asset-gif'] = {
+      id: 'asset-gif',
+      type: 'gif',
+      name: 'Animated loop',
+      mimeType: 'image/gif',
+      objectUrl: 'blob:gif',
+    };
+    project.elements['video-demo'] = {
+      id: 'video-demo',
+      type: 'video',
+      assetId: 'asset-video',
+      x: 120,
+      y: 80,
+      width: 640,
+      height: 360,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      loop: true,
+      controls: true,
+      muted: true,
+      autoplayInPreview: true,
+      trimStartSeconds: 2,
+      trimEndSeconds: 6,
+    };
+    project.elements['gif-demo'] = {
+      id: 'gif-demo',
+      type: 'gif',
+      assetId: 'asset-gif',
+      x: 220,
+      y: 180,
+      width: 320,
+      height: 180,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      playing: true,
+    };
+    project.pages[0]?.elementIds.push('video-demo', 'gif-demo');
+    return project;
+  }
+
+  function updateVideoElement(project: ProjectDocument, patch: Partial<VideoElement>): ProjectDocument {
+    const videoElement = project.elements['video-demo'];
+    if (videoElement?.type !== 'video') {
+      throw new Error('Expected video-demo test fixture to be a video element.');
+    }
+    return {
+      ...project,
+      elements: {
+        ...project.elements,
+        'video-demo': {
+          ...videoElement,
+          ...patch,
+        },
+      },
+    };
+  }
+
   it('renders page elements and selected image toolbar', () => {
     const project = createSampleProject();
     const { container } = render(
@@ -133,6 +204,155 @@ describe('CanvasWorkspace', () => {
     expect(screen.queryByRole('button', { name: 'Cancel BG Remover' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'BG Remover' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  it('does not show image-only floating tools for selected videos or GIFs', () => {
+    const project = createMediaProject();
+
+    const { rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'BG Remover' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Flip' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Crop' })).not.toBeInTheDocument();
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['gif-demo'] }}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'BG Remover' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Flip' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Crop' })).not.toBeInTheDocument();
+  });
+
+  it('renders video media with playback attributes and preview autoplay', () => {
+    const project = createMediaProject();
+
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+
+    const editorVideo = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    expect(editorVideo).toBeInTheDocument();
+    expect(editorVideo.autoplay).toBe(false);
+    expect(editorVideo.loop).toBe(true);
+    expect(editorVideo.controls).toBe(true);
+    expect(editorVideo.muted).toBe(true);
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    const previewVideo = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    expect(previewVideo.autoplay).toBe(true);
+    expect(previewVideo.dataset.trimStart).toBe('2');
+    expect(previewVideo.dataset.trimEnd).toBe('6');
+  });
+
+  it('allows native controls on the selected video in editor mode', () => {
+    const project = createMediaProject();
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+      />,
+    );
+
+    const unselectedVideo = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    expect(unselectedVideo.style.pointerEvents).toBe('none');
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+
+    const selectedVideo = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    expect(selectedVideo.style.pointerEvents).toBe('auto');
+  });
+
+  it('seeks the selected video when trim sliders update the boundaries', () => {
+    const project = createMediaProject();
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+
+    const video = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    fireEvent.loadedMetadata(video);
+    expect(video.currentTime).toBe(2);
+
+    const startTrimmedProject = updateVideoElement(project, { trimStartSeconds: 4 });
+    rerender(
+      <CanvasWorkspace
+        project={startTrimmedProject}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+    expect(video.currentTime).toBe(4);
+
+    const endTrimmedProject = updateVideoElement(startTrimmedProject, { trimEndSeconds: 5 });
+    rerender(
+      <CanvasWorkspace
+        project={endTrimmedProject}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+    expect(video.currentTime).toBe(5);
+  });
+
+  it('renders GIF media as an animated non-image element', () => {
+    const project = createMediaProject();
+    const { container } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['gif-demo'] }}
+      />,
+    );
+
+    expect(container.querySelector('img[aria-label="Animated loop"]')).toBeInTheDocument();
+  });
+
+  it('keeps selected GIF overlays transparent to pointer input so the canvas object can move', () => {
+    const project = createMediaProject();
+    const { container } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['gif-demo'] }}
+      />,
+    );
+
+    const selectedGif = container.querySelector('img[aria-label="Animated loop"]') as HTMLImageElement;
+    expect(selectedGif.style.pointerEvents).toBe('none');
   });
 
   it('shows image extraction progress before segmentation is ready', () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -160,6 +160,37 @@ function createClipboardData(options: { editorObject?: boolean; files?: File[] }
   };
 }
 
+function createProjectWithVideo(): ProjectDocument {
+  const project = createSampleProject();
+  project.assets['asset-video'] = {
+    id: 'asset-video',
+    type: 'video',
+    name: 'Demo clip',
+    mimeType: 'video/mp4',
+    objectUrl: 'blob:video',
+  };
+  project.elements['video-demo'] = {
+    id: 'video-demo',
+    type: 'video',
+    assetId: 'asset-video',
+    x: 120,
+    y: 80,
+    width: 640,
+    height: 360,
+    rotation: 0,
+    locked: false,
+    visible: true,
+    opacity: 1,
+    loop: false,
+    controls: true,
+    muted: true,
+    autoplayInPreview: true,
+    trimStartSeconds: 0,
+  };
+  project.pages[0]?.elementIds.push('video-demo');
+  return project;
+}
+
 function createReadyPrepareTranslationMock() {
   return vi.fn(
     (
@@ -192,6 +223,21 @@ async function selectImageLayer(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Selected Image' }));
 }
 
+function mockVideoMetadataLoad() {
+  const createElement = document.createElement.bind(document);
+  return vi.spyOn(document, 'createElement').mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+    const element = createElement(tagName, options);
+    if (tagName.toLowerCase() === 'video') {
+      Object.defineProperty(element, 'videoWidth', { configurable: true, value: 1280 });
+      Object.defineProperty(element, 'videoHeight', { configurable: true, value: 720 });
+      queueMicrotask(() => {
+        element.dispatchEvent(new Event('loadedmetadata'));
+      });
+    }
+    return element;
+  });
+}
+
 describe('EditorShell', () => {
   afterEach(() => {
     window.history.pushState({}, '', '/editor/');
@@ -200,6 +246,7 @@ describe('EditorShell', () => {
       value: undefined,
     });
     delete (window as WebMcpDemoWindow).localStudioWebMcpTools;
+    vi.restoreAllMocks();
   });
 
   it('registers WebMCP tools when explicitly enabled', async () => {
@@ -672,7 +719,7 @@ describe('EditorShell', () => {
     );
   });
 
-  it('inserts text and images from the floating toolbar', async () => {
+  it('inserts text and media from the floating toolbar', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
     const repository = new SavingProjectRepository();
@@ -712,13 +759,41 @@ describe('EditorShell', () => {
 
     const image = new File(['image-bytes'], 'toolbar-image.png', { type: 'image/png' });
     await selectImageLayer(user);
-    await user.click(screen.getByRole('button', { name: 'Insert Image' }));
-    await user.upload(screen.getByLabelText('Insert image file'), image);
+    await user.click(screen.getByRole('button', { name: 'Insert Media' }));
+    await user.upload(screen.getByLabelText('Insert media file'), image);
 
     expect(await screen.findByRole('button', { name: 'toolbar-image.png' })).toHaveAttribute(
       'aria-pressed',
       'true',
     );
+
+    mockVideoMetadataLoad();
+    const video = new File(['video-bytes'], 'toolbar-video.mp4', { type: 'video/mp4' });
+    await user.click(screen.getByRole('button', { name: 'Insert Media' }));
+    await user.upload(screen.getByLabelText('Insert media file'), video);
+
+    await waitFor(() => {
+      const savedProject = repository.savedProjects.at(-1);
+      const importedVideo = Object.values(savedProject?.elements ?? {}).find(
+        (element) => element.type === 'video',
+      );
+      expect(importedVideo).toMatchObject({ type: 'video' });
+      expect(savedProject?.assets[importedVideo?.assetId ?? '']?.name).toBe('toolbar-video.mp4');
+    });
+    expect(screen.getByRole('tab', { name: 'Design' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByLabelText('Show selected video controls')).toBeChecked();
+  });
+
+  it('opens the media settings panel when a video layer is selected', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices({ initialProject: createProjectWithVideo() })} />);
+
+    await openLeftTab(user, 'Layout');
+    await user.click(screen.getByRole('button', { name: 'Demo clip' }));
+
+    expect(screen.getByRole('tab', { name: 'Design' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Playback')).toBeInTheDocument();
+    expect(screen.getByLabelText('Show selected video controls')).toBeChecked();
   });
 
   it('deletes the selected layer with Delete and Backspace keystrokes', async () => {

--- a/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
@@ -58,10 +58,10 @@ describe('LeftToolPanel', () => {
     expect(screen.queryByText('Image Editing Models')).not.toBeInTheDocument();
   });
 
-  it('imports image files from the Assets menu', async () => {
+  it('imports media files from the Assets menu', async () => {
     const user = userEvent.setup();
-    const onImportImage = vi.fn();
-    const file = new File(['image'], 'asset.png', { type: 'image/png' });
+    const onImportMedia = vi.fn();
+    const file = new File(['video'], 'clip.mp4', { type: 'video/mp4' });
 
     render(
       <LeftToolPanel
@@ -72,14 +72,14 @@ describe('LeftToolPanel', () => {
         activePageId="page-1"
         selection={{ pageId: 'page-1', elementIds: [] }}
         modelStates={modelStates}
-        onImportImage={onImportImage}
+        onImportMedia={onImportMedia}
       />,
     );
 
     await user.click(screen.getByRole('tab', { name: 'Assets' }));
-    await user.upload(screen.getByLabelText('Import image file'), file);
+    await user.upload(screen.getByLabelText('Import media file'), file);
 
-    expect(onImportImage).toHaveBeenCalledWith(file);
+    expect(onImportMedia).toHaveBeenCalledWith(file);
   });
 
   it('adds styled text presets from the Text menu', async () => {

--- a/apps/editor/tests/unit/ui/editor/PageRail.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/PageRail.test.tsx
@@ -26,7 +26,7 @@ describe('PageRail', () => {
     expect(onAddPage).toHaveBeenCalledTimes(1);
   });
 
-  it('imports a local image file from disk', async () => {
+  it('imports a local media file from disk', async () => {
     const user = userEvent.setup();
     const onImportImage = vi.fn();
     const file = new File(['image-bytes'], 'sample.png', { type: 'image/png' });
@@ -39,7 +39,7 @@ describe('PageRail', () => {
       />,
     );
 
-    await user.upload(screen.getByLabelText('Import image file'), file);
+    await user.upload(screen.getByLabelText('Import media file'), file);
 
     expect(onImportImage).toHaveBeenCalledWith(file);
   });

--- a/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { createSampleProject } from '../../../../src/domain/sampleProject';
+import type { ProjectDocument } from '../../../../src/domain/model';
 import { RightPanel } from '../../../../src/ui/editor/RightPanel';
 
 const modelStates = [
@@ -18,6 +19,59 @@ const modelStates = [
 
 describe('RightPanel', () => {
   const project = createSampleProject();
+
+  function createMediaProject(): ProjectDocument {
+    const mediaProject = createSampleProject();
+    mediaProject.assets['asset-video'] = {
+      id: 'asset-video',
+      type: 'video',
+      name: 'Demo clip',
+      mimeType: 'video/mp4',
+      objectUrl: 'blob:video',
+    };
+    mediaProject.assets['asset-gif'] = {
+      id: 'asset-gif',
+      type: 'gif',
+      name: 'Animated loop',
+      mimeType: 'image/gif',
+      objectUrl: 'blob:gif',
+    };
+    mediaProject.elements['video-demo'] = {
+      id: 'video-demo',
+      type: 'video',
+      assetId: 'asset-video',
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      loop: false,
+      controls: false,
+      muted: false,
+      autoplayInPreview: false,
+      trimStartSeconds: 0,
+      trimEndSeconds: 0,
+    };
+    mediaProject.elements['gif-demo'] = {
+      id: 'gif-demo',
+      type: 'gif',
+      assetId: 'asset-gif',
+      x: 0,
+      y: 0,
+      width: 320,
+      height: 180,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      playing: true,
+    };
+    mediaProject.pages[0]?.elementIds.push('video-demo', 'gif-demo');
+    return mediaProject;
+  }
 
   it('switches between Layout, Design, and AI Tools tabs', async () => {
     const user = userEvent.setup();
@@ -233,5 +287,65 @@ describe('RightPanel', () => {
 
     await user.selectOptions(screen.getByLabelText('Selected text alignment'), 'left');
     expect(onUpdateElementStyle).toHaveBeenCalledWith('text-title', { align: 'left' });
+  });
+
+  it('shows video playback settings for selected videos', async () => {
+    const user = userEvent.setup();
+    const onUpdateMediaPlayback = vi.fn();
+
+    render(
+      <RightPanel
+        activeTab="design"
+        onTabChange={vi.fn()}
+        project={createMediaProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+        modelStates={modelStates}
+        onUpdateMediaPlayback={onUpdateMediaPlayback}
+      />,
+    );
+
+    expect(screen.getByText('Playback')).toBeInTheDocument();
+    expect(screen.getByLabelText('Loop selected video')).not.toBeChecked();
+    expect(screen.getByLabelText('Show selected video controls')).not.toBeChecked();
+    expect(screen.getByLabelText('Mute selected video')).not.toBeChecked();
+    expect(screen.getByLabelText('Autoplay selected video in preview')).not.toBeChecked();
+
+    await user.click(screen.getByLabelText('Loop selected video'));
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { loop: true });
+
+    expect(screen.getByLabelText('Selected video trim start')).toHaveAttribute('type', 'range');
+    expect(screen.getByLabelText('Selected video trim end')).toHaveAttribute('type', 'range');
+
+    fireEvent.change(screen.getByLabelText('Selected video trim start'), {
+      target: { value: '1.5' },
+    });
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { trimStartSeconds: 1.5 });
+
+    fireEvent.change(screen.getByLabelText('Selected video trim end'), {
+      target: { value: '9.5' },
+    });
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { trimEndSeconds: 9.5 });
+  });
+
+  it('does not show playback controls for selected GIF objects', () => {
+    const onUpdateMediaPlayback = vi.fn();
+
+    render(
+      <RightPanel
+        activeTab="design"
+        onTabChange={vi.fn()}
+        project={createMediaProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['gif-demo'] }}
+        modelStates={modelStates}
+        onUpdateMediaPlayback={onUpdateMediaPlayback}
+      />,
+    );
+
+    expect(screen.queryByText('GIF Playback')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Play selected GIF')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Selected video trim start')).not.toBeInTheDocument();
+    expect(onUpdateMediaPlayback).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Adds support for GIF and video assets across the editor model, commands, and browser file-system repository.
- Updates the canvas, page rail, panels, and shell to surface and manage media-rich slides.
- Extends editor automation and view-model flows to handle the new slide content consistently.
- Covers the new behavior with domain, service, and UI tests.

## Testing
- Added and updated unit tests for domain commands, repository asset handling, and editor UI components.
- Verified the editor flow with targeted component and interaction coverage.