### PR TITLE
Add public asset planning and mirror settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ Save project files to disk and restore from local version history.
 
 ![Local project history](apps/landing/public/fs-history.gif)
 
+### Mirror projects with MinIO
+
+LocalStudio can mirror the complete project folder to MinIO so another computer can import the same project, assets, and version history. Local disk is still the source of truth while editing; MinIO sync runs in the background after successful local saves.
+
+Start the local MinIO stack:
+
+```bash
+docker compose -f docker-compose.minio.yml up
+```
+
+Default local settings:
+
+- API endpoint: `http://localhost:9000`
+- Console: `http://localhost:9001`
+- Bucket: `localstudio`
+- Access key: `localstudio`
+- Secret key: `localstudio123`
+- Region: `us-east-1`
+- Public base URL: `http://localhost:9000/localstudio`
+- Prefix: `mirrors`
+- Path-style URLs: enabled
+
+In the editor, open `File` -> `Mirror Settings` and enter those values. Use `File` -> `Mirror Now` to force an upload, or `File` -> `Import Remote` on another computer to download a mirrored project into a new local folder and continue syncing.
+
+The dev compose file sets the `localstudio` bucket to public download mode so mirrored files can be shared through the public base URL. For production, use a MinIO bucket or prefix policy that matches what you intend to publish. Browser-stored MinIO keys are persisted locally, so scope credentials to this bucket and avoid using root credentials outside local development.
+
 ### Powered by Web AI
 
 Browser-native AI capabilities keep the workflow fast, private, and local-first.

--- a/apps/editor/src/app/composition.ts
+++ b/apps/editor/src/app/composition.ts
@@ -6,6 +6,7 @@ import type {
   ImageGenerationService,
   LocalSetupService,
   MagicEraserService,
+  MirrorService,
   ModelSetupService,
   PaletteService,
   PromptService,
@@ -31,6 +32,7 @@ import { BrowserModelSetupService } from '../services/modelSetupService';
 import { BrowserShareService } from '../services/shareService';
 import { TransformersLanguageDetectionRuntime } from '../services/webGpuLanguageDetectionRuntime';
 import { TransformersTextGenerationRuntime } from '../services/webGpuTextGenerationRuntime';
+import { MinioMirrorService, type MinioMirrorConfig } from '../services/minioMirrorService';
 
 export interface AppServices {
   initialProject: ProjectDocument;
@@ -49,6 +51,7 @@ export interface AppServices {
   backgroundRemovalService: BackgroundRemovalService;
   smartGrabService: SmartGrabService;
   magicEraserService: MagicEraserService;
+  mirrorService: MirrorService<MinioMirrorConfig>;
 }
 
 interface CreateAppServicesOptions {
@@ -86,12 +89,18 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
       textGenerationRuntime,
       languageDetectionRuntime,
     ),
-    promptService: new BrowserPromptService(modelSetupService, undefined, undefined, textGenerationRuntime),
+    promptService: new BrowserPromptService(
+      modelSetupService,
+      undefined,
+      undefined,
+      textGenerationRuntime,
+    ),
     imageGenerationService: new BrowserImageGenerationService(),
     paletteService: new MockPaletteService(),
     backgroundRemovalService: new BrowserBackgroundRemovalService(),
     smartGrabService: new MockSmartGrabService(),
     magicEraserService: new MockMagicEraserService(),
+    mirrorService: new MinioMirrorService(),
   };
 }
 

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -23,9 +23,7 @@ body {
   display: grid;
   place-items: center;
   padding: 32px;
-  background:
-    linear-gradient(180deg, rgba(55, 253, 118, 0.07), transparent 34%),
-    var(--ew-bg);
+  background: linear-gradient(180deg, rgba(55, 253, 118, 0.07), transparent 34%), var(--ew-bg);
   color: var(--ew-text);
 }
 
@@ -183,8 +181,7 @@ button {
   grid-template-columns: minmax(380px, 520px) minmax(720px, 1fr);
   background:
     linear-gradient(90deg, rgba(46, 167, 255, 0.14), transparent 42%),
-    linear-gradient(180deg, rgba(55, 253, 118, 0.08), transparent 36%),
-    #05090a;
+    linear-gradient(180deg, rgba(55, 253, 118, 0.08), transparent 36%), #05090a;
   color: #eefaf5;
 }
 
@@ -487,8 +484,7 @@ button {
   min-height: 100vh;
   padding: 18px;
   background:
-    linear-gradient(135deg, rgba(159, 255, 210, 0.08), transparent 30%),
-    rgba(3, 5, 6, 0.88);
+    linear-gradient(135deg, rgba(159, 255, 210, 0.08), transparent 30%), rgba(3, 5, 6, 0.88);
 }
 
 .webmcp-editor-frame iframe {
@@ -669,6 +665,12 @@ button {
   cursor: not-allowed;
 }
 
+.toolbar-dropdown-separator {
+  height: 1px;
+  margin: 6px 2px;
+  background: rgba(122, 255, 199, 0.16);
+}
+
 .toolbar-divider {
   width: 1px;
   height: 24px;
@@ -813,6 +815,10 @@ button {
   gap: 4px;
 }
 
+.toolbar-icon-group {
+  position: relative;
+}
+
 .stitch-icon-button {
   position: relative;
   width: 32px;
@@ -843,6 +849,59 @@ button {
 
 .persistence-on {
   color: var(--ew-green);
+}
+
+.persistence-attention {
+  color: #f6c453;
+  animation: persistencePulse 900ms ease-in-out infinite;
+}
+
+.persistence-notice {
+  position: absolute;
+  top: 42px;
+  left: 0;
+  z-index: 151;
+  width: max-content;
+  max-width: 260px;
+  border: 1px solid rgba(246, 196, 83, 0.34);
+  border-radius: 6px;
+  background: rgba(18, 16, 8, 0.98);
+  color: #f6c453;
+  font-size: 12px;
+  line-height: 1.35;
+  padding: 8px 10px;
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.42);
+}
+
+@keyframes persistencePulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(246, 196, 83, 0);
+  }
+
+  50% {
+    box-shadow: 0 0 0 5px rgba(246, 196, 83, 0.18);
+  }
+}
+
+.mirror-status-button {
+  color: var(--ew-dim);
+}
+
+.mirror-syncing {
+  color: #f6c453;
+}
+
+.mirror-synced {
+  color: var(--ew-green);
+}
+
+.mirror-failed {
+  color: #ffb4ab;
+}
+
+.mirror-disabled {
+  color: var(--ew-dim);
 }
 
 .persistence-unavailable {
@@ -1244,8 +1303,7 @@ button {
   opacity: 0.8;
   background:
     linear-gradient(135deg, rgba(55, 253, 118, 0.18), transparent 45%),
-    radial-gradient(circle at 70% 30%, rgba(0, 119, 154, 0.45), transparent 38%),
-    #111f14;
+    radial-gradient(circle at 70% 30%, rgba(0, 119, 154, 0.45), transparent 38%), #111f14;
 }
 
 .slide-empty-icon {
@@ -1529,9 +1587,7 @@ button {
   place-items: center;
   border: 1px dashed rgba(55, 253, 118, 0.3);
   border-radius: 3px;
-  background:
-    linear-gradient(135deg, rgba(55, 253, 118, 0.08), transparent 44%),
-    #050d10;
+  background: linear-gradient(135deg, rgba(55, 253, 118, 0.08), transparent 44%), #050d10;
   color: var(--ew-muted);
   cursor: pointer;
   font-family: 'Orbitron', sans-serif;
@@ -1734,9 +1790,7 @@ button {
   border: 1px solid rgba(55, 253, 118, 0.42);
   border-radius: 6px;
   color: var(--ew-muted);
-  background:
-    linear-gradient(135deg, rgba(55, 253, 118, 0.16), transparent),
-    #101b1d;
+  background: linear-gradient(135deg, rgba(55, 253, 118, 0.16), transparent), #101b1d;
 }
 
 .canvas-title,
@@ -1919,10 +1973,34 @@ button {
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(to right, transparent calc(33.333% - 0.5px), rgba(255, 255, 255, 0.42) calc(33.333% - 0.5px), rgba(255, 255, 255, 0.42) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px)),
-    linear-gradient(to right, transparent calc(66.666% - 0.5px), rgba(255, 255, 255, 0.42) calc(66.666% - 0.5px), rgba(255, 255, 255, 0.42) calc(66.666% + 0.5px), transparent calc(66.666% + 0.5px)),
-    linear-gradient(to bottom, transparent calc(33.333% - 0.5px), rgba(255, 255, 255, 0.42) calc(33.333% - 0.5px), rgba(255, 255, 255, 0.42) calc(33.333% + 0.5px), transparent calc(33.333% + 0.5px)),
-    linear-gradient(to bottom, transparent calc(66.666% - 0.5px), rgba(255, 255, 255, 0.42) calc(66.666% - 0.5px), rgba(255, 255, 255, 0.42) calc(66.666% + 0.5px), transparent calc(66.666% + 0.5px));
+    linear-gradient(
+      to right,
+      transparent calc(33.333% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(33.333% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(33.333% + 0.5px),
+      transparent calc(33.333% + 0.5px)
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(66.666% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(66.666% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(66.666% + 0.5px),
+      transparent calc(66.666% + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(33.333% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(33.333% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(33.333% + 0.5px),
+      transparent calc(33.333% + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(66.666% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(66.666% - 0.5px),
+      rgba(255, 255, 255, 0.42) calc(66.666% + 0.5px),
+      transparent calc(66.666% + 0.5px)
+    );
   opacity: 0.55;
 }
 
@@ -2142,7 +2220,9 @@ button {
 .text-toolbar-font {
   width: 124px;
   padding: 0 10px;
-  font: 600 13px 'Open Sans', sans-serif;
+  font:
+    600 13px 'Open Sans',
+    sans-serif;
 }
 
 .text-toolbar-size {
@@ -2160,7 +2240,9 @@ button {
   background: transparent;
   color: var(--ew-text);
   text-align: center;
-  font: 800 13px 'Open Sans', sans-serif;
+  font:
+    800 13px 'Open Sans',
+    sans-serif;
 }
 
 .text-toolbar-size button {
@@ -2204,7 +2286,9 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font: 900 14px 'Open Sans', sans-serif;
+  font:
+    900 14px 'Open Sans',
+    sans-serif;
   cursor: pointer;
   transition:
     background 140ms ease,
@@ -2357,8 +2441,7 @@ button {
   overflow: hidden;
   background:
     radial-gradient(circle at 24% 42%, rgba(55, 253, 118, 0.22), transparent 24%),
-    linear-gradient(135deg, rgba(55, 253, 118, 0.12), transparent 52%),
-    #050d10;
+    linear-gradient(135deg, rgba(55, 253, 118, 0.12), transparent 52%), #050d10;
 }
 
 .page-card-canvas-hidden {
@@ -2446,6 +2529,15 @@ button {
   gap: 10px;
 }
 
+.editor-footer-left {
+  min-width: 32px;
+}
+
+.footer-settings-button {
+  border: 1px solid rgba(122, 255, 199, 0.12);
+  background: rgba(5, 13, 16, 0.48);
+}
+
 .footer-note,
 .footer-toggle,
 .footer-page-count {
@@ -2473,6 +2565,310 @@ button {
   border-color: rgba(55, 253, 118, 0.28);
   background: rgba(55, 253, 118, 0.08);
   color: var(--ew-green);
+}
+
+.settings-panel,
+.mirror-settings-panel,
+.remote-import-panel {
+  position: fixed;
+  left: 16px;
+  bottom: 52px;
+  z-index: 140;
+  width: min(440px, calc(100vw - 32px));
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(122, 255, 199, 0.2);
+  border-radius: 8px;
+  background: rgba(8, 18, 12, 0.98);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.48),
+    0 0 24px rgba(55, 253, 118, 0.08);
+}
+
+.settings-panel {
+  width: min(280px, calc(100vw - 32px));
+}
+
+.remote-import-panel {
+  width: min(360px, calc(100vw - 32px));
+}
+
+.local-project-setup-panel {
+  position: absolute;
+  top: 42px;
+  left: 0;
+  z-index: 150;
+  width: min(380px, calc(100vw - 32px));
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid rgba(122, 255, 199, 0.2);
+  border-radius: 8px;
+  background: rgba(8, 18, 12, 0.98);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.48),
+    0 0 24px rgba(55, 253, 118, 0.08);
+}
+
+.settings-panel-header,
+.mirror-settings-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.settings-panel-header h2,
+.mirror-settings-header h2,
+.mirror-settings-header p {
+  margin: 0;
+}
+
+.settings-panel-header h2,
+.mirror-settings-header h2 {
+  color: var(--ew-text);
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-panel-row {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(122, 255, 199, 0.14);
+  border-radius: 6px;
+  background: rgba(5, 13, 16, 0.72);
+  color: var(--ew-text);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 0 10px;
+  text-align: left;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.settings-panel-row:hover {
+  border-color: rgba(55, 253, 118, 0.28);
+  background: rgba(55, 253, 118, 0.08);
+  color: var(--ew-green);
+}
+
+.settings-panel-header p,
+.mirror-settings-header p,
+.mirror-settings-status {
+  color: var(--ew-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.settings-panel-header p {
+  margin: 4px 0 0;
+}
+
+.mirror-settings-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.mirror-settings-grid label {
+  display: grid;
+  gap: 5px;
+  color: var(--ew-muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.mirror-settings-grid label:first-child,
+.mirror-settings-grid label:nth-child(6),
+.mirror-settings-grid label:nth-child(7) {
+  grid-column: 1 / -1;
+}
+
+.mirror-settings-grid input {
+  min-width: 0;
+  height: 32px;
+  border: 1px solid rgba(122, 255, 199, 0.18);
+  border-radius: 4px;
+  outline: 0;
+  background: rgba(5, 13, 16, 0.9);
+  color: var(--ew-text);
+  font-size: 12px;
+  padding: 0 9px;
+}
+
+.mirror-settings-grid input:focus {
+  border-color: var(--ew-green);
+  box-shadow: 0 0 0 2px rgba(55, 253, 118, 0.14);
+}
+
+.local-project-setup-field {
+  display: grid;
+  gap: 6px;
+  color: var(--ew-muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.local-project-setup-field input {
+  min-width: 0;
+  height: 34px;
+  border: 1px solid rgba(122, 255, 199, 0.18);
+  border-radius: 4px;
+  outline: 0;
+  background: rgba(5, 13, 16, 0.9);
+  color: var(--ew-text);
+  font-size: 13px;
+  padding: 0 9px;
+}
+
+.local-project-setup-field input:focus {
+  border-color: var(--ew-green);
+  box-shadow: 0 0 0 2px rgba(55, 253, 118, 0.14);
+}
+
+.mirror-secret-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 32px;
+  gap: 6px;
+}
+
+.mirror-secret-toggle {
+  border: 1px solid rgba(122, 255, 199, 0.18);
+  background: rgba(5, 13, 16, 0.72);
+}
+
+.mirror-checkbox-row {
+  grid-column: 1 / -1;
+  display: inline-flex !important;
+  align-items: center;
+  gap: 8px !important;
+}
+
+.mirror-checkbox-row input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--ew-green);
+}
+
+.mirror-settings-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+}
+
+.mirror-settings-status-error {
+  color: #ffb4ab;
+}
+
+.mirror-settings-help {
+  display: grid;
+  gap: 8px;
+  color: var(--ew-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.mirror-settings-help p {
+  margin: 0;
+}
+
+.mirror-settings-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mirror-settings-links a {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(55, 253, 118, 0.24);
+  border-radius: 4px;
+  color: var(--ew-green);
+  padding: 0 8px;
+  text-decoration: none;
+}
+
+.mirror-settings-links a:hover {
+  background: rgba(55, 253, 118, 0.08);
+}
+
+.mirror-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.remote-import-status {
+  margin: 0;
+  color: var(--ew-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.remote-import-status-error {
+  color: #ffb4ab;
+}
+
+.remote-import-list {
+  display: grid;
+  gap: 8px;
+}
+
+.remote-import-row {
+  width: 100%;
+  min-height: 52px;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(122, 255, 199, 0.14);
+  border-radius: 6px;
+  background: rgba(5, 13, 16, 0.72);
+  color: var(--ew-text);
+  cursor: pointer;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.remote-import-row:hover:not(:disabled) {
+  border-color: rgba(55, 253, 118, 0.28);
+  background: rgba(55, 253, 118, 0.08);
+}
+
+.remote-import-row:disabled {
+  cursor: wait;
+  opacity: 0.64;
+}
+
+.remote-import-row strong,
+.remote-import-row small {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remote-import-row strong {
+  font-size: 13px;
+}
+
+.remote-import-row small {
+  margin-top: 3px;
+  color: var(--ew-muted);
+  font-size: 11px;
 }
 
 .prompt-examples {

--- a/apps/editor/src/services/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/browserFileSystemProjectRepository.ts
@@ -1,5 +1,6 @@
 import type { ProjectDocument } from '../domain/model';
 import type {
+  MirrorFile,
   ProjectRepository,
   VersionHistoryEntry,
   VersionHistoryManifest,
@@ -23,7 +24,9 @@ type PermissionCapableDirectoryHandle = FileSystemDirectoryHandle & {
 
 type WindowWithDirectoryPicker = Window &
   typeof globalThis & {
-    showDirectoryPicker?: (options?: { mode?: 'read' | 'readwrite' }) => Promise<FileSystemDirectoryHandle>;
+    showDirectoryPicker?: (options?: {
+      mode?: 'read' | 'readwrite';
+    }) => Promise<FileSystemDirectoryHandle>;
   };
 
 const PROJECT_FILE_NAME = 'project.json';
@@ -99,7 +102,11 @@ async function createFileBackedProjectSnapshot(
 
     if (!isDataUrl(asset.objectUrl) && !isBlobUrl(asset.objectUrl)) continue;
     const fileName = asset.fileName ?? `${assetId}.${getAssetFileExtension(asset.mimeType)}`;
-    await writeBlobFileToDirectory(assetsDirectory, fileName, await objectUrlToBlob(asset.objectUrl));
+    await writeBlobFileToDirectory(
+      assetsDirectory,
+      fileName,
+      await objectUrlToBlob(asset.objectUrl),
+    );
     const assetForDisk = { ...asset };
     delete assetForDisk.objectUrl;
     projectForDisk.assets[assetId] = {
@@ -123,11 +130,24 @@ async function writeBlobFileToDirectory(
   await writable.close();
 }
 
+async function readProjectNameFromMirrorFiles(files: MirrorFile[]) {
+  const projectFile = files.find((file) => file.path === PROJECT_FILE_NAME);
+  if (!projectFile) return undefined;
+  const project = JSON.parse(await projectFile.blob.text()) as ProjectDocument;
+  return project.name.trim() || undefined;
+}
+
 function getChangedElementKeys(previousProject: ProjectDocument, nextProject: ProjectDocument) {
   const changedElementIds = new Set<string>();
-  const elementIds = new Set([...Object.keys(previousProject.elements), ...Object.keys(nextProject.elements)]);
+  const elementIds = new Set([
+    ...Object.keys(previousProject.elements),
+    ...Object.keys(nextProject.elements),
+  ]);
   for (const elementId of elementIds) {
-    if (JSON.stringify(previousProject.elements[elementId]) !== JSON.stringify(nextProject.elements[elementId])) {
+    if (
+      JSON.stringify(previousProject.elements[elementId]) !==
+      JSON.stringify(nextProject.elements[elementId])
+    ) {
       changedElementIds.add(elementId);
     }
   }
@@ -158,7 +178,10 @@ function createChangeSummary(project: ProjectDocument, previousProject?: Project
     firstChangedElementId ??= elementId;
   }
 
-  const pageIds = new Set([...previousProject.pages.map((page) => page.id), ...project.pages.map((page) => page.id)]);
+  const pageIds = new Set([
+    ...previousProject.pages.map((page) => page.id),
+    ...project.pages.map((page) => page.id),
+  ]);
   for (const pageId of pageIds) {
     const previousPage = previousProject.pages.find((page) => page.id === pageId);
     const nextPage = project.pages.find((page) => page.id === pageId);
@@ -166,12 +189,19 @@ function createChangeSummary(project: ProjectDocument, previousProject?: Project
       changeCount += 1;
       firstChangedPageId ??= nextPage?.id ?? previousPage?.id;
       const pageElementIds = [...(nextPage?.elementIds ?? []), ...(previousPage?.elementIds ?? [])];
-      firstChangedElementId ??= pageElementIds.find((elementId) => changedElementIds.has(elementId));
+      firstChangedElementId ??= pageElementIds.find((elementId) =>
+        changedElementIds.has(elementId),
+      );
     }
   }
 
-  for (const assetId of new Set([...Object.keys(previousProject.assets), ...Object.keys(project.assets)])) {
-    if (JSON.stringify(previousProject.assets[assetId]) !== JSON.stringify(project.assets[assetId])) {
+  for (const assetId of new Set([
+    ...Object.keys(previousProject.assets),
+    ...Object.keys(project.assets),
+  ])) {
+    if (
+      JSON.stringify(previousProject.assets[assetId]) !== JSON.stringify(project.assets[assetId])
+    ) {
       changeCount += 1;
     }
   }
@@ -195,6 +225,8 @@ function createChangeSummary(project: ProjectDocument, previousProject?: Project
 
 export class BrowserFileSystemProjectRepository implements ProjectRepository {
   private directoryHandle: FileSystemDirectoryHandle | null = null;
+  private parentDirectoryHandle: FileSystemDirectoryHandle | null = null;
+  private projectDirectoryName: string | null = null;
   private readonly recentProjectStore: RecentProjectHandleStore;
 
   constructor(private readonly options: FileSystemProjectRepositoryOptions = {}) {
@@ -207,6 +239,28 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     await this.recentProjectStore.save(this.directoryHandle);
     const project = await this.loadProject();
     if (project) await this.recentProjectStore.save(this.directoryHandle, project.name);
+    return project;
+  }
+
+  async importMirrorFiles(files: MirrorFile): Promise<ProjectDocument>;
+  async importMirrorFiles(files: MirrorFile[]): Promise<ProjectDocument>;
+  async importMirrorFiles(files: MirrorFile | MirrorFile[]): Promise<ProjectDocument> {
+    const pickDirectory = this.options.pickDirectory ?? getBrowserDirectoryPicker();
+    const selectedDirectoryHandle = await pickDirectory();
+    const mirrorFiles = Array.isArray(files) ? files : [files];
+    const projectDirectoryName = await readProjectNameFromMirrorFiles(mirrorFiles);
+    this.parentDirectoryHandle = projectDirectoryName ? selectedDirectoryHandle : null;
+    this.projectDirectoryName = projectDirectoryName ?? selectedDirectoryHandle.name ?? null;
+    this.directoryHandle = projectDirectoryName
+      ? await selectedDirectoryHandle.getDirectoryHandle(projectDirectoryName, { create: true })
+      : selectedDirectoryHandle;
+    await this.ensureReadWritePermission(this.directoryHandle);
+    for (const file of mirrorFiles) {
+      await this.writeMirrorFile(this.directoryHandle, file);
+    }
+    const project = await this.loadProject();
+    if (!project) throw new Error('The mirrored project did not include project.json.');
+    await this.recentProjectStore.save(this.directoryHandle, project.name);
     return project;
   }
 
@@ -230,8 +284,12 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     return this.hydrateProjectAssets(project);
   }
 
-  async saveProject(project: ProjectDocument): Promise<void> {
-    const directoryHandle = await this.ensureProjectDirectory(project.name);
+  async saveProject(
+    project: ProjectDocument,
+    options?: { projectDirectoryName?: string },
+  ): Promise<void> {
+    const previousProjectDirectoryName = this.projectDirectoryName;
+    const directoryHandle = await this.ensureProjectDirectory(project.name, options);
     const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
     await Promise.all([
       directoryHandle.getDirectoryHandle('cache', { create: true }),
@@ -254,6 +312,15 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       schemaVersion: 1,
       savedAt: new Date().toISOString(),
     });
+    if (
+      previousProjectDirectoryName &&
+      previousProjectDirectoryName !== this.projectDirectoryName &&
+      this.parentDirectoryHandle?.removeEntry
+    ) {
+      await this.parentDirectoryHandle
+        .removeEntry(previousProjectDirectoryName, { recursive: true })
+        .catch(() => undefined);
+    }
   }
 
   async getVersionHistory(): Promise<VersionHistoryEntry[]> {
@@ -262,11 +329,16 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     return manifest.versions;
   }
 
-  async saveVersion(project: ProjectDocument, metadata: VersionSnapshotMetadata): Promise<VersionHistoryEntry> {
+  async saveVersion(
+    project: ProjectDocument,
+    metadata: VersionSnapshotMetadata,
+  ): Promise<VersionHistoryEntry> {
     const directoryHandle = await this.ensureProjectDirectory(project.name);
     const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
     const historyDirectory = await directoryHandle.getDirectoryHandle('history', { create: true });
-    const versionsDirectory = await historyDirectory.getDirectoryHandle('versions', { create: true });
+    const versionsDirectory = await historyDirectory.getDirectoryHandle('versions', {
+      create: true,
+    });
     const manifest = await this.readVersionHistoryManifest(directoryHandle, project.id);
     const createdAt = new Date().toISOString();
     const id = createVersionId(new Date(createdAt));
@@ -280,15 +352,26 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       summary: changeSummary.summary,
       changeCount: changeSummary.changeCount,
       fileName,
-      ...(changeSummary.firstChangedPageId ? { firstChangedPageId: changeSummary.firstChangedPageId } : {}),
-      ...(changeSummary.firstChangedElementId ? { firstChangedElementId: changeSummary.firstChangedElementId } : {}),
+      ...(changeSummary.firstChangedPageId
+        ? { firstChangedPageId: changeSummary.firstChangedPageId }
+        : {}),
+      ...(changeSummary.firstChangedElementId
+        ? { firstChangedElementId: changeSummary.firstChangedElementId }
+        : {}),
     };
 
     const projectForHistory = await createFileBackedProjectSnapshot(project, assetsDirectory);
-    await this.writeJsonFile(versionsDirectory, fileName, cloneProjectForHistory(projectForHistory));
+    await this.writeJsonFile(
+      versionsDirectory,
+      fileName,
+      cloneProjectForHistory(projectForHistory),
+    );
     const nextVersions = [entry, ...manifest.versions.filter((version) => version.id !== entry.id)];
     const retainedVersions = nextVersions.slice(0, VERSION_HISTORY_LIMIT);
-    await this.removePrunedVersionFiles(versionsDirectory, nextVersions.slice(VERSION_HISTORY_LIMIT));
+    await this.removePrunedVersionFiles(
+      versionsDirectory,
+      nextVersions.slice(VERSION_HISTORY_LIMIT),
+    );
     await this.writeJsonFile(historyDirectory, VERSION_HISTORY_FILE_NAME, {
       schemaVersion: 1,
       projectId: project.id,
@@ -310,10 +393,34 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     return this.hydrateProjectAssets(JSON.parse(await file.text()) as ProjectDocument);
   }
 
-  private async ensureProjectDirectory(projectName?: string): Promise<FileSystemDirectoryHandle> {
+  private async ensureProjectDirectory(
+    projectName?: string,
+    options?: { projectDirectoryName?: string },
+  ): Promise<FileSystemDirectoryHandle> {
+    const requestedProjectDirectoryName =
+      options?.projectDirectoryName?.trim() ||
+      (this.parentDirectoryHandle && projectName?.trim() ? projectName.trim() : undefined);
+
     if (!this.directoryHandle) {
       const pickDirectory = this.options.pickDirectory ?? getBrowserDirectoryPicker();
-      this.directoryHandle = await pickDirectory();
+      const selectedDirectoryHandle = await pickDirectory();
+      this.parentDirectoryHandle = requestedProjectDirectoryName ? selectedDirectoryHandle : null;
+      this.projectDirectoryName = requestedProjectDirectoryName ?? selectedDirectoryHandle.name ?? null;
+      this.directoryHandle = requestedProjectDirectoryName
+        ? await selectedDirectoryHandle.getDirectoryHandle(requestedProjectDirectoryName, {
+            create: true,
+          })
+        : selectedDirectoryHandle;
+    } else if (
+      requestedProjectDirectoryName &&
+      this.parentDirectoryHandle &&
+      requestedProjectDirectoryName !== this.projectDirectoryName
+    ) {
+      this.directoryHandle = await this.parentDirectoryHandle.getDirectoryHandle(
+        requestedProjectDirectoryName,
+        { create: true },
+      );
+      this.projectDirectoryName = requestedProjectDirectoryName;
     }
     const directoryHandle = this.directoryHandle;
     await this.ensureReadWritePermission(directoryHandle);
@@ -332,10 +439,16 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       const nextPermission = await permissionCapableHandle.requestPermission(permissions);
       if (nextPermission === 'granted') return;
     }
-    throw new Error('LocalStudio.dev needs permission to read and write the selected project folder.');
+    throw new Error(
+      'LocalStudio.dev needs permission to read and write the selected project folder.',
+    );
   }
 
-  private async writeJsonFile(directoryHandle: FileSystemDirectoryHandle, fileName: string, value: unknown) {
+  private async writeJsonFile(
+    directoryHandle: FileSystemDirectoryHandle,
+    fileName: string,
+    value: unknown,
+  ) {
     const temporaryFileName = `${fileName}.tmp`;
     await this.writeTextFile(directoryHandle, temporaryFileName, JSON.stringify(value, null, 2));
     await this.writeTextFile(directoryHandle, fileName, JSON.stringify(value, null, 2));
@@ -344,7 +457,11 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     }
   }
 
-  private async writeTextFile(directoryHandle: FileSystemDirectoryHandle, fileName: string, value: string) {
+  private async writeTextFile(
+    directoryHandle: FileSystemDirectoryHandle,
+    fileName: string,
+    value: string,
+  ) {
     const fileHandle = await directoryHandle.getFileHandle(fileName, { create: true });
     const writable = await fileHandle.createWritable();
     await writable.write(value);
@@ -369,9 +486,25 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     await Promise.all(removals);
   }
 
-  private async removePrunedVersionFiles(directoryHandle: FileSystemDirectoryHandle, entries: VersionHistoryEntry[]) {
+  private async writeMirrorFile(directoryHandle: FileSystemDirectoryHandle, file: MirrorFile) {
+    const pathParts = file.path.split('/').filter(Boolean);
+    const fileName = pathParts.pop();
+    if (!fileName) return;
+    let currentDirectory = directoryHandle;
+    for (const directoryName of pathParts) {
+      currentDirectory = await currentDirectory.getDirectoryHandle(directoryName, { create: true });
+    }
+    await writeBlobFileToDirectory(currentDirectory, fileName, file.blob);
+  }
+
+  private async removePrunedVersionFiles(
+    directoryHandle: FileSystemDirectoryHandle,
+    entries: VersionHistoryEntry[],
+  ) {
     if (!directoryHandle.removeEntry) return;
-    await Promise.all(entries.map((entry) => directoryHandle.removeEntry(entry.fileName).catch(() => undefined)));
+    await Promise.all(
+      entries.map((entry) => directoryHandle.removeEntry(entry.fileName).catch(() => undefined)),
+    );
   }
 
   private async readVersionHistoryManifest(
@@ -422,7 +555,12 @@ class BrowserRecentProjectHandleStore implements RecentProjectHandleStore {
     if (typeof window === 'undefined') return null;
     const database = await this.openDatabase();
     if (projectName) {
-      return (await this.getValue<FileSystemDirectoryHandle>(database, this.getProjectHandleKey(projectName))) ?? null;
+      return (
+        (await this.getValue<FileSystemDirectoryHandle>(
+          database,
+          this.getProjectHandleKey(projectName),
+        )) ?? null
+      );
     }
     if (window.localStorage.getItem(this.localStorageKey) !== 'true') return null;
     return (await this.getValue<FileSystemDirectoryHandle>(database, this.handleKey)) ?? null;
@@ -488,7 +626,8 @@ class BrowserRecentProjectHandleStore implements RecentProjectHandleStore {
 }
 
 function getBrowserDirectoryPicker() {
-  const browserWindow = typeof window === 'undefined' ? undefined : (window as WindowWithDirectoryPicker);
+  const browserWindow =
+    typeof window === 'undefined' ? undefined : (window as WindowWithDirectoryPicker);
   if (!browserWindow?.showDirectoryPicker) {
     throw new Error('The File System Access API is not available in this browser.');
   }

--- a/apps/editor/src/services/interfaces.ts
+++ b/apps/editor/src/services/interfaces.ts
@@ -6,7 +6,12 @@ import type {
 } from '../domain/generatedSlide';
 
 export type ModelStatus = 'unavailable' | 'needs-download' | 'downloading' | 'ready' | 'failed';
-export type AiCapability = 'prompt' | 'translation' | 'language-detection' | 'image-generation' | 'image-editing';
+export type AiCapability =
+  | 'prompt'
+  | 'translation'
+  | 'language-detection'
+  | 'image-generation'
+  | 'image-editing';
 export type AiProviderRuntime = 'chrome-built-in' | 'webgpu-huggingface';
 export type AiProviderCompatibility = 'compatible' | 'incompatible' | 'unknown';
 
@@ -36,11 +41,48 @@ export interface AiProviderState {
 
 export interface ProjectRepository {
   importProject?(): Promise<ProjectDocument | null>;
+  importMirrorFiles?(files: MirrorFile[]): Promise<ProjectDocument>;
   loadProject(options?: { projectName?: string }): Promise<ProjectDocument | null>;
-  saveProject(project: ProjectDocument): Promise<void>;
+  saveProject(project: ProjectDocument, options?: { projectDirectoryName?: string }): Promise<void>;
   getVersionHistory?(): Promise<VersionHistoryEntry[]>;
-  saveVersion?(project: ProjectDocument, metadata: VersionSnapshotMetadata): Promise<VersionHistoryEntry>;
+  saveVersion?(
+    project: ProjectDocument,
+    metadata: VersionSnapshotMetadata,
+  ): Promise<VersionHistoryEntry>;
   loadVersion?(versionId: string): Promise<ProjectDocument | null>;
+}
+
+export interface MirrorFile {
+  path: string;
+  blob: Blob;
+}
+
+export type MirrorStatus = 'disabled' | 'idle' | 'syncing' | 'synced' | 'failed';
+
+export interface MirrorState {
+  enabled: boolean;
+  status: MirrorStatus;
+  lastSyncedAt?: string;
+  error?: string;
+}
+
+export interface MirrorProjectSummary {
+  id: string;
+  name: string;
+  syncedAt: string;
+}
+
+export interface MirrorService<TConfig = unknown> {
+  loadConfig(): TConfig | null;
+  saveConfig(config: TConfig): void;
+  clearConfig(): void;
+  syncProject(
+    project: ProjectDocument,
+    repository: ProjectRepository,
+    config: TConfig,
+  ): Promise<MirrorState>;
+  listProjects(config: TConfig): Promise<MirrorProjectSummary[]>;
+  downloadProject(projectId: string, config: TConfig): Promise<MirrorFile[]>;
 }
 
 export interface VersionHistoryEntry {
@@ -104,7 +146,10 @@ export interface ShareService {
 export interface ModelSetupService {
   getModelStates(): Promise<ModelState[]>;
   downloadRequiredModels(): Promise<ModelState[]>;
-  downloadModel(id: string, options?: { onProgress?: (progress: number) => void }): Promise<ModelState>;
+  downloadModel(
+    id: string,
+    options?: { onProgress?: (progress: number) => void },
+  ): Promise<ModelState>;
   removeModel?(id: string): Promise<ModelState>;
 }
 
@@ -143,7 +188,11 @@ export interface TranslatorService {
     targetLanguage: string,
     options?: { onProgress?: (progress: number) => void },
   ): Promise<void>;
-  translate(text: string, targetLanguage: string, options?: { sourceLanguage?: string }): Promise<string>;
+  translate(
+    text: string,
+    targetLanguage: string,
+    options?: { sourceLanguage?: string },
+  ): Promise<string>;
 }
 
 export type PromptApiAvailability = 'unavailable' | 'downloadable' | 'downloading' | 'ready';
@@ -192,11 +241,17 @@ export interface BackgroundRemovalService {
   ): Promise<void>;
   previewBackgroundMask(
     asset: Asset,
-    options?: { points?: Array<{ x: number; y: number; positive: boolean }>; subjectPoint?: { x: number; y: number } },
+    options?: {
+      points?: Array<{ x: number; y: number; positive: boolean }>;
+      subjectPoint?: { x: number; y: number };
+    },
   ): Promise<{ maskUrl: string; score: number }>;
   removeBackground(
     asset: Asset,
-    options?: { points?: Array<{ x: number; y: number; positive: boolean }>; subjectPoint?: { x: number; y: number } },
+    options?: {
+      points?: Array<{ x: number; y: number; positive: boolean }>;
+      subjectPoint?: { x: number; y: number };
+    },
   ): Promise<{ asset: Asset; bounds?: { x: number; y: number; width: number; height: number } }>;
 }
 

--- a/apps/editor/src/services/minioMirrorService.ts
+++ b/apps/editor/src/services/minioMirrorService.ts
@@ -1,0 +1,498 @@
+import type {
+  MirrorFile,
+  MirrorProjectSummary,
+  MirrorService,
+  MirrorState,
+  ProjectRepository,
+} from './interfaces';
+import type { Asset, ProjectDocument } from '../domain/model';
+
+export interface MinioMirrorConfig {
+  endpoint: string;
+  bucket: string;
+  region: string;
+  accessKey: string;
+  secretKey: string;
+  pathStyle: boolean;
+  publicBaseUrl: string;
+  prefix: string;
+}
+
+interface MinioMirrorServiceOptions {
+  fetch?: typeof fetch;
+  now?: () => Date;
+}
+
+interface MirrorManifestFile {
+  path: string;
+  size: number;
+  checksum: string;
+}
+
+export interface MirrorManifest {
+  schemaVersion: 1;
+  projectId: string;
+  projectName: string;
+  syncedAt: string;
+  publicBaseUrl?: string;
+  files: Record<string, MirrorManifestFile>;
+}
+
+const CONFIG_STORAGE_KEY = 'localstudio.minioMirror.config';
+const MIRROR_MANIFEST_FILE_NAME = 'localstudio-mirror.json';
+const PROJECT_FILE_NAME = 'project.json';
+
+export const DEFAULT_MINIO_MIRROR_CONFIG: MinioMirrorConfig = {
+  accessKey: 'localstudio',
+  bucket: 'localstudio',
+  endpoint: 'http://localhost:9000',
+  pathStyle: true,
+  publicBaseUrl: 'http://localhost:9000/localstudio',
+  region: 'us-east-1',
+  secretKey: 'localstudio123',
+  prefix: 'mirrors',
+};
+
+function normalizePrefix(value: string) {
+  return value.trim().replace(/^\/+|\/+$/g, '');
+}
+
+function joinKey(...parts: string[]) {
+  return parts
+    .map((part) => part.replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean)
+    .join('/');
+}
+
+function getProjectMirrorKey(projectName: string) {
+  return projectName.trim().replace(/[\\/]+/g, '-');
+}
+
+function encodeKeyPath(key: string) {
+  return key.split('/').map(encodeURIComponent).join('/');
+}
+
+function textBlob(value: unknown) {
+  return new Blob([JSON.stringify(value, null, 2)], { type: 'application/json' });
+}
+
+function isDataUrl(value: string | undefined): value is string {
+  return Boolean(value?.startsWith('data:'));
+}
+
+function isBlobUrl(value: string | undefined): value is string {
+  return Boolean(value?.startsWith('blob:'));
+}
+
+function dataUrlToBlob(dataUrl: string) {
+  const [metadata, base64 = ''] = dataUrl.split(',');
+  const mimeType = metadata?.match(/^data:(.*?);base64$/)?.[1] ?? 'application/octet-stream';
+  const bytes = Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+  return new Blob([bytes], { type: mimeType });
+}
+
+function getDefaultFetch() {
+  if (typeof window !== 'undefined') return window.fetch.bind(window);
+  return globalThis.fetch.bind(globalThis);
+}
+
+function getAssetFileExtension(mimeType: string) {
+  if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/gif') return 'gif';
+  if (mimeType === 'image/webp') return 'webp';
+  if (mimeType === 'video/mp4') return 'mp4';
+  if (mimeType === 'video/webm') return 'webm';
+  if (mimeType === 'video/quicktime') return 'mov';
+  return 'png';
+}
+
+function collectReferencedAssetIds(project: ProjectDocument) {
+  const referencedAssetIds = new Set<string>();
+  for (const element of Object.values(project.elements)) {
+    if (element.type === 'image' || element.type === 'gif' || element.type === 'video') {
+      referencedAssetIds.add(element.assetId);
+    }
+  }
+  for (const page of project.pages) {
+    if (page.background.type === 'asset') referencedAssetIds.add(page.background.assetId);
+  }
+  return referencedAssetIds;
+}
+
+function cloneProjectWithoutObjectUrls(project: ProjectDocument): ProjectDocument {
+  return {
+    ...project,
+    assets: Object.fromEntries(
+      Object.entries(project.assets).map(([assetId, asset]) => {
+        const nextAsset = { ...asset };
+        delete nextAsset.objectUrl;
+        return [assetId, nextAsset];
+      }),
+    ),
+  };
+}
+
+async function assetToBlob(asset: Asset, requestFetch: typeof fetch) {
+  if (!asset.objectUrl) return undefined;
+  if (isDataUrl(asset.objectUrl)) return dataUrlToBlob(asset.objectUrl);
+  if (!isBlobUrl(asset.objectUrl)) return undefined;
+  return requestFetch(asset.objectUrl).then((response) => response.blob());
+}
+
+async function sha256Hex(blob: Blob) {
+  const hash = await crypto.subtle.digest('SHA-256', await blob.arrayBuffer());
+  return Array.from(new Uint8Array(hash), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function createFileEntry(path: string, blob: Blob): Promise<MirrorFile & MirrorManifestFile> {
+  return {
+    path,
+    blob,
+    size: blob.size,
+    checksum: await sha256Hex(blob),
+  };
+}
+
+export async function createMirrorFiles(
+  project: ProjectDocument,
+  repository: ProjectRepository,
+  config: MinioMirrorConfig,
+  options: { fetch?: typeof fetch; now?: () => Date } = {},
+): Promise<MirrorFile[]> {
+  const requestFetch = options.fetch ?? getDefaultFetch();
+  const now = options.now ?? (() => new Date());
+  const referencedAssetIds = collectReferencedAssetIds(project);
+  const projectForMirror: ProjectDocument = {
+    ...project,
+    assets: {},
+  };
+  const files: Array<MirrorFile & MirrorManifestFile> = [];
+
+  for (const [assetId, asset] of Object.entries(project.assets)) {
+    if (!referencedAssetIds.has(assetId)) continue;
+    const fileName = asset.fileName ?? `${asset.id}.${getAssetFileExtension(asset.mimeType)}`;
+    const blob = await assetToBlob(asset, requestFetch);
+    if (blob) {
+      const assetForMirror: Asset = {
+        ...asset,
+        fileName,
+        storage: 'file',
+      };
+      delete assetForMirror.objectUrl;
+      projectForMirror.assets[assetId] = assetForMirror;
+      files.push(await createFileEntry(`assets/${fileName}`, blob));
+    } else {
+      projectForMirror.assets[assetId] = { ...asset };
+    }
+  }
+
+  files.push(await createFileEntry(PROJECT_FILE_NAME, textBlob(projectForMirror)));
+
+  const versions = repository.getVersionHistory ? await repository.getVersionHistory() : [];
+  files.push(
+    await createFileEntry(
+      'history/manifest.json',
+      textBlob({
+        schemaVersion: 1,
+        projectId: project.id,
+        latestVersionId: versions[0]?.id,
+        versions,
+      }),
+    ),
+  );
+
+  for (const version of versions) {
+    const versionProject = repository.loadVersion ? await repository.loadVersion(version.id) : null;
+    if (!versionProject) continue;
+    files.push(
+      await createFileEntry(
+        `history/versions/${version.fileName}`,
+        textBlob(cloneProjectWithoutObjectUrls(versionProject)),
+      ),
+    );
+  }
+
+  files.push(
+    await createFileEntry(
+      'config/localstudio.json',
+      textBlob({
+        app: 'LocalStudio.dev',
+        projectId: project.id,
+        schemaVersion: 1,
+        savedAt: project.updatedAt,
+      }),
+    ),
+  );
+
+  const manifestFiles = Object.fromEntries(
+    files.map((file) => [
+      file.path,
+      {
+        path: file.path,
+        size: file.size,
+        checksum: file.checksum,
+      },
+    ]),
+  );
+  const manifest: MirrorManifest = {
+    schemaVersion: 1,
+    projectId: project.id,
+    projectName: project.name,
+    syncedAt: now().toISOString(),
+    files: manifestFiles,
+    ...(config.publicBaseUrl.trim() ? { publicBaseUrl: config.publicBaseUrl.trim() } : {}),
+  };
+  files.push(await createFileEntry(MIRROR_MANIFEST_FILE_NAME, textBlob(manifest)));
+
+  return files;
+}
+
+function toArrayBuffer(value: ArrayBuffer | Uint8Array) {
+  if (value instanceof ArrayBuffer) return value;
+  return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
+}
+
+async function hmacSha256(key: ArrayBuffer | Uint8Array, value: string) {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    toArrayBuffer(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  return new Uint8Array(
+    await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(value)),
+  );
+}
+
+async function hmacHex(key: ArrayBuffer | Uint8Array, value: string) {
+  return Array.from(await hmacSha256(key, value), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+}
+
+async function getSigningKey(config: MinioMirrorConfig, dateStamp: string) {
+  const kDate = await hmacSha256(new TextEncoder().encode(`AWS4${config.secretKey}`), dateStamp);
+  const kRegion = await hmacSha256(kDate, config.region);
+  const kService = await hmacSha256(kRegion, 's3');
+  return hmacSha256(kService, 'aws4_request');
+}
+
+function createObjectUrl(config: MinioMirrorConfig, key = '', query: Record<string, string> = {}) {
+  const endpoint = new URL(config.endpoint);
+  const encodedKey = encodeKeyPath(key);
+  const url = config.pathStyle
+    ? new URL(
+        `${endpoint.origin}/${encodeURIComponent(config.bucket)}${encodedKey ? `/${encodedKey}` : ''}`,
+      )
+    : new URL(`${endpoint.protocol}//${config.bucket}.${endpoint.host}/${encodedKey}`);
+  for (const [name, value] of Object.entries(query)) {
+    url.searchParams.set(name, value);
+  }
+  return url;
+}
+
+async function createSignedHeaders(
+  config: MinioMirrorConfig,
+  method: string,
+  url: URL,
+  contentType?: string,
+) {
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  const dateStamp = amzDate.slice(0, 8);
+  const headers: Record<string, string> = {
+    host: url.host,
+    'x-amz-content-sha256': 'UNSIGNED-PAYLOAD',
+    'x-amz-date': amzDate,
+  };
+  if (contentType) headers['content-type'] = contentType;
+
+  const canonicalHeaders = Object.entries(headers)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => `${name}:${value.trim()}\n`)
+    .join('');
+  const signedHeaders = Object.keys(headers).sort().join(';');
+  const canonicalQuery = Array.from(url.searchParams.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => `${encodeURIComponent(name)}=${encodeURIComponent(value)}`)
+    .join('&');
+  const canonicalRequest = [
+    method,
+    url.pathname,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    'UNSIGNED-PAYLOAD',
+  ].join('\n');
+  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    await crypto.subtle
+      .digest('SHA-256', new TextEncoder().encode(canonicalRequest))
+      .then((hash) =>
+        Array.from(new Uint8Array(hash), (byte) => byte.toString(16).padStart(2, '0')).join(''),
+      ),
+  ].join('\n');
+  const signature = await hmacHex(await getSigningKey(config, dateStamp), stringToSign);
+
+  return {
+    ...headers,
+    authorization: `AWS4-HMAC-SHA256 Credential=${config.accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+}
+
+function getProjectRoot(config: MinioMirrorConfig, projectKey: string) {
+  return joinKey(normalizePrefix(config.prefix), projectKey);
+}
+
+function getProjectFileKey(config: MinioMirrorConfig, projectKey: string, path: string) {
+  return joinKey(getProjectRoot(config, projectKey), path);
+}
+
+function parseMirrorProjects(xml: string) {
+  const document = new DOMParser().parseFromString(xml, 'application/xml');
+  return Array.from(document.querySelectorAll('Contents Key'))
+    .map((node) => node.textContent ?? '')
+    .filter((key) => key.endsWith(`/${MIRROR_MANIFEST_FILE_NAME}`));
+}
+
+export class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
+  private readonly requestFetch: typeof fetch;
+  private readonly now: () => Date;
+
+  constructor(options: MinioMirrorServiceOptions = {}) {
+    this.requestFetch = options.fetch ?? getDefaultFetch();
+    this.now = options.now ?? (() => new Date());
+  }
+
+  loadConfig(): MinioMirrorConfig | null {
+    if (typeof window === 'undefined') return null;
+    const rawConfig = window.localStorage.getItem(CONFIG_STORAGE_KEY);
+    return rawConfig ? (JSON.parse(rawConfig) as MinioMirrorConfig) : null;
+  }
+
+  saveConfig(config: MinioMirrorConfig): void {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
+  }
+
+  clearConfig(): void {
+    if (typeof window === 'undefined') return;
+    window.localStorage.removeItem(CONFIG_STORAGE_KEY);
+  }
+
+  async syncProject(
+    project: ProjectDocument,
+    repository: ProjectRepository,
+    config: MinioMirrorConfig,
+  ): Promise<MirrorState> {
+    const files = await createMirrorFiles(project, repository, config, {
+      fetch: this.requestFetch,
+      now: this.now,
+    });
+    const projectKey = getProjectMirrorKey(project.name);
+    const remoteManifest = await this.loadRemoteManifest(projectKey, config);
+
+    for (const file of files) {
+      const nextChecksum = await sha256Hex(file.blob);
+      if (remoteManifest?.files[file.path]?.checksum === nextChecksum) continue;
+      await this.putObject(getProjectFileKey(config, projectKey, file.path), file.blob, config);
+    }
+
+    return {
+      enabled: true,
+      status: 'synced',
+      lastSyncedAt: this.now().toISOString(),
+    };
+  }
+
+  async listProjects(config: MinioMirrorConfig): Promise<MirrorProjectSummary[]> {
+    const url = createObjectUrl(config, '', {
+      'list-type': '2',
+      'max-keys': '1000',
+      prefix: normalizePrefix(config.prefix) ? `${normalizePrefix(config.prefix)}/` : '',
+    });
+    const response = await this.signedFetch(url, 'GET', config);
+    if (!response.ok) throw new Error(`Could not list MinIO mirrors (${response.status}).`);
+    const manifestKeys = parseMirrorProjects(await response.text());
+    const manifests = await Promise.all(
+      manifestKeys.map(async (key) => {
+        const response = await this.signedFetch(createObjectUrl(config, key), 'GET', config);
+        if (!response.ok) return undefined;
+        const manifest = (await response.json()) as MirrorManifest;
+        const keyParts = key.split('/');
+        return {
+          id: keyParts.at(-2) ?? manifest.projectName,
+          name: manifest.projectName,
+          syncedAt: manifest.syncedAt,
+        };
+      }),
+    );
+    return manifests.filter((item): item is MirrorProjectSummary => Boolean(item));
+  }
+
+  async downloadProject(projectKey: string, config: MinioMirrorConfig): Promise<MirrorFile[]> {
+    const manifestResponse = await this.signedFetch(
+      createObjectUrl(config, getProjectFileKey(config, projectKey, MIRROR_MANIFEST_FILE_NAME)),
+      'GET',
+      config,
+    );
+    if (!manifestResponse.ok)
+      throw new Error(`Could not download MinIO mirror manifest (${manifestResponse.status}).`);
+    const manifest = (await manifestResponse.json()) as MirrorManifest;
+    const files = await Promise.all(
+      Object.keys(manifest.files).map(async (path) => {
+        const response = await this.signedFetch(
+          createObjectUrl(config, getProjectFileKey(config, projectKey, path)),
+          'GET',
+          config,
+        );
+        if (!response.ok)
+          throw new Error(`Could not download mirrored file ${path} (${response.status}).`);
+        return { path, blob: await response.blob() };
+      }),
+    );
+    files.push({ path: MIRROR_MANIFEST_FILE_NAME, blob: textBlob(manifest) });
+    return files;
+  }
+
+  private async loadRemoteManifest(projectKey: string, config: MinioMirrorConfig) {
+    const response = await this.signedFetch(
+      createObjectUrl(config, getProjectFileKey(config, projectKey, MIRROR_MANIFEST_FILE_NAME)),
+      'GET',
+      config,
+    );
+    if (response.status === 404) return null;
+    if (!response.ok) throw new Error(`Could not read MinIO mirror manifest (${response.status}).`);
+    return (await response.json()) as MirrorManifest;
+  }
+
+  private async putObject(key: string, blob: Blob, config: MinioMirrorConfig) {
+    const response = await this.signedFetch(
+      createObjectUrl(config, key),
+      'PUT',
+      config,
+      blob,
+      blob.type,
+    );
+    if (!response.ok) throw new Error(`Could not upload ${key} to MinIO (${response.status}).`);
+  }
+
+  private async signedFetch(
+    url: URL,
+    method: string,
+    config: MinioMirrorConfig,
+    body?: Blob,
+    contentType?: string,
+  ) {
+    const init: RequestInit = {
+      headers: await createSignedHeaders(config, method, url, contentType),
+      method,
+    };
+    if (body) init.body = body;
+    return this.requestFetch(url, init);
+  }
+}

--- a/apps/editor/src/ui/editor/EditorFooter.tsx
+++ b/apps/editor/src/ui/editor/EditorFooter.tsx
@@ -3,6 +3,7 @@ interface EditorFooterProps {
   pageCount: number;
   pagesPanelOpen?: boolean;
   zoomPercent: number;
+  onOpenSettings?: () => void;
   onResetZoom?: () => void;
   onTogglePagesPanel?: () => void;
   onZoomIn?: () => void;
@@ -14,6 +15,7 @@ export function EditorFooter({
   pageCount,
   pagesPanelOpen = true,
   zoomPercent,
+  onOpenSettings,
   onResetZoom,
   onTogglePagesPanel,
   onZoomIn,
@@ -21,7 +23,19 @@ export function EditorFooter({
 }: EditorFooterProps) {
   return (
     <footer className="editor-footer" aria-label="Editor footer controls">
-      <div className="editor-footer-left" />
+      <div className="editor-footer-left">
+        <button
+          className="stitch-icon-button footer-settings-button"
+          type="button"
+          aria-label="Mirror settings"
+          title="Mirror settings"
+          onClick={onOpenSettings}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            settings
+          </span>
+        </button>
+      </div>
       <div className="editor-footer-right">
         <div className="footer-zoom-controls" aria-label="Zoom controls">
           <button
@@ -35,7 +49,12 @@ export function EditorFooter({
               remove
             </span>
           </button>
-          <button className="zoom-value" type="button" aria-label="Reset zoom" onClick={onResetZoom}>
+          <button
+            className="zoom-value"
+            type="button"
+            aria-label="Reset zoom"
+            onClick={onResetZoom}
+          >
             {zoomPercent}%
           </button>
           <button

--- a/apps/editor/src/ui/editor/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/EditorShell.tsx
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from 'react';
 import type Konva from 'konva';
 import type { AppServices } from '../../app/composition';
 import type { ShareMetadata } from '../../services/interfaces';
-import { EditorAutomationController, type EditorAutomationDelegate } from '../../services/editorAutomationController';
+import {
+  EditorAutomationController,
+  type EditorAutomationDelegate,
+} from '../../services/editorAutomationController';
 import { IMAGE_EDITING_MODEL_ID } from '../../services/modelSetupService';
 import {
   WebMcpToolAdapter,
@@ -11,9 +14,13 @@ import {
 } from '../../services/webMcpToolAdapter';
 import { EditorFooter } from './EditorFooter';
 import { LeftToolPanel } from './LeftToolPanel';
+import { LocalProjectSetupPanel } from './LocalProjectSetupPanel';
+import { MirrorSettingsPanel } from './MirrorSettingsPanel';
 import { PagesPanel } from './PagesPanel';
 import { PromptBar } from './PromptBar';
+import { RemoteImportPanel } from './RemoteImportPanel';
 import { ScrollingCanvasWorkspace } from './ScrollingCanvasWorkspace';
+import { SettingsPanel } from './SettingsPanel';
 import { TopToolbar } from './TopToolbar';
 import { VersionHistoryPanel } from './VersionHistoryPanel';
 import { useEditorViewModel } from './useEditorViewModel';
@@ -47,7 +54,9 @@ function hasBrowserTextSelection() {
 function getClipboardImageFile(clipboardData: DataTransfer | null) {
   if (!clipboardData) return undefined;
 
-  const fileFromFiles = Array.from(clipboardData.files).find((file) => file.type.startsWith('image/'));
+  const fileFromFiles = Array.from(clipboardData.files).find((file) =>
+    file.type.startsWith('image/'),
+  );
   if (fileFromFiles) return fileFromFiles;
 
   for (const item of Array.from(clipboardData.items)) {
@@ -61,7 +70,10 @@ function getClipboardImageFile(clipboardData: DataTransfer | null) {
 
 function hasEditorObjectClipboardMarker(clipboardData: DataTransfer | null) {
   if (!clipboardData) return false;
-  if (clipboardData.types && Array.from(clipboardData.types).includes(EDITOR_OBJECT_CLIPBOARD_TYPE)) {
+  if (
+    clipboardData.types &&
+    Array.from(clipboardData.types).includes(EDITOR_OBJECT_CLIPBOARD_TYPE)
+  ) {
     return true;
   }
   return clipboardData.getData?.(EDITOR_OBJECT_CLIPBOARD_TYPE) === EDITOR_OBJECT_CLIPBOARD_MARKER;
@@ -95,7 +107,10 @@ export function EditorShell({ services }: EditorShellProps) {
   const toolbarImageInputRef = useRef<HTMLInputElement>(null);
   const hasSelection = vm.selection.elementIds.length > 0;
   const isHistoryReadOnly = vm.versionHistoryOpen;
-  const activePageIndex = Math.max(0, vm.project.pages.findIndex((page) => page.id === vm.activePageId));
+  const activePageIndex = Math.max(
+    0,
+    vm.project.pages.findIndex((page) => page.id === vm.activePageId),
+  );
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -229,7 +244,8 @@ export function EditorShell({ services }: EditorShellProps) {
   useEffect(() => {
     function handleCopy(event: ClipboardEvent) {
       if (isHistoryReadOnly) return;
-      if (isEditableInteractionTarget(event.target) || hasBrowserTextSelection() || !hasSelection) return;
+      if (isEditableInteractionTarget(event.target) || hasBrowserTextSelection() || !hasSelection)
+        return;
       event.preventDefault();
       vm.copySelectedElements();
       writeEditorObjectClipboardMarker(event.clipboardData);
@@ -237,7 +253,8 @@ export function EditorShell({ services }: EditorShellProps) {
 
     function handleCut(event: ClipboardEvent) {
       if (isHistoryReadOnly) return;
-      if (isEditableInteractionTarget(event.target) || hasBrowserTextSelection() || !hasSelection) return;
+      if (isEditableInteractionTarget(event.target) || hasBrowserTextSelection() || !hasSelection)
+        return;
       event.preventDefault();
       vm.cutSelectedElements();
       writeEditorObjectClipboardMarker(event.clipboardData);
@@ -318,15 +335,36 @@ export function EditorShell({ services }: EditorShellProps) {
         canUndo={!isHistoryReadOnly && vm.canUndo}
         hasSelection={!isHistoryReadOnly && hasSelection}
         persistenceEnabled={vm.persistenceEnabled}
+        mirrorState={vm.mirrorState}
+        persistenceAttention={vm.persistenceAttention}
+        persistenceNotice={vm.persistenceNotice}
+        localProjectSetupPanel={
+          vm.localProjectSetupOpen ? (
+            <LocalProjectSetupPanel
+              initialName={vm.project.name}
+              onCancel={vm.closeLocalProjectSetup}
+              onConfirm={(projectName) => {
+                void vm.confirmLocalProjectSetup(projectName);
+              }}
+            />
+          ) : null
+        }
         lastEditedAt={vm.lastEditedAt}
         saveAnimationKey={vm.saveAnimationKey}
         canTranslateDeck={vm.canTranslateDeck}
         persistenceAvailable={services.persistenceAvailable}
         onDelete={isHistoryReadOnly ? undefined : vm.deleteSelectedElement}
         onDuplicate={isHistoryReadOnly ? undefined : vm.duplicateSelectedElement}
+        onImportRemoteMirror={() => {
+          void vm.importRemoteMirror();
+        }}
         onImportProject={() => {
           void vm.importProject();
         }}
+        onMirrorNow={() => {
+          vm.requestMirrorNow();
+        }}
+        onMirrorToggle={vm.setMirrorEnabled}
         onNewProject={openBlankProjectInNewTab}
         onOpenVersionHistory={() => {
           void vm.openVersionHistory();
@@ -345,14 +383,23 @@ export function EditorShell({ services }: EditorShellProps) {
           setSharePanelOpen(true);
         }}
         onStartPresenterMode={startPresenterMode}
-        onTranslateDeck={isHistoryReadOnly ? undefined : () => {
-          void vm.translateDeck();
+        onSaveLocal={() => {
+          void vm.saveLocalNow();
         }}
+        onTranslateDeck={
+          isHistoryReadOnly
+            ? undefined
+            : () => {
+                void vm.translateDeck();
+              }
+        }
         onUndo={isHistoryReadOnly ? undefined : vm.undo}
         onZoomIn={vm.zoomIn}
         onZoomOut={vm.zoomOut}
       />
-      <div className={vm.pagesPanelOpen ? 'editor-grid' : 'editor-grid editor-grid-pages-collapsed'}>
+      <div
+        className={vm.pagesPanelOpen ? 'editor-grid' : 'editor-grid editor-grid-pages-collapsed'}
+      >
         <LeftToolPanel
           activeTab={vm.activeTab}
           animationPreview={vm.animationPreview}
@@ -374,17 +421,28 @@ export function EditorShell({ services }: EditorShellProps) {
           onClearPageTransition={isHistoryReadOnly ? undefined : vm.clearPageTransition}
           onSetPageTransition={isHistoryReadOnly ? undefined : vm.setPageTransition}
           onSetElementAnimationBuilds={isHistoryReadOnly ? undefined : vm.setElementAnimationBuilds}
-          onClearElementAnimationBuild={isHistoryReadOnly ? undefined : vm.clearElementAnimationBuild}
-          onReorderElementAnimationBuild={isHistoryReadOnly ? undefined : vm.reorderElementAnimationBuild}
+          onClearElementAnimationBuild={
+            isHistoryReadOnly ? undefined : vm.clearElementAnimationBuild
+          }
+          onReorderElementAnimationBuild={
+            isHistoryReadOnly ? undefined : vm.reorderElementAnimationBuild
+          }
           onPlayAnimationPreview={vm.playAnimationPreview}
-          onImportImage={isHistoryReadOnly ? undefined : (file) => {
-            void vm.importImageFile(file);
-          }}
+          onImportImage={
+            isHistoryReadOnly
+              ? undefined
+              : (file) => {
+                  void vm.importImageFile(file);
+                }
+          }
           onRemoveAsset={isHistoryReadOnly ? undefined : vm.removeAsset}
           onImportMedia={isHistoryReadOnly ? undefined : importMediaFile}
           onInsertText={isHistoryReadOnly ? undefined : vm.insertTextElement}
           modelStates={vm.modelStates}
-          attentionModelId={vm.aiToolsAttentionModelId ?? (vm.backgroundSelectionNotice ? IMAGE_EDITING_MODEL_ID : undefined)}
+          attentionModelId={
+            vm.aiToolsAttentionModelId ??
+            (vm.backgroundSelectionNotice ? IMAGE_EDITING_MODEL_ID : undefined)
+          }
           createImageOptions={vm.createImageOptions}
           translationLanguageOptions={vm.translationLanguageOptions}
           promptProviderStates={vm.promptProviderStates}
@@ -417,7 +475,9 @@ export function EditorShell({ services }: EditorShellProps) {
           }}
         />
         <section
-          className={leftPanelOpen ? 'workspace-column workspace-column-left-panel-open' : 'workspace-column'}
+          className={
+            leftPanelOpen ? 'workspace-column workspace-column-left-panel-open' : 'workspace-column'
+          }
           aria-label="Canvas workspace"
           ref={workspaceRef}
         >
@@ -440,48 +500,88 @@ export function EditorShell({ services }: EditorShellProps) {
             canTranslateSelection={vm.canTranslateSelection}
             isTranslating={vm.isTranslating}
             translationNotice={vm.translationNotice}
-            onAlignSelectedElement={isHistoryReadOnly ? undefined : () => {
-              vm.alignSelectedElement('page-center');
-            }}
+            onAlignSelectedElement={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    vm.alignSelectedElement('page-center');
+                  }
+            }
             onAnimationPreviewAdvance={
               vm.isFullscreen || vm.animationPreview?.mode === 'presenter'
                 ? vm.advancePresentationPreview
                 : vm.advanceAnimationPreview
             }
-            onBackgroundSelectionToggle={isHistoryReadOnly ? undefined : vm.toggleBackgroundSelectionMode}
-            onBackgroundSubjectPick={isHistoryReadOnly ? undefined : (elementId, point) => {
-              void vm.pickBackgroundSubject(elementId, point);
-            }}
+            onBackgroundSelectionToggle={
+              isHistoryReadOnly ? undefined : vm.toggleBackgroundSelectionMode
+            }
+            onBackgroundSubjectPick={
+              isHistoryReadOnly
+                ? undefined
+                : (elementId, point) => {
+                    void vm.pickBackgroundSubject(elementId, point);
+                  }
+            }
             onBackgroundPreviewPoint={isHistoryReadOnly ? undefined : vm.previewBackgroundSubject}
             onBackgroundRefinePoint={isHistoryReadOnly ? undefined : vm.refineBackgroundSubject}
-            onBringSelectedElementForward={isHistoryReadOnly ? undefined : () => {
-              vm.setSelectedElementZOrder('forward');
-            }}
-            onCancelBackgroundSelection={isHistoryReadOnly ? undefined : vm.cancelBackgroundSelectionMode}
+            onBringSelectedElementForward={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    vm.setSelectedElementZOrder('forward');
+                  }
+            }
+            onCancelBackgroundSelection={
+              isHistoryReadOnly ? undefined : vm.cancelBackgroundSelectionMode
+            }
             onClearSelection={isHistoryReadOnly ? undefined : vm.clearSelection}
             onDeleteSelectedElement={isHistoryReadOnly ? undefined : vm.deleteSelectedElement}
             onDuplicateSelectedElement={isHistoryReadOnly ? undefined : vm.duplicateSelectedElement}
             onFlipSelectedImage={isHistoryReadOnly ? undefined : vm.flipSelectedImage}
-            onInsertMedia={isHistoryReadOnly ? undefined : () => {
-              toolbarImageInputRef.current?.click();
-            }}
-            onInsertText={isHistoryReadOnly ? undefined : () => {
-              vm.insertTextElement();
-            }}
-            onOpenAnimations={isHistoryReadOnly ? undefined : () => {
-              vm.setActiveTab('animations');
-              setLeftPanelOpen(true);
-            }}
+            onInsertMedia={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    toolbarImageInputRef.current?.click();
+                  }
+            }
+            onInsertText={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    vm.insertTextElement();
+                  }
+            }
+            onOpenAnimations={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    vm.setActiveTab('animations');
+                    setLeftPanelOpen(true);
+                  }
+            }
             onSelectElement={isHistoryReadOnly ? undefined : selectElement}
-            onSendSelectedElementBackward={isHistoryReadOnly ? undefined : () => {
-              vm.setSelectedElementZOrder('backward');
-            }}
-            onTranslatePage={isHistoryReadOnly ? undefined : (pageId) => {
-              void vm.translatePage(pageId);
-            }}
-            onTranslateSelectedText={isHistoryReadOnly ? undefined : () => {
-              void vm.translateSelectedText();
-            }}
+            onSendSelectedElementBackward={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    vm.setSelectedElementZOrder('backward');
+                  }
+            }
+            onTranslatePage={
+              isHistoryReadOnly
+                ? undefined
+                : (pageId) => {
+                    void vm.translatePage(pageId);
+                  }
+            }
+            onTranslateSelectedText={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    void vm.translateSelectedText();
+                  }
+            }
             onUpdateImageCrop={isHistoryReadOnly ? undefined : vm.updateImageCrop}
             onUpdateElementFrame={isHistoryReadOnly ? undefined : vm.updateElementFrame}
             onUpdateElementFrames={isHistoryReadOnly ? undefined : vm.updateElementFrames}
@@ -508,20 +608,22 @@ export function EditorShell({ services }: EditorShellProps) {
               event.target.value = '';
             }}
           />
-          {!isHistoryReadOnly ? <PromptBar
-            createImageNotice={vm.createImageNotice}
-            createImageStatus={vm.createImageStatus}
-            createImageOptions={vm.createImageOptions}
-            generationNotice={vm.promptGenerationNotice}
-            generationStatus={vm.promptGenerationStatus}
-            isGeneratingImage={vm.isGeneratingImage}
-            isGeneratingSlide={vm.isGeneratingSlide}
-            selectedImageElementId={vm.selectedImagePromptElementId}
-            onCreateImagePromptIntent={() => vm.ensureImageGenerationReadyForPrompt()}
-            onCreateImageSubmit={(prompt, options) => vm.generateImageFromPrompt(prompt, options)}
-            onSlidePromptSubmit={(prompt) => vm.generateSlideFromPrompt(prompt)}
-            onStopGeneration={vm.stopPromptGeneration}
-          /> : null}
+          {!isHistoryReadOnly ? (
+            <PromptBar
+              createImageNotice={vm.createImageNotice}
+              createImageStatus={vm.createImageStatus}
+              createImageOptions={vm.createImageOptions}
+              generationNotice={vm.promptGenerationNotice}
+              generationStatus={vm.promptGenerationStatus}
+              isGeneratingImage={vm.isGeneratingImage}
+              isGeneratingSlide={vm.isGeneratingSlide}
+              selectedImageElementId={vm.selectedImagePromptElementId}
+              onCreateImagePromptIntent={() => vm.ensureImageGenerationReadyForPrompt()}
+              onCreateImageSubmit={(prompt, options) => vm.generateImageFromPrompt(prompt, options)}
+              onSlidePromptSubmit={(prompt) => vm.generateSlideFromPrompt(prompt)}
+              onStopGeneration={vm.stopPromptGeneration}
+            />
+          ) : null}
         </section>
         {vm.pagesPanelOpen ? (
           <PagesPanel
@@ -536,9 +638,13 @@ export function EditorShell({ services }: EditorShellProps) {
             onReorderPage={isHistoryReadOnly ? undefined : vm.reorderPage}
             onSelectPage={vm.selectPage}
             onSetPageVisibility={isHistoryReadOnly ? undefined : vm.setPageVisibility}
-            onTranslatePage={isHistoryReadOnly ? undefined : (pageId) => {
-              void vm.translatePage(pageId);
-            }}
+            onTranslatePage={
+              isHistoryReadOnly
+                ? undefined
+                : (pageId) => {
+                    void vm.translatePage(pageId);
+                  }
+            }
           />
         ) : null}
       </div>
@@ -569,12 +675,39 @@ export function EditorShell({ services }: EditorShellProps) {
           onPresent={presentFromSharePanel}
         />
       ) : null}
+      {vm.settingsOpen ? (
+        <SettingsPanel
+          onClose={vm.closeSettings}
+          onOpenMirrorSettings={vm.openMirrorSettings}
+        />
+      ) : null}
+      {vm.mirrorSettingsOpen ? (
+        <MirrorSettingsPanel
+          config={vm.mirrorConfig}
+          mirrorState={vm.mirrorState}
+          onClose={vm.closeMirrorSettings}
+          onSave={vm.saveMirrorConfig}
+          onTestConnection={vm.testMirrorConnection}
+        />
+      ) : null}
+      {vm.remoteImportOpen ? (
+        <RemoteImportPanel
+          error={vm.remoteImportError}
+          projects={vm.remoteImportProjects}
+          status={vm.remoteImportStatus}
+          onClose={vm.closeRemoteImport}
+          onImportProject={(projectId) => {
+            void vm.importRemoteMirrorProject(projectId);
+          }}
+        />
+      ) : null}
       <EditorFooter
         activePageIndex={activePageIndex}
         pageCount={vm.project.pages.length}
         pagesPanelOpen={vm.pagesPanelOpen}
         zoomPercent={vm.zoomPercent}
         onResetZoom={vm.resetZoom}
+        onOpenSettings={vm.openSettings}
         onTogglePagesPanel={vm.togglePagesPanel}
         onZoomIn={vm.zoomIn}
         onZoomOut={vm.zoomOut}

--- a/apps/editor/src/ui/editor/LocalProjectSetupPanel.tsx
+++ b/apps/editor/src/ui/editor/LocalProjectSetupPanel.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface LocalProjectSetupPanelProps {
+  initialName: string;
+  onCancel: () => void;
+  onConfirm: (projectName: string) => void;
+}
+
+export function LocalProjectSetupPanel({
+  initialName,
+  onCancel,
+  onConfirm,
+}: LocalProjectSetupPanelProps) {
+  const [draftName, setDraftName] = useState(initialName);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const normalizedName = draftName.trim();
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  return (
+    <aside
+      className="local-project-setup-panel"
+      data-anchor="persistence"
+      role="dialog"
+      aria-modal="false"
+      aria-label="Save local project"
+    >
+      <div className="settings-panel-header">
+        <div>
+          <h2>Save local project</h2>
+          <p>Name the project folder before choosing where to create it.</p>
+        </div>
+        <button
+          className="stitch-icon-button"
+          type="button"
+          aria-label="Cancel local save"
+          onClick={onCancel}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
+        </button>
+      </div>
+
+      <label className="local-project-setup-field">
+        <span>Project folder name</span>
+        <input
+          ref={inputRef}
+          aria-label="Project folder name"
+          value={draftName}
+          onChange={(event) => setDraftName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && normalizedName) {
+              event.preventDefault();
+              onConfirm(normalizedName);
+            }
+            if (event.key === 'Escape') {
+              onCancel();
+            }
+          }}
+        />
+      </label>
+
+      <div className="mirror-settings-actions">
+        <button className="footer-toggle" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          className="export-button font-orbitron"
+          type="button"
+          disabled={!normalizedName}
+          onClick={() => onConfirm(normalizedName)}
+        >
+          Choose folder
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/editor/src/ui/editor/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/MirrorSettingsPanel.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useRef, useState } from 'react';
+import type { MirrorState } from '../../services/interfaces';
+import type { MinioMirrorConfig } from '../../services/minioMirrorService';
+
+interface MirrorSettingsPanelProps {
+  config: MinioMirrorConfig;
+  mirrorState: MirrorState;
+  onClose: () => void;
+  onSave: (config: MinioMirrorConfig) => void;
+  onTestConnection: (config: MinioMirrorConfig) => void | Promise<void>;
+}
+
+export function MirrorSettingsPanel({
+  config,
+  mirrorState,
+  onClose,
+  onSave,
+  onTestConnection,
+}: MirrorSettingsPanelProps) {
+  const panelRef = useRef<HTMLElement>(null);
+  const [draft, setDraft] = useState(config);
+  const [secretVisible, setSecretVisible] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'ready' | 'failed'>(
+    'idle',
+  );
+  const [connectionError, setConnectionError] = useState<string | undefined>();
+
+  function updateDraft(patch: Partial<MinioMirrorConfig>) {
+    setDraft((current) => ({ ...current, ...patch }));
+  }
+
+  function normalizedDraft(): MinioMirrorConfig {
+    return {
+      ...draft,
+      accessKey: draft.accessKey.trim(),
+      bucket: draft.bucket.trim(),
+      endpoint: draft.endpoint.trim().replace(/\/+$/g, ''),
+      publicBaseUrl: draft.publicBaseUrl.trim().replace(/\/+$/g, ''),
+      region: draft.region.trim() || 'us-east-1',
+      prefix: draft.prefix.trim(),
+    };
+  }
+
+  async function testConnection() {
+    setConnectionStatus('testing');
+    setConnectionError(undefined);
+    try {
+      await onTestConnection(normalizedDraft());
+      setConnectionStatus('ready');
+    } catch (error) {
+      setConnectionStatus('failed');
+      setConnectionError(error instanceof Error ? error.message : 'MinIO connection failed.');
+    }
+  }
+
+  const publicBucketUrl = `${draft.endpoint.replace(/\/+$/g, '')}/${draft.bucket.trim()}`;
+  const consoleUrl = draft.endpoint.replace(/\/+$/g, '');
+
+  useEffect(() => {
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (panelRef.current?.contains(target)) return;
+      onClose();
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [onClose]);
+
+  return (
+    <aside
+      ref={panelRef}
+      className="mirror-settings-panel"
+      role="dialog"
+      aria-modal="false"
+      aria-label="Mirror settings"
+    >
+      <div className="mirror-settings-header">
+        <div>
+          <h2>Mirror settings</h2>
+          <p>Sync this local project folder to MinIO.</p>
+        </div>
+        <button
+          className="stitch-icon-button"
+          type="button"
+          aria-label="Close mirror settings"
+          onClick={onClose}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
+        </button>
+      </div>
+
+      <div className="mirror-settings-grid">
+        <label>
+          <span>Endpoint</span>
+          <input
+            value={draft.endpoint}
+            onChange={(event) => updateDraft({ endpoint: event.target.value })}
+          />
+        </label>
+        <label>
+          <span>Bucket</span>
+          <input
+            value={draft.bucket}
+            onChange={(event) => updateDraft({ bucket: event.target.value })}
+          />
+        </label>
+        <label>
+          <span>Region</span>
+          <input
+            value={draft.region}
+            onChange={(event) => updateDraft({ region: event.target.value })}
+          />
+        </label>
+        <label>
+          <span>Access key</span>
+          <input
+            value={draft.accessKey}
+            onChange={(event) => updateDraft({ accessKey: event.target.value })}
+          />
+        </label>
+        <label>
+          <span>Secret key</span>
+          <span className="mirror-secret-control">
+            <input
+              aria-label="Secret key"
+              type={secretVisible ? 'text' : 'password'}
+              value={draft.secretKey}
+              onChange={(event) => updateDraft({ secretKey: event.target.value })}
+            />
+            <button
+              className="stitch-icon-button mirror-secret-toggle"
+              type="button"
+              aria-label={secretVisible ? 'Hide secret key' : 'Show secret key'}
+              onClick={() => setSecretVisible((current) => !current)}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                {secretVisible ? 'visibility_off' : 'visibility'}
+              </span>
+            </button>
+          </span>
+        </label>
+        <label>
+          <span>Public base URL</span>
+          <input
+            value={draft.publicBaseUrl}
+            onChange={(event) => updateDraft({ publicBaseUrl: event.target.value })}
+          />
+        </label>
+        <label>
+          <span>Prefix</span>
+          <input
+            value={draft.prefix}
+            onChange={(event) => updateDraft({ prefix: event.target.value })}
+          />
+        </label>
+        <label className="mirror-checkbox-row">
+          <input
+            checked={draft.pathStyle}
+            type="checkbox"
+            onChange={(event) => updateDraft({ pathStyle: event.target.checked })}
+          />
+          <span>Path-style URLs</span>
+        </label>
+      </div>
+
+      <p
+        className={
+          mirrorState.status === 'failed' || connectionStatus === 'failed'
+            ? 'mirror-settings-status mirror-settings-status-error'
+            : 'mirror-settings-status'
+        }
+      >
+        {connectionStatus === 'ready' ? (
+          <>
+            <span className="material-symbols-outlined" aria-hidden="true">
+              check_circle
+            </span>
+            Connection is ready.
+          </>
+        ) : connectionStatus === 'failed' ? (
+          connectionError
+        ) : mirrorState.status === 'failed' ? (
+          (mirrorState.error ?? 'MinIO connection failed.')
+        ) : mirrorState.status === 'syncing' || connectionStatus === 'testing' ? (
+          'Checking MinIO connection...'
+        ) : mirrorState.status === 'synced' ? (
+          'MinIO connection is ready.'
+        ) : (
+          'Keys are stored in this browser profile.'
+        )}
+      </p>
+
+      <div className="mirror-settings-help">
+        <p>Default MinIO login: localstudio / localstudio123</p>
+        {connectionStatus === 'ready' ? (
+          <div className="mirror-settings-links">
+            <a href={publicBucketUrl} target="_blank" rel="noreferrer">
+              Open public bucket
+            </a>
+            <a href={consoleUrl} target="_blank" rel="noreferrer">
+              Open MinIO console
+            </a>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mirror-settings-actions">
+        <button className="footer-toggle" type="button" onClick={() => void testConnection()}>
+          {connectionStatus === 'testing' ? 'Checking MinIO connection...' : 'Test connection'}
+        </button>
+        <button
+          className="export-button font-orbitron"
+          type="button"
+          onClick={() => onSave(normalizedDraft())}
+        >
+          Save settings
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/editor/src/ui/editor/RemoteImportPanel.tsx
+++ b/apps/editor/src/ui/editor/RemoteImportPanel.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import type { MirrorProjectSummary } from '../../services/interfaces';
+
+export type RemoteImportStatus = 'loading' | 'ready' | 'empty' | 'importing' | 'failed';
+
+interface RemoteImportPanelProps {
+  error?: string | undefined;
+  projects: MirrorProjectSummary[];
+  status: RemoteImportStatus;
+  onClose: () => void;
+  onImportProject: (projectId: string) => void;
+}
+
+function formatSyncedAt(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Last sync unknown';
+  return `Synced ${date.toLocaleString([], {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })}`;
+}
+
+export function RemoteImportPanel({
+  error,
+  projects,
+  status,
+  onClose,
+  onImportProject,
+}: RemoteImportPanelProps) {
+  const panelRef = useRef<HTMLElement>(null);
+  const busy = status === 'loading' || status === 'importing';
+
+  useEffect(() => {
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (panelRef.current?.contains(target)) return;
+      onClose();
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [onClose]);
+
+  return (
+    <aside
+      ref={panelRef}
+      className="remote-import-panel"
+      role="dialog"
+      aria-modal="false"
+      aria-label="Import remote project"
+    >
+      <div className="settings-panel-header">
+        <div>
+          <h2>Import remote</h2>
+          <p>Choose a mirrored project from MinIO.</p>
+        </div>
+        <button
+          className="stitch-icon-button"
+          type="button"
+          aria-label="Close remote import"
+          onClick={onClose}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
+        </button>
+      </div>
+
+      {status === 'loading' ? <p className="remote-import-status">Loading mirrors...</p> : null}
+      {status === 'empty' ? (
+        <p className="remote-import-status">No mirrored projects were found in this bucket.</p>
+      ) : null}
+      {status === 'failed' ? (
+        <p className="remote-import-status remote-import-status-error">
+          {error ?? 'Could not import the remote mirror.'}
+        </p>
+      ) : null}
+
+      {projects.length > 0 ? (
+        <div className="remote-import-list">
+          {projects.map((project) => (
+            <button
+              className="remote-import-row"
+              disabled={busy}
+              key={project.id}
+              type="button"
+              aria-label={`Import ${project.name}`}
+              onClick={() => onImportProject(project.id)}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                cloud_download
+              </span>
+              <span>
+                <strong>{project.name}</strong>
+                <small>{formatSyncedAt(project.syncedAt)}</small>
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/editor/src/ui/editor/SettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/SettingsPanel.tsx
@@ -1,0 +1,25 @@
+interface SettingsPanelProps {
+  onClose: () => void;
+  onOpenMirrorSettings: () => void;
+}
+
+export function SettingsPanel({ onClose, onOpenMirrorSettings }: SettingsPanelProps) {
+  return (
+    <aside className="settings-panel" role="dialog" aria-modal="false" aria-label="Settings">
+      <div className="settings-panel-header">
+        <h2>Settings</h2>
+        <button className="stitch-icon-button" type="button" aria-label="Close settings" onClick={onClose}>
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
+        </button>
+      </div>
+      <button className="settings-panel-row" type="button" onClick={onOpenMirrorSettings}>
+        <span className="material-symbols-outlined" aria-hidden="true">
+          cloud_sync
+        </span>
+        <span>Mirror settings</span>
+      </button>
+    </aside>
+  );
+}

--- a/apps/editor/src/ui/editor/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/TopToolbar.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { ProjectDocument } from '../../domain/model';
+import type { MirrorState } from '../../services/interfaces';
 
 interface TopToolbarProps {
   project: ProjectDocument;
@@ -12,14 +13,22 @@ interface TopToolbarProps {
   persistenceEnabled?: boolean;
   persistenceAvailable?: boolean;
   lastEditedAt?: string | undefined;
+  mirrorState?: MirrorState;
+  localProjectSetupPanel?: ReactNode;
+  persistenceAttention?: boolean;
+  persistenceNotice?: string | undefined;
   saveAnimationKey?: number;
   canTranslateDeck?: boolean;
   onDelete?: (() => void) | undefined;
   onDuplicate?: (() => void) | undefined;
   onImportProject?: (() => void) | undefined;
+  onImportRemoteMirror?: (() => void) | undefined;
+  onMirrorNow?: (() => void) | undefined;
+  onMirrorToggle?: ((enabled: boolean) => void) | undefined;
   onOpenVersionHistory?: (() => void) | undefined;
   onNewProject?: (() => void) | undefined;
   onPersistenceToggle?: ((enabled: boolean) => void) | undefined;
+  onSaveLocal?: (() => void) | undefined;
   onProjectNameChange?: ((name: string) => void) | undefined;
   onRedo?: (() => void) | undefined;
   onResetZoom?: (() => void) | undefined;
@@ -34,11 +43,19 @@ interface TopToolbarProps {
 
 type HeaderMenu = 'File' | 'Edit' | 'View' | 'Help';
 
-interface HeaderMenuAction {
+interface HeaderMenuActionItem {
+  kind?: 'item';
   label: string;
   disabled?: boolean;
   onSelect?: (() => void) | undefined;
 }
+
+interface HeaderMenuSeparator {
+  kind: 'separator';
+  label: string;
+}
+
+type HeaderMenuAction = HeaderMenuActionItem | HeaderMenuSeparator;
 
 const menuLabels: HeaderMenu[] = ['File', 'Edit', 'View', 'Help'];
 const githubUrl = 'https://github.com/ErickWendel/localstudio';
@@ -94,11 +111,18 @@ export function TopToolbar({
   persistenceEnabled = false,
   persistenceAvailable = true,
   lastEditedAt,
+  mirrorState = { enabled: false, status: 'disabled' },
+  localProjectSetupPanel,
+  persistenceAttention = false,
+  persistenceNotice,
   saveAnimationKey = 0,
   canTranslateDeck = false,
   onDelete,
   onDuplicate,
   onImportProject,
+  onImportRemoteMirror,
+  onMirrorNow,
+  onMirrorToggle,
   onOpenVersionHistory,
   onNewProject,
   onPersistenceToggle,
@@ -108,6 +132,7 @@ export function TopToolbar({
   onSelectLayers,
   onShare,
   onStartPresenterMode,
+  onSaveLocal,
   onTranslateDeck,
   onUndo,
   onZoomIn,
@@ -161,19 +186,22 @@ export function TopToolbar({
     File: [
       { label: 'New Project', disabled: !onNewProject, onSelect: onNewProject },
       { label: 'Import Project', disabled: !onImportProject, onSelect: onImportProject },
-      {
-        label: 'Save Local',
-        disabled: !persistenceAvailable,
-        onSelect: () => onPersistenceToggle?.(true),
-      },
+      { label: 'Import Remote', disabled: !onImportRemoteMirror, onSelect: onImportRemoteMirror },
       { label: 'Share', onSelect: triggerShare },
+      { kind: 'separator', label: 'File storage actions' },
+      { label: 'Save', disabled: !onSaveLocal, onSelect: onSaveLocal },
+      { label: 'Mirror Now', disabled: !onMirrorNow, onSelect: onMirrorNow },
     ],
     Edit: [
-  { label: 'Undo', disabled: !canUndo, onSelect: onUndo },
+      { label: 'Undo', disabled: !canUndo, onSelect: onUndo },
       { label: 'Redo', disabled: !canRedo, onSelect: onRedo },
       { label: 'Duplicate', disabled: !hasSelection, onSelect: onDuplicate },
       { label: 'Delete', disabled: !hasSelection, onSelect: onDelete },
-      { label: 'Translate Deck', disabled: !canTranslateDeck || !onTranslateDeck, onSelect: onTranslateDeck },
+      {
+        label: 'Translate Deck',
+        disabled: !canTranslateDeck || !onTranslateDeck,
+        onSelect: onTranslateDeck,
+      },
     ],
     View: [
       { label: 'Zoom Out', disabled: !onZoomOut, onSelect: onZoomOut },
@@ -190,6 +218,7 @@ export function TopToolbar({
   };
 
   function handleMenuAction(action: HeaderMenuAction) {
+    if (action.kind === 'separator') return;
     if (action.disabled) return;
     action.onSelect?.();
     closeMenu();
@@ -211,6 +240,39 @@ export function TopToolbar({
     : persistenceEnabled
       ? 'Persistence enabled'
       : 'Persistence disabled';
+  const mirrorLabel = !persistenceEnabled
+    ? 'Unsaved deck'
+    : !mirrorState.enabled
+      ? 'Local only'
+      : mirrorState.status === 'syncing'
+        ? 'Mirroring'
+        : mirrorState.status === 'failed'
+          ? 'Mirror failed'
+          : mirrorState.status === 'synced'
+            ? 'Mirrored'
+            : 'Local only';
+  const mirrorStatusDisabled = !persistenceEnabled;
+  const mirrorStatusLabel = mirrorStatusDisabled
+    ? 'Mirror disabled'
+    : !mirrorState.enabled
+      ? 'Mirror disabled'
+      : mirrorState.status === 'syncing'
+        ? 'Mirror syncing'
+        : mirrorState.status === 'synced'
+          ? 'Mirror up to date'
+          : mirrorState.status === 'failed'
+            ? 'Mirror failed'
+            : 'Mirror ready';
+  const mirrorStatusClassName = [
+    'stitch-icon-button',
+    'mirror-status-button',
+    mirrorStatusDisabled || !mirrorState.enabled ? 'mirror-disabled' : '',
+    !mirrorStatusDisabled && mirrorState.status === 'syncing' ? 'mirror-syncing' : '',
+    !mirrorStatusDisabled && mirrorState.status === 'synced' ? 'mirror-synced' : '',
+    !mirrorStatusDisabled && mirrorState.status === 'failed' ? 'mirror-failed' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <header className="top-toolbar">
@@ -227,29 +289,38 @@ export function TopToolbar({
                     : 'toolbar-menu-item font-orbitron'
                 }
                 type="button"
-              onClick={() => {
-                setPlayMenuOpen(false);
-                setOpenMenu((current) => (current === item ? null : item));
-              }}
+                onClick={() => {
+                  setPlayMenuOpen(false);
+                  setOpenMenu((current) => (current === item ? null : item));
+                }}
               >
                 {item}
               </button>
               {openMenu === item ? (
                 <div className="toolbar-dropdown" role="menu" aria-label={`${item} menu`}>
-                  {menuActions[item].map((action) => (
-                    <button
-                      className="toolbar-dropdown-item"
-                      disabled={action.disabled}
-                      key={action.label}
-                      role="menuitem"
-                      type="button"
-                      onClick={() => {
-                        handleMenuAction(action);
-                      }}
-                    >
-                      {action.label}
-                    </button>
-                  ))}
+                  {menuActions[item].map((action) =>
+                    action.kind === 'separator' ? (
+                      <div
+                        aria-label={action.label}
+                        className="toolbar-dropdown-separator"
+                        key={action.label}
+                        role="separator"
+                      />
+                    ) : (
+                      <button
+                        className="toolbar-dropdown-item"
+                        disabled={action.disabled}
+                        key={action.label}
+                        role="menuitem"
+                        type="button"
+                        onClick={() => {
+                          handleMenuAction(action);
+                        }}
+                      >
+                        {action.label}
+                      </button>
+                    ),
+                  )}
                 </div>
               ) : null}
             </div>
@@ -321,7 +392,11 @@ export function TopToolbar({
               </span>
             </button>
             {playMenuOpen ? (
-              <div className="toolbar-dropdown project-play-dropdown" role="menu" aria-label="Presentation play menu">
+              <div
+                className="toolbar-dropdown project-play-dropdown"
+                role="menu"
+                aria-label="Presentation play menu"
+              >
                 <button
                   className="toolbar-dropdown-item project-play-dropdown-item"
                   role="menuitem"
@@ -336,7 +411,9 @@ export function TopToolbar({
               </div>
             ) : null}
           </div>
-          <span className="local-only-badge">Local only</span>
+          <span className="local-only-badge" title={mirrorState.error}>
+            {mirrorLabel}
+          </span>
         </div>
       </div>
       <div className="toolbar-right">
@@ -347,7 +424,9 @@ export function TopToolbar({
                 ? 'stitch-icon-button persistence-off persistence-unavailable'
                 : persistenceEnabled
                   ? 'stitch-icon-button persistence-on'
-                  : 'stitch-icon-button persistence-off'
+                  : persistenceAttention
+                    ? 'stitch-icon-button persistence-off persistence-attention'
+                    : 'stitch-icon-button persistence-off'
             }
             disabled={!persistenceAvailable}
             title={persistenceTitle}
@@ -366,6 +445,30 @@ export function TopToolbar({
                 ×
               </span>
             ) : null}
+          </button>
+          {persistenceNotice ? (
+            <div className="persistence-notice" role="status">
+              {persistenceNotice}
+            </div>
+          ) : null}
+          {localProjectSetupPanel}
+          <button
+            className={mirrorStatusClassName}
+            disabled={mirrorStatusDisabled}
+            title={mirrorState.error ?? mirrorStatusLabel}
+            type="button"
+            aria-label={mirrorStatusLabel}
+            onClick={() => {
+              if (mirrorState.enabled) {
+                onMirrorToggle?.(false);
+                return;
+              }
+              onMirrorNow?.();
+            }}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              {mirrorState.status === 'syncing' ? 'sync' : 'cloud_sync'}
+            </span>
           </button>
           <button
             className="stitch-icon-button history-save-applied"
@@ -404,7 +507,11 @@ export function TopToolbar({
             </span>
           </button>
         </div>
-        <button className="language-chip" type="button" aria-label={`Current slide language ${languageLabel}`}>
+        <button
+          className="language-chip"
+          type="button"
+          aria-label={`Current slide language ${languageLabel}`}
+        >
           <span className="language-flag" aria-hidden="true">
             {languageFlag}
           </span>

--- a/apps/editor/src/ui/editor/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/useEditorViewModel.ts
@@ -54,9 +54,24 @@ import type {
   SelectionState,
   SlideTransition,
 } from '../../domain/model';
-import { createBlankProject, SAMPLE_HERO_IMAGE_SIZE, SAMPLE_HERO_IMAGE_URL } from '../../domain/sampleProject';
+import {
+  createBlankProject,
+  SAMPLE_HERO_IMAGE_SIZE,
+  SAMPLE_HERO_IMAGE_URL,
+} from '../../domain/sampleProject';
 import type { EditorAutomationDelegate } from '../../services/editorAutomationController';
-import type { AiProviderState, ModelState, PromptApiAvailability, VersionHistoryEntry } from '../../services/interfaces';
+import type {
+  AiProviderState,
+  MirrorProjectSummary,
+  MirrorState,
+  ModelState,
+  PromptApiAvailability,
+  VersionHistoryEntry,
+} from '../../services/interfaces';
+import {
+  DEFAULT_MINIO_MIRROR_CONFIG,
+  type MinioMirrorConfig,
+} from '../../services/minioMirrorService';
 import {
   GEMMA_LLM_MODEL_ID,
   LANGUAGE_DETECTION_MODEL_ID,
@@ -68,7 +83,10 @@ import {
 } from '../../services/imageGenerationModels';
 import { IMAGE_EDITING_MODEL_ID } from '../../services/modelSetupService';
 import { looksLikeImageGenerationRequest } from '../../services/prompts/slideTaskPrompt';
-import { defaultCreateImagePromptOptions, type CreateImagePromptOptions } from './imagePromptOptions';
+import {
+  defaultCreateImagePromptOptions,
+  type CreateImagePromptOptions,
+} from './imagePromptOptions';
 import { TRANSLATION_LANGUAGE_OPTIONS } from './translationLanguages';
 
 export type RightPanelTab = 'layout' | 'text' | 'design' | 'ai-tools' | 'assets' | 'animations';
@@ -125,11 +143,14 @@ interface AnimationPreviewState {
   waitingForClick: boolean;
 }
 
+export type RemoteImportStatus = 'loading' | 'ready' | 'empty' | 'importing' | 'failed';
+
 const PERSISTENCE_PREFERENCE_KEY = 'ew-canvas-ai.persistence-enabled';
 const TRANSLATION_TARGET_LANGUAGE_KEY = 'localstudio.ai.translation-target-language';
 const IMAGE_EDITING_MODEL_REQUIRED_MESSAGE = 'You must download the image editing tools first.';
 const PROMPT_API_REQUIRED_MESSAGE = 'LLM model must be prepared before using prompt-to-slides.';
-const IMAGE_GENERATION_MODEL_REQUIRED_MESSAGE = 'Download image generation models before creating images.';
+const IMAGE_GENERATION_MODEL_REQUIRED_MESSAGE =
+  'Download image generation models before creating images.';
 const IMAGE_PROMPT_MODE_REQUIRED_MESSAGE = 'Use Create image from the + menu to generate images.';
 const IMAGE_GENERATION_DIMENSION_MULTIPLE = 16;
 const BACKGROUND_PREVIEW_DEBOUNCE_MS = 120;
@@ -188,7 +209,9 @@ function readPersistencePreference() {
 function readTranslationTargetLanguage() {
   if (typeof window === 'undefined') return '';
   const storedTarget = window.localStorage.getItem(TRANSLATION_TARGET_LANGUAGE_KEY);
-  return TRANSLATION_LANGUAGE_OPTIONS.some((option) => option.code === storedTarget) ? storedTarget ?? '' : '';
+  return TRANSLATION_LANGUAGE_OPTIONS.some((option) => option.code === storedTarget)
+    ? (storedTarget ?? '')
+    : '';
 }
 
 function writeProjectNameToUrl(projectName: string) {
@@ -203,7 +226,8 @@ function writeProjectNameToUrl(projectName: string) {
 }
 
 function normalizeProjectDocument(project: ProjectDocument): ProjectDocument {
-  const shouldRestoreHeroImage = Boolean(project.assets['asset-hero']) && !project.elements['image-hero'];
+  const shouldRestoreHeroImage =
+    Boolean(project.assets['asset-hero']) && !project.elements['image-hero'];
   const pageId = project.pages[0]?.id;
   const elements: ProjectDocument['elements'] = {};
 
@@ -356,7 +380,13 @@ function getPageTextSample(project: ProjectDocument, pageId: string) {
 }
 
 type TranslationScope = 'selection' | 'slide' | 'deck';
-type TranslationPatch = { fontSize?: number; height?: number; text: string; width?: number; x?: number };
+type TranslationPatch = {
+  fontSize?: number;
+  height?: number;
+  text: string;
+  width?: number;
+  x?: number;
+};
 
 function normalizeTranslatedText(originalText: string, translatedText: string) {
   if (originalText.includes('\n')) return translatedText.trim();
@@ -387,8 +417,12 @@ function fitTranslatedTextToOriginalFrame(
 
   const desiredWidth = Math.ceil(estimatedWidth + horizontalPadding);
   const originalCenter = element.x + element.width / 2;
-  const pageWidth = page?.width ?? Math.max(element.x + desiredWidth, originalCenter + desiredWidth / 2);
-  const maxWidthAroundCenter = Math.max(1, 2 * Math.min(originalCenter, pageWidth - originalCenter));
+  const pageWidth =
+    page?.width ?? Math.max(element.x + desiredWidth, originalCenter + desiredWidth / 2);
+  const maxWidthAroundCenter = Math.max(
+    1,
+    2 * Math.min(originalCenter, pageWidth - originalCenter),
+  );
   const nextWidth = Math.max(element.width, Math.min(desiredWidth, maxWidthAroundCenter));
   const nextX = Math.max(0, Math.min(pageWidth - nextWidth, originalCenter - nextWidth / 2));
 
@@ -400,7 +434,10 @@ function fitTranslatedTextToOriginalFrame(
     };
   }
 
-  const estimatedLineCount = Math.max(1, Math.ceil(estimatedWidth / Math.max(1, nextWidth - horizontalPadding)));
+  const estimatedLineCount = Math.max(
+    1,
+    Math.ceil(estimatedWidth / Math.max(1, nextWidth - horizontalPadding)),
+  );
   return {
     text: normalizedText,
     width: nextWidth,
@@ -410,12 +447,19 @@ function fitTranslatedTextToOriginalFrame(
 }
 
 export function useEditorViewModel(services: AppServices) {
-  const initialProject = useMemo(() => normalizeProjectDocument(services.initialProject), [
-    services.initialProject,
-  ]);
+  const initialProject = useMemo(
+    () => normalizeProjectDocument(services.initialProject),
+    [services.initialProject],
+  );
+  const storedMirrorConfig = useMemo(
+    () => services.mirrorService.loadConfig(),
+    [services.mirrorService],
+  );
   const shouldRestoreStoredProject = useMemo(
-    () => !services.skipStoredProjectLoad && readPersistencePreference(),
-    [services.skipStoredProjectLoad],
+    () =>
+      !services.skipStoredProjectLoad &&
+      (readPersistencePreference() || Boolean(storedMirrorConfig)),
+    [services.skipStoredProjectLoad, storedMirrorConfig],
   );
   const [project, setProject] = useState<ProjectDocument>(initialProject);
   const projectRef = useRef(project);
@@ -435,20 +479,29 @@ export function useEditorViewModel(services: AppServices) {
   const [backgroundSelectionNotice, setBackgroundSelectionNotice] = useState<string | undefined>();
   const [processingElementIds, setProcessingElementIds] = useState<string[]>([]);
   const [backgroundPreview, setBackgroundPreview] = useState<BackgroundPreviewState | undefined>();
-  const [backgroundPreparation, setBackgroundPreparation] = useState<BackgroundPreparationState | undefined>();
-  const [translationTargetLanguage, setTranslationTargetLanguageState] = useState(readTranslationTargetLanguage);
+  const [backgroundPreparation, setBackgroundPreparation] = useState<
+    BackgroundPreparationState | undefined
+  >();
+  const [translationTargetLanguage, setTranslationTargetLanguageState] = useState(
+    readTranslationTargetLanguage,
+  );
   const [promptProviderStates, setPromptProviderStates] = useState<AiProviderState[]>([]);
   const [translationProviderStates, setTranslationProviderStates] = useState<AiProviderState[]>([]);
-  const [languageDetectionProviderStates, setLanguageDetectionProviderStates] = useState<AiProviderState[]>([]);
+  const [languageDetectionProviderStates, setLanguageDetectionProviderStates] = useState<
+    AiProviderState[]
+  >([]);
   const [translationTargetAttention, setTranslationTargetAttention] = useState(false);
-  const [translationPreparation, setTranslationPreparation] = useState<TranslationPreparationState>({
-    progress: 0,
-    status: readTranslationTargetLanguage() ? 'ready' : 'idle',
-  });
-  const [languageDetectionPreparation, setLanguageDetectionPreparation] = useState<TranslationPreparationState>({
-    progress: 0,
-    status: 'idle',
-  });
+  const [translationPreparation, setTranslationPreparation] = useState<TranslationPreparationState>(
+    {
+      progress: 0,
+      status: readTranslationTargetLanguage() ? 'ready' : 'idle',
+    },
+  );
+  const [languageDetectionPreparation, setLanguageDetectionPreparation] =
+    useState<TranslationPreparationState>({
+      progress: 0,
+      status: 'idle',
+    });
   const [promptPreparation, setPromptPreparation] = useState<PromptPreparationState>({
     availability: 'unavailable',
     progress: 0,
@@ -461,7 +514,9 @@ export function useEditorViewModel(services: AppServices) {
   const [isGeneratingSlide, setIsGeneratingSlide] = useState(false);
   const [createImageNotice, setCreateImageNotice] = useState<string | undefined>();
   const [createImageStatus, setCreateImageStatus] = useState<string | undefined>();
-  const [createImageOptions, setCreateImageOptions] = useState<CreateImagePromptOptions>(defaultCreateImagePromptOptions);
+  const [createImageOptions, setCreateImageOptions] = useState<CreateImagePromptOptions>(
+    defaultCreateImagePromptOptions,
+  );
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
   const [aiToolsAttentionModelId, setAiToolsAttentionModelId] = useState<string | undefined>();
   const [pageLanguageCodes, setPageLanguageCodes] = useState<Record<string, string>>({});
@@ -480,12 +535,37 @@ export function useEditorViewModel(services: AppServices) {
   const [highlightVersionChanges, setHighlightVersionChanges] = useState(true);
   const [lastEditedAt, setLastEditedAt] = useState<string | undefined>(initialProject.updatedAt);
   const [saveAnimationKey, setSaveAnimationKey] = useState(0);
-  const [, setBackgroundSelectionPoints] = useState<Record<string, BackgroundSelectionPoint[]>>(
-    {},
+  const [mirrorState, setMirrorState] = useState<MirrorState>(() => ({
+    enabled: Boolean(storedMirrorConfig),
+    status: storedMirrorConfig ? 'idle' : 'disabled',
+  }));
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [mirrorSettingsOpen, setMirrorSettingsOpen] = useState(false);
+  const [remoteImportOpen, setRemoteImportOpen] = useState(false);
+  const [localProjectSetupOpen, setLocalProjectSetupOpen] = useState(false);
+  const [persistenceAttention, setPersistenceAttention] = useState(false);
+  const [persistenceNotice, setPersistenceNotice] = useState<string | undefined>();
+  const [remoteImportStatus, setRemoteImportStatus] = useState<RemoteImportStatus>('loading');
+  const [remoteImportProjects, setRemoteImportProjects] = useState<MirrorProjectSummary[]>([]);
+  const [remoteImportError, setRemoteImportError] = useState<string | undefined>();
+  const [mirrorConfig, setMirrorConfig] = useState<MinioMirrorConfig>(
+    () => storedMirrorConfig ?? DEFAULT_MINIO_MIRROR_CONFIG,
   );
+  const mirrorConfigRef = useRef<MinioMirrorConfig | null>(storedMirrorConfig);
+  const mirrorSyncInFlightRef = useRef(false);
+  const mirrorSyncQueuedRef = useRef(false);
+  const mirrorDebounceRef = useRef<number | undefined>(undefined);
+  const queueMirrorSyncRef = useRef<() => void>(() => undefined);
+  const syncMirrorNowRef = useRef<(project?: ProjectDocument) => void>(() => undefined);
+  const [, setBackgroundSelectionPoints] = useState<Record<string, BackgroundSelectionPoint[]>>({});
   projectRef.current = project;
   activePageIdRef.current = activePageId;
   selectedElementIdsRef.current = selectedElementIds;
+  mirrorConfigRef.current = mirrorState.enabled ? mirrorConfig : null;
+  queueMirrorSyncRef.current = queueMirrorSync;
+  syncMirrorNowRef.current = (projectToSync) => {
+    void syncMirrorNow(projectToSync);
+  };
   const backgroundSelectionPointsRef = useRef<Record<string, BackgroundSelectionPoint[]>>({});
   const backgroundPreviewTimeoutRef = useRef<number | undefined>(undefined);
   const animationPreviewQueueRef = useRef<ElementAnimationBuild[]>([]);
@@ -496,10 +576,10 @@ export function useEditorViewModel(services: AppServices) {
   const languageDetectionSequenceRef = useRef(0);
   const skipNextProjectSaveRef = useRef(shouldRestoreStoredProject);
   const lastVersionProjectRef = useRef<ProjectDocument>(initialProject);
-  const selection = useMemo<SelectionState>(() => ({ pageId: activePageId, elementIds: selectedElementIds }), [
-    activePageId,
-    selectedElementIds,
-  ]);
+  const selection = useMemo<SelectionState>(
+    () => ({ pageId: activePageId, elementIds: selectedElementIds }),
+    [activePageId, selectedElementIds],
+  );
   const selectedImageElement = useMemo<ImageElement | undefined>(() => {
     if (selectedElementIds.length !== 1) return undefined;
     const element = project.elements[selectedElementIds[0] ?? ''];
@@ -526,7 +606,9 @@ export function useEditorViewModel(services: AppServices) {
         setTranslationProviderStates(await services.translatorService.getProviderStates());
       }
       if (services.translatorService.getLanguageDetectionProviderStates) {
-        setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
+        setLanguageDetectionProviderStates(
+          await services.translatorService.getLanguageDetectionProviderStates(),
+        );
       }
     }
 
@@ -587,7 +669,9 @@ export function useEditorViewModel(services: AppServices) {
     if (!persistenceEnabled) return;
 
     void services.projectRepository
-      .loadProject(services.storedProjectName ? { projectName: services.storedProjectName } : undefined)
+      .loadProject(
+        services.storedProjectName ? { projectName: services.storedProjectName } : undefined,
+      )
       .then((savedProject) => {
         if (!isMounted) return;
         if (savedProject) {
@@ -599,9 +683,13 @@ export function useEditorViewModel(services: AppServices) {
           lastVersionProjectRef.current = normalizedProject;
           setLastEditedAt(normalizedProject.updatedAt);
           if (services.projectRepository.getVersionHistory) {
-            void services.projectRepository.getVersionHistory().then(setVersionHistoryEntries).catch(() => undefined);
+            void services.projectRepository
+              .getVersionHistory()
+              .then(setVersionHistoryEntries)
+              .catch(() => undefined);
           }
           writeProjectNameToUrl(normalizedProject.name);
+          if (storedMirrorConfig) syncMirrorNowRef.current(normalizedProject);
         }
         setHasLoadedProject(true);
       })
@@ -617,7 +705,7 @@ export function useEditorViewModel(services: AppServices) {
     return () => {
       isMounted = false;
     };
-  }, [persistenceEnabled, services.projectRepository, services.storedProjectName]);
+  }, [persistenceEnabled, services.projectRepository, services.storedProjectName, storedMirrorConfig]);
 
   useEffect(() => {
     if (!hasLoadedProject || !persistenceEnabled) return;
@@ -636,9 +724,13 @@ export function useEditorViewModel(services: AppServices) {
         });
         lastVersionProjectRef.current = project;
         setLastEditedAt(entry.createdAt);
-        setVersionHistoryEntries((current) => [entry, ...current.filter((item) => item.id !== entry.id)]);
+        setVersionHistoryEntries((current) => [
+          entry,
+          ...current.filter((item) => item.id !== entry.id),
+        ]);
       })
       .then(() => {
+        queueMirrorSyncRef.current();
         writeProjectNameToUrl(project.name);
       })
       .catch(() => {
@@ -648,6 +740,14 @@ export function useEditorViewModel(services: AppServices) {
         }
       });
   }, [hasLoadedProject, persistenceEnabled, project, services.projectRepository]);
+
+  useEffect(() => {
+    return () => {
+      if (mirrorDebounceRef.current !== undefined) {
+        window.clearTimeout(mirrorDebounceRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (pageLanguageCodes[activePageId]) return;
@@ -728,13 +828,17 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function isBackgroundPreparationReady(elementId: string) {
-    return backgroundPreparation?.elementId === elementId && backgroundPreparation.status === 'ready';
+    return (
+      backgroundPreparation?.elementId === elementId && backgroundPreparation.status === 'ready'
+    );
   }
 
   async function downloadRequiredModels() {
     setModelStates((currentStates) =>
       currentStates.map((state) =>
-        state.required && state.status !== 'ready' ? { ...state, status: 'downloading', progress: 10 } : state,
+        state.required && state.status !== 'ready'
+          ? { ...state, status: 'downloading', progress: 10 }
+          : state,
       ),
     );
     const next = await services.modelSetupService.downloadRequiredModels();
@@ -746,7 +850,9 @@ export function useEditorViewModel(services: AppServices) {
       setTranslationProviderStates(await services.translatorService.getProviderStates());
     }
     if (services.translatorService.getLanguageDetectionProviderStates) {
-      setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
+      setLanguageDetectionProviderStates(
+        await services.translatorService.getLanguageDetectionProviderStates(),
+      );
     }
     if (next.some((state) => state.id === IMAGE_EDITING_MODEL_ID && state.status === 'ready')) {
       setBackgroundSelectionNotice(undefined);
@@ -760,7 +866,9 @@ export function useEditorViewModel(services: AppServices) {
   async function downloadModel(id: string) {
     setModelStates((currentStates) =>
       currentStates.map((state) =>
-        state.id === id && state.status !== 'ready' ? { ...state, status: 'downloading', progress: 10 } : state,
+        state.id === id && state.status !== 'ready'
+          ? { ...state, status: 'downloading', progress: 10 }
+          : state,
       ),
     );
     const next = await services.modelSetupService.downloadModel(id, {
@@ -782,7 +890,9 @@ export function useEditorViewModel(services: AppServices) {
       setTranslationProviderStates(await services.translatorService.getProviderStates());
     }
     if (services.translatorService.getLanguageDetectionProviderStates) {
-      setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
+      setLanguageDetectionProviderStates(
+        await services.translatorService.getLanguageDetectionProviderStates(),
+      );
     }
     if (id === IMAGE_EDITING_MODEL_ID && next.status === 'ready') {
       setBackgroundSelectionNotice(undefined);
@@ -796,7 +906,9 @@ export function useEditorViewModel(services: AppServices) {
   async function removeModel(id: string) {
     if (!services.modelSetupService.removeModel) return;
 
-    const selectedPromptProviderId = promptProviderStates.find((provider) => provider.modelId === id && provider.selected)?.id;
+    const selectedPromptProviderId = promptProviderStates.find(
+      (provider) => provider.modelId === id && provider.selected,
+    )?.id;
     const selectedTranslationProviderId = translationProviderStates.find(
       (provider) => provider.modelId === id && provider.selected,
     )?.id;
@@ -830,7 +942,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function isImageGenerationReady() {
-    return modelStates.some((state) => state.id === IMAGE_GENERATION_MODEL_ID && state.status === 'ready');
+    return modelStates.some(
+      (state) => state.id === IMAGE_GENERATION_MODEL_ID && state.status === 'ready',
+    );
   }
 
   function ensureImageGenerationReadyForPrompt() {
@@ -850,8 +964,14 @@ export function useEditorViewModel(services: AppServices) {
     const availability = await services.promptService.checkAvailability();
     setPromptPreparation((current) => ({
       availability,
-      progress: availability === 'ready' ? 100 : current.status === 'downloading' ? current.progress : 0,
-      status: availability === 'ready' ? 'ready' : current.status === 'downloading' ? 'downloading' : 'idle',
+      progress:
+        availability === 'ready' ? 100 : current.status === 'downloading' ? current.progress : 0,
+      status:
+        availability === 'ready'
+          ? 'ready'
+          : current.status === 'downloading'
+            ? 'downloading'
+            : 'idle',
     }));
     return availability;
   }
@@ -892,7 +1012,9 @@ export function useEditorViewModel(services: AppServices) {
       }
       setPromptPreparation({ availability: 'unavailable', progress: 0, status: 'failed' });
       setPromptApiAttention(true);
-      setPromptApiNotice(error instanceof Error ? error.message : 'Chrome Prompt API could not be prepared.');
+      setPromptApiNotice(
+        error instanceof Error ? error.message : 'Chrome Prompt API could not be prepared.',
+      );
     }
   }
 
@@ -951,7 +1073,8 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   async function prepareSelectedLanguageDetectionProvider(providerState?: AiProviderState) {
-    const selectedProvider = providerState ?? languageDetectionProviderStates.find((provider) => provider.selected);
+    const selectedProvider =
+      providerState ?? languageDetectionProviderStates.find((provider) => provider.selected);
     if (!selectedProvider?.modelId || selectedProvider.readiness === 'ready') return;
 
     setLanguageDetectionPreparation({ progress: 4, status: 'downloading' });
@@ -967,27 +1090,36 @@ export function useEditorViewModel(services: AppServices) {
       setLanguageDetectionPreparation({ progress: 100, status: 'ready' });
       setModelStates(await services.modelSetupService.getModelStates());
       if (services.translatorService.getLanguageDetectionProviderStates) {
-        setLanguageDetectionProviderStates(await services.translatorService.getLanguageDetectionProviderStates());
+        setLanguageDetectionProviderStates(
+          await services.translatorService.getLanguageDetectionProviderStates(),
+        );
       }
     } catch (error) {
       setLanguageDetectionPreparation({ progress: 0, status: 'failed' });
-      setTranslationNotice(error instanceof Error ? error.message : 'Language detection model could not be prepared.');
+      setTranslationNotice(
+        error instanceof Error ? error.message : 'Language detection model could not be prepared.',
+      );
     }
   }
 
   async function prepareSelectedTranslationProvider(providerState?: AiProviderState) {
-    const selectedProvider = providerState ?? translationProviderStates.find((provider) => provider.selected);
+    const selectedProvider =
+      providerState ?? translationProviderStates.find((provider) => provider.selected);
     if (selectedProvider?.modelId && selectedProvider.readiness !== 'ready') {
       setTranslationPreparation({ progress: 4, status: 'downloading' });
       try {
-        await services.translatorService.prepareTranslation('en', translationTargetLanguage || 'en', {
-          onProgress: (progress) => {
-            setTranslationPreparation((current) => ({
-              progress: Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
-              status: progress >= 100 ? 'ready' : 'downloading',
-            }));
+        await services.translatorService.prepareTranslation(
+          'en',
+          translationTargetLanguage || 'en',
+          {
+            onProgress: (progress) => {
+              setTranslationPreparation((current) => ({
+                progress: Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+                status: progress >= 100 ? 'ready' : 'downloading',
+              }));
+            },
           },
-        });
+        );
         setTranslationPreparation({ progress: 100, status: 'ready' });
         setModelStates(await services.modelSetupService.getModelStates());
         if (services.translatorService.getProviderStates) {
@@ -1002,7 +1134,9 @@ export function useEditorViewModel(services: AppServices) {
           }
         }
         setTranslationPreparation({ progress: 0, status: 'failed' });
-        setTranslationNotice(error instanceof Error ? error.message : 'Translation model could not be prepared.');
+        setTranslationNotice(
+          error instanceof Error ? error.message : 'Translation model could not be prepared.',
+        );
       }
     }
     if (translationTargetLanguage) {
@@ -1053,14 +1187,18 @@ export function useEditorViewModel(services: AppServices) {
     setIsGeneratingSlide(true);
     try {
       setPromptGenerationStatus('Planning slide...');
-      const generatedTasks = await services.promptService.generateSlideTasksFromPrompt(trimmedPrompt, {
-        targetLanguageHint: 'same as user prompt',
-      });
+      const generatedTasks = await services.promptService.generateSlideTasksFromPrompt(
+        trimmedPrompt,
+        {
+          targetLanguageHint: 'same as user prompt',
+        },
+      );
       if (!isCurrentRun()) return;
       const pageId = activePageId;
 
       commitProject(
-        (currentProject) => new PrepareGeneratedSlideCommand(pageId, generatedTasks.page).execute(currentProject),
+        (currentProject) =>
+          new PrepareGeneratedSlideCommand(pageId, generatedTasks.page).execute(currentProject),
         { activePageId: pageId, selectedElementIds: [] },
       );
 
@@ -1079,7 +1217,8 @@ export function useEditorViewModel(services: AppServices) {
         generatedElements.push(element);
         const selectedElementId = `generated-${pageId}-${element.id.replace(/[^a-z0-9-_]/gi, '-').toLowerCase()}`;
         commitProject(
-          (currentProject) => new AddGeneratedSlideElementCommand(pageId, element).execute(currentProject),
+          (currentProject) =>
+            new AddGeneratedSlideElementCommand(pageId, element).execute(currentProject),
           { activePageId: pageId, selectedElementIds: [selectedElementId] },
         );
       }
@@ -1090,7 +1229,9 @@ export function useEditorViewModel(services: AppServices) {
       }));
     } catch (error) {
       if (!isCurrentRun()) return;
-      setPromptGenerationNotice(error instanceof Error ? error.message : 'Prompt API could not generate the slide.');
+      setPromptGenerationNotice(
+        error instanceof Error ? error.message : 'Prompt API could not generate the slide.',
+      );
     } finally {
       if (isCurrentRun()) {
         setPromptGenerationStatus(undefined);
@@ -1137,7 +1278,8 @@ export function useEditorViewModel(services: AppServices) {
       if (!isCurrentRun()) return;
       if (imageToReplace) {
         commitProject(
-          (currentProject) => new ReplaceImageAssetCommand(imageToReplace.id, asset).execute(currentProject),
+          (currentProject) =>
+            new ReplaceImageAssetCommand(imageToReplace.id, asset).execute(currentProject),
           { selectedElementIds: [imageToReplace.id] },
         );
         return;
@@ -1223,7 +1365,11 @@ export function useEditorViewModel(services: AppServices) {
     });
   }
 
-  function getSelectionForProject(nextProject: ProjectDocument, pageId: string, currentSelection: string[]) {
+  function getSelectionForProject(
+    nextProject: ProjectDocument,
+    pageId: string,
+    currentSelection: string[],
+  ) {
     const page = nextProject.pages.find((item) => item.id === pageId) ?? nextProject.pages[0];
     const retainedSelection = currentSelection.filter((id) => page?.elementIds.includes(id));
     if (retainedSelection.length > 0) return retainedSelection;
@@ -1281,23 +1427,79 @@ export function useEditorViewModel(services: AppServices) {
     }));
   }
 
-  async function setPersistence(nextEnabled: boolean) {
+  function setPersistence(nextEnabled: boolean) {
     if (!nextEnabled) {
       setPersistenceEnabled(false);
+      setLocalProjectSetupOpen(false);
+      setPersistenceAttention(false);
+      setPersistenceNotice(undefined);
       if (typeof window !== 'undefined') {
         window.localStorage.setItem(PERSISTENCE_PREFERENCE_KEY, 'false');
       }
       return;
     }
 
+    setLocalProjectSetupOpen(true);
+  }
+
+  async function persistCurrentProject(projectToSave = projectRef.current) {
+    await services.projectRepository.saveProject(projectToSave);
+    const previousProject = lastVersionProjectRef.current;
+    lastVersionProjectRef.current = projectToSave;
+    setLastEditedAt(projectToSave.updatedAt);
+    setSaveAnimationKey((current) => current + 1);
+    if (!services.projectRepository.saveVersion) return;
+    const entry = await services.projectRepository.saveVersion(projectToSave, {
+      previousProject,
+      force: true,
+    });
+    setLastEditedAt(entry.createdAt);
+    setVersionHistoryEntries((current) => [
+      entry,
+      ...current.filter((item) => item.id !== entry.id),
+    ]);
+  }
+
+  async function saveLocalNow() {
+    if (!persistenceEnabled) {
+      setPersistence(true);
+      return;
+    }
     try {
-      await services.projectRepository.saveProject(project);
-      lastVersionProjectRef.current = project;
-      setLastEditedAt(project.updatedAt);
+      await persistCurrentProject();
+      writeProjectNameToUrl(projectRef.current.name);
+    } catch {
+      setPersistenceEnabled(false);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(PERSISTENCE_PREFERENCE_KEY, 'false');
+      }
+    }
+  }
+
+  function closeLocalProjectSetup() {
+    setLocalProjectSetupOpen(false);
+  }
+
+  async function confirmLocalProjectSetup(projectName: string) {
+    const nextName = projectName.trim();
+    if (!nextName) return;
+    const nextProject = {
+      ...projectRef.current,
+      name: nextName,
+      updatedAt: new Date().toISOString(),
+    };
+    try {
+      await services.projectRepository.saveProject(nextProject, { projectDirectoryName: nextName });
+      setProject(nextProject);
+      lastVersionProjectRef.current = nextProject;
+      setLastEditedAt(nextProject.updatedAt);
       setSaveAnimationKey((current) => current + 1);
       skipNextProjectSaveRef.current = true;
       setPersistenceEnabled(true);
-      writeProjectNameToUrl(project.name);
+      setPersistenceAttention(false);
+      setPersistenceNotice(undefined);
+      setLocalProjectSetupOpen(false);
+      writeProjectNameToUrl(nextProject.name);
       if (typeof window !== 'undefined') {
         window.localStorage.setItem(PERSISTENCE_PREFERENCE_KEY, 'true');
       }
@@ -1331,7 +1533,10 @@ export function useEditorViewModel(services: AppServices) {
       lastVersionProjectRef.current = normalizedProject;
       setLastEditedAt(normalizedProject.updatedAt);
       if (services.projectRepository.getVersionHistory) {
-        void services.projectRepository.getVersionHistory().then(setVersionHistoryEntries).catch(() => undefined);
+        void services.projectRepository
+          .getVersionHistory()
+          .then(setVersionHistoryEntries)
+          .catch(() => undefined);
       }
       writeProjectNameToUrl(normalizedProject.name);
       if (typeof window !== 'undefined') {
@@ -1342,6 +1547,203 @@ export function useEditorViewModel(services: AppServices) {
       if (typeof window !== 'undefined') {
         window.localStorage.setItem(PERSISTENCE_PREFERENCE_KEY, 'false');
       }
+    }
+  }
+
+  function openSettings() {
+    setSettingsOpen(true);
+  }
+
+  function closeSettings() {
+    setSettingsOpen(false);
+  }
+
+  function openMirrorSettings() {
+    setSettingsOpen(false);
+    setMirrorSettingsOpen(true);
+  }
+
+  function closeMirrorSettings() {
+    setMirrorSettingsOpen(false);
+  }
+
+  function closeRemoteImport() {
+    setRemoteImportOpen(false);
+  }
+
+  function saveMirrorConfig(config: MinioMirrorConfig) {
+    services.mirrorService.saveConfig(config);
+    setMirrorConfig(config);
+    mirrorConfigRef.current = config;
+    setMirrorState({ enabled: true, status: 'idle' });
+  }
+
+  function setMirrorEnabled(enabled: boolean) {
+    if (enabled) {
+      if (!mirrorConfigRef.current) {
+        openMirrorSettings();
+      }
+      return;
+    }
+    services.mirrorService.clearConfig();
+    mirrorConfigRef.current = null;
+    setMirrorState({ enabled: false, status: 'disabled' });
+  }
+
+  async function testMirrorConnection(config: MinioMirrorConfig) {
+    setMirrorState({ enabled: true, status: 'syncing' });
+    try {
+      await services.mirrorService.listProjects(config);
+      setMirrorState({ enabled: true, status: 'idle' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'MinIO connection failed.';
+      setMirrorState({
+        enabled: true,
+        status: 'failed',
+        error: message,
+      });
+      throw new Error(message, { cause: error });
+    }
+  }
+
+  function queueMirrorSync() {
+    if (!mirrorConfigRef.current) return;
+    if (typeof window === 'undefined') {
+      void syncMirrorNow();
+      return;
+    }
+    if (mirrorDebounceRef.current !== undefined) {
+      window.clearTimeout(mirrorDebounceRef.current);
+    }
+    mirrorDebounceRef.current = window.setTimeout(() => {
+      void syncMirrorNow();
+    }, 750);
+  }
+
+  async function syncMirrorNow(projectToSync: ProjectDocument = projectRef.current) {
+    const config = mirrorConfigRef.current;
+    if (!config) {
+      openMirrorSettings();
+      return;
+    }
+    if (mirrorSyncInFlightRef.current) {
+      mirrorSyncQueuedRef.current = true;
+      return;
+    }
+    mirrorSyncInFlightRef.current = true;
+    setMirrorState((current) => {
+      const { error, ...rest } = current;
+      void error;
+      return { ...rest, enabled: true, status: 'syncing' };
+    });
+    try {
+      const nextState = await services.mirrorService.syncProject(
+        projectToSync,
+        services.projectRepository,
+        mirrorConfigRef.current!,
+      );
+      setMirrorState(nextState);
+    } catch (error) {
+      setMirrorState({
+        enabled: true,
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'MinIO mirror sync failed.',
+      });
+    } finally {
+      mirrorSyncInFlightRef.current = false;
+      if (mirrorSyncQueuedRef.current) {
+        mirrorSyncQueuedRef.current = false;
+        void syncMirrorNow();
+      }
+    }
+  }
+
+  function requestMirrorNow() {
+    if (!persistenceEnabled) {
+      setPersistenceAttention(true);
+      setPersistenceNotice('Save the project before mirroring.');
+      return;
+    }
+    if (!mirrorConfigRef.current) {
+      openMirrorSettings();
+      return;
+    }
+    void syncMirrorNow();
+  }
+
+  async function importRemoteMirror() {
+    const config = mirrorConfigRef.current;
+    if (!config) {
+      openMirrorSettings();
+      return;
+    }
+    if (!config || !services.projectRepository.importMirrorFiles) return;
+    setRemoteImportOpen(true);
+    setRemoteImportStatus('loading');
+    setRemoteImportError(undefined);
+    try {
+      const mirrors = await services.mirrorService.listProjects(config);
+      if (mirrors.length === 0) {
+        setRemoteImportProjects([]);
+        setRemoteImportStatus('empty');
+        return;
+      }
+      setRemoteImportProjects(mirrors);
+      setRemoteImportStatus('ready');
+    } catch (error) {
+      setRemoteImportStatus('failed');
+      setRemoteImportError(
+        error instanceof Error ? error.message : 'Could not list mirrored projects.',
+      );
+      setMirrorState({
+        enabled: Boolean(config),
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'MinIO mirror import failed.',
+      });
+    }
+  }
+
+  async function importRemoteMirrorProject(projectId: string) {
+    const config = mirrorConfigRef.current;
+    if (!config || !services.projectRepository.importMirrorFiles) return;
+    setRemoteImportStatus('importing');
+    setRemoteImportError(undefined);
+    try {
+      const files = await services.mirrorService.downloadProject(projectId, config);
+      const importedProject = await services.projectRepository.importMirrorFiles(files);
+      const normalizedProject = normalizeProjectDocument(importedProject);
+      setProject(normalizedProject);
+      setActivePageId(normalizedProject.pages[0]?.id ?? '');
+      setPageLanguageCodes({});
+      setSelectedElementIds([]);
+      setHistory({ past: [], future: [] });
+      setBackgroundSelectionMode(false);
+      setBackgroundSelectionNotice(undefined);
+      clearBackgroundPreview();
+      clearBackgroundPreparation();
+      clearBackgroundSelectionPoints();
+      skipNextProjectSaveRef.current = true;
+      setPersistenceEnabled(true);
+      lastVersionProjectRef.current = normalizedProject;
+      setLastEditedAt(normalizedProject.updatedAt);
+      if (services.projectRepository.getVersionHistory) {
+        void services.projectRepository
+          .getVersionHistory()
+          .then(setVersionHistoryEntries)
+          .catch(() => undefined);
+      }
+      writeProjectNameToUrl(normalizedProject.name);
+      window.localStorage.setItem(PERSISTENCE_PREFERENCE_KEY, 'true');
+      setMirrorState({ enabled: true, status: 'synced', lastSyncedAt: new Date().toISOString() });
+      setRemoteImportOpen(false);
+    } catch (error) {
+      setRemoteImportStatus('failed');
+      setRemoteImportError(error instanceof Error ? error.message : 'MinIO mirror import failed.');
+      setMirrorState({
+        enabled: Boolean(config),
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'MinIO mirror import failed.',
+      });
     }
   }
 
@@ -1390,7 +1792,10 @@ export function useEditorViewModel(services: AppServices) {
         previousProject: project,
         force: true,
       });
-      setVersionHistoryEntries((current) => [entry, ...current.filter((item) => item.id !== entry.id)]);
+      setVersionHistoryEntries((current) => [
+        entry,
+        ...current.filter((item) => item.id !== entry.id),
+      ]);
       setLastEditedAt(entry.createdAt);
     }
     lastVersionProjectRef.current = normalizedProject;
@@ -1425,7 +1830,10 @@ export function useEditorViewModel(services: AppServices) {
             ? patch
             : {
                 ...patch,
-                height: Math.max(patch.height, getMinimumTextHeight(element.text, element.fontSize)),
+                height: Math.max(
+                  patch.height,
+                  getMinimumTextHeight(element.text, element.fontSize),
+                ),
               }
           : patch;
       return new UpdateElementFrameCommand(elementId, nextPatch).execute(currentProject);
@@ -1433,7 +1841,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function updateElementFrames(patches: Record<string, ElementFramePatch>) {
-    commitProject((currentProject) => new UpdateElementFramesCommand(patches).execute(currentProject));
+    commitProject((currentProject) =>
+      new UpdateElementFramesCommand(patches).execute(currentProject),
+    );
   }
 
   function updateTextContent(elementId: string, text: string) {
@@ -1443,7 +1853,9 @@ export function useEditorViewModel(services: AppServices) {
       if (!element || element.type !== 'text') return nextProject;
       const minimumHeight = getMinimumTextHeight(element.text, element.fontSize);
       if (element.height >= minimumHeight) return nextProject;
-      return new UpdateElementFrameCommand(elementId, { height: minimumHeight }).execute(nextProject);
+      return new UpdateElementFrameCommand(elementId, { height: minimumHeight }).execute(
+        nextProject,
+      );
     });
   }
 
@@ -1454,7 +1866,9 @@ export function useEditorViewModel(services: AppServices) {
       if (!element || element.type !== 'text') return nextProject;
       const minimumHeight = getMinimumTextHeight(element.text, element.fontSize);
       if (element.height >= minimumHeight) return nextProject;
-      return new UpdateElementFrameCommand(elementId, { height: minimumHeight }).execute(nextProject);
+      return new UpdateElementFrameCommand(elementId, { height: minimumHeight }).execute(
+        nextProject,
+      );
     });
   }
 
@@ -1665,12 +2079,15 @@ export function useEditorViewModel(services: AppServices) {
   ) {
     const getVisibleUnlockedTextId = (elementId: string) => {
       const element = sourceProject.elements[elementId];
-      if (!element || element.type !== 'text' || element.locked || element.visible === false) return undefined;
+      if (!element || element.type !== 'text' || element.locked || element.visible === false)
+        return undefined;
       return element.id;
     };
 
     if (scope === 'selection') {
-      return selectedElementIds.map(getVisibleUnlockedTextId).filter((id): id is string => Boolean(id));
+      return selectedElementIds
+        .map(getVisibleUnlockedTextId)
+        .filter((id): id is string => Boolean(id));
     }
 
     const pages =
@@ -1705,7 +2122,10 @@ export function useEditorViewModel(services: AppServices) {
           options?.sourceLanguage ? { sourceLanguage: options.sourceLanguage } : undefined,
         );
         const page = project.pages.find((item) => item.elementIds.includes(elementId));
-        return [elementId, fitTranslatedTextToOriginalFrame(element, translatedText, page)] as const;
+        return [
+          elementId,
+          fitTranslatedTextToOriginalFrame(element, translatedText, page),
+        ] as const;
       }),
     );
     const translations = Object.fromEntries(
@@ -1714,7 +2134,9 @@ export function useEditorViewModel(services: AppServices) {
       ),
     );
 
-    commitProject((currentProject) => new TranslateTextElementsCommand(translations).execute(currentProject));
+    commitProject((currentProject) =>
+      new TranslateTextElementsCommand(translations).execute(currentProject),
+    );
     return Array.from(
       new Set(
         elementIds
@@ -1775,9 +2197,12 @@ export function useEditorViewModel(services: AppServices) {
           },
         }),
       );
-      const selectedTranslationProvider = translationProviderStates.find((provider) => provider.selected);
+      const selectedTranslationProvider = translationProviderStates.find(
+        (provider) => provider.selected,
+      );
       const shouldPrepareLanguagePair =
-        !selectedTranslationProvider?.modelId || selectedTranslationProvider.runtime === 'chrome-built-in';
+        !selectedTranslationProvider?.modelId ||
+        selectedTranslationProvider.runtime === 'chrome-built-in';
       if (shouldPrepareLanguagePair) {
         setTranslationPreparation({ progress: 8, sourceLanguage, status: 'downloading' });
         await services.translatorService.prepareTranslation(sourceLanguage, nextLanguage, {
@@ -1793,7 +2218,9 @@ export function useEditorViewModel(services: AppServices) {
       setTranslationPreparation({ progress: 100, sourceLanguage, status: 'ready' });
     } catch (error) {
       setTranslationPreparation({ progress: 0, status: 'failed' });
-      setTranslationNotice(error instanceof Error ? error.message : 'Translation language could not be prepared.');
+      setTranslationNotice(
+        error instanceof Error ? error.message : 'Translation language could not be prepared.',
+      );
     }
   }
 
@@ -1835,11 +2262,15 @@ export function useEditorViewModel(services: AppServices) {
         const normalizedTargetLanguage = normalizeLanguageCode(translationTargetLanguage);
         setPageLanguageCodes((current) => ({
           ...current,
-          ...Object.fromEntries(translatedPageIds.map((pageId) => [pageId, normalizedTargetLanguage])),
+          ...Object.fromEntries(
+            translatedPageIds.map((pageId) => [pageId, normalizedTargetLanguage]),
+          ),
         }));
       }
     } catch (error) {
-      setTranslationNotice(error instanceof Error ? error.message : 'Translation could not be completed.');
+      setTranslationNotice(
+        error instanceof Error ? error.message : 'Translation could not be completed.',
+      );
     } finally {
       setIsTranslating(false);
     }
@@ -1861,7 +2292,13 @@ export function useEditorViewModel(services: AppServices) {
     return projectRef.current;
   }
 
-  async function generateImageForAutomation(input: { height?: number; prompt: string; seed?: number; steps?: number; width?: number }) {
+  async function generateImageForAutomation(input: {
+    height?: number;
+    prompt: string;
+    seed?: number;
+    steps?: number;
+    width?: number;
+  }) {
     const options =
       input.height !== undefined ||
       input.seed !== undefined ||
@@ -1879,15 +2316,25 @@ export function useEditorViewModel(services: AppServices) {
     return projectRef.current;
   }
 
-  async function translateTextForAutomation(input: { pageId?: string; scope: TranslationScope; targetLanguage: string }) {
+  async function translateTextForAutomation(input: {
+    pageId?: string;
+    scope: TranslationScope;
+    targetLanguage: string;
+  }) {
     await setTranslationTargetLanguage(input.targetLanguage);
     const translationOptions = input.pageId ? { pageId: input.pageId } : undefined;
-    const translatedPageIds = await translateTextScope(input.scope, input.targetLanguage, translationOptions);
+    const translatedPageIds = await translateTextScope(
+      input.scope,
+      input.targetLanguage,
+      translationOptions,
+    );
     if (translatedPageIds.length > 0) {
       const normalizedTargetLanguage = normalizeLanguageCode(input.targetLanguage);
       setPageLanguageCodes((current) => ({
         ...current,
-        ...Object.fromEntries(translatedPageIds.map((pageId) => [pageId, normalizedTargetLanguage])),
+        ...Object.fromEntries(
+          translatedPageIds.map((pageId) => [pageId, normalizedTargetLanguage]),
+        ),
       }));
     }
     return {
@@ -1921,7 +2368,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function setElementLock(elementId: string, locked: boolean) {
-    commitProject((currentProject) => new SetElementLockCommand(elementId, locked).execute(currentProject));
+    commitProject((currentProject) =>
+      new SetElementLockCommand(elementId, locked).execute(currentProject),
+    );
   }
 
   function getSelectedElementsForClipboard() {
@@ -1960,7 +2409,9 @@ export function useEditorViewModel(services: AppServices) {
 
     commitProject(
       (currentProject) =>
-        new AddElementsCommand(activePageId, pastedElements, elementClipboard.assets).execute(currentProject),
+        new AddElementsCommand(activePageId, pastedElements, elementClipboard.assets).execute(
+          currentProject,
+        ),
       { selectedElementIds: pastedElements.map((element) => element.id) },
     );
     setElementClipboard({
@@ -1987,7 +2438,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function deleteSelectedElement() {
-    const deletableElementIds = selectedElementIds.filter((elementId) => !processingElementIds.includes(elementId));
+    const deletableElementIds = selectedElementIds.filter(
+      (elementId) => !processingElementIds.includes(elementId),
+    );
     if (deletableElementIds.length === 0) return;
     setBackgroundSelectionMode(false);
     setBackgroundSelectionNotice(undefined);
@@ -2034,7 +2487,13 @@ export function useEditorViewModel(services: AppServices) {
     const selectedElement = project.elements[selectedElementIds[0] ?? ''];
     const titleTemplate = project.elements['text-title'];
     const subtitleTemplate = project.elements['text-subtitle'];
-    const presetStyles: Record<TextPreset, Omit<Extract<DesignElement, { type: 'text' }>, 'id' | 'locked' | 'opacity' | 'rotation' | 'type' | 'visible' | 'x' | 'y'>> = {
+    const presetStyles: Record<
+      TextPreset,
+      Omit<
+        Extract<DesignElement, { type: 'text' }>,
+        'id' | 'locked' | 'opacity' | 'rotation' | 'type' | 'visible' | 'x' | 'y'
+      >
+    > = {
       title:
         titleTemplate?.type === 'text'
           ? {
@@ -2118,7 +2577,8 @@ export function useEditorViewModel(services: AppServices) {
     };
 
     commitProject(
-      (currentProject) => new AddElementsCommand(activePageId, [nextElement]).execute(currentProject),
+      (currentProject) =>
+        new AddElementsCommand(activePageId, [nextElement]).execute(currentProject),
       { selectedElementIds: [elementId] },
     );
   }
@@ -2126,23 +2586,31 @@ export function useEditorViewModel(services: AppServices) {
   function alignSelectedElement(mode: AlignMode) {
     const elementId = selectedElementIds[0];
     if (!elementId) return;
-    commitProject((currentProject) => new AlignElementCommand(activePageId, elementId, mode).execute(currentProject));
+    commitProject((currentProject) =>
+      new AlignElementCommand(activePageId, elementId, mode).execute(currentProject),
+    );
   }
 
   function setSelectedElementZOrder(mode: ZOrderMode) {
     const elementId = selectedElementIds[0];
     if (!elementId) return;
-    commitProject((currentProject) => new SetZOrderCommand(activePageId, elementId, mode).execute(currentProject));
+    commitProject((currentProject) =>
+      new SetZOrderCommand(activePageId, elementId, mode).execute(currentProject),
+    );
   }
 
   function flipSelectedImage() {
     const elementId = selectedElementIds[0];
     if (!elementId || selectedElementIds.length !== 1) return;
-    commitProject((currentProject) => new ToggleImageFlipCommand(elementId).execute(currentProject));
+    commitProject((currentProject) =>
+      new ToggleImageFlipCommand(elementId).execute(currentProject),
+    );
   }
 
   function updateImageCrop(elementId: string, patch: ImageCropPatch) {
-    commitProject((currentProject) => new UpdateImageCropCommand(elementId, patch).execute(currentProject));
+    commitProject((currentProject) =>
+      new UpdateImageCropCommand(elementId, patch).execute(currentProject),
+    );
   }
 
   function reorderElement(elementId: string, targetElementId: string, position: 'before' | 'after' = 'before') {
@@ -2156,7 +2624,9 @@ export function useEditorViewModel(services: AppServices) {
       displayOrder.splice(position === 'after' ? targetDisplayIndex + 1 : targetDisplayIndex, 0, elementId);
       const nextPageOrder = [...displayOrder].reverse();
       const targetPageIndex = nextPageOrder.indexOf(elementId);
-      return new ReorderElementCommand(activePageId, elementId, targetPageIndex).execute(currentProject);
+      return new ReorderElementCommand(activePageId, elementId, targetPageIndex).execute(
+        currentProject,
+      );
     });
   }
 
@@ -2195,9 +2665,9 @@ export function useEditorViewModel(services: AppServices) {
     const nextPageId = createId('page');
     commitProject(
       (currentProject) =>
-        new DuplicatePageCommand(pageId, nextPageId, (elementId) => createId(`${elementId}-page`)).execute(
-          currentProject,
-        ),
+        new DuplicatePageCommand(pageId, nextPageId, (elementId) =>
+          createId(`${elementId}-page`),
+        ).execute(currentProject),
       { activePageId: nextPageId, selectedElementIds: [] },
     );
   }
@@ -2207,17 +2677,23 @@ export function useEditorViewModel(services: AppServices) {
     const pageIndex = project.pages.findIndex((page) => page.id === pageId);
     if (pageIndex < 0) return;
     const nextPageId =
-      project.pages[pageIndex + 1]?.id ?? project.pages[pageIndex - 1]?.id ?? project.pages[0]?.id ?? '';
-    commitProject(
-      (currentProject) => new DeletePageCommand(pageId).execute(currentProject),
-      { activePageId: nextPageId, selectedElementIds: [] },
-    );
+      project.pages[pageIndex + 1]?.id ??
+      project.pages[pageIndex - 1]?.id ??
+      project.pages[0]?.id ??
+      '';
+    commitProject((currentProject) => new DeletePageCommand(pageId).execute(currentProject), {
+      activePageId: nextPageId,
+      selectedElementIds: [],
+    });
   }
 
   function reorderPage(pageId: string, targetIndex: number) {
-    commitProject((currentProject) => new ReorderPageCommand(pageId, targetIndex).execute(currentProject), {
-      activePageId: pageId,
-    });
+    commitProject(
+      (currentProject) => new ReorderPageCommand(pageId, targetIndex).execute(currentProject),
+      {
+        activePageId: pageId,
+      },
+    );
   }
 
   function renamePage(pageId: string, name: string) {
@@ -2225,7 +2701,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function setPageVisibility(pageId: string, visible: boolean) {
-    commitProject((currentProject) => new SetPageVisibilityCommand(pageId, visible).execute(currentProject));
+    commitProject((currentProject) =>
+      new SetPageVisibilityCommand(pageId, visible).execute(currentProject),
+    );
   }
 
   function activateScrolledPage(pageId: string) {
@@ -2264,9 +2742,11 @@ export function useEditorViewModel(services: AppServices) {
     setProject(previousProject);
     const nextActivePageId = previousProject.pages.some((page) => page.id === activePageId)
       ? activePageId
-      : previousProject.pages[0]?.id ?? '';
+      : (previousProject.pages[0]?.id ?? '');
     setActivePageId(nextActivePageId);
-    setSelectedElementIds(getSelectionForProject(previousProject, nextActivePageId, selectedElementIds));
+    setSelectedElementIds(
+      getSelectionForProject(previousProject, nextActivePageId, selectedElementIds),
+    );
   }
 
   function redo() {
@@ -2280,9 +2760,11 @@ export function useEditorViewModel(services: AppServices) {
     setProject(nextProject);
     const nextActivePageId = nextProject.pages.some((page) => page.id === activePageId)
       ? activePageId
-      : nextProject.pages[0]?.id ?? '';
+      : (nextProject.pages[0]?.id ?? '');
     setActivePageId(nextActivePageId);
-    setSelectedElementIds(getSelectionForProject(nextProject, nextActivePageId, selectedElementIds));
+    setSelectedElementIds(
+      getSelectionForProject(nextProject, nextActivePageId, selectedElementIds),
+    );
   }
 
   function zoomIn() {
@@ -2397,15 +2879,21 @@ export function useEditorViewModel(services: AppServices) {
       return {
         elementId,
         pending: true,
-        ...(shouldKeepCurrentPreview && currentPreview.maskUrl ? { maskUrl: currentPreview.maskUrl } : {}),
-        ...(shouldKeepCurrentPreview && currentPreview.score !== undefined ? { score: currentPreview.score } : {}),
+        ...(shouldKeepCurrentPreview && currentPreview.maskUrl
+          ? { maskUrl: currentPreview.maskUrl }
+          : {}),
+        ...(shouldKeepCurrentPreview && currentPreview.score !== undefined
+          ? { score: currentPreview.score }
+          : {}),
       };
     });
 
     backgroundPreviewTimeoutRef.current = window.setTimeout(() => {
       void (async () => {
         try {
-          const result = await services.backgroundRemovalService.previewBackgroundMask(asset, { points });
+          const result = await services.backgroundRemovalService.previewBackgroundMask(asset, {
+            points,
+          });
           if (backgroundPreviewSequenceRef.current !== sequence) return;
           setBackgroundPreview({
             elementId,
@@ -2416,7 +2904,9 @@ export function useEditorViewModel(services: AppServices) {
         } catch {
           if (backgroundPreviewSequenceRef.current !== sequence) return;
           setBackgroundPreview((currentPreview) =>
-            currentPreview?.elementId === elementId ? { ...currentPreview, pending: false } : currentPreview,
+            currentPreview?.elementId === elementId
+              ? { ...currentPreview, pending: false }
+              : currentPreview,
           );
         }
       })();
@@ -2443,14 +2933,20 @@ export function useEditorViewModel(services: AppServices) {
       return {
         elementId,
         pending: true,
-        ...(shouldKeepCurrentPreview && currentPreview.maskUrl ? { maskUrl: currentPreview.maskUrl } : {}),
-        ...(shouldKeepCurrentPreview && currentPreview.score !== undefined ? { score: currentPreview.score } : {}),
+        ...(shouldKeepCurrentPreview && currentPreview.maskUrl
+          ? { maskUrl: currentPreview.maskUrl }
+          : {}),
+        ...(shouldKeepCurrentPreview && currentPreview.score !== undefined
+          ? { score: currentPreview.score }
+          : {}),
       };
     });
 
     void (async () => {
       try {
-        const result = await services.backgroundRemovalService.previewBackgroundMask(asset, { points });
+        const result = await services.backgroundRemovalService.previewBackgroundMask(asset, {
+          points,
+        });
         if (backgroundPreviewSequenceRef.current !== sequence) return;
         setBackgroundPreview({
           elementId,
@@ -2520,13 +3016,20 @@ export function useEditorViewModel(services: AppServices) {
   async function importImageFile(file: File) {
     const dataUrl = await readImageFileAsDataUrl(file);
     const assetType = getMediaAssetType(file);
-    const mediaSize = assetType === 'video' ? await readVideoSize(dataUrl) : await readImageSize(dataUrl);
+    const mediaSize =
+      assetType === 'video' ? await readVideoSize(dataUrl) : await readImageSize(dataUrl);
     const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
     if (!page) return;
 
     const assetId = createId('asset');
     const elementId = createId(assetType);
-    const mediaName = file.name.trim() || (assetType === 'video' ? 'Pasted video' : assetType === 'gif' ? 'Pasted GIF' : 'Pasted image');
+    const mediaName =
+      file.name.trim() ||
+      (assetType === 'video'
+        ? 'Pasted video'
+        : assetType === 'gif'
+          ? 'Pasted GIF'
+          : 'Pasted image');
     const fittedMedia = fitImageWithinPage({
       imageWidth: mediaSize.width,
       imageHeight: mediaSize.height,
@@ -2602,34 +3105,36 @@ export function useEditorViewModel(services: AppServices) {
 
     commitProject(
       (currentProject) =>
-      new AddImageElementCommand(activePageId, {
-        asset: {
-          id: assetId,
-          type: 'image',
-          name: mediaName,
-          mimeType: file.type || 'image/*',
-          objectUrl: dataUrl,
-        },
-        element: {
-          id: elementId,
-          type: 'image',
-          assetId,
-          x: fittedMedia.x,
-          y: fittedMedia.y,
-          width: fittedMedia.width,
-          height: fittedMedia.height,
-          rotation: 0,
-          locked: false,
-          visible: true,
-          opacity: 1,
-        },
-      }).execute(currentProject),
+        new AddImageElementCommand(activePageId, {
+          asset: {
+            id: assetId,
+            type: 'image',
+            name: mediaName,
+            mimeType: file.type || 'image/*',
+            objectUrl: dataUrl,
+          },
+          element: {
+            id: elementId,
+            type: 'image',
+            assetId,
+            x: fittedMedia.x,
+            y: fittedMedia.y,
+            width: fittedMedia.width,
+            height: fittedMedia.height,
+            rotation: 0,
+            locked: false,
+            visible: true,
+            opacity: 1,
+          },
+        }).execute(currentProject),
       { selectedElementIds: [elementId] },
     );
   }
 
   function updateMediaPlayback(elementId: string, patch: MediaPlaybackPatch) {
-    commitProject((currentProject) => new UpdateMediaPlaybackCommand(elementId, patch).execute(currentProject));
+    commitProject((currentProject) =>
+      new UpdateMediaPlaybackCommand(elementId, patch).execute(currentProject),
+    );
   }
 
   return {
@@ -2640,6 +3145,17 @@ export function useEditorViewModel(services: AppServices) {
     pagesPanelOpen,
     isFullscreen,
     persistenceEnabled,
+    persistenceAttention,
+    persistenceNotice,
+    mirrorState,
+    mirrorConfig,
+    settingsOpen,
+    mirrorSettingsOpen,
+    localProjectSetupOpen,
+    remoteImportOpen,
+    remoteImportStatus,
+    remoteImportProjects,
+    remoteImportError,
     versionHistoryOpen,
     versionHistoryEntries,
     selectedVersionId,
@@ -2662,6 +3178,21 @@ export function useEditorViewModel(services: AppServices) {
     modelStates,
     setProjectName,
     setPersistence,
+    saveLocalNow,
+    closeLocalProjectSetup,
+    confirmLocalProjectSetup,
+    openSettings,
+    closeSettings,
+    openMirrorSettings,
+    closeMirrorSettings,
+    saveMirrorConfig,
+    testMirrorConnection,
+    syncMirrorNow,
+    requestMirrorNow,
+    setMirrorEnabled,
+    importRemoteMirror,
+    importRemoteMirrorProject,
+    closeRemoteImport,
     importProject,
     openVersionHistory,
     closeVersionHistory,

--- a/apps/editor/src/ui/editor/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/useEditorViewModel.ts
@@ -467,6 +467,8 @@ export function useEditorViewModel(services: AppServices) {
   const [modelStates, setModelStates] = useState<ModelState[]>([]);
   const [hasLoadedProject, setHasLoadedProject] = useState(!shouldRestoreStoredProject);
   const [persistenceEnabled, setPersistenceEnabled] = useState(shouldRestoreStoredProject);
+  const [hasPersistedLocalProject, setHasPersistedLocalProject] =
+    useState(shouldRestoreStoredProject);
   const [activePageId, setActivePageId] = useState(initialProject.pages[0]?.id ?? '');
   const activePageIdRef = useRef(activePageId);
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
@@ -551,6 +553,7 @@ export function useEditorViewModel(services: AppServices) {
   const [mirrorConfig, setMirrorConfig] = useState<MinioMirrorConfig>(
     () => storedMirrorConfig ?? DEFAULT_MINIO_MIRROR_CONFIG,
   );
+  const [hasMirrorConfig, setHasMirrorConfig] = useState(Boolean(storedMirrorConfig));
   const mirrorConfigRef = useRef<MinioMirrorConfig | null>(storedMirrorConfig);
   const mirrorSyncInFlightRef = useRef(false);
   const mirrorSyncQueuedRef = useRef(false);
@@ -561,7 +564,7 @@ export function useEditorViewModel(services: AppServices) {
   projectRef.current = project;
   activePageIdRef.current = activePageId;
   selectedElementIdsRef.current = selectedElementIds;
-  mirrorConfigRef.current = mirrorState.enabled ? mirrorConfig : null;
+  mirrorConfigRef.current = hasMirrorConfig ? mirrorConfig : null;
   queueMirrorSyncRef.current = queueMirrorSync;
   syncMirrorNowRef.current = (projectToSync) => {
     void syncMirrorNow(projectToSync);
@@ -689,6 +692,7 @@ export function useEditorViewModel(services: AppServices) {
               .catch(() => undefined);
           }
           writeProjectNameToUrl(normalizedProject.name);
+          setHasPersistedLocalProject(true);
           if (storedMirrorConfig) syncMirrorNowRef.current(normalizedProject);
         }
         setHasLoadedProject(true);
@@ -716,6 +720,7 @@ export function useEditorViewModel(services: AppServices) {
     void services.projectRepository
       .saveProject(project)
       .then(async () => {
+        setHasPersistedLocalProject(true);
         setLastEditedAt(project.updatedAt);
         setSaveAnimationKey((current) => current + 1);
         if (!services.projectRepository.saveVersion) return;
@@ -1439,11 +1444,42 @@ export function useEditorViewModel(services: AppServices) {
       return;
     }
 
+    if (hasPersistedLocalProject) {
+      void reenablePersistence();
+      return;
+    }
+
     setLocalProjectSetupOpen(true);
+  }
+
+  async function reenablePersistence() {
+    try {
+      const projectToSave = projectRef.current;
+      await services.projectRepository.saveProject(projectToSave);
+      lastVersionProjectRef.current = projectToSave;
+      setHasPersistedLocalProject(true);
+      setLastEditedAt(projectToSave.updatedAt);
+      setSaveAnimationKey((current) => current + 1);
+      skipNextProjectSaveRef.current = true;
+      setPersistenceEnabled(true);
+      setPersistenceAttention(false);
+      setPersistenceNotice(undefined);
+      setLocalProjectSetupOpen(false);
+      writeProjectNameToUrl(projectToSave.name);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(PERSISTENCE_PREFERENCE_KEY, 'true');
+      }
+    } catch {
+      setPersistenceEnabled(false);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(PERSISTENCE_PREFERENCE_KEY, 'false');
+      }
+    }
   }
 
   async function persistCurrentProject(projectToSave = projectRef.current) {
     await services.projectRepository.saveProject(projectToSave);
+    setHasPersistedLocalProject(true);
     const previousProject = lastVersionProjectRef.current;
     lastVersionProjectRef.current = projectToSave;
     setLastEditedAt(projectToSave.updatedAt);
@@ -1495,6 +1531,7 @@ export function useEditorViewModel(services: AppServices) {
       setLastEditedAt(nextProject.updatedAt);
       setSaveAnimationKey((current) => current + 1);
       skipNextProjectSaveRef.current = true;
+      setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       setPersistenceAttention(false);
       setPersistenceNotice(undefined);
@@ -1529,6 +1566,7 @@ export function useEditorViewModel(services: AppServices) {
       clearBackgroundPreparation();
       clearBackgroundSelectionPoints();
       skipNextProjectSaveRef.current = true;
+      setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       lastVersionProjectRef.current = normalizedProject;
       setLastEditedAt(normalizedProject.updatedAt);
@@ -1574,19 +1612,22 @@ export function useEditorViewModel(services: AppServices) {
   function saveMirrorConfig(config: MinioMirrorConfig) {
     services.mirrorService.saveConfig(config);
     setMirrorConfig(config);
+    setHasMirrorConfig(true);
     mirrorConfigRef.current = config;
     setMirrorState({ enabled: true, status: 'idle' });
+    void syncMirrorNow();
   }
 
   function setMirrorEnabled(enabled: boolean) {
     if (enabled) {
       if (!mirrorConfigRef.current) {
         openMirrorSettings();
+        return;
       }
+      setMirrorState({ enabled: true, status: 'idle' });
+      void syncMirrorNow();
       return;
     }
-    services.mirrorService.clearConfig();
-    mirrorConfigRef.current = null;
     setMirrorState({ enabled: false, status: 'disabled' });
   }
 
@@ -1607,7 +1648,7 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function queueMirrorSync() {
-    if (!mirrorConfigRef.current) return;
+    if (!mirrorState.enabled || !mirrorConfigRef.current) return;
     if (typeof window === 'undefined') {
       void syncMirrorNow();
       return;
@@ -1668,6 +1709,9 @@ export function useEditorViewModel(services: AppServices) {
       openMirrorSettings();
       return;
     }
+    if (!mirrorState.enabled) {
+      setMirrorState({ enabled: true, status: 'idle' });
+    }
     void syncMirrorNow();
   }
 
@@ -1723,6 +1767,7 @@ export function useEditorViewModel(services: AppServices) {
       clearBackgroundPreparation();
       clearBackgroundSelectionPoints();
       skipNextProjectSaveRef.current = true;
+      setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       lastVersionProjectRef.current = normalizedProject;
       setLastEditedAt(normalizedProject.updatedAt);

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
@@ -71,6 +71,12 @@ class MockDirectoryHandle {
   requestPermission(): Promise<PermissionState> {
     return Promise.resolve('granted');
   }
+
+  removeEntry(name: string): Promise<void> {
+    this.files.delete(name);
+    this.directories.delete(name);
+    return Promise.resolve();
+  }
 }
 
 class MemoryRecentProjectHandleStore implements RecentProjectHandleStore {
@@ -153,6 +159,25 @@ describe('BrowserFileSystemProjectRepository', () => {
     });
   });
 
+  it('moves a persisted project into a renamed child folder when the project name changes', async () => {
+    const parentDirectory = new MockDirectoryHandle('Projects');
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory: () => Promise.resolve(parentDirectory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+    const project = { ...createSampleProject(), name: 'Launch Deck' };
+
+    await repository.saveProject(project, { projectDirectoryName: 'Launch Deck' });
+    await repository.saveProject({ ...project, name: 'Renamed Launch Deck' });
+
+    expect(parentDirectory.directories.has('Launch Deck')).toBe(false);
+    const renamedDirectory = parentDirectory.directories.get('Renamed Launch Deck')!;
+    expect(renamedDirectory).toBeDefined();
+    expect(JSON.parse(await readMockText(renamedDirectory.files.get('project.json')!))).toMatchObject({
+      name: 'Renamed Launch Deck',
+    });
+  });
+
   it('imports an existing project folder without overwriting it first', async () => {
     const directory = new MockDirectoryHandle();
     const project = createSampleProject();
@@ -168,8 +193,8 @@ describe('BrowserFileSystemProjectRepository', () => {
     expect(directory.directories.size).toBe(0);
   });
 
-  it('imports a mirrored remote project into a selected local folder', async () => {
-    const directory = new MockDirectoryHandle('Chosen Folder Name');
+  it('imports a mirrored remote project into a child folder named from the remote project', async () => {
+    const directory = new MockDirectoryHandle('Projects');
     const project = createSampleProject();
     const repository = new BrowserFileSystemProjectRepository({
       pickDirectory: () => Promise.resolve(directory as unknown as FileSystemDirectoryHandle),
@@ -194,11 +219,13 @@ describe('BrowserFileSystemProjectRepository', () => {
       },
     ]);
 
-    expect(importedProject.name).toBe('Chosen Folder Name');
-    expect(JSON.parse(await readMockText(directory.files.get('project.json')!))).toMatchObject({
-      name: 'Chosen Folder Name',
+    expect(importedProject.name).toBe('Remote Mirror');
+    const projectDirectory = directory.directories.get('Remote Mirror')!;
+    expect(projectDirectory).toBeDefined();
+    expect(JSON.parse(await readMockText(projectDirectory.files.get('project.json')!))).toMatchObject({
+      name: 'Remote Mirror',
     });
-    expect(directory.directories.get('config')?.files.has('localstudio.json')).toBe(true);
+    expect(projectDirectory.directories.get('config')?.files.has('localstudio.json')).toBe(true);
   });
 
   it('reopens the last project folder from the recent handle store', async () => {

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
@@ -5,11 +5,11 @@ import {
 } from '../../../src/services/browserFileSystemProjectRepository';
 
 class MockWritable {
-  constructor(private readonly onClose: (value: string) => void) {}
+  constructor(private readonly onClose: (value: string | Blob) => void) {}
 
-  private value = '';
+  private value: string | Blob = '';
 
-  write(value: string): Promise<void> {
+  write(value: string | Blob): Promise<void> {
     this.value = value;
     return Promise.resolve();
   }
@@ -23,7 +23,7 @@ class MockWritable {
 class MockFileHandle {
   constructor(
     private readonly name: string,
-    private readonly files: Map<string, string>,
+    private readonly files: Map<string, string | Blob>,
   ) {}
 
   createWritable(): Promise<MockWritable> {
@@ -34,15 +34,19 @@ class MockFileHandle {
     );
   }
 
-  getFile(): Promise<{ text: () => Promise<string> }> {
+  getFile(): Promise<{ text: () => Promise<string>; type: string }> {
     const value = this.files.get(this.name);
     if (value === undefined) return Promise.reject(new DOMException('Not found', 'NotFoundError'));
-    return Promise.resolve({ text: () => Promise.resolve(value) });
+    if (typeof value === 'string')
+      return Promise.resolve({ text: () => Promise.resolve(value), type: 'application/json' });
+    return Promise.resolve(value);
   }
 }
 
 class MockDirectoryHandle {
-  readonly files = new Map<string, string>();
+  constructor(readonly name = 'LocalStudio Project') {}
+
+  readonly files = new Map<string, string | Blob>();
   readonly directories = new Map<string, MockDirectoryHandle>();
 
   getFileHandle(name: string, options?: { create?: boolean }): Promise<MockFileHandle> {
@@ -55,7 +59,7 @@ class MockDirectoryHandle {
   getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<MockDirectoryHandle> {
     if (!this.directories.has(name)) {
       if (!options?.create) throw new DOMException('Not found', 'NotFoundError');
-      this.directories.set(name, new MockDirectoryHandle());
+      this.directories.set(name, new MockDirectoryHandle(name));
     }
     return Promise.resolve(this.directories.get(name)!);
   }
@@ -85,6 +89,10 @@ class MemoryRecentProjectHandleStore implements RecentProjectHandleStore {
   }
 }
 
+async function readMockText(value: string | Blob) {
+  return typeof value === 'string' ? value : value.text();
+}
+
 describe('BrowserFileSystemProjectRepository', () => {
   it('creates the project folder structure and writes project metadata', async () => {
     const directory = new MockDirectoryHandle();
@@ -99,11 +107,15 @@ describe('BrowserFileSystemProjectRepository', () => {
     expect(directory.directories.has('assets')).toBe(true);
     expect(directory.directories.has('cache')).toBe(true);
     expect(directory.directories.has('config')).toBe(true);
-    expect(JSON.parse(directory.files.get('project.json')!)).toMatchObject({
+    expect(JSON.parse(await readMockText(directory.files.get('project.json')!))).toMatchObject({
       id: project.id,
       name: project.name,
     });
-    expect(JSON.parse(directory.directories.get('config')!.files.get('localstudio.json')!)).toMatchObject({
+    expect(
+      JSON.parse(
+        await readMockText(directory.directories.get('config')!.files.get('localstudio.json')!),
+      ),
+    ).toMatchObject({
       app: 'LocalStudio.dev',
       projectId: project.id,
     });
@@ -124,6 +136,23 @@ describe('BrowserFileSystemProjectRepository', () => {
     expect(loaded?.pages).toHaveLength(1);
   });
 
+  it('creates a named child project folder during initial persistence setup', async () => {
+    const parentDirectory = new MockDirectoryHandle('Projects');
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory: () => Promise.resolve(parentDirectory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+    const project = { ...createSampleProject(), name: 'Launch Deck' };
+
+    await repository.saveProject(project, { projectDirectoryName: 'Launch Deck' });
+
+    const projectDirectory = parentDirectory.directories.get('Launch Deck')!;
+    expect(projectDirectory).toBeDefined();
+    expect(JSON.parse(await readMockText(projectDirectory.files.get('project.json')!))).toMatchObject({
+      name: 'Launch Deck',
+    });
+  });
+
   it('imports an existing project folder without overwriting it first', async () => {
     const directory = new MockDirectoryHandle();
     const project = createSampleProject();
@@ -137,6 +166,39 @@ describe('BrowserFileSystemProjectRepository', () => {
 
     expect(importedProject?.name).toBe('Imported Project');
     expect(directory.directories.size).toBe(0);
+  });
+
+  it('imports a mirrored remote project into a selected local folder', async () => {
+    const directory = new MockDirectoryHandle('Chosen Folder Name');
+    const project = createSampleProject();
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory: () => Promise.resolve(directory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+
+    const importedProject = await repository.importMirrorFiles([
+      {
+        path: 'project.json',
+        blob: new Blob([JSON.stringify({ ...project, name: 'Remote Mirror' })], {
+          type: 'application/json',
+        }),
+      },
+      {
+        path: 'config/localstudio.json',
+        blob: new Blob(
+          [JSON.stringify({ app: 'LocalStudio.dev', projectId: project.id, schemaVersion: 1 })],
+          {
+            type: 'application/json',
+          },
+        ),
+      },
+    ]);
+
+    expect(importedProject.name).toBe('Chosen Folder Name');
+    expect(JSON.parse(await readMockText(directory.files.get('project.json')!))).toMatchObject({
+      name: 'Chosen Folder Name',
+    });
+    expect(directory.directories.get('config')?.files.has('localstudio.json')).toBe(true);
   });
 
   it('reopens the last project folder from the recent handle store', async () => {
@@ -173,9 +235,11 @@ describe('BrowserFileSystemProjectRepository', () => {
       recentProjectStore,
     }).saveProject(betaProject);
 
-    const loaded = await new BrowserFileSystemProjectRepository({ recentProjectStore }).loadProject({
-      projectName: 'Alpha Deck',
-    });
+    const loaded = await new BrowserFileSystemProjectRepository({ recentProjectStore }).loadProject(
+      {
+        projectName: 'Alpha Deck',
+      },
+    );
 
     expect(loaded?.id).toBe('alpha');
     expect(loaded?.name).toBe('Alpha Deck');
@@ -211,7 +275,9 @@ describe('BrowserFileSystemProjectRepository', () => {
     expect(entry.changeCount).toBeGreaterThan(0);
     const historyDirectory = directory.directories.get('history')!;
     const versionsDirectory = historyDirectory.directories.get('versions')!;
-    expect(JSON.parse(historyDirectory.files.get('manifest.json')!)).toMatchObject({
+    expect(
+      JSON.parse(await readMockText(historyDirectory.files.get('manifest.json')!)),
+    ).toMatchObject({
       latestVersionId: entry.id,
       versions: [expect.objectContaining({ id: entry.id })],
     });

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -1,0 +1,203 @@
+import { vi } from 'vitest';
+import type { ProjectDocument } from '../../../src/domain/model';
+import { createSampleProject } from '../../../src/domain/sampleProject';
+import {
+  createMirrorFiles,
+  MinioMirrorService,
+  type MinioMirrorConfig,
+} from '../../../src/services/minioMirrorService';
+import type { ProjectRepository, VersionHistoryEntry } from '../../../src/services/interfaces';
+
+const config: MinioMirrorConfig = {
+  accessKey: 'localstudio',
+  bucket: 'localstudio',
+  endpoint: 'http://localhost:9000',
+  pathStyle: true,
+  publicBaseUrl: 'http://localhost:9000/localstudio',
+  region: 'us-east-1',
+  secretKey: 'localstudio123',
+  prefix: 'mirrors',
+};
+
+class VersionedRepository implements ProjectRepository {
+  constructor(
+    private readonly versions: VersionHistoryEntry[],
+    private readonly versionProject: ProjectDocument,
+  ) {}
+
+  loadProject(): Promise<ProjectDocument | null> {
+    return Promise.resolve(null);
+  }
+
+  saveProject(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getVersionHistory(): Promise<VersionHistoryEntry[]> {
+    return Promise.resolve(this.versions);
+  }
+
+  loadVersion(): Promise<ProjectDocument | null> {
+    return Promise.resolve(this.versionProject);
+  }
+}
+
+function getRequestUrl(input: RequestInfo | URL) {
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return input;
+}
+
+describe('createMirrorFiles', () => {
+  it('creates a complete portable project mirror payload', async () => {
+    const project = createSampleProject();
+    const versionProject = {
+      ...project,
+      name: 'Older name',
+      updatedAt: '2026-06-29T10:00:00.000Z',
+    };
+    const version: VersionHistoryEntry = {
+      id: 'version-1',
+      authorName: 'Local user',
+      changeCount: 1,
+      createdAt: '2026-06-29T10:00:00.000Z',
+      fileName: 'version-1.json',
+      projectName: project.name,
+      summary: '1 edit',
+    };
+
+    const files = await createMirrorFiles(
+      project,
+      new VersionedRepository([version], versionProject),
+      config,
+    );
+    const paths = files.map((file) => file.path).sort();
+
+    expect(paths).toEqual([
+      'config/localstudio.json',
+      'history/manifest.json',
+      'history/versions/version-1.json',
+      'localstudio-mirror.json',
+      'project.json',
+    ]);
+    expect(
+      JSON.parse(await files.find((file) => file.path === 'project.json')!.blob.text()),
+    ).toMatchObject({
+      id: project.id,
+      name: project.name,
+    });
+    expect(
+      JSON.parse(await files.find((file) => file.path === 'history/manifest.json')!.blob.text()),
+    ).toMatchObject({
+      latestVersionId: 'version-1',
+      versions: [expect.objectContaining({ id: 'version-1' })],
+    });
+    expect(
+      JSON.parse(await files.find((file) => file.path === 'localstudio-mirror.json')!.blob.text()),
+    ).toMatchObject({
+      schemaVersion: 1,
+      projectId: project.id,
+      projectName: project.name,
+      publicBaseUrl: config.publicBaseUrl,
+    });
+  });
+});
+
+describe('MinioMirrorService', () => {
+  it('binds the browser fetch function when no fetch override is provided', async () => {
+    const project = createSampleProject();
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(function (this: unknown, input: RequestInfo | URL, init?: RequestInit) {
+      expect(this).toBe(globalThis);
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      await new MinioMirrorService({ now: () => new Date('2026-06-30T10:00:00.000Z') }).syncProject(
+        project,
+        new VersionedRepository([], project),
+        config,
+      );
+    } finally {
+      vi.stubGlobal('fetch', originalFetch);
+    }
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('uploads changed mirror files and skips unchanged remote entries', async () => {
+    const project = createSampleProject();
+    const remoteManifest = {
+      schemaVersion: 1,
+      projectId: project.id,
+      projectName: project.name,
+      syncedAt: '2026-06-29T10:00:00.000Z',
+      publicBaseUrl: config.publicBaseUrl,
+      files: {
+        'project.json': {
+          path: 'project.json',
+          size: JSON.stringify(project, null, 2).length,
+          checksum: await crypto.subtle
+            .digest('SHA-256', new TextEncoder().encode(JSON.stringify(project, null, 2)))
+            .then((hash) =>
+              Array.from(new Uint8Array(hash), (byte) => byte.toString(16).padStart(2, '0')).join(
+                '',
+              ),
+            ),
+        },
+      },
+    };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response(JSON.stringify(remoteManifest), { status: 200 }));
+      }
+      if (init?.method === 'PUT') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new MinioMirrorService({
+      fetch: fetchMock,
+      now: () => new Date('2026-06-30T10:00:00.000Z'),
+    });
+
+    await service.syncProject(project, new VersionedRepository([], project), config);
+
+    const putUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'PUT')
+      .map(([input]) => getRequestUrl(input));
+    expect(putUrls.some((url) => url.endsWith('/project.json'))).toBe(false);
+    expect(putUrls.some((url) => url.endsWith('/localstudio-mirror.json'))).toBe(true);
+  });
+
+  it('stores mirrored objects under the readable project name prefix', async () => {
+    const project = { ...createSampleProject(), name: 'Client Launch Deck' };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new MinioMirrorService({ fetch: fetchMock });
+
+    await service.syncProject(project, new VersionedRepository([], project), config);
+
+    const putUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'PUT')
+      .map(([input]) => getRequestUrl(input));
+    expect(putUrls.every((url) => url.includes('/mirrors/Client%20Launch%20Deck/'))).toBe(true);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/EditorFooter.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorFooter.test.tsx
@@ -8,6 +8,7 @@ describe('EditorFooter', () => {
     const user = userEvent.setup();
     const handlers = {
       onResetZoom: vi.fn(),
+      onOpenSettings: vi.fn(),
       onTogglePagesPanel: vi.fn(),
       onZoomIn: vi.fn(),
       onZoomOut: vi.fn(),
@@ -24,6 +25,7 @@ describe('EditorFooter', () => {
     );
 
     expect(screen.getByText('2 / 4')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
     await user.click(screen.getByRole('button', { name: 'Zoom Out' }));
     await user.click(screen.getByRole('button', { name: 'Reset zoom' }));
     await user.click(screen.getByRole('button', { name: 'Zoom In' }));
@@ -33,6 +35,7 @@ describe('EditorFooter', () => {
     expect(handlers.onResetZoom).toHaveBeenCalledTimes(1);
     expect(handlers.onZoomIn).toHaveBeenCalledTimes(1);
     expect(handlers.onTogglePagesPanel).toHaveBeenCalledTimes(1);
+    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole('button', { name: 'Enter fullscreen' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Exit fullscreen' })).not.toBeInTheDocument();
   });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { createAppServices as createRealAppServices } from '../../../../src/app/composition';
@@ -115,13 +115,9 @@ class RecordingMirrorService implements MirrorService<MinioMirrorConfig> {
     return undefined;
   }
 
-  listProjects(): Promise<MirrorProjectSummary[]> {
-    return Promise.resolve([]);
-  }
+  listProjects = vi.fn((): Promise<MirrorProjectSummary[]> => Promise.resolve([]));
 
-  downloadProject(): Promise<MirrorFile[]> {
-    return Promise.resolve([]);
-  }
+  downloadProject = vi.fn((): Promise<MirrorFile[]> => Promise.resolve([]));
 }
 
 class RecordingTranslatorService implements TranslatorService {
@@ -163,6 +159,25 @@ class ImportingProjectRepository implements ProjectRepository {
   saveProject(project: ProjectDocument): Promise<void> {
     this.savedProjects.push(project);
     return Promise.resolve();
+  }
+}
+
+class RemoteMirrorImportingProjectRepository implements ProjectRepository {
+  importedFilePaths: string[] = [];
+
+  loadProject(): Promise<ProjectDocument | null> {
+    return Promise.resolve(null);
+  }
+
+  saveProject(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async importMirrorFiles(files: MirrorFile[]): Promise<ProjectDocument> {
+    this.importedFilePaths = files.map((file) => file.path);
+    const projectFile = files.find((file) => file.path === 'project.json');
+    if (!projectFile) throw new Error('Missing project.json');
+    return JSON.parse(await projectFile.blob.text()) as ProjectDocument;
   }
 }
 
@@ -458,6 +473,27 @@ describe('EditorShell', () => {
     expect(screen.getByRole('button', { name: 'Edit project name Mirror Debug Deck' })).toBeInTheDocument();
   });
 
+  it('re-enables persistence without opening the folder setup again', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new SavingProjectRepository();
+    services.projectRepository = repository;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+    expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Persistence enabled' }));
+    expect(screen.getByRole('button', { name: 'Persistence disabled' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Save local project' })).not.toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+    expect(repository.savedProjects).toHaveLength(2);
+  });
+
   it('writes the persisted project name into the tab URL', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
@@ -528,6 +564,69 @@ describe('EditorShell', () => {
     expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
   });
 
+  it('syncs the current project after mirror settings are saved', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new SavingProjectRepository();
+    const mirrorService = new RecordingMirrorService(null);
+    services.projectRepository = repository;
+    services.mirrorService = mirrorService;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+    await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
+    await user.click(within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+      name: 'Mirror settings',
+    }));
+    await user.click(screen.getByRole('button', { name: 'Save settings' }));
+
+    await waitFor(() => {
+      expect(mirrorService.syncProject).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Untitled AI Deck' }),
+        repository,
+        mirrorConfig,
+      );
+    });
+  });
+
+  it('mirrors the renamed project name from the header bar', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new SavingProjectRepository();
+    const mirrorService = new RecordingMirrorService(null);
+    services.projectRepository = repository;
+    services.mirrorService = mirrorService;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+    await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
+    await user.click(within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+      name: 'Mirror settings',
+    }));
+    await user.click(screen.getByRole('button', { name: 'Save settings' }));
+    await waitFor(() => {
+      expect(mirrorService.syncProject).toHaveBeenCalledTimes(1);
+    });
+    mirrorService.syncProject.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'Edit project name Untitled AI Deck' }));
+    await user.clear(screen.getByRole('textbox', { name: 'Project name' }));
+    await user.type(screen.getByRole('textbox', { name: 'Project name' }), 'Renamed Mirror Deck{Enter}');
+
+    await waitFor(
+      () => {
+        expect(mirrorService.syncProject).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'Renamed Mirror Deck' }),
+          repository,
+          mirrorConfig,
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
   it('disables mirroring when the mirror status icon is clicked', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
@@ -547,8 +646,17 @@ describe('EditorShell', () => {
     const mirrorButton = await screen.findByRole('button', { name: 'Mirror up to date' });
     await user.click(mirrorButton);
 
-    expect(mirrorService.clearConfig).toHaveBeenCalledTimes(1);
+    expect(mirrorService.clearConfig).not.toHaveBeenCalled();
     expect(screen.getByText('Local only')).toBeInTheDocument();
+
+    const disabledMirrorButton = screen.getByRole('button', { name: 'Mirror disabled' });
+    expect(disabledMirrorButton).not.toBeDisabled();
+    await user.click(disabledMirrorButton);
+
+    await waitFor(() => {
+      expect(mirrorService.syncProject).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toBeInTheDocument();
   });
 
   it('imports an existing project from the File menu', async () => {
@@ -569,6 +677,38 @@ describe('EditorShell', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
     expect(window.location.search).toBe('?project=Imported+LocalStudio+Project');
+  });
+
+  it('displays the remote project name after importing a mirrored project', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new RemoteMirrorImportingProjectRepository();
+    const mirrorService = new RecordingMirrorService(mirrorConfig);
+    services.projectRepository = repository;
+    services.mirrorService = mirrorService;
+    mirrorService.listProjects.mockResolvedValue([
+      { id: 'Remote Mirror Deck', name: 'Remote Mirror Deck', syncedAt: '2026-06-30T10:00:00.000Z' },
+    ]);
+    mirrorService.downloadProject.mockResolvedValue([
+      {
+        path: 'project.json',
+        blob: new Blob(
+          [JSON.stringify({ ...services.initialProject, id: 'remote-project', name: 'Remote Mirror Deck' })],
+          { type: 'application/json' },
+        ),
+      },
+    ]);
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Import Remote' }));
+    await user.click(await screen.findByRole('button', { name: 'Import Remote Mirror Deck' }));
+
+    expect(
+      await screen.findByRole('button', { name: 'Edit project name Remote Mirror Deck' }),
+    ).toBeInTheDocument();
+    expect(repository.importedFilePaths).toContain('project.json');
+    expect(window.location.search).toBe('?project=Remote+Mirror+Deck');
   });
 
   it('preserves hydrated sample hero object URLs during import normalization', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -6,9 +6,14 @@ import type { Asset, ProjectDocument } from '../../../../src/domain/model';
 import { createSampleProject } from '../../../../src/domain/sampleProject';
 import type {
   BackgroundRemovalService,
+  MirrorFile,
+  MirrorProjectSummary,
+  MirrorService,
+  MirrorState,
   ProjectRepository,
   TranslatorService,
 } from '../../../../src/services/interfaces';
+import type { MinioMirrorConfig } from '../../../../src/services/minioMirrorService';
 import type { WebMcpDemoWindow, WebMcpTool } from '../../../../src/services/webMcpToolAdapter';
 import { InMemoryModelSetupService } from '../../../../src/services/modelSetupService';
 import { EditorShell } from '../../../../src/ui/editor/EditorShell';
@@ -70,6 +75,52 @@ class SavingProjectRepository implements ProjectRepository {
   saveProject(project: ProjectDocument): Promise<void> {
     this.savedProjects.push(project);
     return Promise.resolve();
+  }
+}
+
+const mirrorConfig: MinioMirrorConfig = {
+  accessKey: 'localstudio',
+  bucket: 'localstudio',
+  endpoint: 'http://localhost:9000',
+  pathStyle: true,
+  publicBaseUrl: 'http://localhost:9000/localstudio',
+  region: 'us-east-1',
+  secretKey: 'localstudio123',
+  prefix: 'mirrors',
+};
+
+class RecordingMirrorService implements MirrorService<MinioMirrorConfig> {
+  constructor(private readonly storedConfig: MinioMirrorConfig | null = mirrorConfig) {}
+
+  clearConfig = vi.fn();
+
+  syncProject = vi.fn(
+    (
+      project: ProjectDocument,
+      repository: ProjectRepository,
+      config: MinioMirrorConfig,
+    ): Promise<MirrorState> => {
+      void project;
+      void repository;
+      void config;
+      return Promise.resolve({ enabled: true, status: 'synced' });
+    },
+  );
+
+  loadConfig(): MinioMirrorConfig | null {
+    return this.storedConfig;
+  }
+
+  saveConfig(): void {
+    return undefined;
+  }
+
+  listProjects(): Promise<MirrorProjectSummary[]> {
+    return Promise.resolve([]);
+  }
+
+  downloadProject(): Promise<MirrorFile[]> {
+    return Promise.resolve([]);
   }
 }
 
@@ -394,8 +445,17 @@ describe('EditorShell', () => {
     render(<EditorShell services={services} />);
 
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    expect(screen.getByRole('dialog', { name: 'Save local project' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Save local project' })).toHaveAttribute(
+      'data-anchor',
+      'persistence',
+    );
+    await user.clear(screen.getByRole('textbox', { name: 'Project folder name' }));
+    await user.type(screen.getByRole('textbox', { name: 'Project folder name' }), 'Mirror Debug Deck');
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
 
     expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit project name Mirror Debug Deck' })).toBeInTheDocument();
   });
 
   it('writes the persisted project name into the tab URL', async () => {
@@ -406,6 +466,7 @@ describe('EditorShell', () => {
     render(<EditorShell services={services} />);
 
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
 
     expect(window.location.search).toBe('?project=Untitled+AI+Deck');
   });
@@ -418,6 +479,7 @@ describe('EditorShell', () => {
     render(<EditorShell services={services} />);
 
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
     expect(repository.savedProjects.at(-1)?.name).toBe('Untitled AI Deck');
 
     await user.click(screen.getByRole('button', { name: 'Edit project name Untitled AI Deck' }));
@@ -436,6 +498,57 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
 
     expect(await screen.findByRole('button', { name: 'Persistence disabled' })).toBeInTheDocument();
+  });
+
+  it('prompts the user to save before mirroring an unsaved project from the File menu', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Mirror Now' }));
+
+    expect(screen.getByText('Save the project before mirroring.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Persistence disabled' })).toHaveClass(
+      'persistence-attention',
+    );
+  });
+
+  it('opens mirror settings when mirroring is requested without a saved mirror config', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    services.projectRepository = new SavingProjectRepository();
+    services.mirrorService = new RecordingMirrorService(null);
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Mirror Now' }));
+
+    expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
+  });
+
+  it('disables mirroring when the mirror status icon is clicked', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const mirrorService = new RecordingMirrorService();
+    const repository = new DeferredLoadingProjectRepository();
+    services.projectRepository = repository;
+    services.mirrorService = mirrorService;
+    render(<EditorShell services={services} />);
+
+    act(() => {
+      repository.resolveLoadedProject({
+        ...services.initialProject,
+        name: 'Mirrored Folder',
+      });
+    });
+
+    const mirrorButton = await screen.findByRole('button', { name: 'Mirror up to date' });
+    await user.click(mirrorButton);
+
+    expect(mirrorService.clearConfig).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Local only')).toBeInTheDocument();
   });
 
   it('imports an existing project from the File menu', async () => {
@@ -507,6 +620,7 @@ describe('EditorShell', () => {
     const { unmount } = render(<EditorShell services={firstServices} />);
 
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
     unmount();
     const secondServices = createAppServices();
     secondServices.projectRepository = new SavingProjectRepository();
@@ -536,6 +650,37 @@ describe('EditorShell', () => {
       await screen.findByRole('button', { name: 'Edit project name Restored LocalStudio Project' }),
     ).toBeInTheDocument();
     expect(repository.savedProjects).toHaveLength(0);
+  });
+
+  it('restores mirroring from saved config and syncs the loaded local project', async () => {
+    const repository = new DeferredLoadingProjectRepository();
+    const mirrorService = new RecordingMirrorService();
+    const services = createAppServices();
+    services.projectRepository = repository;
+    services.mirrorService = mirrorService;
+
+    render(<EditorShell services={services} />);
+
+    act(() => {
+      repository.resolveLoadedProject({
+        ...services.initialProject,
+        id: 'mirrored-project',
+        name: 'Mirrored Folder',
+      });
+    });
+
+    expect(
+      await screen.findByRole('button', { name: 'Edit project name Mirrored Folder' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mirrorService.syncProject).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'mirrored-project', name: 'Mirrored Folder' }),
+        repository,
+        mirrorConfig,
+      );
+    });
   });
 
   it('disables persistence and keeps the initial project when startup restore fails', async () => {
@@ -942,6 +1087,7 @@ describe('EditorShell', () => {
     );
 
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
 
     await waitFor(() => {
       const savedProject = repository.savedProjects.at(-1);
@@ -1063,6 +1209,7 @@ describe('EditorShell', () => {
       expect(screen.getByRole('button', { name: 'Add a heading' })).toHaveAttribute('aria-pressed', 'true');
     });
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
     await waitFor(() => {
       const insertedText = Object.values(repository.savedProjects.at(-1)?.elements ?? {}).find(
         (element) =>
@@ -1263,6 +1410,7 @@ describe('EditorShell', () => {
       });
     });
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
 
     await waitFor(() => {
       const title = repository.savedProjects.at(-1)?.elements['text-title'];

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { MirrorSettingsPanel } from '../../../../src/ui/editor/MirrorSettingsPanel';
+import type { MinioMirrorConfig } from '../../../../src/services/minioMirrorService';
+
+const config: MinioMirrorConfig = {
+  accessKey: 'localstudio',
+  bucket: 'localstudio',
+  endpoint: 'http://localhost:9000',
+  pathStyle: true,
+  publicBaseUrl: 'http://localhost:9000/localstudio',
+  region: 'us-east-1',
+  secretKey: 'localstudio123',
+  prefix: 'mirrors',
+};
+
+describe('MirrorSettingsPanel', () => {
+  it('closes when clicking outside the panel', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <div>
+        <button type="button">Outside target</button>
+        <MirrorSettingsPanel
+          config={config}
+          mirrorState={{ enabled: true, status: 'idle' }}
+          onClose={onClose}
+          onSave={vi.fn()}
+          onTestConnection={vi.fn()}
+        />
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Outside target' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows prefilled MinIO settings and tests the current connection', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    const onTestConnection = vi.fn(() => Promise.resolve());
+
+    render(
+      <MirrorSettingsPanel
+        config={config}
+        mirrorState={{ enabled: true, status: 'idle' }}
+        onClose={onClose}
+        onSave={onSave}
+        onTestConnection={onTestConnection}
+      />,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Endpoint')).toHaveValue('http://localhost:9000');
+    expect(screen.getByLabelText('Bucket')).toHaveValue('localstudio');
+    const secretInput = screen.getByLabelText('Secret key');
+    expect(secretInput).toHaveValue('localstudio123');
+    expect(secretInput).toHaveAttribute('type', 'password');
+    expect(screen.getByLabelText('Path-style URLs')).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: 'Show secret key' }));
+    expect(secretInput).toHaveAttribute('type', 'text');
+
+    await user.clear(screen.getByLabelText('Prefix'));
+    await user.type(screen.getByLabelText('Prefix'), 'public-projects');
+    await user.click(screen.getByRole('button', { name: 'Test connection' }));
+    expect(onTestConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ prefix: 'public-projects' }),
+    );
+    expect(await screen.findByText('Connection is ready.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Default MinIO login: localstudio / localstudio123'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open public bucket' })).toHaveAttribute(
+      'href',
+      'http://localhost:9000/localstudio',
+    );
+    expect(screen.getByRole('link', { name: 'Open MinIO console' })).toHaveAttribute(
+      'href',
+      'http://localhost:9000',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save settings' }));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ prefix: 'public-projects' }));
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/RemoteImportPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RemoteImportPanel.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { RemoteImportPanel } from '../../../../src/ui/editor/RemoteImportPanel';
+
+describe('RemoteImportPanel', () => {
+  it('shows mirrored projects as selectable rows and imports the chosen project', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onImportProject = vi.fn();
+
+    render(
+      <RemoteImportPanel
+        projects={[
+          { id: 'project-alpha', name: 'Alpha Deck', syncedAt: '2026-06-30T12:00:00.000Z' },
+          { id: 'project-beta', name: 'Beta Deck', syncedAt: '2026-06-30T13:00:00.000Z' },
+        ]}
+        status="ready"
+        onClose={onClose}
+        onImportProject={onImportProject}
+      />,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Import remote project' })).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Import Beta Deck/ }));
+
+    expect(onImportProject).toHaveBeenCalledWith('project-beta');
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/SettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/SettingsPanel.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { SettingsPanel } from '../../../../src/ui/editor/SettingsPanel';
+
+describe('SettingsPanel', () => {
+  it('opens mirror settings from the settings list', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onOpenMirrorSettings = vi.fn();
+
+    render(<SettingsPanel onClose={onClose} onOpenMirrorSettings={onOpenMirrorSettings} />);
+
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
+
+    expect(onOpenMirrorSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -9,8 +9,10 @@ describe('TopToolbar', () => {
     const user = userEvent.setup();
     const onShare = vi.fn();
     const onImportProject = vi.fn();
+    const onImportRemoteMirror = vi.fn();
+    const onMirrorNow = vi.fn();
     const onNewProject = vi.fn();
-    const onPersistenceToggle = vi.fn();
+    const onSaveLocal = vi.fn();
     const onSelectLayers = vi.fn();
     const onTranslateDeck = vi.fn();
 
@@ -20,8 +22,10 @@ describe('TopToolbar', () => {
         language="PT-BR"
         onShare={onShare}
         onImportProject={onImportProject}
+        onImportRemoteMirror={onImportRemoteMirror}
+        onMirrorNow={onMirrorNow}
         onNewProject={onNewProject}
-        onPersistenceToggle={onPersistenceToggle}
+        onSaveLocal={onSaveLocal}
         onSelectLayers={onSelectLayers}
         onTranslateDeck={onTranslateDeck}
         canTranslateDeck
@@ -35,11 +39,23 @@ describe('TopToolbar', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Import Project' }));
     expect(onImportProject).toHaveBeenCalledTimes(1);
     await user.click(screen.getByRole('button', { name: 'File' }));
-    await user.click(screen.getByRole('menuitem', { name: 'Save Local' }));
-    expect(onPersistenceToggle).toHaveBeenCalledWith(true);
+    await user.click(screen.getByRole('menuitem', { name: 'Import Remote' }));
+    expect(onImportRemoteMirror).toHaveBeenCalledTimes(1);
     await user.click(screen.getByRole('button', { name: 'File' }));
     await user.click(screen.getByRole('menuitem', { name: 'Share' }));
     expect(onShare).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    expect(screen.getByRole('separator', { name: 'File storage actions' })).toBeInTheDocument();
+    await user.click(screen.getByRole('menuitem', { name: 'Save' }));
+    expect(onSaveLocal).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Mirror Now' }));
+    expect(onMirrorNow).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    expect(screen.queryByRole('menuitem', { name: 'Save Local' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Export' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'MinIO Mirror Settings' })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'View' }));
     await user.click(screen.getByRole('menuitem', { name: 'Toggle Layers Panel' }));
@@ -99,8 +115,86 @@ describe('TopToolbar', () => {
     expect(persistenceButton).toHaveTextContent('×');
 
     await user.click(screen.getByRole('button', { name: 'File' }));
-    expect(screen.getByRole('menuitem', { name: 'Save Local' })).toBeDisabled();
+    expect(screen.queryByRole('menuitem', { name: 'Save Local' })).not.toBeInTheDocument();
     expect(onPersistenceToggle).not.toHaveBeenCalled();
+  });
+
+  it('shows mirror status beside persistence and syncs when clicked', async () => {
+    const user = userEvent.setup();
+    const onMirrorNow = vi.fn();
+    const onMirrorToggle = vi.fn();
+    const { rerender } = render(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled={false}
+        mirrorState={{ enabled: true, status: 'synced' }}
+        onMirrorNow={onMirrorNow}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Mirror disabled' })).toBeDisabled();
+
+    rerender(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled
+        mirrorState={{ enabled: true, status: 'syncing' }}
+        onMirrorNow={onMirrorNow}
+        onMirrorToggle={onMirrorToggle}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Mirror syncing' })).toHaveClass('mirror-syncing');
+
+    rerender(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled
+        mirrorState={{ enabled: true, status: 'synced' }}
+        onMirrorNow={onMirrorNow}
+        onMirrorToggle={onMirrorToggle}
+      />,
+    );
+    const mirrorButton = screen.getByRole('button', { name: 'Mirror up to date' });
+    expect(mirrorButton).toHaveClass('mirror-synced');
+    await user.click(mirrorButton);
+    expect(onMirrorToggle).toHaveBeenCalledWith(false);
+    expect(onMirrorNow).not.toHaveBeenCalled();
+  });
+
+  it('labels deck storage state by persistence and mirror activation', () => {
+    const { rerender } = render(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled={false}
+        mirrorState={{ enabled: false, status: 'disabled' }}
+      />,
+    );
+
+    expect(screen.getByText('Unsaved deck')).toBeInTheDocument();
+
+    rerender(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled
+        mirrorState={{ enabled: false, status: 'disabled' }}
+      />,
+    );
+    expect(screen.getByText('Local only')).toBeInTheDocument();
+
+    rerender(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled
+        mirrorState={{ enabled: true, status: 'syncing' }}
+      />,
+    );
+    expect(screen.getByText('Mirroring')).toBeInTheDocument();
   });
 
   it('opens version history from the toolbar when persistence is enabled', async () => {

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -140,6 +140,21 @@ describe('TopToolbar', () => {
         project={createSampleProject()}
         language="PT-BR"
         persistenceEnabled
+        mirrorState={{ enabled: false, status: 'disabled' }}
+        onMirrorNow={onMirrorNow}
+        onMirrorToggle={onMirrorToggle}
+      />,
+    );
+    const disabledMirrorButton = screen.getByRole('button', { name: 'Mirror disabled' });
+    expect(disabledMirrorButton).not.toBeDisabled();
+    await user.click(disabledMirrorButton);
+    expect(onMirrorNow).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled
         mirrorState={{ enabled: true, status: 'syncing' }}
         onMirrorNow={onMirrorNow}
         onMirrorToggle={onMirrorToggle}
@@ -161,7 +176,7 @@ describe('TopToolbar', () => {
     expect(mirrorButton).toHaveClass('mirror-synced');
     await user.click(mirrorButton);
     expect(onMirrorToggle).toHaveBeenCalledWith(false);
-    expect(onMirrorNow).not.toHaveBeenCalled();
+    expect(onMirrorNow).toHaveBeenCalledTimes(1);
   });
 
   it('labels deck storage state by persistence and mirror activation', () => {

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -1,0 +1,28 @@
+services:
+  minio:
+    image: quay.io/minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: localstudio
+      MINIO_ROOT_PASSWORD: localstudio123
+      MINIO_API_CORS_ALLOW_ORIGIN: '*'
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    volumes:
+      - minio-data:/data
+
+  mc:
+    image: quay.io/minio/mc:latest
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 localstudio localstudio123; do sleep 1; done;
+      mc mb --ignore-existing local/localstudio;
+      mc anonymous set download local/localstudio;
+      echo 'MinIO bucket localstudio is ready for LocalStudio mirroring.';
+      "
+
+volumes:
+  minio-data:


### PR DESCRIPTION
## Summary
- Add UI and view-model support for planning public asset options in the editor shell
- Extend repository and MinIO mirror services to support the new asset flow
- Update editor layout, settings panels, and footer copy to reflect the new workflow
- Add unit coverage for the updated services and editor UI components

## Testing
- Added and updated unit tests for repository, mirror service, and editor UI components
- UI behavior validated through component-level tests for the new settings and toolbar flows