### PR TITLE
Add an Elements tab for inserting and styling shapes

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -2732,6 +2732,67 @@ button {
   gap: 8px;
 }
 
+.elements-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.element-tile {
+  position: relative;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: #2b2d31;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.element-tile:hover {
+  border-color: rgba(55, 253, 118, 0.48);
+  background: #34363b;
+  color: #ffffff;
+  box-shadow: 0 0 18px rgba(55, 253, 118, 0.12);
+  transform: translateY(-1px);
+}
+
+.element-tile-icon {
+  position: relative;
+  z-index: 1;
+}
+
+.element-shape-preview {
+  position: absolute;
+  width: 42%;
+  height: 26%;
+  border: 2px solid currentColor;
+}
+
+.element-preview-parallelogram {
+  transform: skewX(-18deg);
+}
+
+.element-shape-preview-svg {
+  position: absolute;
+  z-index: 1;
+  width: 38px;
+  height: 38px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 3px;
+}
+
 .text-brand-preview button,
 .text-preset-button {
   width: 100%;

--- a/apps/editor/src/domain/commands/basicCommands.ts
+++ b/apps/editor/src/domain/commands/basicCommands.ts
@@ -30,12 +30,12 @@ export type VideoPlaybackPatch = Partial<
 export type MediaPlaybackPatch = GifPlaybackPatch | VideoPlaybackPatch;
 export type ElementStylePatch = Partial<{
   align: 'left' | 'center' | 'right';
-  fill: string;
+  fill: string | null;
   fontFamily: string;
   fontSize: number;
   fontWeight: number;
   opacity: number;
-  stroke: string;
+  stroke: string | null;
   strokeWidth: number;
 }>;
 
@@ -657,7 +657,7 @@ export class UpdateElementStyleCommand implements EditorCommand {
       nextElement = {
         ...nextElement,
         ...(this.patch.align ? { align: this.patch.align } : {}),
-        ...(this.patch.fill ? { fill: this.patch.fill } : {}),
+        ...(typeof this.patch.fill === 'string' ? { fill: this.patch.fill } : {}),
         ...(this.patch.fontFamily ? { fontFamily: this.patch.fontFamily } : {}),
         ...(this.patch.fontSize !== undefined ? { fontSize: Math.max(1, this.patch.fontSize) } : {}),
         ...(this.patch.fontWeight !== undefined ? { fontWeight: this.patch.fontWeight } : {}),
@@ -665,12 +665,20 @@ export class UpdateElementStyleCommand implements EditorCommand {
     }
 
     if (element.type === 'shape') {
-      nextElement = {
+      const { fill, stroke, strokeWidth } = this.patch;
+      const nextShapeElement = {
         ...nextElement,
-        ...(this.patch.fill ? { fill: this.patch.fill } : {}),
-        ...(this.patch.stroke ? { stroke: this.patch.stroke } : {}),
-        ...(this.patch.strokeWidth !== undefined ? { strokeWidth: Math.max(0, this.patch.strokeWidth) } : {}),
+        ...(typeof fill === 'string' ? { fill } : {}),
+        ...(typeof stroke === 'string' ? { stroke } : {}),
+        ...(strokeWidth !== undefined ? { strokeWidth: Math.max(0, strokeWidth) } : {}),
       };
+      if (fill === null) {
+        delete nextShapeElement.fill;
+      }
+      if (stroke === null) {
+        delete nextShapeElement.stroke;
+      }
+      nextElement = nextShapeElement;
     }
 
     return {

--- a/apps/editor/src/domain/model.ts
+++ b/apps/editor/src/domain/model.ts
@@ -1,4 +1,15 @@
 export type ElementType = 'text' | 'image' | 'gif' | 'video' | 'shape';
+export type ShapeKind =
+  | 'arc'
+  | 'arrow'
+  | 'diamond'
+  | 'ellipse'
+  | 'line'
+  | 'parallelogram'
+  | 'pentagon'
+  | 'rect'
+  | 'rounded-rect'
+  | 'triangle';
 
 export interface ProjectDocument {
   id: string;
@@ -85,8 +96,8 @@ export interface VideoElement extends BaseElement {
 
 export interface ShapeElement extends BaseElement {
   type: 'shape';
-  shape: 'rect' | 'ellipse';
-  fill: string;
+  shape: ShapeKind;
+  fill?: string;
   stroke?: string;
   strokeWidth?: number;
 }

--- a/apps/editor/src/services/editorAutomationController.ts
+++ b/apps/editor/src/services/editorAutomationController.ts
@@ -123,7 +123,10 @@ function compactElement(element: DesignElement): SnapshotElement {
       trimStartSeconds: element.trimStartSeconds,
     };
   }
-  return { ...base, fill: element.fill };
+  return {
+    ...base,
+    ...(element.fill ? { fill: element.fill } : {}),
+  };
 }
 
 export function createProjectSnapshot(state: EditorAutomationState): ProjectSnapshot {

--- a/apps/editor/src/ui/editor/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/CanvasWorkspace.tsx
@@ -1,8 +1,17 @@
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type RefObject } from 'react';
 import type Konva from 'konva';
-import { Circle, Image as KonvaImage, Layer, Line, Rect, Stage, Text, Transformer } from 'react-konva';
+import { Arrow, Circle, Image as KonvaImage, Layer, Line, Rect, Stage, Text, Transformer } from 'react-konva';
 import type { ElementFramePatch, ImageCropPatch } from '../../domain/commands/basicCommands';
-import type { CropRect, DesignElement, GifElement, ImageElement, ProjectDocument, SelectionState, VideoElement } from '../../domain/model';
+import type {
+  CropRect,
+  DesignElement,
+  GifElement,
+  ImageElement,
+  ProjectDocument,
+  SelectionState,
+  ShapeElement,
+  VideoElement,
+} from '../../domain/model';
 import { getNormalizedElementPoint } from './backgroundSelection';
 import { FloatingSelectionToolbar } from './FloatingSelectionToolbar';
 import { calculateImageCropPatch, type ImageCropHandle } from './imageCrop';
@@ -98,6 +107,27 @@ function useCanvasImage(src: string | undefined) {
   }, [src]);
 
   return loadedImage && loadedImage.src === src ? loadedImage.image : undefined;
+}
+
+function getPolygonPoints(shape: ShapeElement['shape'], width: number, height: number) {
+  if (shape === 'triangle') return [width / 2, 0, width, height, 0, height];
+  if (shape === 'diamond') return [width / 2, 0, width, height / 2, width / 2, height, 0, height / 2];
+  if (shape === 'parallelogram') return [width * 0.24, 0, width, 0, width * 0.76, height, 0, height];
+  if (shape === 'pentagon') {
+    return Array.from({ length: 5 }).flatMap((_, index) => {
+      const angle = -Math.PI / 2 + (index * Math.PI * 2) / 5;
+      return [width / 2 + Math.cos(angle) * (width / 2), height / 2 + Math.sin(angle) * (height / 2)];
+    });
+  }
+  return [];
+}
+
+function getShapePaint(element: ShapeElement) {
+  const strokeWidth = element.stroke && (element.strokeWidth ?? 0) > 0 ? (element.strokeWidth ?? 0) : 0;
+  return {
+    ...(element.fill ? { fill: element.fill } : {}),
+    ...(element.stroke && strokeWidth > 0 ? { stroke: element.stroke, strokeWidth } : {}),
+  };
 }
 
 export function CanvasWorkspace({
@@ -631,13 +661,90 @@ export function CanvasWorkspace({
                 const commonProps = getCommonElementProps(element);
 
                 if (element.type === 'shape') {
-                  return (
-                    <Rect
-                      {...commonProps}
-                      key={element.id}
-                      fill={element.fill}
-                    />
-                  );
+                  const paint = getShapePaint(element);
+                  if (element.shape === 'ellipse') {
+                    return (
+                      <Rect
+                        {...commonProps}
+                        {...paint}
+                        key={element.id}
+                        cornerRadius={Math.min(commonProps.width, commonProps.height) / 2}
+                      />
+                    );
+                  }
+                  if (element.shape === 'rounded-rect') {
+                    return (
+                      <Rect
+                        {...commonProps}
+                        {...paint}
+                        key={element.id}
+                        cornerRadius={Math.min(commonProps.width, commonProps.height) * 0.18}
+                      />
+                    );
+                  }
+                  if (element.shape === 'line') {
+                    return (
+                      <Line
+                        {...commonProps}
+                        key={element.id}
+                        points={[0, commonProps.height, commonProps.width, 0]}
+                        stroke={element.stroke ?? element.fill ?? '#37FD76'}
+                        strokeWidth={Math.max(1, element.strokeWidth ?? 4)}
+                      />
+                    );
+                  }
+                  if (element.shape === 'arrow') {
+                    return (
+                      <Arrow
+                        {...commonProps}
+                        key={element.id}
+                        fill={element.stroke ?? element.fill ?? '#37FD76'}
+                        points={[0, commonProps.height / 2, commonProps.width, commonProps.height / 2]}
+                        pointerLength={Math.min(42, commonProps.width * 0.22)}
+                        pointerWidth={Math.min(46, commonProps.height * 0.48)}
+                        stroke={element.stroke ?? element.fill ?? '#37FD76'}
+                        strokeWidth={Math.max(1, element.strokeWidth ?? 10)}
+                      />
+                    );
+                  }
+                  if (element.shape === 'arc') {
+                    return (
+                      <Line
+                        {...commonProps}
+                        key={element.id}
+                        bezier
+                        points={[
+                          0,
+                          commonProps.height,
+                          commonProps.width * 0.12,
+                          0,
+                          commonProps.width * 0.88,
+                          0,
+                          commonProps.width,
+                          commonProps.height,
+                        ]}
+                        stroke={element.stroke ?? element.fill ?? '#37FD76'}
+                        strokeWidth={Math.max(1, element.strokeWidth ?? 4)}
+                      />
+                    );
+                  }
+                  if (
+                    element.shape === 'triangle' ||
+                    element.shape === 'pentagon' ||
+                    element.shape === 'diamond' ||
+                    element.shape === 'parallelogram'
+                  ) {
+                    return (
+                      <Line
+                        {...commonProps}
+                        {...paint}
+                        closed
+                        key={element.id}
+                        points={getPolygonPoints(element.shape, commonProps.width, commonProps.height)}
+                      />
+                    );
+                  }
+                  return <Rect {...commonProps} {...paint} key={element.id} />;
                 }
 
                 if (element.type === 'image') {

--- a/apps/editor/src/ui/editor/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/DesignPanel.tsx
@@ -6,7 +6,7 @@ import type {
   SelectionState,
   VideoElement,
 } from '../../domain/model';
-import type { MediaPlaybackPatch } from '../../domain/commands/basicCommands';
+import type { ElementStylePatch, MediaPlaybackPatch } from '../../domain/commands/basicCommands';
 import { PanelSection } from '../components/PanelSection';
 import { TEXT_FONT_FAMILIES, TEXT_FONT_WEIGHTS } from './textStyleOptions';
 
@@ -16,19 +16,7 @@ interface DesignPanelProps {
   project: ProjectDocument;
   activePageId: string;
   selection: SelectionState;
-  onUpdateElementStyle?: (
-    elementId: string,
-    patch: Partial<{
-      align: 'left' | 'center' | 'right';
-      fill: string;
-      fontFamily: string;
-      fontSize: number;
-      fontWeight: number;
-      opacity: number;
-      stroke: string;
-      strokeWidth: number;
-    }>,
-  ) => void;
+  onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
 }
@@ -222,38 +210,79 @@ export function DesignPanel({
         <PanelSection title="Shape">
           <label className="design-control">
             <span>Fill</span>
-            <input
-              aria-label="Selected shape fill"
-              type="color"
-              value={selectedElement.fill}
+            <select
+              aria-label="Selected shape fill mode"
+              value={selectedElement.fill ? 'color' : 'none'}
               onChange={(event) => {
-                updateSelectedStyle({ fill: event.target.value });
+                updateSelectedStyle({
+                  fill: event.target.value === 'color' ? selectedElement.fill ?? '#37FD76' : null,
+                });
               }}
-            />
+            >
+              <option value="none">No fill</option>
+              <option value="color">Color fill</option>
+            </select>
           </label>
+          {selectedElement.fill ? (
+            <label className="design-control">
+              <span>Fill color</span>
+              <input
+                aria-label="Selected shape fill color"
+                type="color"
+                value={selectedElement.fill}
+                onChange={(event) => {
+                  updateSelectedStyle({ fill: event.target.value });
+                }}
+              />
+            </label>
+          ) : null}
           <label className="design-control">
-            <span>Stroke</span>
-            <input
-              aria-label="Selected shape stroke"
-              type="color"
-              value={selectedElement.stroke ?? '#37FD76'}
+            <span>Border</span>
+            <select
+              aria-label="Selected shape border mode"
+              value={selectedElement.stroke && (selectedElement.strokeWidth ?? 0) > 0 ? 'color' : 'none'}
               onChange={(event) => {
-                updateSelectedStyle({ stroke: event.target.value });
+                updateSelectedStyle(
+                  event.target.value === 'color'
+                    ? {
+                        stroke: selectedElement.stroke ?? '#37FD76',
+                        strokeWidth: selectedElement.strokeWidth && selectedElement.strokeWidth > 0 ? selectedElement.strokeWidth : 2,
+                      }
+                    : { stroke: null, strokeWidth: 0 },
+                );
               }}
-            />
+            >
+              <option value="none">No border</option>
+              <option value="color">Color border</option>
+            </select>
           </label>
-          <label className="design-control">
-            <span>Stroke width</span>
-            <input
-              aria-label="Selected shape stroke width"
-              min="0"
-              type="number"
-              value={selectedElement.strokeWidth ?? 0}
-              onChange={(event) => {
-                updateSelectedStyle({ strokeWidth: Number(event.target.value) });
-              }}
-            />
-          </label>
+          {selectedElement.stroke && (selectedElement.strokeWidth ?? 0) > 0 ? (
+            <>
+              <label className="design-control">
+                <span>Border color</span>
+                <input
+                  aria-label="Selected shape border color"
+                  type="color"
+                  value={selectedElement.stroke}
+                  onChange={(event) => {
+                    updateSelectedStyle({ stroke: event.target.value });
+                  }}
+                />
+              </label>
+              <label className="design-control">
+                <span>Border width</span>
+                <input
+                  aria-label="Selected shape border width"
+                  min="1"
+                  type="number"
+                  value={selectedElement.strokeWidth ?? 2}
+                  onChange={(event) => {
+                    updateSelectedStyle({ strokeWidth: Number(event.target.value) });
+                  }}
+                />
+              </label>
+            </>
+          ) : null}
         </PanelSection>
       ) : null}
     </div>

--- a/apps/editor/src/ui/editor/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/EditorShell.tsx
@@ -350,6 +350,7 @@ export function EditorShell({ services }: EditorShellProps) {
           onRemoveAsset={isHistoryReadOnly ? undefined : vm.removeAsset}
           onImportMedia={isHistoryReadOnly ? undefined : importMediaFile}
           onInsertText={isHistoryReadOnly ? undefined : vm.insertTextElement}
+          onInsertShape={isHistoryReadOnly ? undefined : vm.insertShapeElement}
           modelStates={vm.modelStates}
           attentionModelId={vm.aiToolsAttentionModelId ?? (vm.backgroundSelectionNotice ? IMAGE_EDITING_MODEL_ID : undefined)}
           createImageOptions={vm.createImageOptions}

--- a/apps/editor/src/ui/editor/ElementsPanel.tsx
+++ b/apps/editor/src/ui/editor/ElementsPanel.tsx
@@ -1,0 +1,76 @@
+import {
+  ArrowRight,
+  Circle,
+  Diamond,
+  Minus,
+  Pentagon,
+  RectangleHorizontal,
+  Square,
+  Triangle,
+  type LucideIcon,
+} from 'lucide-react';
+import type { ShapeKind } from '../../domain/model';
+
+export const elementShapeCatalog: Array<{
+  icon?: LucideIcon;
+  label: string;
+  shape: ShapeKind;
+}> = [
+  { shape: 'ellipse', label: 'circle', icon: Circle },
+  { shape: 'line', label: 'line', icon: Minus },
+  { shape: 'rect', label: 'square', icon: Square },
+  { shape: 'rounded-rect', label: 'rounded rectangle', icon: RectangleHorizontal },
+  { shape: 'triangle', label: 'triangle', icon: Triangle },
+  { shape: 'pentagon', label: 'pentagon', icon: Pentagon },
+  { shape: 'diamond', label: 'diamond', icon: Diamond },
+  { shape: 'parallelogram', label: 'parallelogram' },
+  { shape: 'arrow', label: 'arrow', icon: ArrowRight },
+  { shape: 'arc', label: 'arc' },
+];
+
+interface ElementsPanelProps {
+  onInsertShape?: (shape: ShapeKind) => void;
+}
+
+export function ElementsPanel({ onInsertShape }: ElementsPanelProps) {
+  return (
+    <section className="panel-stack" aria-label="Elements tools">
+      <div className="panel-section">
+        <h2 className="panel-heading">Elements</h2>
+        <p className="panel-muted">Add editable shapes to the current slide.</p>
+      </div>
+      <div className="elements-grid" aria-label="Shape elements">
+        {elementShapeCatalog.map((item) => {
+          const Icon = item.icon;
+          return (
+            <button
+              aria-label={`Add ${item.label}`}
+              className="element-tile"
+              key={item.shape}
+              type="button"
+              onClick={() => {
+                onInsertShape?.(item.shape);
+              }}
+            >
+              <ShapeTilePreview shape={item.shape} />
+              {Icon ? <Icon aria-hidden="true" className="element-tile-icon" size={24} strokeWidth={2.2} /> : null}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function ShapeTilePreview({ shape }: { shape: ShapeKind }) {
+  if (shape === 'parallelogram') return <span className="element-shape-preview element-preview-parallelogram" />;
+  if (shape === 'arc') {
+    return (
+      <svg aria-hidden="true" className="element-shape-preview-svg" viewBox="0 0 48 48">
+        <path d="M9 38 C10 14 32 9 39 20" />
+        <path d="M34 11 L40 20 L29 22" />
+      </svg>
+    );
+  }
+  return null;
+}

--- a/apps/editor/src/ui/editor/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/LeftToolPanel.tsx
@@ -1,11 +1,12 @@
-import { Brush, ImagePlus, Layers3, Sparkles, Type } from 'lucide-react';
+import { Brush, ImagePlus, Layers3, Shapes, Sparkles, Type } from 'lucide-react';
 import { useMemo, useRef } from 'react';
 import { collectReferencedAssetIds } from '../../domain/assetUsage';
-import type { Asset, PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
+import type { Asset, PageBackground, ProjectDocument, SelectionState, ShapeKind } from '../../domain/model';
 import type { ElementStylePatch, MediaPlaybackPatch } from '../../domain/commands/basicCommands';
 import type { AiProviderState, ModelState } from '../../services/interfaces';
 import { AiToolsPanel } from './AiToolsPanel';
 import { DesignPanel } from './DesignPanel';
+import { ElementsPanel } from './ElementsPanel';
 import type { CreateImagePromptOptions } from './imagePromptOptions';
 import { LayersPanel } from './LayersPanel';
 import { TextPanel } from './TextPanel';
@@ -38,6 +39,7 @@ interface LeftToolPanelProps {
   onRemoveAsset?: ((assetId: string) => void) | undefined;
   onImportMedia?: ((file: File) => void) | undefined;
   onInsertText?: ((preset: TextPreset) => void) | undefined;
+  onInsertShape?: ((shape: ShapeKind) => void) | undefined;
   onPreparePromptApi?: (() => Promise<void>) | undefined;
   onPrepareLanguageDetectionProvider?: (() => Promise<void>) | undefined;
   onPrepareTranslationProvider?: (() => Promise<void>) | undefined;
@@ -61,6 +63,7 @@ interface LeftToolPanelProps {
 const menuItems: Array<{ id: RightPanelTab; label: string; icon: typeof Layers3 }> = [
   { id: 'layout', label: 'Layout', icon: Layers3 },
   { id: 'text', label: 'Text', icon: Type },
+  { id: 'elements', label: 'Elements', icon: Shapes },
   { id: 'design', label: 'Design', icon: Brush },
   { id: 'ai-tools', label: 'AI Tools', icon: Sparkles },
   { id: 'assets', label: 'Assets', icon: ImagePlus },
@@ -93,6 +96,7 @@ export function LeftToolPanel({
   onRemoveAsset,
   onImportMedia,
   onInsertText,
+  onInsertShape,
   onPreparePromptApi,
   onPrepareLanguageDetectionProvider,
   onPrepareTranslationProvider,
@@ -181,6 +185,9 @@ export function LeftToolPanel({
         ) : null}
         {panelOpen && activeTab === 'text' ? (
           <TextPanel {...(onInsertText ? { onInsertText } : {})} />
+        ) : null}
+        {panelOpen && activeTab === 'elements' ? (
+          <ElementsPanel {...(onInsertShape ? { onInsertShape } : {})} />
         ) : null}
         {panelOpen && activeTab === 'ai-tools' ? (
           <AiToolsPanel

--- a/apps/editor/src/ui/editor/RightPanel.tsx
+++ b/apps/editor/src/ui/editor/RightPanel.tsx
@@ -9,7 +9,7 @@ import type { CreateImagePromptOptions } from './imagePromptOptions';
 import { LayersPanel } from './LayersPanel';
 import type { RightPanelTab } from './useEditorViewModel';
 
-type LegacyRightPanelTab = Exclude<RightPanelTab, 'assets' | 'text'>;
+type LegacyRightPanelTab = Exclude<RightPanelTab, 'assets' | 'elements' | 'text'>;
 
 interface RightPanelProps {
   activeTab: LegacyRightPanelTab;

--- a/apps/editor/src/ui/editor/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/useEditorViewModel.ts
@@ -38,7 +38,16 @@ import {
 } from '../../domain/commands/basicCommands';
 import type { GeneratedSlideElement } from '../../domain/generatedSlide';
 import { fitImageWithinPage } from '../../domain/imageSizing';
-import type { DesignElement, ImageElement, Page, PageBackground, ProjectDocument, SelectionState } from '../../domain/model';
+import type {
+  DesignElement,
+  ImageElement,
+  Page,
+  PageBackground,
+  ProjectDocument,
+  SelectionState,
+  ShapeElement,
+  ShapeKind,
+} from '../../domain/model';
 import { createBlankProject, SAMPLE_HERO_IMAGE_SIZE, SAMPLE_HERO_IMAGE_URL } from '../../domain/sampleProject';
 import type { EditorAutomationDelegate } from '../../services/editorAutomationController';
 import type { AiProviderState, ModelState, PromptApiAvailability, VersionHistoryEntry } from '../../services/interfaces';
@@ -56,7 +65,7 @@ import { looksLikeImageGenerationRequest } from '../../services/prompts/slideTas
 import { defaultCreateImagePromptOptions, type CreateImagePromptOptions } from './imagePromptOptions';
 import { TRANSLATION_LANGUAGE_OPTIONS } from './translationLanguages';
 
-export type RightPanelTab = 'layout' | 'text' | 'design' | 'ai-tools' | 'assets';
+export type RightPanelTab = 'layout' | 'text' | 'elements' | 'design' | 'ai-tools' | 'assets';
 export type TextPreset = 'title' | 'subtitle' | 'body';
 
 interface EditorHistory {
@@ -1881,6 +1890,53 @@ export function useEditorViewModel(services: AppServices) {
     );
   }
 
+  function insertShapeElement(shape: ShapeKind) {
+    const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
+    if (!page) return;
+    const selectedElement = project.elements[selectedElementIds[0] ?? ''];
+    const isLinearShape = shape === 'line' || shape === 'arc';
+    const defaultFrame: Record<ShapeKind, { width: number; height: number }> = {
+      arc: { width: 260, height: 180 },
+      arrow: { width: 260, height: 140 },
+      diamond: { width: 180, height: 180 },
+      ellipse: { width: 180, height: 180 },
+      line: { width: 260, height: 120 },
+      parallelogram: { width: 240, height: 150 },
+      pentagon: { width: 190, height: 190 },
+      rect: { width: 180, height: 180 },
+      'rounded-rect': { width: 240, height: 150 },
+      triangle: { width: 190, height: 180 },
+    };
+    const { width, height } = defaultFrame[shape];
+    const elementId = createId('shape');
+    const nextElement: ShapeElement = {
+      id: elementId,
+      type: 'shape',
+      shape,
+      x: selectedElement
+        ? Math.min(page.width - width, selectedElement.x + PASTED_ELEMENT_OFFSET)
+        : (page.width - width) / 2,
+      y: selectedElement
+        ? Math.min(page.height - height, selectedElement.y + PASTED_ELEMENT_OFFSET)
+        : (page.height - height) / 2,
+      width,
+      height,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      ...(isLinearShape
+        ? { stroke: '#37FD76', strokeWidth: 4 }
+        : { fill: '#37FD76' }),
+    };
+
+    commitProject(
+      (currentProject) => new AddElementsCommand(activePageId, [nextElement]).execute(currentProject),
+      { selectedElementIds: [elementId] },
+    );
+    setActiveTab('design');
+  }
+
   function alignSelectedElement(mode: AlignMode) {
     const elementId = selectedElementIds[0];
     if (!elementId) return;
@@ -2494,6 +2550,7 @@ export function useEditorViewModel(services: AppServices) {
     cutSelectedElements,
     pasteCopiedElements,
     insertTextElement,
+    insertShapeElement,
     alignSelectedElement,
     setSelectedElementZOrder,
     flipSelectedImage,

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -27,6 +27,38 @@ import {
   TranslateTextElementsCommand,
 } from '../../../../src/domain/commands/basicCommands';
 import { createSampleProject } from '../../../../src/domain/sampleProject';
+import type { ShapeElement } from '../../../../src/domain/model';
+
+function createShapeFixture(overrides: Partial<ShapeElement> = {}) {
+  const project = createSampleProject();
+  const shape: ShapeElement = {
+    id: 'shape-test',
+    type: 'shape',
+    shape: 'rect',
+    x: 120,
+    y: 160,
+    width: 240,
+    height: 180,
+    rotation: 0,
+    locked: false,
+    visible: true,
+    opacity: 1,
+    fill: '#37FD76',
+    stroke: '#FFFFFF',
+    strokeWidth: 4,
+    ...overrides,
+  };
+  return {
+    ...project,
+    elements: {
+      ...project.elements,
+      [shape.id]: shape,
+    },
+    pages: project.pages.map((page) =>
+      page.id === 'page-1' ? { ...page, elementIds: [...page.elementIds, shape.id] } : page,
+    ),
+  };
+}
 
 describe('editor commands', () => {
   it('aligns an element to page horizontal center immutably', () => {
@@ -253,6 +285,44 @@ describe('editor commands', () => {
       fill: '#37FD76',
       fontSize: 96,
       opacity: 1,
+    });
+  });
+
+  it('clears shape fill and border style immutably', () => {
+    const project = createShapeFixture();
+    const next = new UpdateElementStyleCommand('shape-test', {
+      fill: null,
+      stroke: null,
+      strokeWidth: 0,
+    }).execute(project);
+
+    expect(next).not.toBe(project);
+    expect(next.elements['shape-test']).toMatchObject({
+      type: 'shape',
+      strokeWidth: 0,
+    });
+    expect(next.elements['shape-test']).not.toHaveProperty('fill');
+    expect(next.elements['shape-test']).not.toHaveProperty('stroke');
+    expect(project.elements['shape-test']).toMatchObject({
+      fill: '#37FD76',
+      stroke: '#FFFFFF',
+      strokeWidth: 4,
+    });
+  });
+
+  it('does not update locked shape style', () => {
+    const project = createShapeFixture({ locked: true });
+    const next = new UpdateElementStyleCommand('shape-test', {
+      fill: null,
+      stroke: null,
+      strokeWidth: 0,
+    }).execute(project);
+
+    expect(next).toBe(project);
+    expect(next.elements['shape-test']).toMatchObject({
+      fill: '#37FD76',
+      stroke: '#FFFFFF',
+      strokeWidth: 4,
     });
   });
 

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -2,10 +2,23 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { createSampleProject } from '../../../../src/domain/sampleProject';
-import type { ProjectDocument, VideoElement } from '../../../../src/domain/model';
+import type { ProjectDocument, ShapeElement, VideoElement } from '../../../../src/domain/model';
 import { CanvasWorkspace } from '../../../../src/ui/editor/CanvasWorkspace';
 
 describe('CanvasWorkspace', () => {
+  const shapeCatalog: ShapeElement['shape'][] = [
+    'ellipse',
+    'line',
+    'rect',
+    'rounded-rect',
+    'triangle',
+    'pentagon',
+    'diamond',
+    'parallelogram',
+    'arrow',
+    'arc',
+  ];
+
   function createMediaProject(): ProjectDocument {
     const project = createSampleProject();
     project.assets['asset-video'] = {
@@ -92,6 +105,54 @@ describe('CanvasWorkspace', () => {
     expect(screen.getByLabelText('BG Remover')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Flip' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Crop' })).toBeEnabled();
+  });
+
+  it('renders every supported shape catalog item without crashing', () => {
+    const project = createSampleProject();
+    const shapes = Object.fromEntries(
+      shapeCatalog.map((shape, index) => [
+        `shape-${shape}`,
+        {
+          id: `shape-${shape}`,
+          type: 'shape' as const,
+          shape,
+          x: 80 + index * 24,
+          y: 120 + index * 18,
+          width: 180,
+          height: 140,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          fill: '#37FD76',
+          stroke: '#FFFFFF',
+          strokeWidth: 2,
+        },
+      ]),
+    );
+    const shapedProject: ProjectDocument = {
+      ...project,
+      elements: {
+        ...project.elements,
+        ...shapes,
+      },
+      pages: project.pages.map((page) =>
+        page.id === 'page-1'
+          ? { ...page, elementIds: [...page.elementIds, ...Object.keys(shapes)] }
+          : page,
+      ),
+    };
+
+    const { container } = render(
+      <CanvasWorkspace
+        project={shapedProject}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['shape-arrow'] }}
+      />,
+    );
+
+    expect(container.querySelector('canvas')).toBeInTheDocument();
+    expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-selected-elements', 'shape-arrow');
   });
 
   it('toggles crop mode for selected images', async () => {

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import type { ProjectDocument, ShapeElement } from '../../../../src/domain/model';
+import { createSampleProject } from '../../../../src/domain/sampleProject';
+import { DesignPanel } from '../../../../src/ui/editor/DesignPanel';
+
+function createProjectWithSelectedShape(): ProjectDocument {
+  const project = createSampleProject();
+  const shape: ShapeElement = {
+    id: 'shape-test',
+    type: 'shape',
+    shape: 'rect',
+    x: 120,
+    y: 160,
+    width: 240,
+    height: 180,
+    rotation: 0,
+    locked: false,
+    visible: true,
+    opacity: 1,
+    fill: '#37FD76',
+  };
+  return {
+    ...project,
+    elements: {
+      ...project.elements,
+      [shape.id]: shape,
+    },
+    pages: project.pages.map((page) =>
+      page.id === 'page-1' ? { ...page, elementIds: [...page.elementIds, shape.id] } : page,
+    ),
+  };
+}
+
+describe('DesignPanel', () => {
+  it('updates selected shape fill and border modes', async () => {
+    const user = userEvent.setup();
+    const onUpdateElementStyle = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedShape()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['shape-test'] }}
+        onUpdateElementStyle={onUpdateElementStyle}
+      />,
+    );
+
+    expect(screen.getByLabelText('Selected shape fill mode')).toHaveValue('color');
+    await user.selectOptions(screen.getByLabelText('Selected shape fill mode'), 'none');
+    expect(onUpdateElementStyle).toHaveBeenCalledWith('shape-test', { fill: null });
+
+    expect(screen.getByLabelText('Selected shape border mode')).toHaveValue('none');
+    await user.selectOptions(screen.getByLabelText('Selected shape border mode'), 'color');
+    expect(onUpdateElementStyle).toHaveBeenCalledWith('shape-test', {
+      stroke: '#37FD76',
+      strokeWidth: 2,
+    });
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -206,7 +206,7 @@ function createReadyPrepareTranslationMock() {
   );
 }
 
-async function openLeftTab(user: ReturnType<typeof userEvent.setup>, name: 'AI Tools' | 'Layout') {
+async function openLeftTab(user: ReturnType<typeof userEvent.setup>, name: 'AI Tools' | 'Elements' | 'Layout') {
   const tab = screen.getByRole('tab', { name });
   if (tab.getAttribute('aria-selected') !== 'true') {
     await user.click(tab);
@@ -310,6 +310,28 @@ describe('EditorShell', () => {
 
     await openLeftTab(user, 'Layout');
     expect(screen.getByRole('button', { name: 'Selected Image' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('inserts and selects a shape from the Elements panel', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await openLeftTab(user, 'Elements');
+    await user.click(screen.getByRole('button', { name: 'Add triangle' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-selected-elements',
+        expect.stringMatching(/^shape-/),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Design' })).toHaveAttribute('aria-selected', 'true');
+    });
+    expect(screen.getByLabelText('Selected shape fill mode')).toBeInTheDocument();
+
+    await openLeftTab(user, 'Layout');
+    expect(screen.getByRole('button', { name: 'Background Shape' })).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('switches to the layout panel from the header view menu', async () => {

--- a/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
@@ -145,4 +145,30 @@ describe('LeftToolPanel', () => {
     expect(onInsertText).toHaveBeenNthCalledWith(2, 'subtitle');
     expect(onInsertText).toHaveBeenNthCalledWith(3, 'body');
   });
+
+  it('opens the Elements menu and inserts a selected shape', async () => {
+    const user = userEvent.setup();
+    const onInsertShape = vi.fn();
+
+    render(
+      <LeftToolPanel
+        activeTab="elements"
+        open
+        onTabChange={vi.fn()}
+        project={createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        modelStates={modelStates}
+        onInsertShape={onInsertShape}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Elements' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('button', { name: 'Add circle' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add arrow' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Add triangle' }));
+
+    expect(onInsertShape).toHaveBeenCalledWith('triangle');
+  });
 });


### PR DESCRIPTION
## Summary
- Add a new Elements tab with shape presets and insertion flow
- Expand shape rendering to support multiple geometric variants in the canvas
- Update shape styling to handle optional fill and stroke values, including clearing styles
- Add unit and UI coverage for shape insertion, rendering, and style updates

## Testing
- Unit tests added for shape style clearing and shape catalog rendering
- UI tests added for inserting a shape from the Elements panel and verifying the design panel state