### PR TITLE
Add MinIO-backed public sharing

### DIFF
--- a/apps/editor/src/app/composition.ts
+++ b/apps/editor/src/app/composition.ts
@@ -64,6 +64,7 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
   const textGenerationRuntime = new TransformersTextGenerationRuntime();
   const languageDetectionRuntime = new TransformersLanguageDetectionRuntime();
   const persistenceAvailable = isFileSystemAccessAvailable();
+  const mirrorService = new MinioMirrorService();
   const modelSetupService = new BrowserModelSetupService(
     undefined,
     undefined,
@@ -79,7 +80,7 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
     persistenceAvailable,
     projectRepository: createProjectRepository(persistenceAvailable),
     exportService: new BrowserExportService(),
-    shareService: new BrowserShareService(),
+    shareService: new BrowserShareService({ mirrorService }),
     localSetupService: new BrowserLocalSetupService(),
     modelSetupService,
     translatorService: new BrowserTranslatorService(
@@ -100,7 +101,7 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
     backgroundRemovalService: new BrowserBackgroundRemovalService(),
     smartGrabService: new MockSmartGrabService(),
     magicEraserService: new MockMagicEraserService(),
-    mirrorService: new MinioMirrorService(),
+    mirrorService,
   };
 }
 

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -4337,7 +4337,7 @@ button {
   gap: 0;
   overflow: hidden;
   padding: 0;
-  background: #000;
+  background: #050d10;
 }
 
 .public-deck-viewer-embed {
@@ -4392,10 +4392,24 @@ button {
   padding: 0;
 }
 
+.public-deck-viewer-present .public-deck-stage-shell .canvas-workspace {
+  width: 100vw;
+  height: 100vh;
+  display: grid;
+  place-items: center;
+}
+
 .public-deck-viewer-present .public-deck-stage-shell .canvas-frame {
   width: min(100vw, calc(100vh * 16 / 9));
   max-height: 100vh;
+  border: 0;
+  outline: 0;
   box-shadow: none;
+  transform: none !important;
+}
+
+.public-deck-viewer-present .public-deck-stage-shell .canvas-artboard {
+  border-radius: 0;
 }
 
 .public-deck-viewer-embed .public-deck-stage-shell .canvas-frame {

--- a/apps/editor/src/services/minioMirrorService.ts
+++ b/apps/editor/src/services/minioMirrorService.ts
@@ -292,6 +292,11 @@ function createObjectUrl(config: MinioMirrorConfig, key = '', query: Record<stri
   return url;
 }
 
+function createPublicObjectUrl(config: MinioMirrorConfig, key: string) {
+  const publicBaseUrl = config.publicBaseUrl.trim().replace(/\/+$/g, '');
+  return `${publicBaseUrl}/${encodeKeyPath(key)}`;
+}
+
 async function createSignedHeaders(
   config: MinioMirrorConfig,
   method: string,
@@ -457,6 +462,14 @@ export class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
     );
     files.push({ path: MIRROR_MANIFEST_FILE_NAME, blob: textBlob(manifest) });
     return files;
+  }
+
+  getPublicObjectUrl(key: string, config: MinioMirrorConfig): string {
+    return createPublicObjectUrl(config, key);
+  }
+
+  async uploadPublicObject(key: string, blob: Blob, config: MinioMirrorConfig): Promise<void> {
+    await this.putObject(key, blob, config);
   }
 
   private async loadRemoteManifest(projectKey: string, config: MinioMirrorConfig) {

--- a/apps/editor/src/services/shareService.ts
+++ b/apps/editor/src/services/shareService.ts
@@ -1,17 +1,23 @@
-import type { ProjectDocument } from '../domain/model';
 import { getPublicBasePath, normalizeBasePath } from '../app/publicBasePath';
+import type { Asset, ProjectDocument } from '../domain/model';
 import type { ShareMetadata, ShareRecord, ShareService } from './interfaces';
+import {
+  MinioMirrorService,
+  type MinioMirrorConfig,
+} from './minioMirrorService';
 
-const SHARE_STORAGE_KEY = 'localstudio.ai.public-shares.v1';
-
-interface ShareStore {
-  records: Record<string, ShareRecord>;
-}
+const PUBLIC_STORAGE_UNAVAILABLE_MESSAGE = 'Public sharing requires active external storage.';
+const SHARE_FILE_NAME = 'share.json';
 
 interface BrowserShareServiceOptions {
   basePath?: string;
+  fetch?: typeof fetch;
+  mirrorService?: MinioMirrorService;
   origin?: string;
-  storage?: Storage;
+}
+
+interface PublicSharePayload extends ShareRecord {
+  schemaVersion: 1;
 }
 
 function getDefaultOrigin() {
@@ -19,9 +25,9 @@ function getDefaultOrigin() {
   return window.location.origin;
 }
 
-function getDefaultStorage() {
-  if (typeof window === 'undefined') return undefined;
-  return window.localStorage;
+function getDefaultFetch() {
+  if (typeof fetch === 'undefined') return undefined;
+  return fetch.bind(globalThis);
 }
 
 function createShareId() {
@@ -31,90 +37,195 @@ function createShareId() {
   return `share-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function readStore(storage: Storage | undefined): ShareStore {
-  if (!storage) return { records: {} };
-
-  const rawStore = storage.getItem(SHARE_STORAGE_KEY);
-  if (!rawStore) return { records: {} };
-
-  try {
-    const parsedStore = JSON.parse(rawStore) as Partial<ShareStore>;
-    return { records: parsedStore.records ?? {} };
-  } catch {
-    return { records: {} };
-  }
-}
-
-function writeStore(storage: Storage | undefined, store: ShareStore) {
-  storage?.setItem(SHARE_STORAGE_KEY, JSON.stringify(store));
-}
-
 function cloneProject(project: ProjectDocument): ProjectDocument {
   return JSON.parse(JSON.stringify(project)) as ProjectDocument;
 }
 
-function nextUpdatedAt(currentUpdatedAt: string) {
-  const now = Date.now();
-  const current = Date.parse(currentUpdatedAt);
-  return new Date(Number.isFinite(current) && now <= current ? current + 1 : now).toISOString();
+function normalizePrefix(value: string) {
+  return value.trim().replace(/^\/+|\/+$/g, '');
+}
+
+function joinKey(...parts: string[]) {
+  return parts
+    .map((part) => part.replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean)
+    .join('/');
+}
+
+function getShareRootKey(config: MinioMirrorConfig, shareId: string) {
+  return joinKey(normalizePrefix(config.prefix), 'public-shares', shareId);
+}
+
+function getShareFileKey(config: MinioMirrorConfig, shareId: string) {
+  return joinKey(getShareRootKey(config, shareId), SHARE_FILE_NAME);
+}
+
+function getAssetFileExtension(mimeType: string) {
+  if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/gif') return 'gif';
+  if (mimeType === 'image/webp') return 'webp';
+  if (mimeType === 'video/mp4') return 'mp4';
+  if (mimeType === 'video/webm') return 'webm';
+  if (mimeType === 'video/quicktime') return 'mov';
+  return 'png';
+}
+
+function isDataUrl(value: string | undefined): value is string {
+  return Boolean(value?.startsWith('data:'));
+}
+
+function isBlobUrl(value: string | undefined): value is string {
+  return Boolean(value?.startsWith('blob:'));
+}
+
+function dataUrlToBlob(dataUrl: string) {
+  const [metadata, base64 = ''] = dataUrl.split(',');
+  const mimeType = metadata?.match(/^data:(.*?);base64$/)?.[1] ?? 'application/octet-stream';
+  const bytes = Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+  return new Blob([bytes], { type: mimeType });
+}
+
+function textBlob(value: unknown) {
+  return new Blob([JSON.stringify(value, null, 2)], { type: 'application/json' });
+}
+
+function collectReferencedAssetIds(project: ProjectDocument) {
+  const referencedAssetIds = new Set<string>();
+  for (const element of Object.values(project.elements)) {
+    if (element.type === 'image' || element.type === 'gif' || element.type === 'video') {
+      referencedAssetIds.add(element.assetId);
+    }
+  }
+  for (const page of project.pages) {
+    if (page.background.type === 'asset') referencedAssetIds.add(page.background.assetId);
+  }
+  return referencedAssetIds;
+}
+
+async function assetToBlob(asset: Asset, requestFetch: typeof fetch | undefined) {
+  if (!asset.objectUrl) return undefined;
+  if (isDataUrl(asset.objectUrl)) return dataUrlToBlob(asset.objectUrl);
+  if (!isBlobUrl(asset.objectUrl)) return undefined;
+  if (!requestFetch) return undefined;
+  return requestFetch(asset.objectUrl).then((response) => response.blob());
+}
+
+function publicViewerUrl(origin: string, basePath: string, route: 's' | 'embed', shareId: string, shareUrl: string) {
+  const url = new URL(`${origin}${basePath}${route}/${encodeURIComponent(shareId)}`);
+  url.searchParams.set('src', shareUrl);
+  return url.toString();
 }
 
 export class BrowserShareService implements ShareService {
   private readonly basePath: string;
+  private readonly fetchImpl: typeof fetch | undefined;
+  private readonly mirrorService: MinioMirrorService;
   private readonly origin: string;
-  private readonly storage: Storage | undefined;
 
   constructor(options: BrowserShareServiceOptions = {}) {
     this.basePath = normalizeBasePath(options.basePath ?? getPublicBasePath());
+    this.fetchImpl = options.fetch ?? getDefaultFetch();
+    this.mirrorService = options.mirrorService ?? new MinioMirrorService();
     this.origin = options.origin ?? getDefaultOrigin();
-    this.storage = options.storage ?? getDefaultStorage();
   }
 
-  createShare(project: ProjectDocument): Promise<ShareMetadata> {
-    const now = new Date().toISOString();
-    const shareId = createShareId();
-    const record: ShareRecord = {
-      shareId,
-      createdAt: now,
-      updatedAt: now,
-      project: cloneProject(project),
-    };
-    const store = readStore(this.storage);
-    store.records[shareId] = record;
-    writeStore(this.storage, store);
-    return Promise.resolve(this.toMetadata(record, 'published'));
+  async createShare(project: ProjectDocument): Promise<ShareMetadata> {
+    return this.publishShare(createShareId(), project);
   }
 
-  updateShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata> {
-    const store = readStore(this.storage);
-    const existingRecord = store.records[shareId];
-    if (!existingRecord) return Promise.reject(new Error(`Share ${shareId} was not found.`));
-
-    const record: ShareRecord = {
-      ...existingRecord,
-      updatedAt: nextUpdatedAt(existingRecord.updatedAt),
-      project: cloneProject(project),
-    };
-    store.records[shareId] = record;
-    writeStore(this.storage, store);
-    return Promise.resolve(this.toMetadata(record, 'published'));
+  async updateShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata> {
+    return this.publishShare(shareId, project);
   }
 
-  getShare(shareId: string): Promise<ShareRecord | null> {
-    const store = readStore(this.storage);
-    return Promise.resolve(store.records[shareId] ?? null);
+  async getShare(shareId: string): Promise<ShareRecord | null> {
+    const sourceUrl = this.getShareSourceUrl();
+    if (!sourceUrl) return null;
+
+    try {
+      const response = await (this.fetchImpl ?? getDefaultFetch())?.(sourceUrl, {
+        headers: { accept: 'application/json' },
+      });
+      if (!response?.ok) return null;
+      const payload = (await response.json()) as Partial<PublicSharePayload>;
+      if (payload.shareId !== shareId || !payload.project) return null;
+      return {
+        shareId,
+        createdAt: payload.createdAt ?? new Date().toISOString(),
+        updatedAt: payload.updatedAt ?? payload.createdAt ?? new Date().toISOString(),
+        project: cloneProject(payload.project),
+      };
+    } catch {
+      return null;
+    }
   }
 
   getPublicUrl(shareId: string): string {
-    return `${this.origin}${this.basePath}s/${shareId}`;
+    const config = this.mirrorService.loadConfig();
+    if (!config) return `${this.origin}${this.basePath}s/${shareId}`;
+    const shareUrl = this.mirrorService.getPublicObjectUrl(getShareFileKey(config, shareId), config);
+    return publicViewerUrl(this.origin, this.basePath, 's', shareId, shareUrl);
   }
 
   getEmbedUrl(shareId: string): string {
-    return `${this.origin}${this.basePath}embed/${shareId}`;
+    const config = this.mirrorService.loadConfig();
+    if (!config) return `${this.origin}${this.basePath}embed/${shareId}`;
+    const shareUrl = this.mirrorService.getPublicObjectUrl(getShareFileKey(config, shareId), config);
+    return publicViewerUrl(this.origin, this.basePath, 'embed', shareId, shareUrl);
   }
 
   getEmbedHtml(shareId: string): string {
     return `<iframe src="${this.getEmbedUrl(shareId)}" width="960" height="540" style="border:0;aspect-ratio:16/9;width:100%;max-width:960px;" allowfullscreen></iframe>`;
+  }
+
+  private getShareSourceUrl() {
+    if (typeof window === 'undefined') return undefined;
+    return new URL(window.location.href).searchParams.get('src') ?? undefined;
+  }
+
+  private async publishShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata> {
+    const config = this.mirrorService.loadConfig();
+    if (!config) throw new Error(PUBLIC_STORAGE_UNAVAILABLE_MESSAGE);
+
+    const now = new Date().toISOString();
+    const projectForShare = await this.createPublicProject(project, config, shareId);
+    const payload: PublicSharePayload = {
+      schemaVersion: 1,
+      shareId,
+      createdAt: now,
+      updatedAt: now,
+      project: projectForShare,
+    };
+    await this.mirrorService.uploadPublicObject(getShareFileKey(config, shareId), textBlob(payload), config);
+    return this.toMetadata(payload, 'published');
+  }
+
+  private async createPublicProject(
+    project: ProjectDocument,
+    config: MinioMirrorConfig,
+    shareId: string,
+  ): Promise<ProjectDocument> {
+    const projectForShare = cloneProject(project);
+    const referencedAssetIds = collectReferencedAssetIds(projectForShare);
+
+    await Promise.all(
+      Object.entries(projectForShare.assets).map(async ([assetId, asset]) => {
+        if (!referencedAssetIds.has(assetId)) return;
+        const blob = await assetToBlob(asset, this.fetchImpl);
+        if (!blob) return;
+
+        const fileName = asset.fileName ?? `${asset.id}.${getAssetFileExtension(asset.mimeType)}`;
+        const key = joinKey(getShareRootKey(config, shareId), 'assets', fileName);
+        await this.mirrorService.uploadPublicObject(key, blob, config);
+        projectForShare.assets[assetId] = {
+          ...asset,
+          objectUrl: this.mirrorService.getPublicObjectUrl(key, config),
+          storage: 'remote',
+          fileName,
+        };
+      }),
+    );
+
+    return projectForShare;
   }
 
   private toMetadata(record: ShareRecord, status: ShareMetadata['status']): ShareMetadata {

--- a/apps/editor/src/ui/editor/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/EditorShell.tsx
@@ -310,8 +310,12 @@ export function EditorShell({ services }: EditorShellProps) {
     const shareId = shareMetadata?.shareId;
     if (!shareId) return undefined;
     if (!publicSharingAvailable) {
-      setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
-      return undefined;
+      const timeoutId = window.setTimeout(() => {
+        setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
+      }, 0);
+      return () => {
+        window.clearTimeout(timeoutId);
+      };
     }
     const timeoutId = window.setTimeout(() => {
       setShareMetadata((current) => (current ? { ...current, status: 'syncing' } : current));

--- a/apps/editor/src/ui/editor/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/EditorShell.tsx
@@ -111,6 +111,8 @@ export function EditorShell({ services }: EditorShellProps) {
     0,
     vm.project.pages.findIndex((page) => page.id === vm.activePageId),
   );
+  const publicSharingAvailable = vm.mirrorState.enabled && vm.mirrorState.status === 'synced';
+  const publicSharingUnavailableReason = vm.mirrorState.error ?? 'Public sharing requires active external storage.';
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -307,6 +309,10 @@ export function EditorShell({ services }: EditorShellProps) {
   useEffect(() => {
     const shareId = shareMetadata?.shareId;
     if (!shareId) return undefined;
+    if (!publicSharingAvailable) {
+      setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
+      return undefined;
+    }
     const timeoutId = window.setTimeout(() => {
       setShareMetadata((current) => (current ? { ...current, status: 'syncing' } : current));
       void services.shareService
@@ -322,7 +328,7 @@ export function EditorShell({ services }: EditorShellProps) {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [services.shareService, shareMetadata?.shareId, vm.project]);
+  }, [publicSharingAvailable, services.shareService, shareMetadata?.shareId, vm.project]);
 
   return (
     <div className="app-shell">
@@ -335,6 +341,8 @@ export function EditorShell({ services }: EditorShellProps) {
         canUndo={!isHistoryReadOnly && vm.canUndo}
         hasSelection={!isHistoryReadOnly && hasSelection}
         persistenceEnabled={vm.persistenceEnabled}
+        publicSharingAvailable={publicSharingAvailable}
+        publicSharingUnavailableReason={publicSharingUnavailableReason}
         mirrorState={vm.mirrorState}
         persistenceAttention={vm.persistenceAttention}
         persistenceNotice={vm.persistenceNotice}

--- a/apps/editor/src/ui/editor/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/TopToolbar.tsx
@@ -12,6 +12,8 @@ interface TopToolbarProps {
   hasSelection?: boolean;
   persistenceEnabled?: boolean;
   persistenceAvailable?: boolean;
+  publicSharingAvailable?: boolean;
+  publicSharingUnavailableReason?: string;
   lastEditedAt?: string | undefined;
   mirrorState?: MirrorState;
   localProjectSetupPanel?: ReactNode;
@@ -110,6 +112,8 @@ export function TopToolbar({
   hasSelection = false,
   persistenceEnabled = false,
   persistenceAvailable = true,
+  publicSharingAvailable = true,
+  publicSharingUnavailableReason = 'Public sharing requires active external storage.',
   lastEditedAt,
   mirrorState = { enabled: false, status: 'disabled' },
   localProjectSetupPanel,
@@ -153,6 +157,7 @@ export function TopToolbar({
   }, [isEditingProjectName]);
 
   function triggerShare() {
+    if (!publicSharingAvailable) return;
     if (onShare) {
       onShare();
       return;
@@ -187,7 +192,7 @@ export function TopToolbar({
       { label: 'New Project', disabled: !onNewProject, onSelect: onNewProject },
       { label: 'Import Project', disabled: !onImportProject, onSelect: onImportProject },
       { label: 'Import Remote', disabled: !onImportRemoteMirror, onSelect: onImportRemoteMirror },
-      { label: 'Share', onSelect: triggerShare },
+      { label: 'Share', disabled: !publicSharingAvailable, onSelect: triggerShare },
       { kind: 'separator', label: 'File storage actions' },
       { label: 'Save', disabled: !onSaveLocal, onSelect: onSaveLocal },
       { label: 'Mirror Now', disabled: !onMirrorNow, onSelect: onMirrorNow },
@@ -273,6 +278,7 @@ export function TopToolbar({
   ]
     .filter(Boolean)
     .join(' ');
+  const shareTitle = publicSharingAvailable ? 'Share' : publicSharingUnavailableReason;
 
   return (
     <header className="top-toolbar">
@@ -530,7 +536,13 @@ export function TopToolbar({
             {stars}
           </span>
         </a>
-        <button className="export-button font-orbitron" type="button" onClick={triggerShare}>
+        <button
+          className="export-button font-orbitron"
+          disabled={!publicSharingAvailable}
+          title={shareTitle}
+          type="button"
+          onClick={triggerShare}
+        >
           <span className="material-symbols-outlined" aria-hidden="true">
             ios_share
           </span>

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import type { ProjectDocument, SelectionState } from '../../domain/model';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ElementAnimationBuild, ProjectDocument, SelectionState } from '../../domain/model';
 import type { ShareService } from '../../services/interfaces';
 import { CanvasWorkspace } from '../editor/CanvasWorkspace';
 
@@ -14,20 +14,180 @@ type ViewerState =
   | { status: 'missing' }
   | { status: 'ready'; project: ProjectDocument };
 
+interface AnimationPreviewState {
+  activeBuildElementId: string | undefined;
+  hiddenElementIds: string[];
+  mode: 'presenter';
+  pageId: string;
+  phase: 'transition' | 'animation' | 'waiting' | 'complete';
+  playing: boolean;
+  waitingForClick: boolean;
+}
+
 export function PublicDeckViewer({ shareId, shareService, embed = false }: PublicDeckViewerProps) {
   const [viewerState, setViewerState] = useState<ViewerState>({ status: 'loading' });
   const [activePageIndex, setActivePageIndex] = useState(0);
+  const [animationPreview, setAnimationPreview] = useState<AnimationPreviewState | undefined>();
+  const animationQueueRef = useRef<ElementAnimationBuild[]>([]);
+  const animationTimeoutsRef = useRef<number[]>([]);
   const emptySelection = useMemo<SelectionState>(() => ({ pageId: '', elementIds: [] }), []);
   const viewerClassName = embed
     ? 'public-deck-viewer public-deck-viewer-embed'
     : 'public-deck-viewer public-deck-viewer-present';
+
+  function clearAnimationTimers() {
+    for (const timeoutId of animationTimeoutsRef.current) {
+      window.clearTimeout(timeoutId);
+    }
+    animationTimeoutsRef.current = [];
+  }
+
+  function scheduleAnimation(callback: () => void, delayMs: number) {
+    const timeoutId = window.setTimeout(callback, Math.max(0, delayMs));
+    animationTimeoutsRef.current.push(timeoutId);
+  }
+
+  function completeAnimationSlide() {
+    animationQueueRef.current = [];
+    clearAnimationTimers();
+    setAnimationPreview((current) =>
+      current
+        ? {
+            ...current,
+            activeBuildElementId: undefined,
+            hiddenElementIds: [],
+            phase: 'complete',
+            waitingForClick: false,
+          }
+        : current,
+    );
+  }
+
+  function revealAnimationBuild(build: ElementAnimationBuild) {
+    setAnimationPreview((current) =>
+      current
+        ? {
+            ...current,
+            activeBuildElementId: undefined,
+            hiddenElementIds: current.hiddenElementIds.filter((elementId) => elementId !== build.elementId),
+            waitingForClick: false,
+          }
+        : current,
+    );
+  }
+
+  function runNextAnimationBuild() {
+    const nextBuild = animationQueueRef.current[0];
+    if (!nextBuild) {
+      completeAnimationSlide();
+      return;
+    }
+
+    if (nextBuild.trigger === 'on-click') {
+      setAnimationPreview((current) =>
+        current
+          ? {
+              ...current,
+              activeBuildElementId: nextBuild.elementId,
+              phase: 'waiting',
+              waitingForClick: true,
+            }
+          : current,
+      );
+      return;
+    }
+
+    animationQueueRef.current = animationQueueRef.current.slice(1);
+    setAnimationPreview((current) =>
+      current
+        ? {
+            ...current,
+            activeBuildElementId: nextBuild.elementId,
+            phase: 'animation',
+            waitingForClick: false,
+          }
+        : current,
+    );
+    scheduleAnimation(() => {
+      revealAnimationBuild(nextBuild);
+      runNextAnimationBuild();
+    }, nextBuild.delayMs);
+  }
+
+  function advanceAnimationPreview() {
+    const nextBuild = animationQueueRef.current[0];
+    if (!nextBuild) {
+      completeAnimationSlide();
+      return;
+    }
+    animationQueueRef.current = animationQueueRef.current.slice(1);
+    setAnimationPreview((current) =>
+      current
+        ? {
+            ...current,
+            activeBuildElementId: nextBuild.elementId,
+            phase: 'animation',
+            waitingForClick: false,
+          }
+        : current,
+    );
+    scheduleAnimation(() => {
+      revealAnimationBuild(nextBuild);
+      runNextAnimationBuild();
+    }, nextBuild.delayMs);
+  }
+
+  function playPresentationPage(project: ProjectDocument, pageIndex: number) {
+    const page = project.pages[pageIndex];
+    if (!page) return;
+    const builds = (page.animationBuilds ?? []).filter((build) => page.elementIds.includes(build.elementId));
+    clearAnimationTimers();
+    animationQueueRef.current = builds;
+    setActivePageIndex(pageIndex);
+    const transitionDelay = page.transition?.delayMs ?? 0;
+    setAnimationPreview({
+      activeBuildElementId: undefined,
+      hiddenElementIds: builds.map((build) => build.elementId),
+      mode: 'presenter',
+      pageId: page.id,
+      phase: transitionDelay > 0 ? 'transition' : builds.length > 0 ? 'animation' : 'complete',
+      playing: true,
+      waitingForClick: false,
+    });
+
+    if (builds.length === 0) {
+      if (transitionDelay > 0) scheduleAnimation(completeAnimationSlide, transitionDelay);
+      return;
+    }
+    scheduleAnimation(runNextAnimationBuild, transitionDelay);
+  }
+
+  function advancePresentation() {
+    if (viewerState.status !== 'ready') return;
+    if (animationPreview?.waitingForClick) {
+      advanceAnimationPreview();
+      return;
+    }
+    if (animationPreview?.phase !== 'complete') return;
+    playPresentationPage(viewerState.project, activePageIndex + 1);
+  }
+
+  function rewindPresentation() {
+    if (viewerState.status !== 'ready') return;
+    playPresentationPage(viewerState.project, activePageIndex - 1);
+  }
 
   useEffect(() => {
     let isActive = true;
     void shareService.getShare(shareId).then((record) => {
       if (!isActive) return;
       setViewerState(record ? { status: 'ready', project: record.project } : { status: 'missing' });
-      setActivePageIndex(0);
+      if (record) {
+        playPresentationPage(record.project, 0);
+      } else {
+        setActivePageIndex(0);
+        setAnimationPreview(undefined);
+      }
     });
     return () => {
       isActive = false;
@@ -35,15 +195,21 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
   }, [shareId, shareService]);
 
   useEffect(() => {
+    return () => {
+      clearAnimationTimers();
+    };
+  }, []);
+
+  useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (viewerState.status !== 'ready') return;
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
-        setActivePageIndex((current) => Math.max(0, current - 1));
+        rewindPresentation();
       }
       if (event.key === 'ArrowRight') {
         event.preventDefault();
-        setActivePageIndex((current) => Math.min(viewerState.project.pages.length - 1, current + 1));
+        advancePresentation();
       }
     }
 
@@ -51,7 +217,7 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [viewerState]);
+  }, [activePageIndex, animationPreview, viewerState]);
 
   if (viewerState.status === 'loading') {
     return (
@@ -100,6 +266,8 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
           presentationMode
           readOnly
           zoomPercent={100}
+          animationPreview={animationPreview}
+          onAnimationPreviewAdvance={advancePresentation}
         />
       </section>
       <nav className="public-deck-controls" aria-label="Slide navigation">
@@ -109,7 +277,7 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
           type="button"
           aria-label="Previous slide"
           onClick={() => {
-            setActivePageIndex((current) => Math.max(0, current - 1));
+            rewindPresentation();
           }}
         >
           <span className="material-symbols-outlined" aria-hidden="true">
@@ -125,7 +293,7 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
           type="button"
           aria-label="Next slide"
           onClick={() => {
-            setActivePageIndex((current) => Math.min(project.pages.length - 1, current + 1));
+            advancePresentation();
           }}
         >
           <span className="material-symbols-outlined" aria-hidden="true">

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ElementAnimationBuild, ProjectDocument, SelectionState } from '../../domain/model';
 import type { ShareService } from '../../services/interfaces';
 import { CanvasWorkspace } from '../editor/CanvasWorkspace';
@@ -30,24 +30,25 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
   const [animationPreview, setAnimationPreview] = useState<AnimationPreviewState | undefined>();
   const animationQueueRef = useRef<ElementAnimationBuild[]>([]);
   const animationTimeoutsRef = useRef<number[]>([]);
+  const runNextAnimationBuildRef = useRef<() => void>(() => undefined);
   const emptySelection = useMemo<SelectionState>(() => ({ pageId: '', elementIds: [] }), []);
   const viewerClassName = embed
     ? 'public-deck-viewer public-deck-viewer-embed'
     : 'public-deck-viewer public-deck-viewer-present';
 
-  function clearAnimationTimers() {
+  const clearAnimationTimers = useCallback(() => {
     for (const timeoutId of animationTimeoutsRef.current) {
       window.clearTimeout(timeoutId);
     }
     animationTimeoutsRef.current = [];
-  }
+  }, []);
 
-  function scheduleAnimation(callback: () => void, delayMs: number) {
+  const scheduleAnimation = useCallback((callback: () => void, delayMs: number) => {
     const timeoutId = window.setTimeout(callback, Math.max(0, delayMs));
     animationTimeoutsRef.current.push(timeoutId);
-  }
+  }, []);
 
-  function completeAnimationSlide() {
+  const completeAnimationSlide = useCallback(() => {
     animationQueueRef.current = [];
     clearAnimationTimers();
     setAnimationPreview((current) =>
@@ -61,9 +62,9 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
           }
         : current,
     );
-  }
+  }, [clearAnimationTimers]);
 
-  function revealAnimationBuild(build: ElementAnimationBuild) {
+  const revealAnimationBuild = useCallback((build: ElementAnimationBuild) => {
     setAnimationPreview((current) =>
       current
         ? {
@@ -74,9 +75,9 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
           }
         : current,
     );
-  }
+  }, []);
 
-  function runNextAnimationBuild() {
+  const runNextAnimationBuild = useCallback(() => {
     const nextBuild = animationQueueRef.current[0];
     if (!nextBuild) {
       completeAnimationSlide();
@@ -110,11 +111,14 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
     );
     scheduleAnimation(() => {
       revealAnimationBuild(nextBuild);
-      runNextAnimationBuild();
+      runNextAnimationBuildRef.current();
     }, nextBuild.delayMs);
-  }
+  }, [completeAnimationSlide, revealAnimationBuild, scheduleAnimation]);
+  useEffect(() => {
+    runNextAnimationBuildRef.current = runNextAnimationBuild;
+  }, [runNextAnimationBuild]);
 
-  function advanceAnimationPreview() {
+  const advanceAnimationPreview = useCallback(() => {
     const nextBuild = animationQueueRef.current[0];
     if (!nextBuild) {
       completeAnimationSlide();
@@ -135,9 +139,9 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
       revealAnimationBuild(nextBuild);
       runNextAnimationBuild();
     }, nextBuild.delayMs);
-  }
+  }, [completeAnimationSlide, revealAnimationBuild, runNextAnimationBuild, scheduleAnimation]);
 
-  function playPresentationPage(project: ProjectDocument, pageIndex: number) {
+  const playPresentationPage = useCallback((project: ProjectDocument, pageIndex: number) => {
     const page = project.pages[pageIndex];
     if (!page) return;
     const builds = (page.animationBuilds ?? []).filter((build) => page.elementIds.includes(build.elementId));
@@ -160,9 +164,9 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
       return;
     }
     scheduleAnimation(runNextAnimationBuild, transitionDelay);
-  }
+  }, [clearAnimationTimers, completeAnimationSlide, runNextAnimationBuild, scheduleAnimation]);
 
-  function advancePresentation() {
+  const advancePresentation = useCallback(() => {
     if (viewerState.status !== 'ready') return;
     if (animationPreview?.waitingForClick) {
       advanceAnimationPreview();
@@ -170,12 +174,12 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
     }
     if (animationPreview?.phase !== 'complete') return;
     playPresentationPage(viewerState.project, activePageIndex + 1);
-  }
+  }, [activePageIndex, advanceAnimationPreview, animationPreview, playPresentationPage, viewerState]);
 
-  function rewindPresentation() {
+  const rewindPresentation = useCallback(() => {
     if (viewerState.status !== 'ready') return;
     playPresentationPage(viewerState.project, activePageIndex - 1);
-  }
+  }, [activePageIndex, playPresentationPage, viewerState]);
 
   useEffect(() => {
     let isActive = true;
@@ -192,13 +196,13 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
     return () => {
       isActive = false;
     };
-  }, [shareId, shareService]);
+  }, [playPresentationPage, shareId, shareService]);
 
   useEffect(() => {
     return () => {
       clearAnimationTimers();
     };
-  }, []);
+  }, [clearAnimationTimers]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
@@ -217,7 +221,7 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [activePageIndex, animationPreview, viewerState]);
+  }, [advancePresentation, rewindPresentation, viewerState.status]);
 
   if (viewerState.status === 'loading') {
     return (

--- a/apps/editor/tests/unit/app/App.test.tsx
+++ b/apps/editor/tests/unit/app/App.test.tsx
@@ -117,16 +117,18 @@ describe('App', () => {
     const sourceUrl = `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`;
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => {
-        return new Response(
-          JSON.stringify({
-            schemaVersion: 1,
-            shareId,
-            createdAt: '2026-06-30T10:00:00.000Z',
-            updatedAt: '2026-06-30T10:00:00.000Z',
-            project: createSampleProject(),
-          }),
-          { headers: { 'content-type': 'application/json' }, status: 200 },
+      vi.fn(() => {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              schemaVersion: 1,
+              shareId,
+              createdAt: '2026-06-30T10:00:00.000Z',
+              updatedAt: '2026-06-30T10:00:00.000Z',
+              project: createSampleProject(),
+            }),
+            { headers: { 'content-type': 'application/json' }, status: 200 },
+          ),
         );
       }),
     );
@@ -143,16 +145,18 @@ describe('App', () => {
     const sourceUrl = `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`;
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => {
-        return new Response(
-          JSON.stringify({
-            schemaVersion: 1,
-            shareId,
-            createdAt: '2026-06-30T10:00:00.000Z',
-            updatedAt: '2026-06-30T10:00:00.000Z',
-            project: createSampleProject(),
-          }),
-          { headers: { 'content-type': 'application/json' }, status: 200 },
+      vi.fn(() => {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              schemaVersion: 1,
+              shareId,
+              createdAt: '2026-06-30T10:00:00.000Z',
+              updatedAt: '2026-06-30T10:00:00.000Z',
+              project: createSampleProject(),
+            }),
+            { headers: { 'content-type': 'application/json' }, status: 200 },
+          ),
         );
       }),
     );
@@ -163,7 +167,6 @@ describe('App', () => {
     expect(await screen.findByLabelText('Embedded shared deck')).toBeInTheDocument();
     expect(screen.queryByText('Public view')).not.toBeInTheDocument();
   });
-
   it('renders the WebMCP showcase page under the editor base path with a trailing slash', () => {
     window.history.replaceState({}, '', '/editor/webmcp/');
 

--- a/apps/editor/tests/unit/app/App.test.tsx
+++ b/apps/editor/tests/unit/app/App.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { App } from '../../../src/App';
 import { createSampleProject } from '../../../src/domain/sampleProject';
-import { BrowserShareService } from '../../../src/services/shareService';
 import { TRANSLATION_LANGUAGE_OPTIONS } from '../../../src/ui/editor/translationLanguages';
 
 describe('App', () => {
@@ -114,10 +113,24 @@ describe('App', () => {
   });
 
   it('renders a public shared deck page', async () => {
-    const shareService = new BrowserShareService({ origin: window.location.origin });
-    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000101');
-    await shareService.createShare(createSampleProject());
-    window.history.replaceState({}, '', '/editor/s/00000000-0000-4000-8000-000000000101');
+    const shareId = '00000000-0000-4000-8000-000000000101';
+    const sourceUrl = `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            schemaVersion: 1,
+            shareId,
+            createdAt: '2026-06-30T10:00:00.000Z',
+            updatedAt: '2026-06-30T10:00:00.000Z',
+            project: createSampleProject(),
+          }),
+          { headers: { 'content-type': 'application/json' }, status: 200 },
+        );
+      }),
+    );
+    window.history.replaceState({}, '', `/editor/s/${shareId}?src=${encodeURIComponent(sourceUrl)}`);
 
     render(<App />);
 
@@ -126,10 +139,24 @@ describe('App', () => {
   });
 
   it('renders a compact embedded shared deck page', async () => {
-    const shareService = new BrowserShareService({ origin: window.location.origin });
-    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000102');
-    await shareService.createShare(createSampleProject());
-    window.history.replaceState({}, '', '/editor/embed/00000000-0000-4000-8000-000000000102');
+    const shareId = '00000000-0000-4000-8000-000000000102';
+    const sourceUrl = `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            schemaVersion: 1,
+            shareId,
+            createdAt: '2026-06-30T10:00:00.000Z',
+            updatedAt: '2026-06-30T10:00:00.000Z',
+            project: createSampleProject(),
+          }),
+          { headers: { 'content-type': 'application/json' }, status: 200 },
+        );
+      }),
+    );
+    window.history.replaceState({}, '', `/editor/embed/${shareId}?src=${encodeURIComponent(sourceUrl)}`);
 
     render(<App />);
 

--- a/apps/editor/tests/unit/services/shareService.test.ts
+++ b/apps/editor/tests/unit/services/shareService.test.ts
@@ -1,6 +1,52 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectDocument } from '../../../src/domain/model';
 import { createSampleProject } from '../../../src/domain/sampleProject';
+import { MinioMirrorService, type MinioMirrorConfig } from '../../../src/services/minioMirrorService';
 import { BrowserShareService } from '../../../src/services/shareService';
+
+const config: MinioMirrorConfig = {
+  accessKey: 'localstudio',
+  bucket: 'localstudio',
+  endpoint: 'http://localhost:9000',
+  pathStyle: true,
+  publicBaseUrl: 'http://localhost:9000/localstudio',
+  region: 'us-east-1',
+  secretKey: 'localstudio123',
+  prefix: 'mirrors',
+};
+
+function getRequestUrl(input: RequestInfo | URL) {
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return input;
+}
+
+function createProjectWithInlineAsset(): ProjectDocument {
+  const project = createSampleProject();
+  project.assets['asset-inline'] = {
+    id: 'asset-inline',
+    type: 'image',
+    mimeType: 'image/png',
+    name: 'Inline chart',
+    objectUrl: 'data:image/png;base64,aGVsbG8=',
+    storage: 'inline',
+  };
+  project.elements['inline-image'] = {
+    id: 'inline-image',
+    type: 'image',
+    assetId: 'asset-inline',
+    x: 80,
+    y: 120,
+    width: 320,
+    height: 180,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+  };
+  project.pages[0]?.elementIds.push('inline-image');
+  return project;
+}
 
 describe('BrowserShareService', () => {
   beforeEach(() => {
@@ -8,52 +54,76 @@ describe('BrowserShareService', () => {
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000001');
   });
 
-  it('creates an unlisted share and returns public URLs', async () => {
-    const service = new BrowserShareService({ origin: 'https://localstudio.test' });
+  it('publishes a public share payload and local assets to MinIO', async () => {
+    const uploadedBodies = new Map<string, Blob>();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET') {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT') {
+        uploadedBodies.set(url, init.body as Blob);
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const mirrorService = new MinioMirrorService({ fetch: fetchMock });
+    mirrorService.saveConfig(config);
+    const service = new BrowserShareService({
+      mirrorService,
+      origin: 'https://localstudio.test',
+    });
 
-    const share = await service.createShare(createSampleProject());
+    const share = await service.createShare(createProjectWithInlineAsset());
 
     expect(share.shareId).toBe('00000000-0000-4000-8000-000000000001');
-    expect(share.publicUrl).toBe('https://localstudio.test/editor/s/00000000-0000-4000-8000-000000000001');
-    expect(share.embedUrl).toBe('https://localstudio.test/editor/embed/00000000-0000-4000-8000-000000000001');
-    expect(share.embedHtml).toContain('<iframe');
-    expect(share.embedHtml).toContain('https://localstudio.test/editor/embed/00000000-0000-4000-8000-000000000001');
-    expect(share.status).toBe('published');
+    const publicUrl = new URL(share.publicUrl);
+    expect(publicUrl.pathname).toBe('/editor/s/00000000-0000-4000-8000-000000000001');
+    expect(publicUrl.searchParams.get('src')).toBe(
+      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json',
+    );
+    expect(share.embedHtml).toContain('/editor/embed/00000000-0000-4000-8000-000000000001');
+    expect(share.embedHtml).toContain('src=');
+
+    const putUrls = Array.from(uploadedBodies.keys());
+    expect(putUrls).toContain(
+      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/assets/asset-inline.png',
+    );
+    expect(putUrls).toContain(
+      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json',
+    );
+
+    const sharePayload = JSON.parse(
+      await uploadedBodies
+        .get(
+          'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json',
+        )!
+        .text(),
+    );
+    expect(sharePayload).toMatchObject({
+      schemaVersion: 1,
+      shareId: '00000000-0000-4000-8000-000000000001',
+      project: {
+        name: 'Untitled AI Deck',
+        assets: {
+          'asset-inline': {
+            objectUrl:
+              'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/assets/asset-inline.png',
+            storage: 'remote',
+          },
+        },
+      },
+    });
   });
 
-  it('fetches the latest project for a share', async () => {
-    const service = new BrowserShareService({ origin: 'https://localstudio.test' });
-    const createdShare = await service.createShare(createSampleProject());
+  it('rejects publishing when MinIO config is missing', async () => {
+    const service = new BrowserShareService({
+      mirrorService: new MinioMirrorService({ fetch: vi.fn() }),
+      origin: 'https://localstudio.test',
+    });
 
-    const record = await service.getShare(createdShare.shareId);
-
-    expect(record?.project.name).toBe('Untitled AI Deck');
-    expect(record?.project.assets['asset-hero']?.objectUrl).toBeDefined();
-  });
-
-  it('updates an existing share with the latest project state', async () => {
-    const service = new BrowserShareService({ origin: 'https://localstudio.test' });
-    const project = createSampleProject();
-    const createdShare = await service.createShare(project);
-
-    await service.updateShare(createdShare.shareId, { ...project, name: 'Updated Deck' });
-    const record = await service.getShare(createdShare.shareId);
-
-    expect(record?.project.name).toBe('Updated Deck');
-    expect(record?.updatedAt).not.toBe(record?.createdAt);
-  });
-
-  it('returns null for missing shares', async () => {
-    const service = new BrowserShareService({ origin: 'https://localstudio.test' });
-
-    await expect(service.getShare('missing-share')).resolves.toBeNull();
-  });
-
-  it('rejects updates for missing shares', async () => {
-    const service = new BrowserShareService({ origin: 'https://localstudio.test' });
-
-    await expect(service.updateShare('missing-share', createSampleProject())).rejects.toThrow(
-      'Share missing-share was not found.',
+    await expect(service.createShare(createSampleProject())).rejects.toThrow(
+      'Public sharing requires active external storage.',
     );
   });
 });

--- a/apps/editor/tests/unit/services/shareService.test.ts
+++ b/apps/editor/tests/unit/services/shareService.test.ts
@@ -15,6 +15,12 @@ const config: MinioMirrorConfig = {
   prefix: 'mirrors',
 };
 
+interface PublicSharePayloadFixture {
+  schemaVersion: 1;
+  shareId: string;
+  project: ProjectDocument;
+}
+
 function getRequestUrl(input: RequestInfo | URL) {
   if (input instanceof URL) return input.toString();
   if (input instanceof Request) return input.url;
@@ -99,7 +105,7 @@ describe('BrowserShareService', () => {
           'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json',
         )!
         .text(),
-    );
+    ) as unknown as PublicSharePayloadFixture;
     expect(sharePayload).toMatchObject({
       schemaVersion: 1,
       shareId: '00000000-0000-4000-8000-000000000001',

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -11,6 +11,9 @@ import type {
   MirrorService,
   MirrorState,
   ProjectRepository,
+  ShareMetadata,
+  ShareRecord,
+  ShareService,
   TranslatorService,
 } from '../../../../src/services/interfaces';
 import type { MinioMirrorConfig } from '../../../../src/services/minioMirrorService';
@@ -24,6 +27,20 @@ function createAppServices(options: Parameters<typeof createRealAppServices>[0] 
     initialProject: createSampleProject(),
     ...options,
   });
+}
+
+async function waitForShareButtonReady() {
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Share' })).not.toBeDisabled();
+  });
+}
+
+function enableSyncedSharing(services: ReturnType<typeof createAppServices>) {
+  services.mirrorService = new RecordingMirrorService();
+  services.shareService = new RecordingShareService();
+  services.projectRepository = new LoadingProjectRepository(createSampleProject());
+  services.persistenceAvailable = true;
+  services.skipStoredProjectLoad = false;
 }
 
 class InstantBackgroundRemovalService implements BackgroundRemovalService {
@@ -78,6 +95,21 @@ class SavingProjectRepository implements ProjectRepository {
   }
 }
 
+class LoadingProjectRepository implements ProjectRepository {
+  savedProjects: ProjectDocument[] = [];
+
+  constructor(private readonly project: ProjectDocument) {}
+
+  loadProject(): Promise<ProjectDocument | null> {
+    return Promise.resolve(this.project);
+  }
+
+  saveProject(project: ProjectDocument): Promise<void> {
+    this.savedProjects.push(project);
+    return Promise.resolve();
+  }
+}
+
 const mirrorConfig: MinioMirrorConfig = {
   accessKey: 'localstudio',
   bucket: 'localstudio',
@@ -118,6 +150,57 @@ class RecordingMirrorService implements MirrorService<MinioMirrorConfig> {
   listProjects = vi.fn((): Promise<MirrorProjectSummary[]> => Promise.resolve([]));
 
   downloadProject = vi.fn((): Promise<MirrorFile[]> => Promise.resolve([]));
+}
+
+class RecordingShareService implements ShareService {
+  records = new Map<string, ShareRecord>();
+
+  constructor(private readonly origin = window.location.origin) {}
+
+  createShare = vi.fn(async (project: ProjectDocument): Promise<ShareMetadata> => {
+    const shareId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    this.records.set(shareId, { shareId, createdAt: now, updatedAt: now, project });
+    return this.createMetadata(shareId, now);
+  });
+
+  updateShare = vi.fn(async (shareId: string, project: ProjectDocument): Promise<ShareMetadata> => {
+    const now = new Date().toISOString();
+    this.records.set(shareId, { shareId, createdAt: now, updatedAt: now, project });
+    return this.createMetadata(shareId, now);
+  });
+
+  getShare = vi.fn(async (shareId: string): Promise<ShareRecord | null> => {
+    return this.records.get(shareId) ?? null;
+  });
+
+  getPublicUrl(shareId: string): string {
+    return `${this.origin}/editor/s/${shareId}?src=${encodeURIComponent(
+      `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`,
+    )}`;
+  }
+
+  getEmbedUrl(shareId: string): string {
+    return `${this.origin}/editor/embed/${shareId}?src=${encodeURIComponent(
+      `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`,
+    )}`;
+  }
+
+  getEmbedHtml(shareId: string): string {
+    return `<iframe src="${this.getEmbedUrl(shareId)}" width="960" height="540"></iframe>`;
+  }
+
+  private createMetadata(shareId: string, timestamp: string): ShareMetadata {
+    return {
+      shareId,
+      publicUrl: this.getPublicUrl(shareId),
+      embedUrl: this.getEmbedUrl(shareId),
+      embedHtml: this.getEmbedHtml(shareId),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      status: 'published',
+    };
+  }
 }
 
 class RecordingTranslatorService implements TranslatorService {
@@ -1693,9 +1776,16 @@ describe('EditorShell', () => {
     expect(screen.getByRole('button', { name: 'BG Remover' })).toBeInTheDocument();
   });
 
+  it('keeps Share disabled until the MinIO mirror is synced', () => {
+    render(<EditorShell services={createAppServices()} />);
+
+    expect(screen.getByRole('button', { name: 'Share' })).toBeDisabled();
+  });
+
   it('exports the current slide as a PNG file', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
+    enableSyncedSharing(services);
     const downloadDataUrl = vi.fn();
     services.exportService = {
       getPageImageFileName: () => 'slide.png',
@@ -1705,6 +1795,7 @@ describe('EditorShell', () => {
 
     render(<EditorShell services={services} />);
 
+    await waitForShareButtonReady();
     await user.click(screen.getByRole('button', { name: 'Share' }));
     await user.click(screen.getByRole('button', { name: 'Download' }));
 
@@ -1721,18 +1812,24 @@ describe('EditorShell', () => {
         writeText,
       },
     });
+    const services = createAppServices();
+    enableSyncedSharing(services);
 
-    render(<EditorShell services={createAppServices()} />);
+    render(<EditorShell services={services} />);
 
+    await waitForShareButtonReady();
     await user.click(screen.getByRole('button', { name: 'Share' }));
     await user.click(screen.getByRole('button', { name: 'Copy link' }));
 
+    const expectedPublicUrl = `${
+      window.location.origin
+    }/editor/s/00000000-0000-4000-8000-000000000301?src=${encodeURIComponent(
+      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000301/share.json',
+    )}`;
     expect(
-      await screen.findByDisplayValue(`${window.location.origin}/editor/s/00000000-0000-4000-8000-000000000301`),
+      await screen.findByDisplayValue(expectedPublicUrl),
     ).toBeInTheDocument();
-    expect(writeText).toHaveBeenCalledWith(
-      `${window.location.origin}/editor/s/00000000-0000-4000-8000-000000000301`,
-    );
+    expect(writeText).toHaveBeenCalledWith(expectedPublicUrl);
   });
 
   it('enters fullscreen presentation mode from the share panel', async () => {
@@ -1742,9 +1839,12 @@ describe('EditorShell', () => {
       configurable: true,
       value: requestFullscreen,
     });
+    const services = createAppServices();
+    enableSyncedSharing(services);
 
-    render(<EditorShell services={createAppServices()} />);
+    render(<EditorShell services={services} />);
 
+    await waitForShareButtonReady();
     await user.click(screen.getByRole('button', { name: 'Share' }));
     await user.click(screen.getByRole('button', { name: 'Present' }));
 

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -157,22 +157,22 @@ class RecordingShareService implements ShareService {
 
   constructor(private readonly origin = window.location.origin) {}
 
-  createShare = vi.fn(async (project: ProjectDocument): Promise<ShareMetadata> => {
+  createShare = vi.fn((project: ProjectDocument): Promise<ShareMetadata> => {
     const shareId = crypto.randomUUID();
     const now = new Date().toISOString();
     this.records.set(shareId, { shareId, createdAt: now, updatedAt: now, project });
-    return this.createMetadata(shareId, now);
+    return Promise.resolve(this.createMetadata(shareId, now));
   });
 
-  updateShare = vi.fn(async (shareId: string, project: ProjectDocument): Promise<ShareMetadata> => {
+  updateShare = vi.fn((shareId: string, project: ProjectDocument): Promise<ShareMetadata> => {
     const now = new Date().toISOString();
     this.records.set(shareId, { shareId, createdAt: now, updatedAt: now, project });
-    return this.createMetadata(shareId, now);
+    return Promise.resolve(this.createMetadata(shareId, now));
   });
 
-  getShare = vi.fn(async (shareId: string): Promise<ShareRecord | null> => {
-    return this.records.get(shareId) ?? null;
-  });
+  getShare = vi.fn((shareId: string): Promise<ShareRecord | null> =>
+    Promise.resolve(this.records.get(shareId) ?? null),
+  );
 
   getPublicUrl(shareId: string): string {
     return `${this.origin}/editor/s/${shareId}?src=${encodeURIComponent(

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -212,6 +212,29 @@ describe('TopToolbar', () => {
     expect(screen.getByText('Mirroring')).toBeInTheDocument();
   });
 
+  it('disables sharing until MinIO external storage is ready', async () => {
+    const user = userEvent.setup();
+    const onShare = vi.fn();
+
+    render(
+      <TopToolbar
+        project={createSampleProject()}
+        language="PT-BR"
+        publicSharingAvailable={false}
+        publicSharingUnavailableReason="Public sharing requires active external storage."
+        onShare={onShare}
+      />,
+    );
+
+    const shareButton = screen.getByRole('button', { name: 'Share' });
+    expect(shareButton).toBeDisabled();
+    expect(shareButton).toHaveAttribute('title', 'Public sharing requires active external storage.');
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    expect(screen.getByRole('menuitem', { name: 'Share' })).toBeDisabled();
+    expect(onShare).not.toHaveBeenCalled();
+  });
+
   it('opens version history from the toolbar when persistence is enabled', async () => {
     const user = userEvent.setup();
     const onOpenVersionHistory = vi.fn();

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSampleProject } from '../../../../src/domain/sampleProject';
@@ -78,6 +78,58 @@ describe('PublicDeckViewer', () => {
 
     await user.click(screen.getByRole('button', { name: 'Previous slide' }));
     expect(screen.getByText('1 / 2')).toBeInTheDocument();
+  });
+
+  it('rewinds shared deck slides with the left arrow key after advancing', async () => {
+    const project = createSampleProject();
+    project.pages.push({
+      id: 'page-2',
+      name: 'Slide 2',
+      width: 1920,
+      height: 1080,
+      background: { type: 'color', color: '#111111' },
+      elementIds: [],
+    });
+    const { share, shareService } = createRemoteShare(
+      '00000000-0000-4000-8000-000000000205',
+      project,
+    );
+
+    render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
+
+    expect(await screen.findByText('1 / 2')).toBeInTheDocument();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
+
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+  });
+
+  it('starts shared decks in presenter animation playback mode', async () => {
+    const project = createSampleProject();
+    project.pages[0]!.animationBuilds = [
+      {
+        id: 'animation-title',
+        elementId: 'text-title',
+        effect: 'reveal',
+        trigger: 'on-click',
+        delayMs: 0,
+      },
+    ];
+    const { share, shareService } = createRemoteShare(
+      '00000000-0000-4000-8000-000000000204',
+      project,
+    );
+
+    render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
+
+    const slideCanvas = await screen.findByLabelText('Slide canvas');
+    expect(slideCanvas).toHaveAttribute('data-animation-preview', 'playing');
+    expect(slideCanvas).toHaveAttribute('data-animation-preview-mode', 'presenter');
+    await waitFor(() => {
+      expect(slideCanvas).toHaveAttribute('data-animation-preview-phase', 'waiting');
+      expect(slideCanvas).toHaveAttribute('data-animation-preview-waiting', 'true');
+    });
   });
 
   it('shows a not found state for missing shares', async () => {

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -11,6 +11,12 @@ describe('PublicDeckViewer', () => {
     window.history.replaceState({}, '', '/');
   });
 
+  function getRequestUrl(input: RequestInfo | URL) {
+    if (input instanceof Request) return input.url;
+    if (input instanceof URL) return input.toString();
+    return input;
+  }
+
   function createRemoteShare(
     shareId: string,
     project = createSampleProject(),
@@ -23,13 +29,15 @@ describe('PublicDeckViewer', () => {
     };
     const sourceUrl = `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`;
     window.history.replaceState({}, '', `/editor/s/${shareId}?src=${encodeURIComponent(sourceUrl)}`);
-    const requestFetch = vi.fn(async (url: RequestInfo | URL) => {
-      expect(url.toString()).toBe(sourceUrl);
-      return new Response(JSON.stringify({ schemaVersion: 1, ...share }), {
-        headers: { 'content-type': 'application/json' },
-        status: 200,
-      });
-    }) as typeof fetch;
+    const requestFetch: typeof fetch = vi.fn((input: RequestInfo | URL) => {
+      expect(getRequestUrl(input)).toBe(sourceUrl);
+      return Promise.resolve(
+        new Response(JSON.stringify({ schemaVersion: 1, ...share }), {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        }),
+      );
+    });
     return { share, shareService: new BrowserShareService({ fetch: requestFetch }) };
   }
 
@@ -139,7 +147,7 @@ describe('PublicDeckViewer', () => {
       '/editor/s/missing-share?src=http%3A%2F%2Flocalhost%3A9000%2Flocalstudio%2Fmissing.json',
     );
     const shareService = new BrowserShareService({
-      fetch: vi.fn(async () => new Response(null, { status: 404 })) as typeof fetch,
+      fetch: vi.fn(() => Promise.resolve(new Response(null, { status: 404 }))),
     });
 
     render(<PublicDeckViewer shareId="missing-share" shareService={shareService} />);

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -2,19 +2,39 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSampleProject } from '../../../../src/domain/sampleProject';
+import type { ShareRecord } from '../../../../src/services/interfaces';
 import { BrowserShareService } from '../../../../src/services/shareService';
 import { PublicDeckViewer } from '../../../../src/ui/share/PublicDeckViewer';
 
 describe('PublicDeckViewer', () => {
   beforeEach(() => {
-    window.localStorage.clear();
-    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000201');
+    window.history.replaceState({}, '', '/');
   });
 
-  it('renders a shared deck in read-only mode', async () => {
-    const shareService = new BrowserShareService({ origin: 'https://localstudio.test' });
-    const share = await shareService.createShare(createSampleProject());
+  function createRemoteShare(
+    shareId: string,
+    project = createSampleProject(),
+  ): { shareService: BrowserShareService; share: ShareRecord } {
+    const share: ShareRecord = {
+      shareId,
+      createdAt: '2026-06-30T10:00:00.000Z',
+      updatedAt: '2026-06-30T10:00:00.000Z',
+      project,
+    };
+    const sourceUrl = `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`;
+    window.history.replaceState({}, '', `/editor/s/${shareId}?src=${encodeURIComponent(sourceUrl)}`);
+    const requestFetch = vi.fn(async (url: RequestInfo | URL) => {
+      expect(url.toString()).toBe(sourceUrl);
+      return new Response(JSON.stringify({ schemaVersion: 1, ...share }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      });
+    }) as typeof fetch;
+    return { share, shareService: new BrowserShareService({ fetch: requestFetch }) };
+  }
 
+  it('renders a shared deck in read-only mode', async () => {
+    const { share, shareService } = createRemoteShare('00000000-0000-4000-8000-000000000201');
     render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
 
     expect(await screen.findByLabelText('Public presentation')).toHaveClass('public-deck-viewer-present');
@@ -25,8 +45,7 @@ describe('PublicDeckViewer', () => {
   });
 
   it('keeps embeds in a compact shared deck layout', async () => {
-    const shareService = new BrowserShareService({ origin: 'https://localstudio.test' });
-    const share = await shareService.createShare(createSampleProject());
+    const { share, shareService } = createRemoteShare('00000000-0000-4000-8000-000000000202');
 
     render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} embed />);
 
@@ -36,7 +55,6 @@ describe('PublicDeckViewer', () => {
 
   it('moves between slides with next and previous controls', async () => {
     const user = userEvent.setup();
-    const shareService = new BrowserShareService({ origin: 'https://localstudio.test' });
     const project = createSampleProject();
     project.pages.push({
       id: 'page-2',
@@ -46,7 +64,10 @@ describe('PublicDeckViewer', () => {
       background: { type: 'color', color: '#111111' },
       elementIds: [],
     });
-    const share = await shareService.createShare(project);
+    const { share, shareService } = createRemoteShare(
+      '00000000-0000-4000-8000-000000000203',
+      project,
+    );
 
     render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
 
@@ -60,7 +81,14 @@ describe('PublicDeckViewer', () => {
   });
 
   it('shows a not found state for missing shares', async () => {
-    const shareService = new BrowserShareService({ origin: 'https://localstudio.test' });
+    window.history.replaceState(
+      {},
+      '',
+      '/editor/s/missing-share?src=http%3A%2F%2Flocalhost%3A9000%2Flocalstudio%2Fmissing.json',
+    );
+    const shareService = new BrowserShareService({
+      fetch: vi.fn(async () => new Response(null, { status: 404 })) as typeof fetch,
+    });
 
     render(<PublicDeckViewer shareId="missing-share" shareService={shareService} />);
 


### PR DESCRIPTION
## Summary
- Route public share creation through MinIO instead of local storage
- Upload shared projects and referenced assets to public object storage
- Disable share actions until external storage is synced and surface the unavailable state in the UI
- Update public deck loading tests to read from share source URLs

## Testing
- Updated unit coverage for share publishing, share gating, toolbar behavior, and public deck loading
- Not run (not requested)