### PR TITLE
[codex] Move Transformers workflows to workers

### DIFF
--- a/apps/editor/src/services/bonsaiImageRuntime.ts
+++ b/apps/editor/src/services/bonsaiImageRuntime.ts
@@ -341,7 +341,10 @@ export class WorkerBackedBonsaiImageRuntime implements BonsaiImageRuntime {
   }
 
   private getFallbackRuntime() {
-    this.fallbackRuntime ??= this.options.fallbackRuntime ?? new BrowserBonsaiImageRuntime();
+    if (!this.options.fallbackRuntime) {
+      throw new Error('Web workers are required for browser image generation.');
+    }
+    this.fallbackRuntime ??= this.options.fallbackRuntime;
     return this.fallbackRuntime;
   }
 

--- a/apps/editor/src/services/browserBackgroundRemovalService.ts
+++ b/apps/editor/src/services/browserBackgroundRemovalService.ts
@@ -1,51 +1,12 @@
 import type { Asset } from '../domain/model';
 import type { BackgroundRemovalService } from './interfaces';
-import { TRANSFORMERS_CACHE_KEY } from './imageGenerationModels';
-import { IMAGE_EDITING_TRANSFORMERS_MODEL_ID } from './modelSetupService';
-
-interface SamImageInput {
-  data: Uint8Array | Uint8ClampedArray;
-  width: number;
-  height: number;
-  channels: number;
-}
-
-interface SamMask {
-  data: Uint8Array | Uint8ClampedArray;
-  width: number;
-  height: number;
-}
-
-interface SamProcessedImage {
-  original_sizes: unknown;
-  reshaped_input_sizes: Array<[number, number]>;
-}
-
-interface SamRuntimeModel {
-  get_image_embeddings(image: SamProcessedImage): Promise<Record<string, unknown>>;
-  (inputs: Record<string, unknown>): Promise<{
-    pred_masks: unknown;
-    iou_scores: { data: ArrayLike<number> };
-  }>;
-}
-
-interface SamRuntimeProcessor {
-  (image: SamImageInput): Promise<SamProcessedImage>;
-  post_process_masks(
-    predMasks: unknown,
-    originalSizes: SamProcessedImage['original_sizes'],
-    reshapedInputSizes: SamProcessedImage['reshaped_input_sizes'],
-  ): Promise<Array<Array<unknown>>>;
-}
-
-interface SamRawImageReader {
-  fromURL(url: string): Promise<SamImageInput>;
-  fromTensor(tensor: unknown): SamMask;
-}
-
-interface SamTensorConstructor {
-  new (type: 'float32' | 'int64', data: Array<number | bigint>, dims: number[]): unknown;
-}
+import { TransformersRuntimeClient } from './transformersRuntimeClient';
+import type {
+  BackgroundSegmentationResult,
+  SamImageInput,
+  SegmentationPoint,
+  SubjectMask,
+} from './transformersOperations';
 
 function createObjectUrlFromImageData(imageData: ImageData) {
   return new Promise<string>((resolve, reject) => {
@@ -79,51 +40,27 @@ function createDataUrlFromImageData(imageData: ImageData) {
   return canvas.toDataURL('image/png');
 }
 
-interface EncodedAsset {
-  imageInput: SamImageInput;
-  imageProcessed: SamProcessedImage;
-  imageEmbeddings: Record<string, unknown>;
-}
-
-interface SegmentationResult extends EncodedAsset {
-  mask: SamMask;
-  scores: number[];
-}
-
-interface SubjectMask {
-  data: Uint8Array;
-  width: number;
-  height: number;
-  score: number;
-}
-
 interface CroppedTransparentImageResult {
   objectUrl: string;
   bounds: { x: number; y: number; width: number; height: number };
 }
 
-interface SegmentationPoint {
-  x: number;
-  y: number;
-  positive: boolean;
+interface BackgroundRemovalRuntime {
+  prepareBackgroundRemoval(objectUrl: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  segmentBackgroundRemoval(objectUrl: string, points: SegmentationPoint[]): Promise<BackgroundSegmentationResult>;
 }
 
 const SUBJECT_PADDING_RATIO = 0.035;
 
 export class BrowserBackgroundRemovalService implements BackgroundRemovalService {
-  private modelPromise: Promise<{
-    model: SamRuntimeModel;
-    processor: SamRuntimeProcessor;
-    RawImage: SamRawImageReader;
-    Tensor: SamTensorConstructor;
-  }> | null = null;
-  private encodedAssets = new Map<string, Promise<EncodedAsset>>();
+  constructor(private readonly runtime: BackgroundRemovalRuntime = new TransformersRuntimeClient()) {}
 
   async prepareBackgroundRemoval(
     asset: Asset,
     options?: { onProgress?: (progress: number) => void },
   ): Promise<void> {
-    await this.encodeAsset(asset, options?.onProgress);
+    if (!asset.objectUrl) throw new Error('Selected image has no source URL.');
+    await this.runtime.prepareBackgroundRemoval(asset.objectUrl, options);
     options?.onProgress?.(100);
   }
 
@@ -135,7 +72,7 @@ export class BrowserBackgroundRemovalService implements BackgroundRemovalService
     const points = this.getSegmentationPoints(options);
     if (points.length === 0) throw new Error('At least one point is required for previewing background removal.');
 
-    const segmentation = await this.segmentSeparateSubjects(asset, points);
+    const segmentation = await this.runtime.segmentBackgroundRemoval(asset.objectUrl, points);
     return {
       maskUrl: this.createBlueMaskImage(segmentation.subjectMask),
       score: segmentation.subjectMask.score,
@@ -150,7 +87,7 @@ export class BrowserBackgroundRemovalService implements BackgroundRemovalService
     const points = this.getSegmentationPoints(options);
     if (points.length === 0) throw new Error('At least one point is required for background removal.');
 
-    const segmentation = await this.segmentSeparateSubjects(asset, points);
+    const segmentation = await this.runtime.segmentBackgroundRemoval(asset.objectUrl, points);
     const transparentImage = await this.createTransparentImage(
       segmentation.imageInput,
       segmentation.subjectMask,
@@ -165,135 +102,6 @@ export class BrowserBackgroundRemovalService implements BackgroundRemovalService
         objectUrl: transparentImage.objectUrl,
       },
       bounds: transparentImage.bounds,
-    };
-  }
-
-  private async segmentSeparateSubjects(
-    asset: Asset,
-    points: SegmentationPoint[],
-  ): Promise<EncodedAsset & { subjectMask: SubjectMask }> {
-    const positivePoints = points.filter((point) => point.positive);
-    const promptPoints = positivePoints.length > 0 ? positivePoints : points;
-    const segmentations = await Promise.all(promptPoints.map((point) => this.segment(asset, [point])));
-    if (segmentations.length === 0) throw new Error('At least one point is required for segmentation.');
-    const firstSegmentation = segmentations[0];
-    if (!firstSegmentation) throw new Error('At least one point is required for segmentation.');
-    const subjectData = new Uint8Array(firstSegmentation.mask.width * firstSegmentation.mask.height);
-    let scoreTotal = 0;
-
-    for (const segmentation of segmentations) {
-      const bestMaskIndex = this.getBestMaskIndex(segmentation.scores);
-      const maskCount = segmentation.scores.length;
-      scoreTotal += segmentation.scores[bestMaskIndex] ?? 0;
-
-      for (let pixelIndex = 0; pixelIndex < subjectData.length; pixelIndex += 1) {
-        if (segmentation.mask.data[maskCount * pixelIndex + bestMaskIndex] === 1) {
-          subjectData[pixelIndex] = 1;
-        }
-      }
-    }
-
-    return {
-      ...firstSegmentation,
-      subjectMask: {
-        data: subjectData,
-        width: firstSegmentation.mask.width,
-        height: firstSegmentation.mask.height,
-        score: scoreTotal / segmentations.length,
-      },
-    };
-  }
-
-  private async segment(asset: Asset, points: SegmentationPoint[]): Promise<SegmentationResult> {
-    const { model, processor, RawImage, Tensor } = await this.loadModel();
-    const encodedAsset = await this.encodeAsset(asset);
-    const reshaped = encodedAsset.imageProcessed.reshaped_input_sizes[0]!;
-    const inputPoints = new Tensor(
-      'float32',
-      points.flatMap((point) => [point.x * reshaped[1], point.y * reshaped[0]]),
-      [1, 1, points.length, 2],
-    );
-    const inputLabels = new Tensor(
-      'int64',
-      points.map((point) => (point.positive ? 1n : 0n)),
-      [1, 1, points.length],
-    );
-    const { pred_masks: predMasks, iou_scores: iouScores } = await model({
-      ...encodedAsset.imageEmbeddings,
-      input_points: inputPoints,
-      input_labels: inputLabels,
-    });
-    const masks = await processor.post_process_masks(
-      predMasks,
-      encodedAsset.imageProcessed.original_sizes,
-      encodedAsset.imageProcessed.reshaped_input_sizes,
-    );
-    const mask = RawImage.fromTensor(masks[0]?.[0]);
-    return {
-      ...encodedAsset,
-      mask,
-      scores: Array.from(iouScores.data),
-    };
-  }
-
-  private async encodeAsset(asset: Asset, onProgress?: (progress: number) => void) {
-    if (!asset.objectUrl) throw new Error('Selected image has no source URL.');
-    const cached = this.encodedAssets.get(asset.objectUrl);
-    if (cached) {
-      void cached.then(
-        () => {
-          onProgress?.(100);
-        },
-        () => undefined,
-      );
-      return cached;
-    }
-
-    const encoded = this.createEncodedAsset(asset.objectUrl, onProgress);
-    this.encodedAssets.set(asset.objectUrl, encoded);
-    return encoded;
-  }
-
-  private async createEncodedAsset(
-    objectUrl: string,
-    onProgress?: (progress: number) => void,
-  ): Promise<EncodedAsset> {
-    onProgress?.(8);
-    const { model, processor, RawImage } = await this.loadModel();
-    onProgress?.(28);
-    const imageInput = await RawImage.fromURL(objectUrl);
-    onProgress?.(45);
-    const imageProcessed = await processor(imageInput);
-    onProgress?.(68);
-    const imageEmbeddings = await model.get_image_embeddings(imageProcessed);
-    onProgress?.(100);
-    return { imageInput, imageProcessed, imageEmbeddings };
-  }
-
-  private async loadModel() {
-    this.modelPromise ??= this.createModel();
-    return this.modelPromise;
-  }
-
-  private async createModel() {
-    const { AutoProcessor, RawImage, SamModel, Tensor, env } = await import('@huggingface/transformers');
-
-    env.useBrowserCache = true;
-    env.cacheKey = TRANSFORMERS_CACHE_KEY;
-
-    const [model, processor] = await Promise.all([
-      SamModel.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID, {
-        dtype: 'fp16',
-        device: 'webgpu',
-      }),
-      AutoProcessor.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID),
-    ]);
-
-    return {
-      model: model as unknown as SamRuntimeModel,
-      processor: processor as unknown as SamRuntimeProcessor,
-      RawImage: RawImage as unknown as SamRawImageReader,
-      Tensor: Tensor as unknown as SamTensorConstructor,
     };
   }
 
@@ -362,10 +170,6 @@ export class BrowserBackgroundRemovalService implements BackgroundRemovalService
     }
 
     return createDataUrlFromImageData(imageData);
-  }
-
-  private getBestMaskIndex(scores: number[]) {
-    return scores.reduce((bestIndex, score, index) => (score > scores[bestIndex]! ? index : bestIndex), 0);
   }
 
   private getSegmentationPoints(options?: { points?: SegmentationPoint[]; subjectPoint?: { x: number; y: number } }) {

--- a/apps/editor/src/services/modelSetupService.ts
+++ b/apps/editor/src/services/modelSetupService.ts
@@ -21,7 +21,8 @@ import {
 } from './imageGenerationModels';
 import { WorkerBackedBonsaiImageRuntime } from './bonsaiImageRuntime';
 import { getBrowserLocalStorage, type BrowserKeyValueStorage } from './browserStorage';
-import { createMonotonicProgressReporter, createTransformersProgressCallback } from './progress';
+import { createMonotonicProgressReporter } from './progress';
+import { TransformersRuntimeClient } from './transformersRuntimeClient';
 
 export const IMAGE_EDITING_MODEL_ID = 'image-editing-models';
 export const IMAGE_EDITING_TRANSFORMERS_MODEL_ID = 'Xenova/slimsam-77-uniform';
@@ -113,19 +114,10 @@ function getReadyKey(id: string) {
 }
 
 export class TransformersImageEditingModelLoader implements ImageEditingModelLoader {
+  constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
+
   async loadImageEditingModel(): Promise<void> {
-    const { AutoProcessor, SamModel, env } = await import('@huggingface/transformers');
-
-    env.useBrowserCache = true;
-    env.cacheKey = TRANSFORMERS_CACHE_KEY;
-
-    await Promise.all([
-      SamModel.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID, {
-        dtype: 'fp16',
-        device: 'webgpu',
-      }),
-      AutoProcessor.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID),
-    ]);
+    await this.runtimeClient.preloadImageEditing();
   }
 }
 
@@ -136,36 +128,29 @@ export class TransformersImageGenerationModelLoader implements ImageGenerationMo
 }
 
 export class TransformersTextGenerationModelLoader implements TextGenerationModelLoader {
+  constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
+
   async loadTextGenerationModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
-    const { pipeline, env } = await import('@huggingface/transformers');
+    await this.runtimeClient.preloadTextGeneration(modelId, options);
+  }
 
-    env.useBrowserCache = true;
-    env.cacheKey = TRANSFORMERS_CACHE_KEY;
+  releaseTextGenerationModel(modelId: string): Promise<void> {
+    return this.runtimeClient.releaseTextGeneration(modelId);
+  }
 
-    const textGeneration = await pipeline('text-generation', modelId, {
-      dtype: 'q4',
-      device: 'webgpu',
-      progress_callback: createTransformersProgressCallback(options?.onProgress),
-    });
-    await (textGeneration as { dispose?: () => Promise<void> | void }).dispose?.();
+  removeTextGenerationModel(modelId: string): Promise<void> {
+    return this.runtimeClient.removeTextGeneration(modelId);
   }
 }
 
 export class TransformersLanguageDetectionModelLoader implements LanguageDetectionModelLoader {
+  constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
+
   async loadLanguageDetectionModel(
     modelId: string,
     options?: { onProgress?: (progress: number) => void },
   ): Promise<void> {
-    const { pipeline, env } = await import('@huggingface/transformers');
-
-    env.useBrowserCache = true;
-    env.cacheKey = TRANSFORMERS_CACHE_KEY;
-
-    const detector = await pipeline('text-classification', modelId, {
-      device: 'webgpu',
-      progress_callback: createTransformersProgressCallback(options?.onProgress),
-    });
-    await (detector as { dispose?: () => Promise<void> | void }).dispose?.();
+    await this.runtimeClient.preloadLanguageDetection(modelId, options);
   }
 }
 

--- a/apps/editor/src/services/transformersOperations.ts
+++ b/apps/editor/src/services/transformersOperations.ts
@@ -1,0 +1,385 @@
+import { TRANSFORMERS_CACHE_KEY } from './imageGenerationModels';
+import { createTransformersProgressCallback } from './progress';
+
+const IMAGE_EDITING_TRANSFORMERS_MODEL_ID = 'Xenova/slimsam-77-uniform';
+
+export type TextGenerationInput = string | Array<{ role: string; content: unknown }>;
+export type TextGenerationOptions = Record<string, unknown>;
+
+export interface LanguageDetectionResult {
+  language: string;
+  score?: number | undefined;
+}
+
+export interface SamImageInput {
+  data: Uint8Array | Uint8ClampedArray;
+  width: number;
+  height: number;
+  channels: number;
+}
+
+export interface SamMask {
+  data: Uint8Array | Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+export interface SubjectMask {
+  data: Uint8Array;
+  width: number;
+  height: number;
+  score: number;
+}
+
+export interface SegmentationPoint {
+  x: number;
+  y: number;
+  positive: boolean;
+}
+
+export interface BackgroundSegmentationResult {
+  imageInput: SamImageInput;
+  subjectMask: SubjectMask;
+}
+
+interface SamProcessedImage {
+  original_sizes: unknown;
+  reshaped_input_sizes: Array<[number, number]>;
+}
+
+interface EncodedAsset {
+  imageInput: SamImageInput;
+  imageProcessed: SamProcessedImage;
+  imageEmbeddings: Record<string, unknown>;
+}
+
+interface SegmentationResult extends EncodedAsset {
+  mask: SamMask;
+  scores: number[];
+}
+
+type TextGenerationPipeline = ((prompt: unknown, options?: TextGenerationOptions) => Promise<unknown>) & {
+  dispose?: () => Promise<void> | void;
+};
+
+type TextClassificationResult = { label?: unknown; score?: unknown };
+type TextClassificationPipeline = ((text: string, options?: Record<string, unknown>) => Promise<unknown>) & {
+  dispose?: () => Promise<void> | void;
+};
+
+interface SamRuntimeModel {
+  get_image_embeddings(image: SamProcessedImage): Promise<Record<string, unknown>>;
+  (inputs: Record<string, unknown>): Promise<{
+    pred_masks: unknown;
+    iou_scores: { data: ArrayLike<number> };
+  }>;
+}
+
+interface SamRuntimeProcessor {
+  (image: SamImageInput): Promise<SamProcessedImage>;
+  post_process_masks(
+    predMasks: unknown,
+    originalSizes: SamProcessedImage['original_sizes'],
+    reshapedInputSizes: SamProcessedImage['reshaped_input_sizes'],
+  ): Promise<Array<Array<unknown>>>;
+}
+
+interface SamRawImageReader {
+  fromURL(url: string): Promise<SamImageInput>;
+  fromTensor(tensor: unknown): SamMask;
+}
+
+interface SamTensorConstructor {
+  new (type: 'float32' | 'int64', data: Array<number | bigint>, dims: number[]): unknown;
+}
+
+function extractTextFromGeneratedValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const values = value as unknown[];
+    const lastMessage = values.at(-1);
+    if (lastMessage && typeof lastMessage === 'object') {
+      const content = (lastMessage as { content?: unknown }).content;
+      if (typeof content === 'string') return content;
+      const generatedText = (lastMessage as { generated_text?: unknown }).generated_text;
+      const nestedText = extractTextFromGeneratedValue(generatedText);
+      if (nestedText) return nestedText;
+    }
+
+    const firstMessage = values[0];
+    if (firstMessage && typeof firstMessage === 'object') {
+      const generatedText = (firstMessage as { generated_text?: unknown }).generated_text;
+      const nestedText = extractTextFromGeneratedValue(generatedText);
+      if (nestedText) return nestedText;
+    }
+  }
+  if (value && typeof value === 'object' && 'generated_text' in value) {
+    return extractTextFromGeneratedValue((value as { generated_text?: unknown }).generated_text);
+  }
+  return undefined;
+}
+
+export function extractGeneratedText(result: unknown) {
+  if (typeof result === 'string') return result;
+  const generatedText = extractTextFromGeneratedValue(result);
+  if (generatedText) return generatedText;
+  throw new Error('WebGPU text generation did not return text.');
+}
+
+function isTextClassificationResult(value: unknown): value is TextClassificationResult {
+  return Boolean(value && typeof value === 'object');
+}
+
+function getTopClassificationResult(result: unknown): TextClassificationResult | undefined {
+  if (Array.isArray(result)) {
+    const values: unknown[] = result;
+    const first = values[0];
+    if (Array.isArray(first)) return getTopClassificationResult(first);
+    return isTextClassificationResult(first) ? first : undefined;
+  }
+  return isTextClassificationResult(result) ? result : undefined;
+}
+
+export function extractDetectedLanguage(result: unknown): LanguageDetectionResult {
+  const topResult = getTopClassificationResult(result);
+  const label = topResult?.label;
+  if (typeof label !== 'string' || !label.trim()) {
+    throw new Error('Language detection model did not return a language label.');
+  }
+
+  return {
+    language: label,
+    ...(typeof topResult?.score === 'number' ? { score: topResult.score } : {}),
+  };
+}
+
+export class DirectTransformersOperations {
+  private backgroundModelPromise: Promise<{
+    model: SamRuntimeModel;
+    processor: SamRuntimeProcessor;
+    RawImage: SamRawImageReader;
+    Tensor: SamTensorConstructor;
+  }> | null = null;
+  private encodedAssets = new Map<string, Promise<EncodedAsset>>();
+  private languageDetectionPipelines = new Map<string, Promise<TextClassificationPipeline>>();
+  private textGenerationPipelines = new Map<string, Promise<TextGenerationPipeline>>();
+
+  async preloadTextGeneration(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+    await this.loadTextGenerationPipeline(modelId, options);
+  }
+
+  async generateText(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions) {
+    const textGeneration = await this.loadTextGenerationPipeline(modelId);
+    const generationOptions: TextGenerationOptions = {
+      do_sample: false,
+      max_new_tokens: 2048,
+      ...options,
+    };
+    if (typeof prompt === 'string' && !('return_full_text' in generationOptions)) {
+      generationOptions.return_full_text = false;
+    }
+    const result = await textGeneration(prompt, {
+      ...generationOptions,
+    });
+    return extractGeneratedText(result);
+  }
+
+  async releaseTextGeneration(modelId: string) {
+    const pipelinePromise = this.textGenerationPipelines.get(modelId);
+    this.textGenerationPipelines.delete(modelId);
+    const pipeline = await pipelinePromise;
+    await pipeline?.dispose?.();
+  }
+
+  async removeTextGeneration(modelId: string) {
+    const pipelinePromise = this.textGenerationPipelines.get(modelId);
+    this.textGenerationPipelines.delete(modelId);
+    const pipeline = await pipelinePromise?.catch(() => undefined);
+    await pipeline?.dispose?.();
+  }
+
+  async preloadLanguageDetection(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+    await this.loadLanguageDetectionPipeline(modelId, options);
+  }
+
+  async detectLanguage(modelId: string, text: string) {
+    const detector = await this.loadLanguageDetectionPipeline(modelId);
+    const result = await detector(text, {
+      topk: 1,
+      truncation: true,
+    });
+    return extractDetectedLanguage(result);
+  }
+
+  async preloadImageEditing(options?: { onProgress?: (progress: number) => void }) {
+    await this.loadBackgroundModel();
+    options?.onProgress?.(100);
+  }
+
+  async prepareBackgroundRemoval(objectUrl: string, options?: { onProgress?: (progress: number) => void }) {
+    await this.encodeAsset(objectUrl, options?.onProgress);
+    options?.onProgress?.(100);
+  }
+
+  async segmentBackgroundRemoval(objectUrl: string, points: SegmentationPoint[]): Promise<BackgroundSegmentationResult> {
+    const positivePoints = points.filter((point) => point.positive);
+    const promptPoints = positivePoints.length > 0 ? positivePoints : points;
+    const segmentations = await Promise.all(promptPoints.map((point) => this.segment(objectUrl, [point])));
+    if (segmentations.length === 0) throw new Error('At least one point is required for segmentation.');
+    const firstSegmentation = segmentations[0];
+    if (!firstSegmentation) throw new Error('At least one point is required for segmentation.');
+    const subjectData = new Uint8Array(firstSegmentation.mask.width * firstSegmentation.mask.height);
+    let scoreTotal = 0;
+
+    for (const segmentation of segmentations) {
+      const bestMaskIndex = this.getBestMaskIndex(segmentation.scores);
+      const maskCount = segmentation.scores.length;
+      scoreTotal += segmentation.scores[bestMaskIndex] ?? 0;
+
+      for (let pixelIndex = 0; pixelIndex < subjectData.length; pixelIndex += 1) {
+        if (segmentation.mask.data[maskCount * pixelIndex + bestMaskIndex] === 1) {
+          subjectData[pixelIndex] = 1;
+        }
+      }
+    }
+
+    return {
+      imageInput: firstSegmentation.imageInput,
+      subjectMask: {
+        data: subjectData,
+        width: firstSegmentation.mask.width,
+        height: firstSegmentation.mask.height,
+        score: scoreTotal / segmentations.length,
+      },
+    };
+  }
+
+  private loadTextGenerationPipeline(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+    const existingPipeline = this.textGenerationPipelines.get(modelId);
+    if (existingPipeline) return existingPipeline;
+
+    const pipelinePromise = import('@huggingface/transformers').then(async ({ env, pipeline }) => {
+      env.useBrowserCache = true;
+      env.cacheKey = TRANSFORMERS_CACHE_KEY;
+      return (await pipeline('text-generation', modelId, {
+        dtype: 'q4',
+        device: 'webgpu',
+        progress_callback: createTransformersProgressCallback(options?.onProgress),
+      })) as unknown as TextGenerationPipeline;
+    });
+    this.textGenerationPipelines.set(modelId, pipelinePromise);
+    return pipelinePromise;
+  }
+
+  private loadLanguageDetectionPipeline(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+    const existingPipeline = this.languageDetectionPipelines.get(modelId);
+    if (existingPipeline) return existingPipeline;
+
+    const pipelinePromise = import('@huggingface/transformers').then(async ({ env, pipeline }) => {
+      env.useBrowserCache = true;
+      env.cacheKey = TRANSFORMERS_CACHE_KEY;
+      return await pipeline('text-classification', modelId, {
+        device: 'webgpu',
+        progress_callback: createTransformersProgressCallback(options?.onProgress),
+      });
+    });
+    this.languageDetectionPipelines.set(modelId, pipelinePromise);
+    return pipelinePromise;
+  }
+
+  private async segment(objectUrl: string, points: SegmentationPoint[]): Promise<SegmentationResult> {
+    const { model, processor, RawImage, Tensor } = await this.loadBackgroundModel();
+    const encodedAsset = await this.encodeAsset(objectUrl);
+    const reshaped = encodedAsset.imageProcessed.reshaped_input_sizes[0]!;
+    const inputPoints = new Tensor(
+      'float32',
+      points.flatMap((point) => [point.x * reshaped[1], point.y * reshaped[0]]),
+      [1, 1, points.length, 2],
+    );
+    const inputLabels = new Tensor(
+      'int64',
+      points.map((point) => (point.positive ? 1n : 0n)),
+      [1, 1, points.length],
+    );
+    const { pred_masks: predMasks, iou_scores: iouScores } = await model({
+      ...encodedAsset.imageEmbeddings,
+      input_points: inputPoints,
+      input_labels: inputLabels,
+    });
+    const masks = await processor.post_process_masks(
+      predMasks,
+      encodedAsset.imageProcessed.original_sizes,
+      encodedAsset.imageProcessed.reshaped_input_sizes,
+    );
+    const mask = RawImage.fromTensor(masks[0]?.[0]);
+    return {
+      ...encodedAsset,
+      mask,
+      scores: Array.from(iouScores.data),
+    };
+  }
+
+  private async encodeAsset(objectUrl: string, onProgress?: (progress: number) => void) {
+    const cached = this.encodedAssets.get(objectUrl);
+    if (cached) {
+      void cached.then(
+        () => {
+          onProgress?.(100);
+        },
+        () => undefined,
+      );
+      return cached;
+    }
+
+    const encoded = this.createEncodedAsset(objectUrl, onProgress);
+    this.encodedAssets.set(objectUrl, encoded);
+    return encoded;
+  }
+
+  private async createEncodedAsset(
+    objectUrl: string,
+    onProgress?: (progress: number) => void,
+  ): Promise<EncodedAsset> {
+    onProgress?.(8);
+    const { model, processor, RawImage } = await this.loadBackgroundModel();
+    onProgress?.(28);
+    const imageInput = await RawImage.fromURL(objectUrl);
+    onProgress?.(45);
+    const imageProcessed = await processor(imageInput);
+    onProgress?.(68);
+    const imageEmbeddings = await model.get_image_embeddings(imageProcessed);
+    onProgress?.(100);
+    return { imageInput, imageProcessed, imageEmbeddings };
+  }
+
+  private async loadBackgroundModel() {
+    this.backgroundModelPromise ??= this.createBackgroundModel();
+    return this.backgroundModelPromise;
+  }
+
+  private async createBackgroundModel() {
+    const { AutoProcessor, RawImage, SamModel, Tensor, env } = await import('@huggingface/transformers');
+
+    env.useBrowserCache = true;
+    env.cacheKey = TRANSFORMERS_CACHE_KEY;
+
+    const [model, processor] = await Promise.all([
+      SamModel.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID, {
+        dtype: 'fp16',
+        device: 'webgpu',
+      }),
+      AutoProcessor.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID),
+    ]);
+
+    return {
+      model: model as unknown as SamRuntimeModel,
+      processor: processor as unknown as SamRuntimeProcessor,
+      RawImage: RawImage as unknown as SamRawImageReader,
+      Tensor: Tensor as unknown as SamTensorConstructor,
+    };
+  }
+
+  private getBestMaskIndex(scores: number[]) {
+    return scores.reduce((bestIndex, score, index) => (score > scores[bestIndex]! ? index : bestIndex), 0);
+  }
+}

--- a/apps/editor/src/services/transformersRuntime.worker.ts
+++ b/apps/editor/src/services/transformersRuntime.worker.ts
@@ -1,0 +1,84 @@
+import { DirectTransformersOperations } from './transformersOperations';
+import type { TransformersWorkerRequest, TransformersWorkerResponse } from './transformersRuntimeClient';
+
+const operations = new DirectTransformersOperations();
+
+function postResponse(response: TransformersWorkerResponse) {
+  self.postMessage(response);
+}
+
+self.onmessage = (event: MessageEvent<TransformersWorkerRequest>) => {
+  const request = event.data;
+  void handleRequest(request);
+};
+
+async function handleRequest(request: TransformersWorkerRequest) {
+  try {
+    if (request.type === 'preload-text-generation') {
+      await operations.preloadTextGeneration(request.modelId, {
+        onProgress: (progress) => postResponse({ id: request.id, progress, type: 'progress' }),
+      });
+      postResponse({ id: request.id, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'generate-text') {
+      const result = await operations.generateText(request.modelId, request.prompt, request.options);
+      postResponse({ id: request.id, result, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'release-text-generation') {
+      await operations.releaseTextGeneration(request.modelId);
+      postResponse({ id: request.id, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'remove-text-generation') {
+      await operations.removeTextGeneration(request.modelId);
+      postResponse({ id: request.id, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'preload-language-detection') {
+      await operations.preloadLanguageDetection(request.modelId, {
+        onProgress: (progress) => postResponse({ id: request.id, progress, type: 'progress' }),
+      });
+      postResponse({ id: request.id, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'detect-language') {
+      const result = await operations.detectLanguage(request.modelId, request.text);
+      postResponse({ id: request.id, result, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'preload-image-editing') {
+      await operations.preloadImageEditing({
+        onProgress: (progress) => postResponse({ id: request.id, progress, type: 'progress' }),
+      });
+      postResponse({ id: request.id, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'prepare-background-removal') {
+      await operations.prepareBackgroundRemoval(request.objectUrl, {
+        onProgress: (progress) => postResponse({ id: request.id, progress, type: 'progress' }),
+      });
+      postResponse({ id: request.id, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'segment-background-removal') {
+      const result = await operations.segmentBackgroundRemoval(request.objectUrl, request.points);
+      postResponse({ id: request.id, result, type: 'result' });
+    }
+  } catch (error) {
+    postResponse({
+      id: request.id,
+      message: error instanceof Error ? error.message : 'Transformers worker failed.',
+      type: 'error',
+    });
+  }
+}

--- a/apps/editor/src/services/transformersRuntimeClient.ts
+++ b/apps/editor/src/services/transformersRuntimeClient.ts
@@ -1,0 +1,319 @@
+import type {
+  BackgroundSegmentationResult,
+  LanguageDetectionResult,
+  SegmentationPoint,
+  TextGenerationInput,
+  TextGenerationOptions,
+} from './transformersOperations';
+
+export type TransformersWorkerRequest =
+  | {
+      id: string;
+      modelId: string;
+      type: 'preload-text-generation';
+    }
+  | {
+      id: string;
+      modelId: string;
+      options?: TextGenerationOptions;
+      prompt: TextGenerationInput;
+      type: 'generate-text';
+    }
+  | {
+      id: string;
+      modelId: string;
+      type: 'release-text-generation' | 'remove-text-generation';
+    }
+  | {
+      id: string;
+      modelId: string;
+      type: 'preload-language-detection';
+    }
+  | {
+      id: string;
+      modelId: string;
+      text: string;
+      type: 'detect-language';
+    }
+  | {
+      id: string;
+      type: 'preload-image-editing';
+    }
+  | {
+      id: string;
+      objectUrl: string;
+      type: 'prepare-background-removal';
+    }
+  | {
+      id: string;
+      objectUrl: string;
+      points: SegmentationPoint[];
+      type: 'segment-background-removal';
+    };
+
+export type TransformersWorkerResponse =
+  | {
+      id: string;
+      progress: number;
+      type: 'progress';
+    }
+  | {
+      id: string;
+      result?: BackgroundSegmentationResult | LanguageDetectionResult | string;
+      type: 'result';
+    }
+  | {
+      id: string;
+      message: string;
+      type: 'error';
+    };
+
+interface PendingTransformersRequest {
+  onProgress?: ((progress: number) => void) | undefined;
+  reject: (error: Error) => void;
+  resolve: (result: BackgroundSegmentationResult | LanguageDetectionResult | string | undefined) => void;
+}
+
+interface TransformersRuntimeClientOptions {
+  createWorker?: () => Worker;
+  fallbackOperations?: TransformersOperationsFallback;
+}
+
+interface TransformersOperationsFallback {
+  detectLanguage(modelId: string, text: string): Promise<LanguageDetectionResult>;
+  generateText(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string>;
+  preloadImageEditing(options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  preloadLanguageDetection(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  preloadTextGeneration(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  prepareBackgroundRemoval(objectUrl: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  releaseTextGeneration(modelId: string): Promise<void>;
+  removeTextGeneration(modelId: string): Promise<void>;
+  segmentBackgroundRemoval(objectUrl: string, points: SegmentationPoint[]): Promise<BackgroundSegmentationResult>;
+}
+
+export class TransformersRuntimeClient {
+  private fallbackOperations: TransformersOperationsFallback | undefined;
+  private pendingRequests = new Map<string, PendingTransformersRequest>();
+  private worker: Worker | undefined;
+
+  constructor(private readonly options: TransformersRuntimeClientOptions = {}) {}
+
+  preloadTextGeneration(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+    return this.request(
+      {
+        id: createRequestId(),
+        modelId,
+        type: 'preload-text-generation',
+      },
+      options,
+    ).then(() => undefined);
+  }
+
+  async generateText(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions) {
+    const result = await this.request({
+      id: createRequestId(),
+      modelId,
+      prompt,
+      type: 'generate-text',
+      ...(options ? { options } : {}),
+    });
+    if (typeof result !== 'string') throw new Error('Transformers text worker did not return text.');
+    return result;
+  }
+
+  releaseTextGeneration(modelId: string) {
+    return this.request({
+      id: createRequestId(),
+      modelId,
+      type: 'release-text-generation',
+    }).then(() => undefined);
+  }
+
+  removeTextGeneration(modelId: string) {
+    return this.request({
+      id: createRequestId(),
+      modelId,
+      type: 'remove-text-generation',
+    }).then(() => undefined);
+  }
+
+  preloadLanguageDetection(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+    return this.request(
+      {
+        id: createRequestId(),
+        modelId,
+        type: 'preload-language-detection',
+      },
+      options,
+    ).then(() => undefined);
+  }
+
+  async detectLanguage(modelId: string, text: string) {
+    const result = await this.request({
+      id: createRequestId(),
+      modelId,
+      text,
+      type: 'detect-language',
+    });
+    if (!isLanguageDetectionResult(result)) {
+      throw new Error('Transformers language detection worker did not return a language.');
+    }
+    return result;
+  }
+
+  preloadImageEditing(options?: { onProgress?: (progress: number) => void }) {
+    return this.request(
+      {
+        id: createRequestId(),
+        type: 'preload-image-editing',
+      },
+      options,
+    ).then(() => undefined);
+  }
+
+  prepareBackgroundRemoval(objectUrl: string, options?: { onProgress?: (progress: number) => void }) {
+    return this.request(
+      {
+        id: createRequestId(),
+        objectUrl,
+        type: 'prepare-background-removal',
+      },
+      options,
+    ).then(() => undefined);
+  }
+
+  async segmentBackgroundRemoval(objectUrl: string, points: SegmentationPoint[]) {
+    const result = await this.request({
+      id: createRequestId(),
+      objectUrl,
+      points,
+      type: 'segment-background-removal',
+    });
+    if (!isBackgroundSegmentationResult(result)) {
+      throw new Error('Transformers background removal worker did not return a mask.');
+    }
+    return result;
+  }
+
+  private request(request: TransformersWorkerRequest, options?: { onProgress?: (progress: number) => void }) {
+    const worker = this.getWorker();
+    if (!worker) return this.executeFallbackRequest(request, options);
+
+    return new Promise<BackgroundSegmentationResult | LanguageDetectionResult | string | undefined>((resolve, reject) => {
+      this.pendingRequests.set(request.id, {
+        onProgress: options?.onProgress,
+        reject,
+        resolve,
+      });
+      worker.postMessage(request);
+    });
+  }
+
+  private getWorker() {
+    if (this.worker) return this.worker;
+    try {
+      const worker = this.options.createWorker?.() ?? createDefaultTransformersWorker();
+      worker.onmessage = (event: MessageEvent<TransformersWorkerResponse>) => {
+        this.handleWorkerResponse(event.data);
+      };
+      worker.onerror = (event) => {
+        const message = event instanceof ErrorEvent ? event.message : 'Transformers worker failed.';
+        this.rejectAllPending(message);
+      };
+      this.worker = worker;
+      return worker;
+    } catch {
+      this.fallbackOperations = this.getFallbackOperations();
+      return undefined;
+    }
+  }
+
+  private getFallbackOperations() {
+    if (!this.options.fallbackOperations) {
+      throw new Error('Web workers are required for local Transformers workflows.');
+    }
+    this.fallbackOperations ??= this.options.fallbackOperations;
+    return this.fallbackOperations;
+  }
+
+  private handleWorkerResponse(response: TransformersWorkerResponse) {
+    const pending = this.pendingRequests.get(response.id);
+    if (!pending) return;
+    if (response.type === 'progress') {
+      pending.onProgress?.(response.progress);
+      return;
+    }
+    this.pendingRequests.delete(response.id);
+    if (response.type === 'error') {
+      pending.reject(new Error(response.message));
+      return;
+    }
+    pending.resolve(response.result);
+  }
+
+  private rejectAllPending(message: string) {
+    for (const [id, pending] of this.pendingRequests) {
+      this.pendingRequests.delete(id);
+      pending.reject(new Error(message));
+    }
+  }
+
+  private executeFallbackRequest(
+    request: TransformersWorkerRequest,
+    options?: { onProgress?: (progress: number) => void },
+  ) {
+    const operations = this.getFallbackOperations();
+    switch (request.type) {
+      case 'preload-text-generation':
+        return operations.preloadTextGeneration(request.modelId, options).then(() => undefined);
+      case 'generate-text':
+        return operations.generateText(request.modelId, request.prompt, request.options);
+      case 'release-text-generation':
+        return operations.releaseTextGeneration(request.modelId).then(() => undefined);
+      case 'remove-text-generation':
+        return operations.removeTextGeneration(request.modelId).then(() => undefined);
+      case 'preload-language-detection':
+        return operations.preloadLanguageDetection(request.modelId, options).then(() => undefined);
+      case 'detect-language':
+        return operations.detectLanguage(request.modelId, request.text);
+      case 'preload-image-editing':
+        return operations.preloadImageEditing(options).then(() => undefined);
+      case 'prepare-background-removal':
+        return operations.prepareBackgroundRemoval(request.objectUrl, options).then(() => undefined);
+      case 'segment-background-removal':
+        return operations.segmentBackgroundRemoval(request.objectUrl, request.points);
+    }
+  }
+}
+
+function createRequestId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `transformers-request-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function createDefaultTransformersWorker() {
+  if (typeof Worker === 'undefined') throw new Error('Web workers are not available.');
+  return new Worker(new URL('./transformersRuntime.worker.ts', import.meta.url), {
+    type: 'module',
+  });
+}
+
+function isLanguageDetectionResult(value: unknown): value is LanguageDetectionResult {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      'language' in value &&
+      typeof (value as { language?: unknown }).language === 'string',
+  );
+}
+
+function isBackgroundSegmentationResult(value: unknown): value is BackgroundSegmentationResult {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      'imageInput' in value &&
+      'subjectMask' in value,
+  );
+}

--- a/apps/editor/src/services/webGpuLanguageDetectionRuntime.ts
+++ b/apps/editor/src/services/webGpuLanguageDetectionRuntime.ts
@@ -1,76 +1,25 @@
-import { TRANSFORMERS_CACHE_KEY } from './imageGenerationModels';
-import { createTransformersProgressCallback } from './progress';
+import { TransformersRuntimeClient } from './transformersRuntimeClient';
+import { extractDetectedLanguage, type LanguageDetectionResult } from './transformersOperations';
+
+export { extractDetectedLanguage };
 
 export interface LanguageDetectionRuntime {
   preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
-  detectLanguage(modelId: string, text: string): Promise<{ language: string; score?: number | undefined }>;
-}
-
-type TextClassificationResult = { label?: unknown; score?: unknown };
-type TextClassificationPipeline = ((text: string, options?: Record<string, unknown>) => Promise<unknown>) & {
-  dispose?: () => Promise<void> | void;
-};
-
-function isTextClassificationResult(value: unknown): value is TextClassificationResult {
-  return Boolean(value && typeof value === 'object');
-}
-
-function getTopClassificationResult(result: unknown): TextClassificationResult | undefined {
-  if (Array.isArray(result)) {
-    const values: unknown[] = result;
-    const first = values[0];
-    if (Array.isArray(first)) return getTopClassificationResult(first);
-    return isTextClassificationResult(first) ? first : undefined;
-  }
-  return isTextClassificationResult(result) ? result : undefined;
-}
-
-export function extractDetectedLanguage(result: unknown) {
-  const topResult = getTopClassificationResult(result);
-  const label = topResult?.label;
-  if (typeof label !== 'string' || !label.trim()) {
-    throw new Error('Language detection model did not return a language label.');
-  }
-
-  return {
-    language: label,
-    ...(typeof topResult?.score === 'number' ? { score: topResult.score } : {}),
-  };
+  detectLanguage(modelId: string, text: string): Promise<LanguageDetectionResult>;
 }
 
 export class TransformersLanguageDetectionRuntime implements LanguageDetectionRuntime {
-  private pipelines = new Map<string, Promise<TextClassificationPipeline>>();
+  constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
 
   loadLanguageDetectionModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
     return this.preload(modelId, options);
   }
 
-  async preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
-    await this.loadPipeline(modelId, options);
+  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+    return this.runtimeClient.preloadLanguageDetection(modelId, options);
   }
 
-  async detectLanguage(modelId: string, text: string) {
-    const detector = await this.loadPipeline(modelId);
-    const result = await detector(text, {
-      topk: 1,
-      truncation: true,
-    });
-    return extractDetectedLanguage(result);
-  }
-
-  private loadPipeline(modelId: string, options?: { onProgress?: (progress: number) => void }) {
-    const existingPipeline = this.pipelines.get(modelId);
-    if (existingPipeline) return existingPipeline;
-
-    const pipelinePromise = import('@huggingface/transformers').then(async ({ env, pipeline }) => {
-      env.useBrowserCache = true;
-      env.cacheKey = TRANSFORMERS_CACHE_KEY;
-      return (await pipeline('text-classification', modelId, {
-        device: 'webgpu',
-        progress_callback: createTransformersProgressCallback(options?.onProgress),
-      }));
-    });
-    this.pipelines.set(modelId, pipelinePromise);
-    return pipelinePromise;
+  detectLanguage(modelId: string, text: string) {
+    return this.runtimeClient.detectLanguage(modelId, text);
   }
 }

--- a/apps/editor/src/services/webGpuTextGenerationRuntime.ts
+++ b/apps/editor/src/services/webGpuTextGenerationRuntime.ts
@@ -1,5 +1,11 @@
-import { TRANSFORMERS_CACHE_KEY } from './imageGenerationModels';
-import { createTransformersProgressCallback } from './progress';
+import { TransformersRuntimeClient } from './transformersRuntimeClient';
+import {
+  extractGeneratedText,
+  type TextGenerationInput,
+  type TextGenerationOptions,
+} from './transformersOperations';
+
+export { extractGeneratedText, type TextGenerationInput, type TextGenerationOptions };
 
 export interface TextGenerationRuntime {
   preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
@@ -7,101 +13,26 @@ export interface TextGenerationRuntime {
   removeTextGenerationModel?(modelId: string): Promise<void>;
 }
 
-export type TextGenerationInput = string | Array<{ role: string; content: unknown }>;
-export type TextGenerationOptions = Record<string, unknown>;
-
-type TextGenerationPipeline = ((prompt: unknown, options?: TextGenerationOptions) => Promise<unknown>) & {
-  dispose?: () => Promise<void> | void;
-};
-
-function extractTextFromGeneratedValue(value: unknown): string | undefined {
-  if (typeof value === 'string') return value;
-  if (Array.isArray(value)) {
-    const values = value as unknown[];
-    const lastMessage = values.at(-1);
-    if (lastMessage && typeof lastMessage === 'object') {
-      const content = (lastMessage as { content?: unknown }).content;
-      if (typeof content === 'string') return content;
-      const generatedText = (lastMessage as { generated_text?: unknown }).generated_text;
-      const nestedText = extractTextFromGeneratedValue(generatedText);
-      if (nestedText) return nestedText;
-    }
-
-    const firstMessage = values[0];
-    if (firstMessage && typeof firstMessage === 'object') {
-      const generatedText = (firstMessage as { generated_text?: unknown }).generated_text;
-      const nestedText = extractTextFromGeneratedValue(generatedText);
-      if (nestedText) return nestedText;
-    }
-  }
-  if (value && typeof value === 'object' && 'generated_text' in value) {
-    return extractTextFromGeneratedValue((value as { generated_text?: unknown }).generated_text);
-  }
-  return undefined;
-}
-
-export function extractGeneratedText(result: unknown) {
-  if (typeof result === 'string') return result;
-  const generatedText = extractTextFromGeneratedValue(result);
-  if (generatedText) return generatedText;
-  throw new Error('WebGPU text generation did not return text.');
-}
-
 export class TransformersTextGenerationRuntime implements TextGenerationRuntime {
-  private pipelines = new Map<string, Promise<TextGenerationPipeline>>();
+  constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
 
   loadTextGenerationModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
     return this.preload(modelId, options);
   }
 
-  async releaseTextGenerationModel(modelId: string): Promise<void> {
-    const pipelinePromise = this.pipelines.get(modelId);
-    this.pipelines.delete(modelId);
-    const pipeline = await pipelinePromise;
-    await pipeline?.dispose?.();
+  releaseTextGenerationModel(modelId: string): Promise<void> {
+    return this.runtimeClient.releaseTextGeneration(modelId);
   }
 
-  async preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
-    await this.loadPipeline(modelId, options);
+  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+    return this.runtimeClient.preloadTextGeneration(modelId, options);
   }
 
-  async removeTextGenerationModel(modelId: string): Promise<void> {
-    const pipelinePromise = this.pipelines.get(modelId);
-    this.pipelines.delete(modelId);
-    const pipeline = await pipelinePromise?.catch(() => undefined);
-    await pipeline?.dispose?.();
+  removeTextGenerationModel(modelId: string): Promise<void> {
+    return this.runtimeClient.removeTextGeneration(modelId);
   }
 
-  async generate(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string> {
-    const textGeneration = await this.loadPipeline(modelId);
-    const generationOptions: TextGenerationOptions = {
-      do_sample: false,
-      max_new_tokens: 2048,
-      ...options,
-    };
-    if (typeof prompt === 'string' && !('return_full_text' in generationOptions)) {
-      generationOptions.return_full_text = false;
-    }
-    const result = await textGeneration(prompt, {
-      ...generationOptions,
-    });
-    return extractGeneratedText(result);
-  }
-
-  private loadPipeline(modelId: string, options?: { onProgress?: (progress: number) => void }) {
-    const existingPipeline = this.pipelines.get(modelId);
-    if (existingPipeline) return existingPipeline;
-
-    const pipelinePromise = import('@huggingface/transformers').then(async ({ env, pipeline }) => {
-      env.useBrowserCache = true;
-      env.cacheKey = TRANSFORMERS_CACHE_KEY;
-      return (await pipeline('text-generation', modelId, {
-        dtype: 'q4',
-        device: 'webgpu',
-        progress_callback: createTransformersProgressCallback(options?.onProgress),
-      })) as unknown as TextGenerationPipeline;
-    });
-    this.pipelines.set(modelId, pipelinePromise);
-    return pipelinePromise;
+  generate(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string> {
+    return this.runtimeClient.generateText(modelId, prompt, options);
   }
 }

--- a/apps/editor/tests/unit/services/browserBackgroundRemovalService.test.ts
+++ b/apps/editor/tests/unit/services/browserBackgroundRemovalService.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, vi } from 'vitest';
 import type { Asset } from '../../../src/domain/model';
 import { BrowserBackgroundRemovalService } from '../../../src/services/browserBackgroundRemovalService';
+import type { BackgroundSegmentationResult } from '../../../src/services/transformersOperations';
 
 type MutableGlobal = typeof globalThis & { ImageData?: typeof ImageData };
 
@@ -89,7 +90,27 @@ describe('BrowserBackgroundRemovalService', () => {
   });
 
   it('does not inherit file storage metadata for generated replacement assets', async () => {
-    const service = new BrowserBackgroundRemovalService();
+    const runtime = {
+      prepareBackgroundRemoval: vi.fn(() => Promise.resolve()),
+      segmentBackgroundRemoval: vi.fn(
+        (): Promise<BackgroundSegmentationResult> =>
+          Promise.resolve({
+            imageInput: {
+              data: new Uint8Array([255, 0, 0, 255]),
+              width: 1,
+              height: 1,
+              channels: 4,
+            },
+            subjectMask: {
+              data: new Uint8Array([1]),
+              width: 1,
+              height: 1,
+              score: 1,
+            },
+          }),
+      ),
+    };
+    const service = new BrowserBackgroundRemovalService(runtime);
     const sourceAsset: Asset = {
       id: 'asset-hero',
       type: 'image',

--- a/apps/editor/tests/unit/services/webGpuTextGenerationRuntime.test.ts
+++ b/apps/editor/tests/unit/services/webGpuTextGenerationRuntime.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { extractGeneratedText } from '../../../src/services/webGpuTextGenerationRuntime';
+import {
+  TransformersRuntimeClient,
+  type TransformersWorkerRequest,
+  type TransformersWorkerResponse,
+} from '../../../src/services/transformersRuntimeClient';
 
 describe('extractGeneratedText', () => {
   it('extracts plain generated text responses', () => {
@@ -17,5 +22,116 @@ describe('extractGeneratedText', () => {
         },
       ]),
     ).toBe('olá');
+  });
+});
+
+describe('TransformersRuntimeClient', () => {
+  class FakeWorker {
+    onmessage: ((event: MessageEvent<TransformersWorkerResponse>) => void) | null = null;
+    onerror: ((event: ErrorEvent) => void) | null = null;
+    messages: TransformersWorkerRequest[] = [];
+    postMessage = vi.fn((message: TransformersWorkerRequest) => {
+      this.messages.push(message);
+    });
+
+    emit(response: TransformersWorkerResponse) {
+      this.onmessage?.({ data: response } as MessageEvent<TransformersWorkerResponse>);
+    }
+  }
+
+  function lastWorkerMessage(worker: FakeWorker) {
+    const message = worker.messages.at(-1);
+    if (!message) throw new Error('Expected the worker to receive a message.');
+    return message;
+  }
+
+  it('preloads text generation through the worker and forwards progress', async () => {
+    const worker = new FakeWorker();
+    const client = new TransformersRuntimeClient({
+      createWorker: () => worker as unknown as Worker,
+    });
+    const progress: number[] = [];
+
+    const preloadPromise = client.preloadTextGeneration('model-id', {
+      onProgress: (value) => progress.push(value),
+    });
+    const message = lastWorkerMessage(worker);
+    expect(message).toEqual({
+      id: message.id,
+      modelId: 'model-id',
+      type: 'preload-text-generation',
+    });
+
+    worker.emit({ id: message.id, progress: 48, type: 'progress' });
+    worker.emit({ id: message.id, type: 'result' });
+
+    await expect(preloadPromise).resolves.toBeUndefined();
+    expect(progress).toEqual([48]);
+  });
+
+  it('returns generated text from the worker', async () => {
+    const worker = new FakeWorker();
+    const client = new TransformersRuntimeClient({
+      createWorker: () => worker as unknown as Worker,
+    });
+
+    const generatePromise = client.generateText('model-id', 'hello', { max_new_tokens: 32 });
+    const message = lastWorkerMessage(worker);
+    expect(message).toEqual({
+      id: message.id,
+      modelId: 'model-id',
+      options: { max_new_tokens: 32 },
+      prompt: 'hello',
+      type: 'generate-text',
+    });
+
+    worker.emit({ id: message.id, result: 'olá', type: 'result' });
+
+    await expect(generatePromise).resolves.toBe('olá');
+  });
+
+  it('returns language detection results from the worker', async () => {
+    const worker = new FakeWorker();
+    const client = new TransformersRuntimeClient({
+      createWorker: () => worker as unknown as Worker,
+    });
+
+    const detectionPromise = client.detectLanguage('detector-id', 'Bonjour');
+    const message = lastWorkerMessage(worker);
+    expect(message).toEqual({
+      id: message.id,
+      modelId: 'detector-id',
+      text: 'Bonjour',
+      type: 'detect-language',
+    });
+
+    worker.emit({ id: message.id, result: { language: 'fr', score: 0.99 }, type: 'result' });
+
+    await expect(detectionPromise).resolves.toEqual({ language: 'fr', score: 0.99 });
+  });
+
+  it('returns background segmentation results from the worker', async () => {
+    const worker = new FakeWorker();
+    const client = new TransformersRuntimeClient({
+      createWorker: () => worker as unknown as Worker,
+    });
+    const points = [{ x: 0.5, y: 0.5, positive: true }];
+    const segmentation = {
+      imageInput: { data: new Uint8Array([255, 0, 0, 255]), width: 1, height: 1, channels: 4 },
+      subjectMask: { data: new Uint8Array([1]), width: 1, height: 1, score: 1 },
+    };
+
+    const segmentationPromise = client.segmentBackgroundRemoval('blob:source', points);
+    const message = lastWorkerMessage(worker);
+    expect(message).toEqual({
+      id: message.id,
+      objectUrl: 'blob:source',
+      points,
+      type: 'segment-background-removal',
+    });
+
+    worker.emit({ id: message.id, result: segmentation, type: 'result' });
+
+    await expect(segmentationPromise).resolves.toEqual(segmentation);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a shared worker-backed Transformers runtime for Gemma prompt generation, TranslateGemma, language detection, and model setup preloads.
- Moves SAM background-removal model work into the worker while keeping canvas/object URL assembly on the main thread.
- Removes implicit main-thread Bonsai and Transformers fallbacks so production emits one ML runtime chunk per worker graph.

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build:editor
- Browser-verified production preview at http://localhost:4173/editor/ with the AI Tools panel open and no console warnings/errors.

## Notes
- The PR is draft by default for review.
- Workers are now required for local ML workflows unless tests inject an explicit fallback runtime.