### PR TITLE
[codex] Add TypeScript SRP coding skill

### DIFF
--- a/.agents/skills/typescript-srp-code/SKILL.md
+++ b/.agents/skills/typescript-srp-code/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: typescript-srp-code
+description: Create, edit, review, or refactor any JavaScript or TypeScript code. Use for TS/JS implementation, bug fixes, tests, React components, hooks, services, domain logic, utilities, config helpers, module organization, imports/exports, performance work, JavaScript runtime internals, Web Streams, Web Workers, secure code, and LocalStudio source changes. Applies strict SRP by default: one public value export per file, colocated types, direct imports, and no barrel files.
+---
+
+# TypeScript SRP Code
+
+## Overview
+
+Apply strict SRP-oriented source organization for JavaScript and TypeScript code. Keep behavior scoped by context, keep file ownership obvious, and avoid broad shared files that create merge conflicts.
+
+## Core Rules
+
+- Inspect the nearest existing context folder before adding or moving code.
+- Put each implementation in the context folder that owns its behavior.
+- Keep at most one public value export per source file.
+- Export owned types and interfaces from the same source file as their implementation.
+- Do not create `index.ts` barrels or multi-value re-export files.
+- Import directly from the owning source file instead of looping through aggregate modules.
+- For related runtime constants, export one cohesive typed object instead of many named constants.
+- Keep source moves behavior-preserving unless the user explicitly asks for behavior changes.
+
+## Quality Gates
+
+- Maintainability: one value export, direct imports, colocated owned types, and context folders.
+- Performance: avoid needless work, avoid accidental quadratic paths, avoid main-thread blocking, and avoid unbounded buffering.
+- Platform fit: use streams, workers, abort signals, transferables, and browser primitives when they match the problem.
+- Security: validate external input, avoid unsafe execution or injection, and keep secrets out of client code.
+- Verification: add or run tests, benchmarks, or profiling checks that match the risk of the change.
+
+## Workflow
+
+1. Check the current tree, package scripts, and relevant tests before editing.
+2. Choose the existing context folder by responsibility; create a new context folder only when no existing one fits.
+3. Add or move files so scoped roots do not mix loose implementation files with module folders.
+4. Keep implementation files narrow: one exported class, function, hook, component, service, object, or constant collection.
+5. Keep types colocated when they describe that file's exported value; move shared types only when they are truly owned by a shared concept.
+6. Update imports to direct source paths after moves.
+7. Add or update organization tests when a structural rule needs enforcement.
+8. Run focused tests first, then broader verification appropriate to the change.
+
+## References
+
+- Read `references/localstudio-contexts.md` before editing source organization in this repo.
+- Read `references/performance.md` for performance-sensitive code, render paths, hot loops, async fanout, or large data handling.
+- Read `references/javascript-internals.md` when runtime behavior matters: event loop, microtasks, memory retention, object shapes, deopts, or module loading.
+- Read `references/web-streams.md` when handling large or incremental data, downloads, uploads, transforms, backpressure, or cancellation.
+- Read `references/web-workers.md` when moving CPU-bound work off the main thread or defining worker message contracts.
+- Read `references/secure-typescript.md` when code touches user input, HTML/URLs, storage, auth, permissions, secrets, serialization, or privileged browser APIs.
+
+## LocalStudio Reference
+
+When working in this repo, read `references/localstudio-contexts.md` before editing source organization.

--- a/.agents/skills/typescript-srp-code/agents/openai.yaml
+++ b/.agents/skills/typescript-srp-code/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TypeScript SRP Code"
+  short_description: "TypeScript SRP, context folders, and direct imports."
+  default_prompt: "Use $typescript-srp-code to create or refactor JavaScript/TypeScript code with one value export per file, context folders, and direct imports."

--- a/.agents/skills/typescript-srp-code/references/javascript-internals.md
+++ b/.agents/skills/typescript-srp-code/references/javascript-internals.md
@@ -1,0 +1,38 @@
+# JavaScript Internals
+
+Use this reference when JavaScript runtime behavior affects correctness, responsiveness, memory, or performance.
+
+## Event Loop
+
+- Know whether work runs in a task, microtask, animation frame, idle callback, or worker.
+- Avoid unbounded microtask chains; they can starve rendering and input.
+- Use `requestAnimationFrame` for visual updates that should align with paint.
+- Use chunking, yielding, workers, or streams for long-running CPU work.
+- Propagate cancellation with `AbortSignal` across async boundaries.
+
+## Promises And Concurrency
+
+- Avoid uncontrolled `Promise.all` over large or user-sized inputs.
+- Preserve error handling and cancellation when adding concurrency.
+- Prefer explicit concurrency limits for network, filesystem, model, and image work.
+- Avoid fire-and-forget promises unless failures are intentionally contained and logged.
+
+## Runtime Shapes
+
+- Keep hot objects monomorphic when possible: initialize the same fields in the same order.
+- Avoid mixing unrelated value types in hot arrays or object fields.
+- Avoid megamorphic call sites in hot code by keeping stable function and object shapes.
+- Treat proxies, dynamic property access, and `delete` as potentially expensive in tight loops.
+
+## Memory
+
+- Watch closures that retain large objects, DOM nodes, buffers, images, canvas data, or model outputs.
+- Clean up event listeners, timers, object URLs, observers, streams, and workers.
+- Prefer transferables for large `ArrayBuffer` payloads across worker boundaries.
+- Avoid retaining whole source documents when only a small normalized representation is needed.
+
+## Modules
+
+- Use static imports for core dependencies and dynamic imports for true feature, route, or heavy-runtime boundaries.
+- Keep side effects explicit and localized.
+- Avoid import cycles; direct imports should still point from consumer to owner without looping through barrels.

--- a/.agents/skills/typescript-srp-code/references/localstudio-contexts.md
+++ b/.agents/skills/typescript-srp-code/references/localstudio-contexts.md
@@ -1,0 +1,36 @@
+# LocalStudio Contexts
+
+Use this reference when working inside the LocalStudio `canva-webai-clone` repo.
+
+## Source Of Truth
+
+- `apps/editor/tests/unit/testOrganization.test.ts` enforces the source organization rules.
+- Keep tests out of `src`.
+- Keep at most one public value export per source file.
+- Allow `export type` and `export interface` when they describe the owning implementation.
+- Reject `index.ts` barrels and value re-export loop-through files.
+- Reject loose implementation files directly under scoped module roots.
+
+## Editor Source Contexts
+
+- App routing: `apps/editor/src/app/routing`.
+- Domain concepts: `apps/editor/src/domain/assets`, `documents`, `generated-slides`, `images`, and `projects`.
+- Domain commands: `apps/editor/src/domain/commands/elements`, `generated-slides`, and `shared`.
+- Services: `apps/editor/src/services/automation`, `background-removal`, `browser`, `contracts`, `exporting`, `ids`, `image-generation`, `mirror`, `model-setup`, `prompting`, `sharing`, `storage`, `testing`, `translation`, and `webmcp`.
+- Editor UI: `apps/editor/src/ui/editor/animation`, `background-selection`, `browser`, `canvas`, `media`, `panels`, `persistence`, `prompting`, `shell`, `state`, `text`, `toolbars`, and `translation`.
+- Shared UI areas: `apps/editor/src/ui/components`, `setup`, `share`, and `webmcp`.
+- Vendor code stays under `apps/editor/src/vendor` and should not absorb app-owned abstractions.
+
+## Landing And Packages
+
+- Landing route helpers live under `apps/landing/src/routing`.
+- Add new landing content, layout, feature, or workflow code under explicit context folders instead of loose files when the feature grows beyond a single owner.
+- Package source roots such as `packages/brand/src` follow the same one-value-export and direct-import rules.
+
+## Verification Commands
+
+- `npm run test --workspace @localstudio/editor -- tests/unit/testOrganization.test.ts`
+- `npm run typecheck`
+- `npm run lint`
+- `npm test`
+- `npm run build`

--- a/.agents/skills/typescript-srp-code/references/performance.md
+++ b/.agents/skills/typescript-srp-code/references/performance.md
@@ -1,0 +1,40 @@
+# Performance
+
+Use this reference for JavaScript and TypeScript changes that can affect latency, memory, throughput, bundle size, startup, rendering, or large data handling.
+
+## Defaults
+
+- Measure first when practical: identify the hot path, expected scale, and user-visible symptom.
+- Keep optimizations behavior-preserving and covered by tests.
+- Prefer simple data flow until profiling shows the code is hot.
+- Avoid moving work into shared abstractions when the cost or ownership differs by context.
+
+## Code Shape
+
+- Avoid accidental `O(n^2)` work in reducers, nested loops, diffing, filtering, sorting, and render-derived data.
+- Avoid repeated parsing, regex compilation, object cloning, JSON serialization, or expensive formatting inside hot loops.
+- Prefer `Map` or `Set` for repeated keyed lookup when input size makes linear scans meaningful.
+- Cache only when invalidation is obvious; stale caches are usually worse than recomputation.
+- Keep frequently created objects stable in shape. Initialize fields consistently instead of adding ad hoc properties later.
+- Avoid unnecessary closures, bound functions, and intermediate arrays in hot paths.
+
+## UI And Browser
+
+- Keep CPU-heavy work off the main thread when it can block input, animation, canvas, or rendering.
+- Batch state updates and DOM reads/writes. Avoid layout thrashing.
+- Memoize React values only when it reduces real work or stabilizes expensive child renders.
+- Use virtualization or pagination for large lists.
+- Use dynamic imports at real feature or route boundaries, not as scattered micro-splits.
+
+## Async And Data
+
+- Bound concurrency for network, file, model, and transform work.
+- Prefer streaming for large payloads; do not buffer full data unless the full value is required.
+- Use `AbortSignal` for cancellable work started by user interaction or route changes.
+- Release references to large buffers, blobs, images, canvases, or model outputs when they are no longer needed.
+
+## Verification
+
+- For small changes, add focused tests around the optimized behavior.
+- For hot code, include a benchmark, profile note, or before/after timing when feasible.
+- Check memory growth when touching long-lived caches, workers, streams, object URLs, or browser storage.

--- a/.agents/skills/typescript-srp-code/references/secure-typescript.md
+++ b/.agents/skills/typescript-srp-code/references/secure-typescript.md
@@ -1,0 +1,38 @@
+# Secure TypeScript
+
+Use this reference when code touches user input, HTML, URLs, storage, auth, permissions, secrets, serialization, network calls, files, or privileged browser APIs.
+
+## Boundary Rules
+
+- Validate all external input at the boundary: network, storage, URL params, postMessage, worker messages, files, clipboard, drag-and-drop, and third-party SDKs.
+- Prefer allowlists over denylists for commands, MIME types, origins, protocols, and fields.
+- Treat browser storage as untrusted; parse and validate before use.
+- Keep validation close to the boundary and pass typed, normalized values inward.
+
+## Browser Safety
+
+- Avoid `eval`, `new Function`, dynamic script injection, and string-based timers.
+- Avoid unsafe HTML injection. If HTML is required, sanitize with a vetted sanitizer and keep the trust boundary explicit.
+- Restrict URL protocols to expected values before navigation, linking, fetches, downloads, or embeds.
+- Validate `postMessage` origin and payload shape.
+- Revoke object URLs and avoid leaking sensitive data through URLs, logs, crash reports, analytics, or local storage.
+
+## Secrets And Privilege
+
+- Never put secrets, private tokens, service credentials, or privileged keys in frontend bundles.
+- Keep privileged operations behind explicit capability interfaces.
+- Make permission checks server-side or platform-enforced when trust matters.
+- Avoid broad ambient authority; pass the narrow capability needed for the operation.
+
+## Data And Serialization
+
+- Parse JSON defensively and handle schema mismatches.
+- Avoid prototype pollution through untrusted object keys such as `__proto__`, `constructor`, or `prototype`.
+- Be careful with recursive parsing, decompression, and large files; set size and depth limits where practical.
+- Preserve escaping when generating HTML, Markdown, shell commands, SQL, file paths, or URLs.
+
+## Verification
+
+- Add tests for malformed input, unsafe protocols, disallowed origins, missing permissions, and storage corruption.
+- Review logs and error paths for secret or user-data leakage.
+- Check dependency changes for new network, filesystem, eval, or native-code behavior.

--- a/.agents/skills/typescript-srp-code/references/web-streams.md
+++ b/.agents/skills/typescript-srp-code/references/web-streams.md
@@ -1,0 +1,30 @@
+# Web Streams
+
+Use this reference for large, incremental, or cancellable data flows in browser JavaScript.
+
+## When To Use Streams
+
+- Use streams for large downloads, uploads, generated content, model output, file transforms, compression, decoding, or progress reporting.
+- Do not convert to `string`, `Blob`, `ArrayBuffer`, or JSON until the full value is genuinely required.
+- Prefer a stream pipeline over manual buffering when each step can operate incrementally.
+
+## Design Rules
+
+- Respect backpressure. Do not enqueue without considering `desiredSize` or downstream consumption.
+- Use `TransformStream` for reusable decode, parse, filter, map, progress, or serialization steps.
+- Use `AbortSignal` and `cancel()` paths for user cancellation, route changes, failed downstream work, and timeouts.
+- Release readers and close controllers in success and error paths.
+- Keep stream ownership clear: one file should own the exported stream creator or transform plus its colocated types.
+
+## Common Patterns
+
+- Text decoding: prefer `TextDecoderStream` when supported, or a single `TextDecoder` with streaming decode.
+- Progress: count bytes in a transform instead of buffering chunks.
+- Compression: use `CompressionStream` and `DecompressionStream` when the target browsers support them.
+- Fanout: use `tee()` only when both branches are consumed and cancellation behavior is understood.
+
+## Failure Modes
+
+- Watch for accidental full buffering through `Response.text()`, `Response.blob()`, `new Blob(chunks)`, or array accumulation.
+- Avoid ignoring read errors; stream failures often represent network, decode, or cancellation states.
+- Avoid unbounded queues between producers and consumers.

--- a/.agents/skills/typescript-srp-code/references/web-workers.md
+++ b/.agents/skills/typescript-srp-code/references/web-workers.md
@@ -1,0 +1,36 @@
+# Web Workers
+
+Use this reference when JavaScript or TypeScript work can block the main thread or should be isolated by capability.
+
+## When To Use Workers
+
+- Move CPU-heavy parsing, image processing, model inference, compression, search, indexing, or batch transforms off the main thread.
+- Keep UI orchestration, DOM access, and rendering decisions on the main thread.
+- Use one worker module per capability; do not create a general catch-all worker.
+
+## Message Contracts
+
+- Define typed request, response, progress, error, and cancellation messages.
+- Colocate worker-specific message types with the worker entrypoint or the single owner of the worker client.
+- Version message contracts if persisted, shared externally, or used across independently deployed bundles.
+- Treat worker messages as boundary input: validate shape before trusting it.
+
+## Data Transfer
+
+- Prefer transferables for large `ArrayBuffer`, `MessagePort`, `ImageBitmap`, or `OffscreenCanvas` payloads.
+- Avoid structured cloning large nested objects when a compact transferable representation is possible.
+- Do not transfer a buffer that the sender still needs.
+- Keep serialization costs in mind when deciding whether work belongs in a worker.
+
+## Lifecycle
+
+- Own worker creation, cancellation, error handling, and termination in one narrow module.
+- Terminate idle or abandoned workers when the feature lifetime ends.
+- Propagate `AbortSignal` into worker protocols when work can be canceled.
+- Handle worker startup errors and unsupported-browser fallback paths.
+
+## Verification
+
+- Test success, error, cancellation, and termination paths.
+- Check that large payloads are transferred or streamed rather than repeatedly cloned.
+- Verify UI responsiveness for the motivating workflow.


### PR DESCRIPTION
## Summary

- Adds a project-local `.agents/skills/typescript-srp-code` skill for JavaScript and TypeScript work.
- Broadens the skill trigger so ordinary TS/JS implementation, tests, React code, services, utilities, and config helpers use the SRP guidance by default.
- Documents maintainability rules: one public value export per file, colocated owned types, direct imports, context folders, and no barrels.
- Adds focused references for LocalStudio contexts, performance, JavaScript internals, Web Streams, Web Workers, and secure TypeScript.

## Validation

- Manual skill structure check passed.
- GitHub compare verified this branch is skill-only: 1 commit, 8 added files, 0 commits behind `main`.
- `python3 .../quick_validate.py .agents/skills/typescript-srp-code` was attempted but blocked by missing `PyYAML` in the available Python environment.
- `npm run test --workspace @localstudio/editor -- tests/unit/testOrganization.test.ts` was attempted earlier in this worktree but blocked by missing workspace dependencies: `vitest: command not found`.