### PR TITLE
Add Save As support and mirror settings toggles

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -2810,6 +2810,30 @@ button {
   gap: 8px;
 }
 
+.mirror-settings-toggle-danger {
+  border-color: rgba(255, 95, 86, 0.46);
+  background: rgba(255, 95, 86, 0.12);
+  color: #ff9a94;
+}
+
+.mirror-settings-toggle-danger:hover {
+  border-color: rgba(255, 95, 86, 0.72);
+  background: rgba(255, 95, 86, 0.2);
+  color: #ffc5c1;
+}
+
+.mirror-settings-toggle-success {
+  border-color: rgba(55, 253, 118, 0.42);
+  background: rgba(55, 253, 118, 0.12);
+  color: var(--ew-green);
+}
+
+.mirror-settings-toggle-success:hover {
+  border-color: rgba(55, 253, 118, 0.68);
+  background: rgba(55, 253, 118, 0.2);
+  color: var(--ew-green-fixed);
+}
+
 .remote-import-status {
   margin: 0;
   color: var(--ew-muted);

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -44,6 +44,10 @@ export interface ProjectRepository {
   importMirrorFiles?(files: MirrorFile[]): Promise<ProjectDocument>;
   loadProject(options?: { projectName?: string }): Promise<ProjectDocument | null>;
   saveProject(project: ProjectDocument, options?: { projectDirectoryName?: string }): Promise<void>;
+  saveProjectAs?(
+    project: ProjectDocument,
+    options?: { projectDirectoryName?: string },
+  ): Promise<void>;
   getVersionHistory?(): Promise<VersionHistoryEntry[]>;
   saveVersion?(
     project: ProjectDocument,

--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -210,6 +210,16 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     }
   }
 
+  async saveProjectAs(
+    project: ProjectDocument,
+    options?: { projectDirectoryName?: string },
+  ): Promise<void> {
+    this.directoryHandle = null;
+    this.parentDirectoryHandle = null;
+    this.projectDirectoryName = null;
+    await this.saveProject(project, options);
+  }
+
   async getVersionHistory(): Promise<VersionHistoryEntry[]> {
     const directoryHandle = await this.ensureProjectDirectory();
     const manifest = await this.readVersionHistoryManifest(directoryHandle);

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -5,7 +5,9 @@ import type { MinioMirrorConfig } from '../../../services/mirror/minioMirrorServ
 interface MirrorSettingsPanelProps {
   config: MinioMirrorConfig;
   mirrorState: MirrorState;
+  mirrorDisabledBySettings?: boolean;
   onClose: () => void;
+  onEnabledChange: (enabled: boolean) => void;
   onSave: (config: MinioMirrorConfig) => void;
   onTestConnection: (config: MinioMirrorConfig) => void | Promise<void>;
 }
@@ -13,7 +15,9 @@ interface MirrorSettingsPanelProps {
 export function MirrorSettingsPanel({
   config,
   mirrorState,
+  mirrorDisabledBySettings = false,
   onClose,
+  onEnabledChange,
   onSave,
   onTestConnection,
 }: MirrorSettingsPanelProps) {
@@ -209,11 +213,19 @@ export function MirrorSettingsPanel({
       </div>
 
       <div className="mirror-settings-actions">
+        <button
+          className={mirrorState.enabled ? 'footer-toggle' : 'footer-toggle footer-toggle-active'}
+          type="button"
+          onClick={() => onEnabledChange(!mirrorState.enabled)}
+        >
+          {mirrorState.enabled ? 'Disable mirroring' : 'Enable mirroring'}
+        </button>
         <button className="footer-toggle" type="button" onClick={() => void testConnection()}>
           {connectionStatus === 'testing' ? 'Checking MinIO connection...' : 'Test connection'}
         </button>
         <button
           className="export-button font-orbitron"
+          disabled={mirrorDisabledBySettings}
           type="button"
           onClick={() => onSave(normalizedDraft())}
         >

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -214,9 +214,17 @@ export function MirrorSettingsPanel({
 
       <div className="mirror-settings-actions">
         <button
-          className={mirrorState.enabled ? 'footer-toggle' : 'footer-toggle footer-toggle-active'}
+          className={
+            mirrorState.enabled
+              ? 'footer-toggle mirror-settings-toggle-danger'
+              : 'footer-toggle mirror-settings-toggle-success'
+          }
           type="button"
-          onClick={() => onEnabledChange(!mirrorState.enabled)}
+          onClick={() => {
+            const nextEnabled = !mirrorState.enabled;
+            onEnabledChange(nextEnabled);
+            if (nextEnabled) void testConnection();
+          }}
         >
           {mirrorState.enabled ? 'Disable mirroring' : 'Enable mirroring'}
         </button>

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -281,6 +281,7 @@ export function EditorShell({ services }: EditorShellProps) {
         publicSharingAvailable={publicSharingAvailable}
         publicSharingUnavailableReason={publicSharingUnavailableReason}
         mirrorState={vm.mirrorState}
+        mirrorDisabledBySettings={vm.mirrorDisabledBySettings}
         persistenceAttention={vm.persistenceAttention}
         persistenceNotice={vm.persistenceNotice}
         localProjectSetupPanel={
@@ -311,6 +312,7 @@ export function EditorShell({ services }: EditorShellProps) {
         }}
         onMirrorToggle={vm.setMirrorEnabled}
         onNewProject={openBlankProjectInNewTab}
+        onOpenMirrorSettings={vm.openMirrorSettings}
         onOpenVersionHistory={() => {
           void vm.openVersionHistory();
         }}
@@ -330,6 +332,9 @@ export function EditorShell({ services }: EditorShellProps) {
         onStartPresenterMode={startPresenterMode}
         onSaveLocal={() => {
           void vm.saveLocalNow();
+        }}
+        onSaveLocalAs={() => {
+          void vm.saveLocalAs();
         }}
         onTranslateDeck={
           isHistoryReadOnly
@@ -631,7 +636,9 @@ export function EditorShell({ services }: EditorShellProps) {
         <MirrorSettingsPanel
           config={vm.mirrorConfig}
           mirrorState={vm.mirrorState}
+          mirrorDisabledBySettings={vm.mirrorDisabledBySettings}
           onClose={vm.closeMirrorSettings}
+          onEnabledChange={vm.setMirrorEnabledFromSettings}
           onSave={vm.saveMirrorConfig}
           onTestConnection={vm.testMirrorConnection}
         />

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -422,6 +422,7 @@ export function useEditorViewModel(services: AppServices) {
   }));
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [mirrorSettingsOpen, setMirrorSettingsOpen] = useState(false);
+  const [mirrorDisabledBySettings, setMirrorDisabledBySettings] = useState(false);
   const [remoteImportOpen, setRemoteImportOpen] = useState(false);
   const [localProjectSetupOpen, setLocalProjectSetupOpen] = useState(false);
   const [persistenceAttention, setPersistenceAttention] = useState(false);
@@ -1390,6 +1391,39 @@ export function useEditorViewModel(services: AppServices) {
     }
   }
 
+  async function saveLocalAs() {
+    const projectToSave = projectRef.current;
+    try {
+      if (services.projectRepository.saveProjectAs) {
+        await services.projectRepository.saveProjectAs(projectToSave, {
+          projectDirectoryName: projectToSave.name,
+        });
+      } else {
+        await services.projectRepository.saveProject(projectToSave, {
+          projectDirectoryName: projectToSave.name,
+        });
+      }
+      lastVersionProjectRef.current = projectToSave;
+      setHasPersistedLocalProject(true);
+      setPersistenceEnabled(true);
+      setPersistenceAttention(false);
+      setPersistenceNotice(undefined);
+      setLocalProjectSetupOpen(false);
+      setLastEditedAt(projectToSave.updatedAt);
+      setSaveAnimationKey((current) => current + 1);
+      skipNextProjectSaveRef.current = true;
+      writeProjectNameToUrl(projectToSave.name);
+      if (typeof window !== 'undefined') {
+        editorPreferences.writePersistencePreference(true);
+      }
+    } catch {
+      setPersistenceEnabled(false);
+      if (typeof window !== 'undefined') {
+        editorPreferences.writePersistencePreference(false);
+      }
+    }
+  }
+
   function closeLocalProjectSetup() {
     setLocalProjectSetupOpen(false);
   }
@@ -1491,22 +1525,30 @@ export function useEditorViewModel(services: AppServices) {
     services.mirrorService.saveConfig(config);
     setMirrorConfig(config);
     setHasMirrorConfig(true);
+    setMirrorDisabledBySettings(false);
     mirrorConfigRef.current = config;
     setMirrorState({ enabled: true, status: 'idle' });
+    setMirrorSettingsOpen(false);
     void syncMirrorNow();
   }
 
-  function setMirrorEnabled(enabled: boolean) {
+  function setMirrorEnabled(enabled: boolean, options?: { fromSettings?: boolean }) {
     if (enabled) {
       if (!mirrorConfigRef.current) {
         openMirrorSettings();
         return;
       }
+      setMirrorDisabledBySettings(false);
       setMirrorState({ enabled: true, status: 'idle' });
       void syncMirrorNow();
       return;
     }
+    setMirrorDisabledBySettings(Boolean(options?.fromSettings));
     setMirrorState({ enabled: false, status: 'disabled' });
+  }
+
+  function setMirrorEnabledFromSettings(enabled: boolean) {
+    setMirrorEnabled(enabled, { fromSettings: true });
   }
 
   async function testMirrorConnection(config: MinioMirrorConfig) {
@@ -2955,6 +2997,7 @@ export function useEditorViewModel(services: AppServices) {
     persistenceAttention,
     persistenceNotice,
     mirrorState,
+    mirrorDisabledBySettings,
     mirrorConfig,
     settingsOpen,
     mirrorSettingsOpen,
@@ -2986,6 +3029,7 @@ export function useEditorViewModel(services: AppServices) {
     setProjectName,
     setPersistence,
     saveLocalNow,
+    saveLocalAs,
     closeLocalProjectSetup,
     confirmLocalProjectSetup,
     openSettings,
@@ -2997,6 +3041,7 @@ export function useEditorViewModel(services: AppServices) {
     syncMirrorNow,
     requestMirrorNow,
     setMirrorEnabled,
+    setMirrorEnabledFromSettings,
     importRemoteMirror,
     importRemoteMirrorProject,
     closeRemoteImport,

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -16,6 +16,7 @@ interface TopToolbarProps {
   publicSharingUnavailableReason?: string;
   lastEditedAt?: string | undefined;
   mirrorState?: MirrorState;
+  mirrorDisabledBySettings?: boolean;
   localProjectSetupPanel?: ReactNode;
   persistenceAttention?: boolean;
   persistenceNotice?: string | undefined;
@@ -27,10 +28,12 @@ interface TopToolbarProps {
   onImportRemoteMirror?: (() => void) | undefined;
   onMirrorNow?: (() => void) | undefined;
   onMirrorToggle?: ((enabled: boolean) => void) | undefined;
+  onOpenMirrorSettings?: (() => void) | undefined;
   onOpenVersionHistory?: (() => void) | undefined;
   onNewProject?: (() => void) | undefined;
   onPersistenceToggle?: ((enabled: boolean) => void) | undefined;
   onSaveLocal?: (() => void) | undefined;
+  onSaveLocalAs?: (() => void) | undefined;
   onProjectNameChange?: ((name: string) => void) | undefined;
   onRedo?: (() => void) | undefined;
   onResetZoom?: (() => void) | undefined;
@@ -116,6 +119,7 @@ export function TopToolbar({
   publicSharingUnavailableReason = 'Public sharing requires active external storage.',
   lastEditedAt,
   mirrorState = { enabled: false, status: 'disabled' },
+  mirrorDisabledBySettings = false,
   localProjectSetupPanel,
   persistenceAttention = false,
   persistenceNotice,
@@ -127,6 +131,7 @@ export function TopToolbar({
   onImportRemoteMirror,
   onMirrorNow,
   onMirrorToggle,
+  onOpenMirrorSettings,
   onOpenVersionHistory,
   onNewProject,
   onPersistenceToggle,
@@ -137,6 +142,7 @@ export function TopToolbar({
   onShare,
   onStartPresenterMode,
   onSaveLocal,
+  onSaveLocalAs,
   onTranslateDeck,
   onUndo,
   onZoomIn,
@@ -190,6 +196,7 @@ export function TopToolbar({
       { label: 'Share', disabled: !publicSharingAvailable, onSelect: triggerShare },
       { kind: 'separator', label: 'File storage actions' },
       { label: 'Save', disabled: !onSaveLocal, onSelect: onSaveLocal },
+      { label: 'Save As...', disabled: !onSaveLocalAs, onSelect: onSaveLocalAs },
       { label: 'Mirror Now', disabled: !onMirrorNow, onSelect: onMirrorNow },
     ],
     Edit: [
@@ -460,6 +467,10 @@ export function TopToolbar({
             type="button"
             aria-label={mirrorStatusLabel}
             onClick={() => {
+              if (mirrorDisabledBySettings) {
+                onOpenMirrorSettings?.();
+                return;
+              }
               if (mirrorState.enabled) {
                 onMirrorToggle?.(false);
                 return;

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
@@ -159,6 +159,34 @@ describe('BrowserFileSystemProjectRepository', () => {
     });
   });
 
+  it('prompts for a new parent folder when saving a project as another local folder', async () => {
+    const firstParentDirectory = new MockDirectoryHandle('First Projects');
+    const secondParentDirectory = new MockDirectoryHandle('Second Projects');
+    const pickDirectory = vi
+      .fn()
+      .mockResolvedValueOnce(firstParentDirectory as unknown as FileSystemDirectoryHandle)
+      .mockResolvedValueOnce(secondParentDirectory as unknown as FileSystemDirectoryHandle);
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory,
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+    const project = { ...sampleProject.createSampleProject(), name: 'Launch Deck' };
+
+    await repository.saveProject(project, { projectDirectoryName: project.name });
+    await repository.saveProjectAs(project, { projectDirectoryName: project.name });
+
+    expect(pickDirectory).toHaveBeenCalledTimes(2);
+    expect(firstParentDirectory.directories.get('Launch Deck')).toBeDefined();
+    expect(secondParentDirectory.directories.get('Launch Deck')).toBeDefined();
+    expect(
+      JSON.parse(
+        await readMockText(
+          secondParentDirectory.directories.get('Launch Deck')!.files.get('project.json')!,
+        ),
+      ),
+    ).toMatchObject({ name: 'Launch Deck' });
+  });
+
   it('moves a persisted project into a renamed child folder when the project name changes', async () => {
     const parentDirectory = new MockDirectoryHandle('Projects');
     const repository = new BrowserFileSystemProjectRepository({

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -84,6 +84,7 @@ class RejectingLoadProjectRepository implements ProjectRepository {
 
 class SavingProjectRepository implements ProjectRepository {
   savedProjects: ProjectDocument[] = [];
+  savedProjectsAs: ProjectDocument[] = [];
 
   loadProject(): Promise<ProjectDocument | null> {
     return Promise.resolve(null);
@@ -91,6 +92,11 @@ class SavingProjectRepository implements ProjectRepository {
 
   saveProject(project: ProjectDocument): Promise<void> {
     this.savedProjects.push(project);
+    return Promise.resolve();
+  }
+
+  saveProjectAs(project: ProjectDocument): Promise<void> {
+    this.savedProjectsAs.push(project);
     return Promise.resolve();
   }
 }
@@ -633,6 +639,20 @@ describe('EditorShell', () => {
     expect(repository.savedProjects.at(-1)?.name).toBe('Autosaved Deck');
   });
 
+  it('saves the current project as a new local folder from the File menu', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new SavingProjectRepository();
+    services.projectRepository = repository;
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Save As...' }));
+
+    expect(repository.savedProjectsAs).toHaveLength(1);
+    expect(repository.savedProjectsAs[0]).toMatchObject({ name: 'Untitled AI Deck' });
+  });
+
   it('keeps persistence disabled when the project folder cannot be saved', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
@@ -735,7 +755,7 @@ describe('EditorShell', () => {
     );
   });
 
-  it('disables mirroring when the mirror status icon is clicked', async () => {
+  it('toggles mirroring from the mirror status icon when a saved config is available', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
     const mirrorService = new RecordingMirrorService();
@@ -765,6 +785,40 @@ describe('EditorShell', () => {
       expect(mirrorService.syncProject).toHaveBeenCalledTimes(2);
     });
     expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toBeInTheDocument();
+  });
+
+  it('opens mirror settings from the disabled mirror icon after mirroring is disabled in settings', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new DeferredLoadingProjectRepository();
+    services.projectRepository = repository;
+    services.mirrorService = new RecordingMirrorService();
+    render(<EditorShell services={services} />);
+
+    act(() => {
+      repository.resolveLoadedProject({
+        ...services.initialProject,
+        name: 'Mirrored Folder',
+      });
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Mirror settings' }));
+    await user.click(within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+      name: 'Mirror settings',
+    }));
+    await user.click(screen.getByRole('button', { name: 'Disable mirroring' }));
+
+    expect(screen.getByRole('button', { name: 'Mirror disabled' })).toHaveClass('mirror-disabled');
+
+    await user.click(screen.getByRole('button', { name: 'Mirror disabled' }));
+    expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Enable mirroring' }));
+    await user.click(screen.getByRole('button', { name: 'Save settings' }));
+
+    expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toHaveClass(
+      'mirror-synced',
+    );
   });
 
   it('imports an existing project from the File menu', async () => {

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { MirrorSettingsPanel } from '../../../../src/ui/editor/panels/MirrorSettingsPanel';
@@ -27,6 +28,7 @@ describe('MirrorSettingsPanel', () => {
           config={config}
           mirrorState={{ enabled: true, status: 'idle' }}
           onClose={onClose}
+          onEnabledChange={vi.fn()}
           onSave={vi.fn()}
           onTestConnection={vi.fn()}
         />
@@ -49,6 +51,7 @@ describe('MirrorSettingsPanel', () => {
         config={config}
         mirrorState={{ enabled: true, status: 'idle' }}
         onClose={onClose}
+        onEnabledChange={vi.fn()}
         onSave={onSave}
         onTestConnection={onTestConnection}
       />,
@@ -86,5 +89,37 @@ describe('MirrorSettingsPanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'Save settings' }));
     expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ prefix: 'public-projects' }));
+  });
+
+  it('lets users disable mirroring from settings and keeps saving settings disabled while off', async () => {
+    const user = userEvent.setup();
+    const onEnabledChange = vi.fn();
+    const onSave = vi.fn();
+
+    function StatefulMirrorSettingsPanel() {
+      const [enabled, setEnabled] = useState(true);
+      return (
+        <MirrorSettingsPanel
+          config={config}
+          mirrorDisabledBySettings={!enabled}
+          mirrorState={{ enabled, status: enabled ? 'idle' : 'disabled' }}
+          onClose={vi.fn()}
+          onEnabledChange={(nextEnabled) => {
+            setEnabled(nextEnabled);
+            onEnabledChange(nextEnabled);
+          }}
+          onSave={onSave}
+          onTestConnection={vi.fn()}
+        />
+      );
+    }
+
+    render(<StatefulMirrorSettingsPanel />);
+
+    await user.click(screen.getByRole('button', { name: 'Disable mirroring' }));
+
+    expect(onEnabledChange).toHaveBeenCalledWith(false);
+    expect(screen.getByRole('button', { name: 'Save settings' })).toBeDisabled();
+    expect(onSave).not.toHaveBeenCalled();
   });
 });

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -95,6 +95,7 @@ describe('MirrorSettingsPanel', () => {
     const user = userEvent.setup();
     const onEnabledChange = vi.fn();
     const onSave = vi.fn();
+    const onTestConnection = vi.fn(() => Promise.resolve());
 
     function StatefulMirrorSettingsPanel() {
       const [enabled, setEnabled] = useState(true);
@@ -109,17 +110,30 @@ describe('MirrorSettingsPanel', () => {
             onEnabledChange(nextEnabled);
           }}
           onSave={onSave}
-          onTestConnection={vi.fn()}
+          onTestConnection={onTestConnection}
         />
       );
     }
 
     render(<StatefulMirrorSettingsPanel />);
 
+    expect(screen.getByRole('button', { name: 'Disable mirroring' })).toHaveClass(
+      'mirror-settings-toggle-danger',
+    );
+
     await user.click(screen.getByRole('button', { name: 'Disable mirroring' }));
 
     expect(onEnabledChange).toHaveBeenCalledWith(false);
+    expect(screen.getByRole('button', { name: 'Enable mirroring' })).toHaveClass(
+      'mirror-settings-toggle-success',
+    );
     expect(screen.getByRole('button', { name: 'Save settings' })).toBeDisabled();
     expect(onSave).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Enable mirroring' }));
+
+    expect(onEnabledChange).toHaveBeenLastCalledWith(true);
+    expect(onTestConnection).toHaveBeenCalledWith(config);
+    expect(await screen.findByText('Connection is ready.')).toBeInTheDocument();
   });
 });

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -12,6 +12,7 @@ describe('TopToolbar', () => {
     const onImportRemoteMirror = vi.fn();
     const onMirrorNow = vi.fn();
     const onNewProject = vi.fn();
+    const onSaveLocalAs = vi.fn();
     const onSaveLocal = vi.fn();
     const onSelectLayers = vi.fn();
     const onTranslateDeck = vi.fn();
@@ -26,6 +27,7 @@ describe('TopToolbar', () => {
         onMirrorNow={onMirrorNow}
         onNewProject={onNewProject}
         onSaveLocal={onSaveLocal}
+        onSaveLocalAs={onSaveLocalAs}
         onSelectLayers={onSelectLayers}
         onTranslateDeck={onTranslateDeck}
         canTranslateDeck
@@ -48,6 +50,9 @@ describe('TopToolbar', () => {
     expect(screen.getByRole('separator', { name: 'File storage actions' })).toBeInTheDocument();
     await user.click(screen.getByRole('menuitem', { name: 'Save' }));
     expect(onSaveLocal).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Save As...' }));
+    expect(onSaveLocalAs).toHaveBeenCalledTimes(1);
     await user.click(screen.getByRole('button', { name: 'File' }));
     await user.click(screen.getByRole('menuitem', { name: 'Mirror Now' }));
     expect(onMirrorNow).toHaveBeenCalledTimes(1);
@@ -177,6 +182,29 @@ describe('TopToolbar', () => {
     await user.click(mirrorButton);
     expect(onMirrorToggle).toHaveBeenCalledWith(false);
     expect(onMirrorNow).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens mirror settings from the status icon when mirroring was disabled in settings', async () => {
+    const user = userEvent.setup();
+    const onMirrorNow = vi.fn();
+    const onOpenMirrorSettings = vi.fn();
+
+    render(
+      <TopToolbar
+        project={sampleProject.createSampleProject()}
+        language="PT-BR"
+        persistenceEnabled
+        mirrorDisabledBySettings
+        mirrorState={{ enabled: false, status: 'disabled' }}
+        onMirrorNow={onMirrorNow}
+        onOpenMirrorSettings={onOpenMirrorSettings}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Mirror disabled' }));
+
+    expect(onOpenMirrorSettings).toHaveBeenCalledTimes(1);
+    expect(onMirrorNow).not.toHaveBeenCalled();
   });
 
   it('labels deck storage state by persistence and mirror activation', () => {


### PR DESCRIPTION
## Summary
- Add a Save As flow for local projects, including repository support and toolbar access
- Let mirror settings disable and re-enable mirroring from the settings panel
- Update mirror status behavior so disabled mirrors reopen settings instead of toggling directly
- Add state-specific styling for mirror enable and disable controls

## Testing
- Added unit tests for local Save As behavior in the repository, editor shell, mirror settings panel, and top toolbar
- Added UI/state coverage for mirror status interactions when mirroring is disabled from settings