### PR TITLE
Add remote project removal from the editor

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -2824,6 +2824,21 @@ button {
 .remote-import-list {
   display: grid;
   gap: 8px;
+  max-height: 600px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.remote-import-list-item {
+  display: grid;
+  gap: 8px;
+}
+
+.remote-import-row-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 32px;
+  align-items: center;
+  gap: 8px;
 }
 
 .remote-import-row {
@@ -2869,6 +2884,62 @@ button {
   margin-top: 3px;
   color: var(--ew-muted);
   font-size: 11px;
+}
+
+.remote-import-confirm {
+  border: 1px solid rgba(255, 180, 171, 0.26);
+  border-radius: 6px;
+  background: rgba(46, 15, 18, 0.78);
+  padding: 10px;
+}
+
+.remote-import-confirm p {
+  margin: 0;
+  color: var(--ew-text);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.remote-import-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.remote-import-confirm-actions button {
+  min-height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ew-text);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 0 10px;
+}
+
+.remote-import-confirm-actions .danger-button {
+  border-color: rgba(255, 180, 171, 0.42);
+  background: rgba(255, 180, 171, 0.12);
+  color: #ffdad6;
+}
+
+.remote-import-confirm-actions button:hover:not(:disabled),
+.remote-import-confirm-actions button:focus-visible {
+  border-color: rgba(122, 255, 199, 0.38);
+  background: rgba(55, 253, 118, 0.1);
+}
+
+.remote-import-confirm-actions .danger-button:hover:not(:disabled),
+.remote-import-confirm-actions .danger-button:focus-visible {
+  border-color: #ffb4ab;
+  background: rgba(255, 180, 171, 0.18);
+}
+
+.remote-import-confirm-actions button:disabled {
+  cursor: wait;
+  opacity: 0.64;
 }
 
 .prompt-examples {

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -83,6 +83,7 @@ export interface MirrorService<TConfig = unknown> {
   ): Promise<MirrorState>;
   listProjects(config: TConfig): Promise<MirrorProjectSummary[]>;
   downloadProject(projectId: string, config: TConfig): Promise<MirrorFile[]>;
+  deleteProject?(projectId: string, config: TConfig): Promise<void>;
 }
 
 export interface VersionHistoryEntry {

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -53,7 +53,10 @@ function getDefaultFetch() {
 }
 
 function getProjectRoot(config: MinioMirrorConfig, projectKey: string) {
-  return storageObjectUtils.joinObjectKey(storageObjectUtils.normalizeObjectKeyPart(config.prefix), projectKey);
+  return storageObjectUtils.joinObjectKey(
+    storageObjectUtils.normalizeObjectKeyPart(config.prefix),
+    projectKey,
+  );
 }
 
 function getProjectFileKey(config: MinioMirrorConfig, projectKey: string, path: string) {
@@ -65,6 +68,13 @@ function parseMirrorProjects(xml: string) {
   return Array.from(document.querySelectorAll('Contents Key'))
     .map((node) => node.textContent ?? '')
     .filter((key) => key.endsWith(`/${minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME}`));
+}
+
+function parseObjectKeys(xml: string) {
+  const document = new DOMParser().parseFromString(xml, 'application/xml');
+  return Array.from(document.querySelectorAll('Contents Key'))
+    .map((node) => node.textContent ?? '')
+    .filter(Boolean);
 }
 
 class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
@@ -119,14 +129,20 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
     const url = minioObjectUtils.createObjectUrl(config, '', {
       'list-type': '2',
       'max-keys': '1000',
-      prefix: storageObjectUtils.normalizeObjectKeyPart(config.prefix) ? `${storageObjectUtils.normalizeObjectKeyPart(config.prefix)}/` : '',
+      prefix: storageObjectUtils.normalizeObjectKeyPart(config.prefix)
+        ? `${storageObjectUtils.normalizeObjectKeyPart(config.prefix)}/`
+        : '',
     });
     const response = await this.signedFetch(url, 'GET', config);
     if (!response.ok) throw new Error(`Could not list MinIO mirrors (${response.status}).`);
     const manifestKeys = parseMirrorProjects(await response.text());
     const manifests = await Promise.all(
       manifestKeys.map(async (key) => {
-        const response = await this.signedFetch(minioObjectUtils.createObjectUrl(config, key), 'GET', config);
+        const response = await this.signedFetch(
+          minioObjectUtils.createObjectUrl(config, key),
+          'GET',
+          config,
+        );
         if (!response.ok) return undefined;
         const manifest = (await response.json()) as MirrorManifest;
         const keyParts = key.split('/');
@@ -142,7 +158,10 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
 
   async downloadProject(projectKey: string, config: MinioMirrorConfig): Promise<MirrorFile[]> {
     const manifestResponse = await this.signedFetch(
-      minioObjectUtils.createObjectUrl(config, getProjectFileKey(config, projectKey, minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME)),
+      minioObjectUtils.createObjectUrl(
+        config,
+        getProjectFileKey(config, projectKey, minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME),
+      ),
       'GET',
       config,
     );
@@ -161,8 +180,36 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
         return { path, blob: await response.blob() };
       }),
     );
-    files.push({ path: minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME, blob: storageObjectUtils.jsonBlob(manifest) });
+    files.push({
+      path: minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME,
+      blob: storageObjectUtils.jsonBlob(manifest),
+    });
     return files;
+  }
+
+  async deleteProject(projectKey: string, config: MinioMirrorConfig): Promise<void> {
+    const projectPrefix = `${getProjectRoot(config, projectKey)}/`;
+    const url = minioObjectUtils.createObjectUrl(config, '', {
+      'list-type': '2',
+      'max-keys': '1000',
+      prefix: projectPrefix,
+    });
+    const listResponse = await this.signedFetch(url, 'GET', config);
+    if (!listResponse.ok)
+      throw new Error(`Could not list MinIO mirror objects (${listResponse.status}).`);
+
+    const objectKeys = parseObjectKeys(await listResponse.text());
+    await Promise.all(
+      objectKeys.map(async (key) => {
+        const response = await this.signedFetch(
+          minioObjectUtils.createObjectUrl(config, key),
+          'DELETE',
+          config,
+        );
+        if (!response.ok)
+          throw new Error(`Could not delete mirrored object ${key} (${response.status}).`);
+      }),
+    );
   }
 
   getPublicObjectUrl(key: string, config: MinioMirrorConfig): string {
@@ -175,7 +222,10 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
 
   private async loadRemoteManifest(projectKey: string, config: MinioMirrorConfig) {
     const response = await this.signedFetch(
-      minioObjectUtils.createObjectUrl(config, getProjectFileKey(config, projectKey, minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME)),
+      minioObjectUtils.createObjectUrl(
+        config,
+        getProjectFileKey(config, projectKey, minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME),
+      ),
       'GET',
       config,
     );

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -43,6 +43,8 @@ const DEFAULT_MINIO_MIRROR_CONFIG: MinioMirrorConfig = {
   prefix: 'mirrors',
 };
 
+const DELETE_BATCH_SIZE = 25;
+
 function getProjectMirrorKey(projectName: string) {
   return projectName.trim().replace(/[\\/]+/g, '-');
 }
@@ -70,11 +72,24 @@ function parseMirrorProjects(xml: string) {
     .filter((key) => key.endsWith(`/${minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME}`));
 }
 
-function parseObjectKeys(xml: string) {
+function parseObjectList(xml: string) {
   const document = new DOMParser().parseFromString(xml, 'application/xml');
-  return Array.from(document.querySelectorAll('Contents Key'))
-    .map((node) => node.textContent ?? '')
-    .filter(Boolean);
+  return {
+    keys: Array.from(document.querySelectorAll('Contents Key'))
+      .map((node) => node.textContent ?? '')
+      .filter(Boolean),
+    nextContinuationToken:
+      document.querySelector('NextContinuationToken')?.textContent?.trim() || undefined,
+    truncated: document.querySelector('IsTruncated')?.textContent?.trim() === 'true',
+  };
+}
+
+function chunkArray<T>(items: T[], size: number) {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
 }
 
 class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
@@ -189,27 +204,34 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
 
   async deleteProject(projectKey: string, config: MinioMirrorConfig): Promise<void> {
     const projectPrefix = `${getProjectRoot(config, projectKey)}/`;
-    const url = minioObjectUtils.createObjectUrl(config, '', {
-      'list-type': '2',
-      'max-keys': '1000',
-      prefix: projectPrefix,
-    });
-    const listResponse = await this.signedFetch(url, 'GET', config);
-    if (!listResponse.ok)
-      throw new Error(`Could not list MinIO mirror objects (${listResponse.status}).`);
+    let continuationToken: string | undefined;
+    do {
+      const url = minioObjectUtils.createObjectUrl(config, '', {
+        ...(continuationToken ? { 'continuation-token': continuationToken } : {}),
+        'list-type': '2',
+        'max-keys': '1000',
+        prefix: projectPrefix,
+      });
+      const listResponse = await this.signedFetch(url, 'GET', config);
+      if (!listResponse.ok)
+        throw new Error(`Could not list MinIO mirror objects (${listResponse.status}).`);
 
-    const objectKeys = parseObjectKeys(await listResponse.text());
-    await Promise.all(
-      objectKeys.map(async (key) => {
-        const response = await this.signedFetch(
-          minioObjectUtils.createObjectUrl(config, key),
-          'DELETE',
-          config,
+      const objectList = parseObjectList(await listResponse.text());
+      for (const batch of chunkArray(objectList.keys, DELETE_BATCH_SIZE)) {
+        await Promise.all(
+          batch.map(async (key) => {
+            const response = await this.signedFetch(
+              minioObjectUtils.createObjectUrl(config, key),
+              'DELETE',
+              config,
+            );
+            if (!response.ok)
+              throw new Error(`Could not delete mirrored object ${key} (${response.status}).`);
+          }),
         );
-        if (!response.ok)
-          throw new Error(`Could not delete mirrored object ${key} (${response.status}).`);
-      }),
-    );
+      }
+      continuationToken = objectList.truncated ? objectList.nextContinuationToken : undefined;
+    } while (continuationToken);
   }
 
   getPublicObjectUrl(key: string, config: MinioMirrorConfig): string {

--- a/apps/editor/src/ui/editor/panels/RemoteImportPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/RemoteImportPanel.tsx
@@ -1,13 +1,21 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { MirrorProjectSummary } from '../../../services/contracts/interfaces';
+import { IconButton } from '../../components/IconButton';
 
-export type RemoteImportStatus = 'loading' | 'ready' | 'empty' | 'importing' | 'failed';
+export type RemoteImportStatus =
+  | 'loading'
+  | 'ready'
+  | 'empty'
+  | 'importing'
+  | 'deleting'
+  | 'failed';
 
 interface RemoteImportPanelProps {
   error?: string | undefined;
   projects: MirrorProjectSummary[];
   status: RemoteImportStatus;
   onClose: () => void;
+  onDeleteProject?: (projectId: string) => void;
   onImportProject: (projectId: string) => void;
 }
 
@@ -25,10 +33,13 @@ export function RemoteImportPanel({
   projects,
   status,
   onClose,
+  onDeleteProject,
   onImportProject,
 }: RemoteImportPanelProps) {
   const panelRef = useRef<HTMLElement>(null);
-  const busy = status === 'loading' || status === 'importing';
+  const [deleteProjectId, setDeleteProjectId] = useState<string | undefined>();
+  const busy = status === 'loading' || status === 'importing' || status === 'deleting';
+  const deleteProject = projects.find((project) => project.id === deleteProjectId);
 
   useEffect(() => {
     function handlePointerDown(event: PointerEvent) {
@@ -78,24 +89,71 @@ export function RemoteImportPanel({
       ) : null}
 
       {projects.length > 0 ? (
-        <div className="remote-import-list">
+        <div className="remote-import-list" role="list" aria-label="Remote mirrored projects">
           {projects.map((project) => (
-            <button
-              className="remote-import-row"
-              disabled={busy}
-              key={project.id}
-              type="button"
-              aria-label={`Import ${project.name}`}
-              onClick={() => onImportProject(project.id)}
-            >
-              <span className="material-symbols-outlined" aria-hidden="true">
-                cloud_download
-              </span>
-              <span>
-                <strong>{project.name}</strong>
-                <small>{formatSyncedAt(project.syncedAt)}</small>
-              </span>
-            </button>
+            <div className="remote-import-list-item" role="listitem" key={project.id}>
+              {deleteProject?.id === project.id ? (
+                <div
+                  className="remote-import-confirm"
+                  role="alertdialog"
+                  aria-label="Delete remote project"
+                >
+                  <p>
+                    Remove <strong>{deleteProject.name}</strong> from the remote mirror?
+                  </p>
+                  <div className="remote-import-confirm-actions">
+                    <button
+                      className="secondary-button"
+                      type="button"
+                      disabled={busy}
+                      onClick={() => setDeleteProjectId(undefined)}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="danger-button"
+                      type="button"
+                      disabled={busy}
+                      onClick={() => {
+                        onDeleteProject?.(deleteProject.id);
+                        setDeleteProjectId(undefined);
+                      }}
+                    >
+                      Delete remote project
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+              <div className="remote-import-row-shell">
+                <button
+                  className="remote-import-row"
+                  disabled={busy}
+                  type="button"
+                  aria-label={`Import ${project.name}`}
+                  onClick={() => onImportProject(project.id)}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    cloud_download
+                  </span>
+                  <span>
+                    <strong>{project.name}</strong>
+                    <small>{formatSyncedAt(project.syncedAt)}</small>
+                  </span>
+                </button>
+                {onDeleteProject ? (
+                  <IconButton
+                    label={`Delete ${project.name} from remote`}
+                    disabled={busy}
+                    tone="danger"
+                    onClick={() => setDeleteProjectId(project.id)}
+                  >
+                    <span className="material-symbols-outlined" aria-hidden="true">
+                      close
+                    </span>
+                  </IconButton>
+                ) : null}
+              </div>
+            </div>
           ))}
         </div>
       ) : null}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -45,7 +45,8 @@ export function EditorShell({ services }: EditorShellProps) {
     vm.project.pages.findIndex((page) => page.id === vm.activePageId),
   );
   const publicSharingAvailable = vm.mirrorState.enabled && vm.mirrorState.status === 'synced';
-  const publicSharingUnavailableReason = vm.mirrorState.error ?? 'Public sharing requires active external storage.';
+  const publicSharingUnavailableReason =
+    vm.mirrorState.error ?? 'Public sharing requires active external storage.';
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -138,15 +139,20 @@ export function EditorShell({ services }: EditorShellProps) {
       }
 
       const isPresenterPlayback = vm.animationPreview?.mode === 'presenter';
-      const isPreviewNavigationActive = vm.isFullscreen || Boolean(isPresenterPlayback && vm.animationPreview?.playing);
-      if (isPreviewNavigationActive && !editorShellBrowserUtils.isEditableInteractionTarget(event.target)) {
+      const isPreviewNavigationActive =
+        vm.isFullscreen || Boolean(isPresenterPlayback && vm.animationPreview?.playing);
+      if (
+        isPreviewNavigationActive &&
+        !editorShellBrowserUtils.isEditableInteractionTarget(event.target)
+      ) {
         const isNextPreviewKey =
           event.key === 'ArrowRight' ||
           event.key === 'ArrowDown' ||
           event.key === 'PageDown' ||
           event.key === ' ' ||
           event.key === 'Enter';
-        const isPreviousPreviewKey = event.key === 'ArrowLeft' || event.key === 'ArrowUp' || event.key === 'PageUp';
+        const isPreviousPreviewKey =
+          event.key === 'ArrowLeft' || event.key === 'ArrowUp' || event.key === 'PageUp';
         if (isNextPreviewKey || isPreviousPreviewKey) {
           event.preventDefault();
           if (isNextPreviewKey) vm.advancePresentationPreview();
@@ -179,7 +185,11 @@ export function EditorShell({ services }: EditorShellProps) {
   useEffect(() => {
     function handleCopy(event: ClipboardEvent) {
       if (isHistoryReadOnly) return;
-      if (editorShellBrowserUtils.isEditableInteractionTarget(event.target) || editorShellBrowserUtils.hasBrowserTextSelection() || !hasSelection)
+      if (
+        editorShellBrowserUtils.isEditableInteractionTarget(event.target) ||
+        editorShellBrowserUtils.hasBrowserTextSelection() ||
+        !hasSelection
+      )
         return;
       event.preventDefault();
       vm.copySelectedElements();
@@ -188,7 +198,11 @@ export function EditorShell({ services }: EditorShellProps) {
 
     function handleCut(event: ClipboardEvent) {
       if (isHistoryReadOnly) return;
-      if (editorShellBrowserUtils.isEditableInteractionTarget(event.target) || editorShellBrowserUtils.hasBrowserTextSelection() || !hasSelection)
+      if (
+        editorShellBrowserUtils.isEditableInteractionTarget(event.target) ||
+        editorShellBrowserUtils.hasBrowserTextSelection() ||
+        !hasSelection
+      )
         return;
       event.preventDefault();
       vm.cutSelectedElements();
@@ -199,7 +213,11 @@ export function EditorShell({ services }: EditorShellProps) {
       if (isHistoryReadOnly) return;
       if (editorShellBrowserUtils.isEditableInteractionTarget(event.target)) return;
       event.preventDefault();
-      if (editorShellBrowserUtils.hasEditorObjectClipboardMarker(event.clipboardData) && vm.pasteCopiedElements()) return;
+      if (
+        editorShellBrowserUtils.hasEditorObjectClipboardMarker(event.clipboardData) &&
+        vm.pasteCopiedElements()
+      )
+        return;
       const imageFile = editorShellBrowserUtils.getClipboardImageFile(event.clipboardData);
       if (imageFile) {
         void vm.importImageFile(imageFile);
@@ -227,7 +245,9 @@ export function EditorShell({ services }: EditorShellProps) {
       translateText: (input) => automationDelegateRef.current.translateText(input),
       getState: () => automationDelegateRef.current.getState(),
     };
-    const adapter = new WebMcpToolAdapter(new editorAutomationController.EditorAutomationController(delegate));
+    const adapter = new WebMcpToolAdapter(
+      new editorAutomationController.EditorAutomationController(delegate),
+    );
     const demoWindow = window as WebMcpDemoWindow;
     const modelContext = editorShellBrowserUtils.getWebMcpModelContext();
     demoWindow.localStudioWebMcpTools = adapter.createTools();
@@ -258,7 +278,9 @@ export function EditorShell({ services }: EditorShellProps) {
           setShareMetadata(nextShare);
         })
         .catch(() => {
-          setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
+          setShareMetadata((current) =>
+            current ? { ...current, status: 'sync-failed' } : current,
+          );
         });
     }, 1000);
 
@@ -622,10 +644,7 @@ export function EditorShell({ services }: EditorShellProps) {
         />
       ) : null}
       {vm.settingsOpen ? (
-        <SettingsPanel
-          onClose={vm.closeSettings}
-          onOpenMirrorSettings={vm.openMirrorSettings}
-        />
+        <SettingsPanel onClose={vm.closeSettings} onOpenMirrorSettings={vm.openMirrorSettings} />
       ) : null}
       {vm.mirrorSettingsOpen ? (
         <MirrorSettingsPanel
@@ -642,6 +661,9 @@ export function EditorShell({ services }: EditorShellProps) {
           projects={vm.remoteImportProjects}
           status={vm.remoteImportStatus}
           onClose={vm.closeRemoteImport}
+          onDeleteProject={(projectId) => {
+            void vm.deleteRemoteMirrorProject(projectId);
+          }}
           onImportProject={(projectId) => {
             void vm.importRemoteMirrorProject(projectId);
           }}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -1,7 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { AppServices } from '../../../app/composition';
 import { basicCommands } from '../../../domain/commands/elements/basicCommands';
-import type { AlignMode, ElementAnimationPatch, ElementFramePatch, ImageCropPatch, ElementStylePatch, MediaPlaybackPatch, ZOrderMode } from '../../../domain/commands/elements/basicCommands';
+import type {
+  AlignMode,
+  ElementAnimationPatch,
+  ElementFramePatch,
+  ImageCropPatch,
+  ElementStylePatch,
+  MediaPlaybackPatch,
+  ZOrderMode,
+} from '../../../domain/commands/elements/basicCommands';
 import type { GeneratedSlideElement } from '../../../domain/generated-slides/generatedSlide';
 import { fitImageWithinPage } from '../../../domain/images/imageSizing';
 import type {
@@ -39,7 +47,14 @@ import { translationLanguageUtils } from '../translation/translationLanguageUtil
 import { editorPreferences } from '../persistence/editorPreferences';
 import { useAnimationPreviewController } from '../animation/useAnimationPreviewController';
 
-export type RightPanelTab = 'layout' | 'text' | 'elements' | 'design' | 'ai-tools' | 'assets' | 'animations';
+export type RightPanelTab =
+  | 'layout'
+  | 'text'
+  | 'elements'
+  | 'design'
+  | 'ai-tools'
+  | 'assets'
+  | 'animations';
 export type TextPreset = 'title' | 'subtitle' | 'body';
 
 interface EditorHistory {
@@ -83,7 +98,13 @@ interface ElementClipboardState {
   elements: DesignElement[];
 }
 
-export type RemoteImportStatus = 'loading' | 'ready' | 'empty' | 'importing' | 'failed';
+export type RemoteImportStatus =
+  | 'loading'
+  | 'ready'
+  | 'empty'
+  | 'importing'
+  | 'deleting'
+  | 'failed';
 
 const IMAGE_EDITING_MODEL_REQUIRED_MESSAGE = 'You must download the image editing tools first.';
 const PROMPT_API_REQUIRED_MESSAGE = 'LLM model must be prepared before using prompt-to-slides.';
@@ -156,7 +177,8 @@ function normalizeProjectDocument(project: ProjectDocument): ProjectDocument {
         ? {
             'asset-hero': {
               ...project.assets['asset-hero'],
-              objectUrl: project.assets['asset-hero'].objectUrl ?? sampleProject.SAMPLE_HERO_IMAGE_URL,
+              objectUrl:
+                project.assets['asset-hero'].objectUrl ?? sampleProject.SAMPLE_HERO_IMAGE_URL,
             },
           }
         : {}),
@@ -176,7 +198,11 @@ function normalizeProjectDocument(project: ProjectDocument): ProjectDocument {
             : page,
         )
       : project.pages
-    ).map((page) => ({ ...page, animationBuilds: page.animationBuilds ?? [], visible: page.visible ?? true })),
+    ).map((page) => ({
+      ...page,
+      animationBuilds: page.animationBuilds ?? [],
+      visible: page.visible ?? true,
+    })),
   };
 }
 
@@ -347,8 +373,9 @@ export function useEditorViewModel(services: AppServices) {
   const [modelStates, setModelStates] = useState<ModelState[]>([]);
   const [hasLoadedProject, setHasLoadedProject] = useState(!shouldRestoreStoredProject);
   const [persistenceEnabled, setPersistenceEnabled] = useState(shouldRestoreStoredProject);
-  const [hasPersistedLocalProject, setHasPersistedLocalProject] =
-    useState(shouldRestoreStoredProject);
+  const [hasPersistedLocalProject, setHasPersistedLocalProject] = useState(
+    shouldRestoreStoredProject,
+  );
   const [activePageId, setActivePageId] = useState(initialProject.pages[0]?.id ?? '');
   const activePageIdRef = useRef(activePageId);
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
@@ -587,7 +614,12 @@ export function useEditorViewModel(services: AppServices) {
     return () => {
       isMounted = false;
     };
-  }, [persistenceEnabled, services.projectRepository, services.storedProjectName, storedMirrorConfig]);
+  }, [
+    persistenceEnabled,
+    services.projectRepository,
+    services.storedProjectName,
+    storedMirrorConfig,
+  ]);
 
   useEffect(() => {
     if (!hasLoadedProject || !persistenceEnabled) return;
@@ -737,10 +769,20 @@ export function useEditorViewModel(services: AppServices) {
         await services.translatorService.getLanguageDetectionProviderStates(),
       );
     }
-    if (next.some((state) => state.id === modelSetupService.IMAGE_EDITING_MODEL_ID && state.status === 'ready')) {
+    if (
+      next.some(
+        (state) =>
+          state.id === modelSetupService.IMAGE_EDITING_MODEL_ID && state.status === 'ready',
+      )
+    ) {
       setBackgroundSelectionNotice(undefined);
     }
-    if (next.some((state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID && state.status === 'ready')) {
+    if (
+      next.some(
+        (state) =>
+          state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID && state.status === 'ready',
+      )
+    ) {
       setCreateImageNotice(undefined);
       setAiToolsAttentionModelId(undefined);
     }
@@ -826,7 +868,8 @@ export function useEditorViewModel(services: AppServices) {
 
   function isImageGenerationReady() {
     return modelStates.some(
-      (state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID && state.status === 'ready',
+      (state) =>
+        state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID && state.status === 'ready',
     );
   }
 
@@ -1081,7 +1124,9 @@ export function useEditorViewModel(services: AppServices) {
 
       commitProject(
         (currentProject) =>
-          new basicCommands.PrepareGeneratedSlideCommand(pageId, generatedTasks.page).execute(currentProject),
+          new basicCommands.PrepareGeneratedSlideCommand(pageId, generatedTasks.page).execute(
+            currentProject,
+          ),
         { activePageId: pageId, selectedElementIds: [] },
       );
 
@@ -1101,7 +1146,9 @@ export function useEditorViewModel(services: AppServices) {
         const selectedElementId = `generated-${pageId}-${element.id.replace(/[^a-z0-9-_]/gi, '-').toLowerCase()}`;
         commitProject(
           (currentProject) =>
-            new basicCommands.AddGeneratedSlideElementCommand(pageId, element).execute(currentProject),
+            new basicCommands.AddGeneratedSlideElementCommand(pageId, element).execute(
+              currentProject,
+            ),
           { activePageId: pageId, selectedElementIds: [selectedElementId] },
         );
       }
@@ -1143,12 +1190,16 @@ export function useEditorViewModel(services: AppServices) {
     try {
       const generationOptions = {
         height: normalizeImageGenerationDimension(
-          imageToReplace?.height ?? options?.height ?? imageGenerationModel.DEFAULT_IMAGE_GENERATION_SIZE,
+          imageToReplace?.height ??
+            options?.height ??
+            imageGenerationModel.DEFAULT_IMAGE_GENERATION_SIZE,
         ),
         ...(options?.seed !== undefined ? { seed: options.seed } : {}),
         ...(options?.steps !== undefined ? { steps: options.steps } : {}),
         width: normalizeImageGenerationDimension(
-          imageToReplace?.width ?? options?.width ?? imageGenerationModel.DEFAULT_IMAGE_GENERATION_SIZE,
+          imageToReplace?.width ??
+            options?.width ??
+            imageGenerationModel.DEFAULT_IMAGE_GENERATION_SIZE,
         ),
       };
       const asset = await services.imageGenerationService.generateImage(trimmedPrompt, {
@@ -1162,7 +1213,9 @@ export function useEditorViewModel(services: AppServices) {
       if (imageToReplace) {
         commitProject(
           (currentProject) =>
-            new basicCommands.ReplaceImageAssetCommand(imageToReplace.id, asset).execute(currentProject),
+            new basicCommands.ReplaceImageAssetCommand(imageToReplace.id, asset).execute(
+              currentProject,
+            ),
           { selectedElementIds: [imageToReplace.id] },
         );
         return;
@@ -1670,6 +1723,33 @@ export function useEditorViewModel(services: AppServices) {
     }
   }
 
+  async function deleteRemoteMirrorProject(projectId: string) {
+    const config = mirrorConfigRef.current;
+    if (!config || !services.mirrorService.deleteProject) return;
+    setRemoteImportStatus('deleting');
+    setRemoteImportError(undefined);
+    try {
+      await services.mirrorService.deleteProject(projectId, config);
+      let nextProjectCount = 0;
+      setRemoteImportProjects((projects) => {
+        const nextProjects = projects.filter((project) => project.id !== projectId);
+        nextProjectCount = nextProjects.length;
+        return nextProjects;
+      });
+      setRemoteImportStatus(nextProjectCount > 0 ? 'ready' : 'empty');
+    } catch (error) {
+      setRemoteImportStatus('failed');
+      setRemoteImportError(
+        error instanceof Error ? error.message : 'Could not delete mirrored project.',
+      );
+      setMirrorState({
+        enabled: Boolean(config),
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'MinIO mirror delete failed.',
+      });
+    }
+  }
+
   async function openVersionHistory() {
     if (!services.projectRepository.getVersionHistory) return;
     setVersionHistoryOpen(true);
@@ -1759,7 +1839,9 @@ export function useEditorViewModel(services: AppServices) {
                 ),
               }
           : patch;
-      return new basicCommands.UpdateElementFrameCommand(elementId, nextPatch).execute(currentProject);
+      return new basicCommands.UpdateElementFrameCommand(elementId, nextPatch).execute(
+        currentProject,
+      );
     });
   }
 
@@ -1771,33 +1853,39 @@ export function useEditorViewModel(services: AppServices) {
 
   function updateTextContent(elementId: string, text: string) {
     commitProject((currentProject) => {
-      const nextProject = new basicCommands.UpdateTextContentCommand(elementId, text).execute(currentProject);
+      const nextProject = new basicCommands.UpdateTextContentCommand(elementId, text).execute(
+        currentProject,
+      );
       const element = nextProject.elements[elementId];
       if (!element || element.type !== 'text') return nextProject;
       const minimumHeight = getMinimumTextHeight(element.text, element.fontSize);
       if (element.height >= minimumHeight) return nextProject;
-      return new basicCommands.UpdateElementFrameCommand(elementId, { height: minimumHeight }).execute(
-        nextProject,
-      );
+      return new basicCommands.UpdateElementFrameCommand(elementId, {
+        height: minimumHeight,
+      }).execute(nextProject);
     });
   }
 
   function updateElementStyle(elementId: string, patch: ElementStylePatch) {
     commitProject((currentProject) => {
-      const nextProject = new basicCommands.UpdateElementStyleCommand(elementId, patch).execute(currentProject);
+      const nextProject = new basicCommands.UpdateElementStyleCommand(elementId, patch).execute(
+        currentProject,
+      );
       const element = nextProject.elements[elementId];
       if (!element || element.type !== 'text') return nextProject;
       const minimumHeight = getMinimumTextHeight(element.text, element.fontSize);
       if (element.height >= minimumHeight) return nextProject;
-      return new basicCommands.UpdateElementFrameCommand(elementId, { height: minimumHeight }).execute(
-        nextProject,
-      );
+      return new basicCommands.UpdateElementFrameCommand(elementId, {
+        height: minimumHeight,
+      }).execute(nextProject);
     });
   }
 
   function updatePageBackground(background: PageBackground) {
     commitProject((currentProject) =>
-      new basicCommands.UpdatePageBackgroundCommand(activePageId, background).execute(currentProject),
+      new basicCommands.UpdatePageBackgroundCommand(activePageId, background).execute(
+        currentProject,
+      ),
     );
   }
 
@@ -1808,7 +1896,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function clearPageTransition() {
-    commitProject((currentProject) => new basicCommands.ClearPageTransitionCommand(activePageId).execute(currentProject));
+    commitProject((currentProject) =>
+      new basicCommands.ClearPageTransitionCommand(activePageId).execute(currentProject),
+    );
   }
 
   function setElementAnimationBuilds(elementIds: string[], patch: ElementAnimationPatch) {
@@ -1824,13 +1914,19 @@ export function useEditorViewModel(services: AppServices) {
 
   function clearElementAnimationBuild(elementId: string) {
     commitProject((currentProject) =>
-      new basicCommands.ClearElementAnimationBuildCommand(activePageId, elementId).execute(currentProject),
+      new basicCommands.ClearElementAnimationBuildCommand(activePageId, elementId).execute(
+        currentProject,
+      ),
     );
   }
 
   function reorderElementAnimationBuild(elementId: string, targetIndex: number) {
     commitProject((currentProject) =>
-      new basicCommands.ReorderElementAnimationBuildCommand(activePageId, elementId, targetIndex).execute(currentProject),
+      new basicCommands.ReorderElementAnimationBuildCommand(
+        activePageId,
+        elementId,
+        targetIndex,
+      ).execute(currentProject),
     );
   }
 
@@ -1922,7 +2018,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   async function setTranslationTargetLanguage(languageCode: string) {
-    const nextLanguage = translationLanguageUtils.isSupportedTranslationLanguageCode(languageCode) ? languageCode : '';
+    const nextLanguage = translationLanguageUtils.isSupportedTranslationLanguageCode(languageCode)
+      ? languageCode
+      : '';
     setTranslationTargetLanguageState(nextLanguage);
     setTranslationTargetAttention(false);
     setTranslationNotice(undefined);
@@ -2019,7 +2117,8 @@ export function useEditorViewModel(services: AppServices) {
         translationOptions,
       );
       if (translatedPageIds.length > 0) {
-        const normalizedTargetLanguage = translationLanguageUtils.normalizeLanguageCode(translationTargetLanguage);
+        const normalizedTargetLanguage =
+          translationLanguageUtils.normalizeLanguageCode(translationTargetLanguage);
         setPageLanguageCodes((current) => ({
           ...current,
           ...Object.fromEntries(
@@ -2089,7 +2188,9 @@ export function useEditorViewModel(services: AppServices) {
       translationOptions,
     );
     if (translatedPageIds.length > 0) {
-      const normalizedTargetLanguage = translationLanguageUtils.normalizeLanguageCode(input.targetLanguage);
+      const normalizedTargetLanguage = translationLanguageUtils.normalizeLanguageCode(
+        input.targetLanguage,
+      );
       setPageLanguageCodes((current) => ({
         ...current,
         ...Object.fromEntries(
@@ -2169,9 +2270,11 @@ export function useEditorViewModel(services: AppServices) {
 
     commitProject(
       (currentProject) =>
-        new basicCommands.AddElementsCommand(activePageId, pastedElements, elementClipboard.assets).execute(
-          currentProject,
-        ),
+        new basicCommands.AddElementsCommand(
+          activePageId,
+          pastedElements,
+          elementClipboard.assets,
+        ).execute(currentProject),
       { selectedElementIds: pastedElements.map((element) => element.id) },
     );
     setElementClipboard({
@@ -2183,7 +2286,9 @@ export function useEditorViewModel(services: AppServices) {
 
   function deleteElement(elementId: string) {
     commitProject((currentProject) => {
-      const nextProject = new basicCommands.DeleteElementCommand(activePageId, elementId).execute(currentProject);
+      const nextProject = new basicCommands.DeleteElementCommand(activePageId, elementId).execute(
+        currentProject,
+      );
       const nextPage = nextProject.pages.find((page) => page.id === activePageId);
       if (selectedElementIds.includes(elementId)) {
         const nextSelectedId = nextPage?.elementIds.at(-1);
@@ -2194,7 +2299,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function removeAsset(assetId: string) {
-    commitProject((currentProject) => new basicCommands.RemoveAssetCommand(assetId).execute(currentProject));
+    commitProject((currentProject) =>
+      new basicCommands.RemoveAssetCommand(assetId).execute(currentProject),
+    );
   }
 
   function deleteSelectedElement() {
@@ -2236,7 +2343,9 @@ export function useEditorViewModel(services: AppServices) {
     const nextElementId = createPrefixedId(`${elementId}-copy`);
     commitProject(
       (currentProject) =>
-        new basicCommands.DuplicateElementCommand(activePageId, elementId, nextElementId).execute(currentProject),
+        new basicCommands.DuplicateElementCommand(activePageId, elementId, nextElementId).execute(
+          currentProject,
+        ),
       { selectedElementIds: [nextElementId] },
     );
   }
@@ -2378,13 +2487,12 @@ export function useEditorViewModel(services: AppServices) {
       locked: false,
       visible: true,
       opacity: 1,
-      ...(isLinearShape
-        ? { stroke: '#37FD76', strokeWidth: 4 }
-        : { fill: '#37FD76' }),
+      ...(isLinearShape ? { stroke: '#37FD76', strokeWidth: 4 } : { fill: '#37FD76' }),
     };
 
     commitProject(
-      (currentProject) => new basicCommands.AddElementsCommand(activePageId, [nextElement]).execute(currentProject),
+      (currentProject) =>
+        new basicCommands.AddElementsCommand(activePageId, [nextElement]).execute(currentProject),
       { selectedElementIds: [elementId] },
     );
     setActiveTab('design');
@@ -2420,7 +2528,11 @@ export function useEditorViewModel(services: AppServices) {
     );
   }
 
-  function reorderElement(elementId: string, targetElementId: string, position: 'before' | 'after' = 'before') {
+  function reorderElement(
+    elementId: string,
+    targetElementId: string,
+    position: 'before' | 'after' = 'before',
+  ) {
     commitProject((currentProject) => {
       const page = currentProject.pages.find((item) => item.id === activePageId);
       if (!page) return currentProject;
@@ -2428,17 +2540,26 @@ export function useEditorViewModel(services: AppServices) {
       const displayOrder = [...page.elementIds].reverse().filter((id) => id !== elementId);
       const targetDisplayIndex = displayOrder.indexOf(targetElementId);
       if (targetDisplayIndex < 0) return currentProject;
-      displayOrder.splice(position === 'after' ? targetDisplayIndex + 1 : targetDisplayIndex, 0, elementId);
+      displayOrder.splice(
+        position === 'after' ? targetDisplayIndex + 1 : targetDisplayIndex,
+        0,
+        elementId,
+      );
       const nextPageOrder = [...displayOrder].reverse();
       const targetPageIndex = nextPageOrder.indexOf(elementId);
-      return new basicCommands.ReorderElementCommand(activePageId, elementId, targetPageIndex).execute(
-        currentProject,
-      );
+      return new basicCommands.ReorderElementCommand(
+        activePageId,
+        elementId,
+        targetPageIndex,
+      ).execute(currentProject);
     });
   }
 
   function addPage(afterPageId = activePageId) {
-    const sourcePage = project.pages.find((item) => item.id === afterPageId) ?? project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
+    const sourcePage =
+      project.pages.find((item) => item.id === afterPageId) ??
+      project.pages.find((item) => item.id === activePageId) ??
+      project.pages[0];
     if (!sourcePage) return;
     const pageId = createPrefixedId('page');
     const nextPage: Page = {
@@ -2488,15 +2609,19 @@ export function useEditorViewModel(services: AppServices) {
       project.pages[pageIndex - 1]?.id ??
       project.pages[0]?.id ??
       '';
-    commitProject((currentProject) => new basicCommands.DeletePageCommand(pageId).execute(currentProject), {
-      activePageId: nextPageId,
-      selectedElementIds: [],
-    });
+    commitProject(
+      (currentProject) => new basicCommands.DeletePageCommand(pageId).execute(currentProject),
+      {
+        activePageId: nextPageId,
+        selectedElementIds: [],
+      },
+    );
   }
 
   function reorderPage(pageId: string, targetIndex: number) {
     commitProject(
-      (currentProject) => new basicCommands.ReorderPageCommand(pageId, targetIndex).execute(currentProject),
+      (currentProject) =>
+        new basicCommands.ReorderPageCommand(pageId, targetIndex).execute(currentProject),
       {
         activePageId: pageId,
       },
@@ -2504,7 +2629,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function renamePage(pageId: string, name: string) {
-    commitProject((currentProject) => new basicCommands.RenamePageCommand(pageId, name).execute(currentProject));
+    commitProject((currentProject) =>
+      new basicCommands.RenamePageCommand(pageId, name).execute(currentProject),
+    );
   }
 
   function setPageVisibility(pageId: string, visible: boolean) {
@@ -2599,7 +2726,9 @@ export function useEditorViewModel(services: AppServices) {
       return;
     }
 
-    const imageEditingModel = modelStates.find((state) => state.id === modelSetupService.IMAGE_EDITING_MODEL_ID);
+    const imageEditingModel = modelStates.find(
+      (state) => state.id === modelSetupService.IMAGE_EDITING_MODEL_ID,
+    );
     if (imageEditingModel?.status !== 'ready') {
       setActiveTab('ai-tools');
       setBackgroundSelectionNotice(IMAGE_EDITING_MODEL_REQUIRED_MESSAGE);
@@ -2999,6 +3128,7 @@ export function useEditorViewModel(services: AppServices) {
     setMirrorEnabled,
     importRemoteMirror,
     importRemoteMirrorProject,
+    deleteRemoteMirrorProject,
     closeRemoteImport,
     importProject,
     openVersionHistory,

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -464,6 +464,7 @@ export function useEditorViewModel(services: AppServices) {
   const mirrorConfigRef = useRef<MinioMirrorConfig | null>(storedMirrorConfig);
   const mirrorSyncInFlightRef = useRef(false);
   const mirrorSyncQueuedRef = useRef(false);
+  const lastMirroredProjectNameRef = useRef<string | undefined>(undefined);
   const mirrorDebounceRef = useRef<number | undefined>(undefined);
   const queueMirrorSyncRef = useRef<() => void>(() => undefined);
   const syncMirrorNowRef = useRef<(project?: ProjectDocument) => void>(() => undefined);
@@ -1656,6 +1657,15 @@ export function useEditorViewModel(services: AppServices) {
         services.projectRepository,
         mirrorConfigRef.current!,
       );
+      const previousMirroredProjectName = lastMirroredProjectNameRef.current;
+      if (
+        previousMirroredProjectName &&
+        previousMirroredProjectName !== projectToSync.name &&
+        services.mirrorService.deleteProject
+      ) {
+        await services.mirrorService.deleteProject(previousMirroredProjectName, config);
+      }
+      lastMirroredProjectNameRef.current = projectToSync.name;
       setMirrorState(nextState);
     } catch (error) {
       setMirrorState({

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
@@ -164,8 +164,8 @@ describe('BrowserFileSystemProjectRepository', () => {
     const secondParentDirectory = new MockDirectoryHandle('Second Projects');
     const pickDirectory = vi
       .fn()
-      .mockResolvedValueOnce(firstParentDirectory as unknown as FileSystemDirectoryHandle)
-      .mockResolvedValueOnce(secondParentDirectory as unknown as FileSystemDirectoryHandle);
+      .mockResolvedValueOnce(firstParentDirectory)
+      .mockResolvedValueOnce(secondParentDirectory);
     const repository = new BrowserFileSystemProjectRepository({
       pickDirectory,
       recentProjectStore: new MemoryRecentProjectHandleStore(),

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -212,6 +212,65 @@ describe('minioMirrorService.MinioMirrorService', () => {
     ).toBe(true);
   });
 
+  it('deletes mirrored project objects across paginated listings', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (
+        init?.method === 'GET' &&
+        url.includes('list-type=2') &&
+        !url.includes('continuation-token=')
+      ) {
+        return Promise.resolve(
+          new Response(
+            `<ListBucketResult>
+              <IsTruncated>true</IsTruncated>
+              <NextContinuationToken>page-2</NextContinuationToken>
+              <Contents><Key>mirrors/Client Launch/project.json</Key></Contents>
+            </ListBucketResult>`,
+            { status: 200 },
+          ),
+        );
+      }
+      if (
+        init?.method === 'GET' &&
+        url.includes('list-type=2') &&
+        url.includes('continuation-token=page-2')
+      ) {
+        return Promise.resolve(
+          new Response(
+            `<ListBucketResult>
+              <IsTruncated>false</IsTruncated>
+              <Contents><Key>mirrors/Client Launch/localstudio-mirror.json</Key></Contents>
+            </ListBucketResult>`,
+            { status: 200 },
+          ),
+        );
+      }
+      if (init?.method === 'DELETE') {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await service.deleteProject('Client Launch', config);
+
+    const listUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'GET')
+      .map(([input]) => getRequestUrl(input));
+    const deleteUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'DELETE')
+      .map(([input]) => getRequestUrl(input));
+    expect(listUrls).toHaveLength(2);
+    expect(deleteUrls).toHaveLength(2);
+    expect(deleteUrls.some((url) => url.endsWith('/mirrors/Client%20Launch/project.json'))).toBe(
+      true,
+    );
+    expect(
+      deleteUrls.some((url) => url.endsWith('/mirrors/Client%20Launch/localstudio-mirror.json')),
+    ).toBe(true);
+  });
+
   it('stores mirrored objects under the readable project name prefix', async () => {
     const project = { ...sampleProject.createSampleProject(), name: 'Client Launch Deck' };
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -3,7 +3,10 @@ import type { ProjectDocument } from '../../../src/domain/documents/model';
 import { sampleProject } from '../../../src/domain/projects/sampleProject';
 import { minioMirrorService } from '../../../src/services/mirror/minioMirrorService';
 import type { MinioMirrorConfig } from '../../../src/services/mirror/minioMirrorService';
-import type { ProjectRepository, VersionHistoryEntry } from '../../../src/services/contracts/interfaces';
+import type {
+  ProjectRepository,
+  VersionHistoryEntry,
+} from '../../../src/services/contracts/interfaces';
 
 const config: MinioMirrorConfig = {
   accessKey: 'localstudio',
@@ -118,11 +121,9 @@ describe('minioMirrorService.MinioMirrorService', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     try {
-      await new minioMirrorService.MinioMirrorService({ now: () => new Date('2026-06-30T10:00:00.000Z') }).syncProject(
-        project,
-        new VersionedRepository([], project),
-        config,
-      );
+      await new minioMirrorService.MinioMirrorService({
+        now: () => new Date('2026-06-30T10:00:00.000Z'),
+      }).syncProject(project, new VersionedRepository([], project), config);
     } finally {
       vi.stubGlobal('fetch', originalFetch);
     }
@@ -174,6 +175,41 @@ describe('minioMirrorService.MinioMirrorService', () => {
       .map(([input]) => getRequestUrl(input));
     expect(putUrls.some((url) => url.endsWith('/project.json'))).toBe(false);
     expect(putUrls.some((url) => url.endsWith('/localstudio-mirror.json'))).toBe(true);
+  });
+
+  it('deletes every object under a mirrored project prefix', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.includes('list-type=2')) {
+        return Promise.resolve(
+          new Response(
+            `<ListBucketResult>
+              <Contents><Key>mirrors/Client Launch/project.json</Key></Contents>
+              <Contents><Key>mirrors/Client Launch/localstudio-mirror.json</Key></Contents>
+            </ListBucketResult>`,
+            { status: 200 },
+          ),
+        );
+      }
+      if (init?.method === 'DELETE') {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await service.deleteProject('Client Launch', config);
+
+    const deleteUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'DELETE')
+      .map(([input]) => getRequestUrl(input));
+    expect(deleteUrls).toHaveLength(2);
+    expect(deleteUrls.some((url) => url.endsWith('/mirrors/Client%20Launch/project.json'))).toBe(
+      true,
+    );
+    expect(
+      deleteUrls.some((url) => url.endsWith('/mirrors/Client%20Launch/localstudio-mirror.json')),
+    ).toBe(true);
   });
 
   it('stores mirrored objects under the readable project name prefix', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -17,7 +17,10 @@ import type {
   TranslatorService,
 } from '../../../../src/services/contracts/interfaces';
 import type { MinioMirrorConfig } from '../../../../src/services/mirror/minioMirrorService';
-import type { WebMcpDemoWindow, WebMcpTool } from '../../../../src/services/webmcp/webMcpToolAdapter';
+import type {
+  WebMcpDemoWindow,
+  WebMcpTool,
+} from '../../../../src/services/webmcp/webMcpToolAdapter';
 import { modelSetupService } from '../../../../src/services/model-setup/modelSetupService';
 import { EditorShell } from '../../../../src/ui/editor/shell/EditorShell';
 
@@ -150,6 +153,8 @@ class RecordingMirrorService implements MirrorService<MinioMirrorConfig> {
   listProjects = vi.fn((): Promise<MirrorProjectSummary[]> => Promise.resolve([]));
 
   downloadProject = vi.fn((): Promise<MirrorFile[]> => Promise.resolve([]));
+
+  deleteProject = vi.fn((): Promise<void> => Promise.resolve());
 }
 
 class RecordingShareService implements ShareService {
@@ -170,8 +175,9 @@ class RecordingShareService implements ShareService {
     return Promise.resolve(this.createMetadata(shareId, now));
   });
 
-  getShare = vi.fn((shareId: string): Promise<ShareRecord | null> =>
-    Promise.resolve(this.records.get(shareId) ?? null),
+  getShare = vi.fn(
+    (shareId: string): Promise<ShareRecord | null> =>
+      Promise.resolve(this.records.get(shareId) ?? null),
   );
 
   getPublicUrl(shareId: string): string {
@@ -377,17 +383,19 @@ async function selectImageLayer(user: ReturnType<typeof userEvent.setup>) {
 
 function mockVideoMetadataLoad() {
   const createElement = document.createElement.bind(document);
-  return vi.spyOn(document, 'createElement').mockImplementation((tagName: string, options?: ElementCreationOptions) => {
-    const element = createElement(tagName, options);
-    if (tagName.toLowerCase() === 'video') {
-      Object.defineProperty(element, 'videoWidth', { configurable: true, value: 1280 });
-      Object.defineProperty(element, 'videoHeight', { configurable: true, value: 720 });
-      queueMicrotask(() => {
-        element.dispatchEvent(new Event('loadedmetadata'));
-      });
-    }
-    return element;
-  });
+  return vi
+    .spyOn(document, 'createElement')
+    .mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+      const element = createElement(tagName, options);
+      if (tagName.toLowerCase() === 'video') {
+        Object.defineProperty(element, 'videoWidth', { configurable: true, value: 1280 });
+        Object.defineProperty(element, 'videoHeight', { configurable: true, value: 720 });
+        queueMicrotask(() => {
+          element.dispatchEvent(new Event('loadedmetadata'));
+        });
+      }
+      return element;
+    });
 }
 
 describe('EditorShell', () => {
@@ -469,7 +477,10 @@ describe('EditorShell', () => {
     expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-selected-elements', '');
 
     await openLeftTab(user, 'Layout');
-    expect(screen.getByRole('button', { name: 'Selected Image' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'Selected Image' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
   });
 
   it('inserts and selects a shape from the Elements panel', async () => {
@@ -491,7 +502,10 @@ describe('EditorShell', () => {
     expect(screen.getByLabelText('Selected shape fill mode')).toBeInTheDocument();
 
     await openLeftTab(user, 'Layout');
-    expect(screen.getByRole('button', { name: 'Background Shape' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Background Shape' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
   });
 
   it('switches to the layout panel from the header view menu', async () => {
@@ -545,9 +559,15 @@ describe('EditorShell', () => {
       'data-selected-elements',
       'image-hero,text-subtitle,text-title',
     );
-    expect(screen.getByRole('button', { name: 'Selected Image' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Selected Image' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
     expect(screen.getByRole('button', { name: 'Title' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('button', { name: 'Subtitle' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Subtitle' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
   });
 
   it('renames the project from the toolbar', async () => {
@@ -558,7 +578,9 @@ describe('EditorShell', () => {
     await user.clear(screen.getByRole('textbox', { name: 'Project name' }));
     await user.type(screen.getByRole('textbox', { name: 'Project name' }), 'Browser Deck{Enter}');
 
-    expect(screen.getByRole('button', { name: 'Edit project name Browser Deck' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Edit project name Browser Deck' }),
+    ).toBeInTheDocument();
   });
 
   it('toggles persistence from disabled to enabled', async () => {
@@ -574,11 +596,16 @@ describe('EditorShell', () => {
       'persistence',
     );
     await user.clear(screen.getByRole('textbox', { name: 'Project folder name' }));
-    await user.type(screen.getByRole('textbox', { name: 'Project folder name' }), 'Mirror Debug Deck');
+    await user.type(
+      screen.getByRole('textbox', { name: 'Project folder name' }),
+      'Mirror Debug Deck',
+    );
     await user.click(screen.getByRole('button', { name: 'Choose folder' }));
 
     expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Edit project name Mirror Debug Deck' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Edit project name Mirror Debug Deck' }),
+    ).toBeInTheDocument();
   });
 
   it('re-enables persistence without opening the folder setup again', async () => {
@@ -684,9 +711,11 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
     await user.click(screen.getByRole('button', { name: 'Choose folder' }));
     await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
-    await user.click(within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
-      name: 'Mirror settings',
-    }));
+    await user.click(
+      within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+        name: 'Mirror settings',
+      }),
+    );
     await user.click(screen.getByRole('button', { name: 'Save settings' }));
 
     await waitFor(() => {
@@ -710,9 +739,11 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
     await user.click(screen.getByRole('button', { name: 'Choose folder' }));
     await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
-    await user.click(within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
-      name: 'Mirror settings',
-    }));
+    await user.click(
+      within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+        name: 'Mirror settings',
+      }),
+    );
     await user.click(screen.getByRole('button', { name: 'Save settings' }));
     await waitFor(() => {
       expect(mirrorService.syncProject).toHaveBeenCalledTimes(1);
@@ -721,7 +752,10 @@ describe('EditorShell', () => {
 
     await user.click(screen.getByRole('button', { name: 'Edit project name Untitled AI Deck' }));
     await user.clear(screen.getByRole('textbox', { name: 'Project name' }));
-    await user.type(screen.getByRole('textbox', { name: 'Project name' }), 'Renamed Mirror Deck{Enter}');
+    await user.type(
+      screen.getByRole('textbox', { name: 'Project name' }),
+      'Renamed Mirror Deck{Enter}',
+    );
 
     await waitFor(
       () => {
@@ -795,13 +829,23 @@ describe('EditorShell', () => {
     services.projectRepository = repository;
     services.mirrorService = mirrorService;
     mirrorService.listProjects.mockResolvedValue([
-      { id: 'Remote Mirror Deck', name: 'Remote Mirror Deck', syncedAt: '2026-06-30T10:00:00.000Z' },
+      {
+        id: 'Remote Mirror Deck',
+        name: 'Remote Mirror Deck',
+        syncedAt: '2026-06-30T10:00:00.000Z',
+      },
     ]);
     mirrorService.downloadProject.mockResolvedValue([
       {
         path: 'project.json',
         blob: new Blob(
-          [JSON.stringify({ ...services.initialProject, id: 'remote-project', name: 'Remote Mirror Deck' })],
+          [
+            JSON.stringify({
+              ...services.initialProject,
+              id: 'remote-project',
+              name: 'Remote Mirror Deck',
+            }),
+          ],
           { type: 'application/json' },
         ),
       },
@@ -965,7 +1009,10 @@ describe('EditorShell', () => {
     expect(screen.getByRole('button', { name: 'Insert Media' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Insert Text' }));
     await openLeftTab(user, 'Layout');
-    expect(screen.getByRole('button', { name: 'Add a heading' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Add a heading' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
   });
 
   it('duplicates the active slide with copied elements and remapped animations', async () => {
@@ -974,7 +1021,13 @@ describe('EditorShell', () => {
     project.pages[0] = {
       ...project.pages[0]!,
       animationBuilds: [
-        { id: 'build-image-hero', elementId: 'image-hero', effect: 'reveal', trigger: 'on-click', delayMs: 0 },
+        {
+          id: 'build-image-hero',
+          elementId: 'image-hero',
+          effect: 'reveal',
+          trigger: 'on-click',
+          delayMs: 0,
+        },
       ],
     };
 
@@ -988,7 +1041,10 @@ describe('EditorShell', () => {
     expect(screen.getByRole('button', { name: 'Insert Media' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Insert Text' }));
     await openLeftTab(user, 'Layout');
-    expect(screen.getByRole('button', { name: 'Add a heading' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Add a heading' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
     await openLeftTab(user, 'Animate');
     expect(screen.getByRole('listitem', { name: 'Build 1: Image' })).toBeInTheDocument();
   });
@@ -1000,7 +1056,13 @@ describe('EditorShell', () => {
       ...project.pages[0]!,
       transition: { effect: 'reveal', delayMs: 0 },
       animationBuilds: [
-        { id: 'build-image-hero', elementId: 'image-hero', effect: 'reveal', trigger: 'on-click', delayMs: 0 },
+        {
+          id: 'build-image-hero',
+          elementId: 'image-hero',
+          effect: 'reveal',
+          trigger: 'on-click',
+          delayMs: 0,
+        },
       ],
     };
 
@@ -1009,8 +1071,14 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Play presentation' }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview', 'playing');
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-mode', 'presenter');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview',
+        'playing',
+      );
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'presenter',
+      );
     });
     expect(screen.queryByLabelText('Animation build 1 for Image')).not.toBeInTheDocument();
   });
@@ -1021,7 +1089,13 @@ describe('EditorShell', () => {
     project.pages[0] = {
       ...project.pages[0]!,
       animationBuilds: [
-        { id: 'build-image-hero', elementId: 'image-hero', effect: 'reveal', trigger: 'on-click', delayMs: 0 },
+        {
+          id: 'build-image-hero',
+          elementId: 'image-hero',
+          effect: 'reveal',
+          trigger: 'on-click',
+          delayMs: 0,
+        },
       ],
     };
 
@@ -1031,8 +1105,14 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Play animation preview' }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview', 'playing');
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-mode', 'editor');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview',
+        'playing',
+      );
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'editor',
+      );
       expect(screen.getByText('Click the slide to play the next animation.')).toBeInTheDocument();
     });
   });
@@ -1044,7 +1124,13 @@ describe('EditorShell', () => {
       ...project.pages[0]!,
       transition: { effect: 'reveal', delayMs: 0 },
       animationBuilds: [
-        { id: 'build-image-hero', elementId: 'image-hero', effect: 'reveal', trigger: 'on-click', delayMs: 0 },
+        {
+          id: 'build-image-hero',
+          elementId: 'image-hero',
+          effect: 'reveal',
+          trigger: 'on-click',
+          delayMs: 0,
+        },
       ],
     };
 
@@ -1053,14 +1139,22 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Play presentation' }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-waiting', 'true');
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-mode', 'presenter');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-waiting',
+        'true',
+      );
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'presenter',
+      );
     });
 
     fireEvent.keyDown(window, { key: 'ArrowRight' });
 
     await waitFor(() => {
-      expect(screen.queryByText('Click the slide to play the next animation.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Click the slide to play the next animation.'),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -1072,7 +1166,13 @@ describe('EditorShell', () => {
         ...project.pages[0]!,
         transition: { effect: 'reveal', delayMs: 0 },
         animationBuilds: [
-          { id: 'build-image-hero', elementId: 'image-hero', effect: 'reveal', trigger: 'on-click', delayMs: 0 },
+          {
+            id: 'build-image-hero',
+            elementId: 'image-hero',
+            effect: 'reveal',
+            trigger: 'on-click',
+            delayMs: 0,
+          },
         ],
       },
       {
@@ -1092,17 +1192,25 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Play presentation' }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-waiting', 'true');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-waiting',
+        'true',
+      );
     });
 
     fireEvent.keyDown(window, { key: 'ArrowRight' });
 
     await waitFor(() => {
-      expect(screen.queryByText('Click the slide to play the next animation.')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Click the slide to play the next animation.'),
+      ).not.toBeInTheDocument();
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-phase', 'complete');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-phase',
+        'complete',
+      );
     });
 
     fireEvent.keyDown(window, { key: 'ArrowRight' });
@@ -1139,7 +1247,13 @@ describe('EditorShell', () => {
         ...project.pages[0]!,
         transition: { effect: 'reveal', delayMs: 0 },
         animationBuilds: [
-          { id: 'build-image-hero', elementId: 'image-hero', effect: 'reveal', trigger: 'on-click', delayMs: 0 },
+          {
+            id: 'build-image-hero',
+            elementId: 'image-hero',
+            effect: 'reveal',
+            trigger: 'on-click',
+            delayMs: 0,
+          },
         ],
       },
       {
@@ -1152,7 +1266,9 @@ describe('EditorShell', () => {
         animationBuilds: [],
       },
     ];
-    const { container } = render(<EditorShell services={createAppServices({ initialProject: project })} />);
+    const { container } = render(
+      <EditorShell services={createAppServices({ initialProject: project })} />,
+    );
 
     await user.click(screen.getByRole('button', { name: 'Play presentation' }));
 
@@ -1161,13 +1277,19 @@ describe('EditorShell', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-waiting', 'true');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-waiting',
+        'true',
+      );
     });
 
     fireEvent.mouseDown(container.querySelector('canvas')!);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-phase', 'complete');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-phase',
+        'complete',
+      );
     });
 
     fireEvent.mouseDown(container.querySelector('canvas')!);
@@ -1207,7 +1329,10 @@ describe('EditorShell', () => {
 
     await waitFor(() => {
       expect(screen.getByText('2 / 2')).toBeInTheDocument();
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-mode', 'presenter');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'presenter',
+      );
     });
 
     await user.click(screen.getByRole('button', { name: 'Presentation play options' }));
@@ -1215,7 +1340,10 @@ describe('EditorShell', () => {
 
     await waitFor(() => {
       expect(screen.getByText('1 / 2')).toBeInTheDocument();
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview-mode', 'presenter');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'presenter',
+      );
     });
   });
 
@@ -1239,7 +1367,13 @@ describe('EditorShell', () => {
       {
         ...project.pages[0]!,
         animationBuilds: [
-          { id: 'build-image-hero', elementId: 'image-hero', effect: 'reveal', trigger: 'on-click', delayMs: 0 },
+          {
+            id: 'build-image-hero',
+            elementId: 'image-hero',
+            effect: 'reveal',
+            trigger: 'on-click',
+            delayMs: 0,
+          },
         ],
       },
       {
@@ -1256,14 +1390,19 @@ describe('EditorShell', () => {
     render(<EditorShell services={createAppServices({ initialProject: project })} />);
 
     await selectImageLayer(user);
-    expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-selected-elements', 'image-hero');
+    expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+      'data-selected-elements',
+      'image-hero',
+    );
     expect(screen.getByRole('button', { name: 'Add page after Slide 1' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Play presentation' }));
 
     await waitFor(() => {
       expect(document.fullscreenElement).toBe(screen.getByLabelText('Canvas workspace'));
-      expect(screen.queryByRole('button', { name: 'Add page after Slide 1' })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Add page after Slide 1' }),
+      ).not.toBeInTheDocument();
     });
 
     fullscreenElement = null;
@@ -1271,7 +1410,10 @@ describe('EditorShell', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Add page after Slide 1' })).toBeInTheDocument();
-      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-animation-preview', 'idle');
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview',
+        'idle',
+      );
       expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-selected-elements', '');
     });
   });
@@ -1399,7 +1541,9 @@ describe('EditorShell', () => {
       'aria-pressed',
       'true',
     );
-    expect(screen.queryByRole('button', { name: 'stale-system-image.png' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'stale-system-image.png' }),
+    ).not.toBeInTheDocument();
   });
 
   it('imports a newer system image paste instead of an older editor object copy', async () => {
@@ -1454,16 +1598,17 @@ describe('EditorShell', () => {
 
     await user.click(screen.getByRole('button', { name: 'Insert Text' }));
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Add a heading' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: 'Add a heading' })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
     });
     await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
     await user.click(screen.getByRole('button', { name: 'Choose folder' }));
     await waitFor(() => {
       const insertedText = Object.values(repository.savedProjects.at(-1)?.elements ?? {}).find(
         (element) =>
-          element.type === 'text' &&
-          element.id !== 'text-title' &&
-          element.id !== 'text-subtitle',
+          element.type === 'text' && element.id !== 'text-title' && element.id !== 'text-subtitle',
       );
       expect(insertedText).toMatchObject({
         type: 'text',
@@ -1507,7 +1652,9 @@ describe('EditorShell', () => {
 
   it('opens the media settings panel when a video layer is selected', async () => {
     const user = userEvent.setup();
-    render(<EditorShell services={createAppServices({ initialProject: createProjectWithVideo() })} />);
+    render(
+      <EditorShell services={createAppServices({ initialProject: createProjectWithVideo() })} />,
+    );
 
     await openLeftTab(user, 'Layout');
     await user.click(screen.getByRole('button', { name: 'Demo clip' }));
@@ -1578,18 +1725,21 @@ describe('EditorShell', () => {
     services.translatorService = new RecordingTranslatorService();
     render(<EditorShell services={services} />);
 
-    expect(await screen.findByRole('button', { name: 'Current slide language English' })).toBeInTheDocument();
-    expect((services.translatorService as RecordingTranslatorService).detectLanguage).toHaveBeenCalledWith(
-      expect.any(String),
-      { allowModelPreparation: false },
-    );
+    expect(
+      await screen.findByRole('button', { name: 'Current slide language English' }),
+    ).toBeInTheDocument();
+    expect(
+      (services.translatorService as RecordingTranslatorService).detectLanguage,
+    ).toHaveBeenCalledWith(expect.any(String), { allowModelPreparation: false });
 
     await openLeftTab(user, 'AI Tools');
     await user.selectOptions(screen.getByLabelText('Translate to'), 'pt');
     expect(await screen.findByText('Pair: en → pt')).toBeInTheDocument();
     await user.click(screen.getAllByRole('button', { name: 'Translate Slide 1' })[0]!);
 
-    expect(await screen.findByRole('button', { name: 'Current slide language Portuguese' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Current slide language Portuguese' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('Pair: pt → pt')).toBeInTheDocument();
   });
 
@@ -1622,7 +1772,9 @@ describe('EditorShell', () => {
     services.translatorService = {
       detectLanguage: vi.fn().mockResolvedValue('en'),
       prepareTranslation: createReadyPrepareTranslationMock(),
-      translate: vi.fn().mockRejectedValue(new Error('Chrome Built-in AI translation is not ready.')),
+      translate: vi
+        .fn()
+        .mockRejectedValue(new Error('Chrome Built-in AI translation is not ready.')),
     };
     render(<EditorShell services={services} />);
 
@@ -1631,14 +1783,18 @@ describe('EditorShell', () => {
     await selectTitleLayer(user);
     await user.click(screen.getByRole('button', { name: 'Translate Selected Text' }));
 
-    expect(await screen.findByText('Chrome Built-in AI translation is not ready.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Chrome Built-in AI translation is not ready.'),
+    ).toBeInTheDocument();
   });
 
   it('fits translated selected text back into the original text frame', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
     const repository = new SavingProjectRepository();
-    const translate = vi.fn().mockResolvedValue('Revolucion\n de diseno impulsada por inteligencia artificial');
+    const translate = vi
+      .fn()
+      .mockResolvedValue('Revolucion\n de diseno impulsada por inteligencia artificial');
     services.projectRepository = repository;
     services.translatorService = {
       detectLanguage: vi.fn().mockResolvedValue('en'),
@@ -1700,9 +1856,13 @@ describe('EditorShell', () => {
       expect(translator.translate).toHaveBeenCalledWith('AI Design Revolution', 'pt', {
         sourceLanguage: 'en',
       });
-      expect(translator.translate).toHaveBeenCalledWith('Browser-native creative automation', 'pt', {
-        sourceLanguage: 'en',
-      });
+      expect(translator.translate).toHaveBeenCalledWith(
+        'Browser-native creative automation',
+        'pt',
+        {
+          sourceLanguage: 'en',
+        },
+      );
     });
   });
 
@@ -1711,10 +1871,7 @@ describe('EditorShell', () => {
     const services = createAppServices();
     const translate = vi.fn().mockResolvedValue('AI Design Revolution');
     services.translatorService = {
-      detectLanguage: vi
-        .fn()
-        .mockResolvedValueOnce('es')
-        .mockResolvedValue('gl'),
+      detectLanguage: vi.fn().mockResolvedValueOnce('es').mockResolvedValue('gl'),
       prepareTranslation: createReadyPrepareTranslationMock(),
       translate,
     };
@@ -1748,9 +1905,13 @@ describe('EditorShell', () => {
       expect(translator.translate).toHaveBeenCalledWith('AI Design Revolution', 'pt', {
         sourceLanguage: 'en',
       });
-      expect(translator.translate).toHaveBeenCalledWith('Browser-native creative automation', 'pt', {
-        sourceLanguage: 'en',
-      });
+      expect(translator.translate).toHaveBeenCalledWith(
+        'Browser-native creative automation',
+        'pt',
+        {
+          sourceLanguage: 'en',
+        },
+      );
     });
   });
 
@@ -1761,9 +1922,13 @@ describe('EditorShell', () => {
 
     await user.click(screen.getByRole('button', { name: 'BG Remover' }));
 
-    expect(screen.getByText('You must download the image editing tools first.')).toBeInTheDocument();
     expect(
-      screen.queryByText('Right click adds areas to keep. Left click applies the background removal.'),
+      screen.getByText('You must download the image editing tools first.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Right click adds areas to keep. Left click applies the background removal.',
+      ),
     ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'BG Remover' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'AI Tools' })).toHaveAttribute('aria-selected', 'true');
@@ -1773,7 +1938,9 @@ describe('EditorShell', () => {
 
     await user.keyboard('{Escape}');
 
-    expect(screen.queryByText('You must download the image editing tools first.')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('You must download the image editing tools first.'),
+    ).not.toBeInTheDocument();
   });
 
   it('enters and cancels background subject selection after image editing models are ready', async () => {
@@ -1789,14 +1956,18 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'BG Remover' }));
 
     expect(
-      await screen.findByText('Right click adds areas to keep. Left click applies the background removal.'),
+      await screen.findByText(
+        'Right click adds areas to keep. Left click applies the background removal.',
+      ),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel BG Remover' })).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
 
     expect(
-      screen.queryByText('Right click adds areas to keep. Left click applies the background removal.'),
+      screen.queryByText(
+        'Right click adds areas to keep. Left click applies the background removal.',
+      ),
     ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'BG Remover' })).toBeInTheDocument();
   });
@@ -1824,7 +1995,10 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Share' }));
     await user.click(screen.getByRole('button', { name: 'Download' }));
 
-    expect(downloadDataUrl).toHaveBeenCalledWith(expect.stringMatching(/^data:image\/png/), 'slide.png');
+    expect(downloadDataUrl).toHaveBeenCalledWith(
+      expect.stringMatching(/^data:image\/png/),
+      'slide.png',
+    );
   });
 
   it('creates and shows a public link from the share panel', async () => {
@@ -1851,9 +2025,7 @@ describe('EditorShell', () => {
     }/editor/s/00000000-0000-4000-8000-000000000301?src=${encodeURIComponent(
       'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000301/share.json',
     )}`;
-    expect(
-      await screen.findByDisplayValue(expectedPublicUrl),
-    ).toBeInTheDocument();
+    expect(await screen.findByDisplayValue(expectedPublicUrl)).toBeInTheDocument();
     expect(writeText).toHaveBeenCalledWith(expectedPublicUrl);
   });
 

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -787,6 +787,9 @@ describe('EditorShell', () => {
       },
       { timeout: 2000 },
     );
+    await waitFor(() => {
+      expect(mirrorService.deleteProject).toHaveBeenCalledWith('Untitled AI Deck', mirrorConfig);
+    });
   });
 
   it('toggles mirroring from the mirror status icon when a saved config is available', async () => {

--- a/apps/editor/tests/unit/ui/editor/RemoteImportPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RemoteImportPanel.test.tsx
@@ -28,4 +28,38 @@ describe('RemoteImportPanel', () => {
 
     expect(onImportProject).toHaveBeenCalledWith('project-beta');
   });
+
+  it('confirms before deleting a remote project and keeps row import separate', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onImportProject = vi.fn();
+    const onDeleteProject = vi.fn();
+
+    render(
+      <RemoteImportPanel
+        projects={[
+          { id: 'project-alpha', name: 'Alpha Deck', syncedAt: '2026-06-30T12:00:00.000Z' },
+        ]}
+        status="ready"
+        onClose={onClose}
+        onDeleteProject={onDeleteProject}
+        onImportProject={onImportProject}
+      />,
+    );
+
+    const list = screen.getByRole('list', { name: 'Remote mirrored projects' });
+    expect(list).toHaveClass('remote-import-list');
+
+    await user.click(screen.getByRole('button', { name: 'Delete Alpha Deck from remote' }));
+
+    expect(onImportProject).not.toHaveBeenCalled();
+    const confirmation = screen.getByRole('alertdialog', { name: 'Delete remote project' });
+    expect(confirmation).toBeInTheDocument();
+    expect(confirmation.parentElement?.firstElementChild).toBe(confirmation);
+
+    await user.click(screen.getByRole('button', { name: 'Delete remote project' }));
+
+    expect(onDeleteProject).toHaveBeenCalledWith('project-alpha');
+    expect(onImportProject).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Add support for removing remote projects from the editor flow
- Update the remote import panel and editor shell to expose the new removal action
- Extend mirror service contracts and MinIO mirror behavior to support remote deletion
- Cover the new behavior with unit tests for the service and editor UI

## Testing
- Unit tests added/updated for `minioMirrorService`, `EditorShell`, and `RemoteImportPanel`
- Not run (not requested)