### PR TITLE
Add ETA-aware progress reporting for AI setup and runtime tasks

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -4177,6 +4177,33 @@ button {
   color: var(--ew-muted);
   font-size: 10px;
   text-transform: uppercase;
+  gap: 8px;
+}
+
+.download-progress-copy {
+  display: inline-flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  line-height: 1.25;
+  text-align: right;
+  text-transform: none;
+}
+
+.download-progress-primary {
+  max-width: 100%;
+  color: var(--ew-text);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.download-progress-secondary {
+  color: var(--ew-muted);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
 }
 
 .model-progress {

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -15,15 +15,24 @@ export type AiCapability =
 export type AiProviderRuntime = 'chrome-built-in' | 'webgpu-huggingface';
 export type AiProviderCompatibility = 'compatible' | 'incompatible' | 'unknown';
 
+export interface ModelDownloadProgressDetails {
+  estimatedRemainingMs?: number | undefined;
+  loadedBytes?: number | undefined;
+  totalBytes?: number | undefined;
+}
+
 export interface ModelState {
   id: string;
   label: string;
   description?: string;
   error?: string | undefined;
+  estimatedRemainingMs?: number | undefined;
+  loadedBytes?: number | undefined;
   provider: 'chrome' | 'transformers';
   status: ModelStatus;
   progress: number;
   required: boolean;
+  totalBytes?: number | undefined;
 }
 
 export interface AiProviderState {
@@ -153,7 +162,7 @@ export interface ModelSetupService {
   downloadRequiredModels(): Promise<ModelState[]>;
   downloadModel(
     id: string,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<ModelState>;
   removeModel?(id: string): Promise<ModelState>;
 }
@@ -183,15 +192,20 @@ export interface TranslatorService {
   setSelectedProvider?(providerId: string): Promise<AiProviderState[]>;
   getLanguageDetectionProviderStates?(): Promise<AiProviderState[]>;
   setLanguageDetectionProvider?(providerId: string): Promise<AiProviderState[]>;
-  prepareLanguageDetection?(options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  prepareLanguageDetection?(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void>;
   detectLanguage(
     text: string,
-    options?: { allowModelPreparation?: boolean; onProgress?: (progress: number) => void },
+    options?: {
+      allowModelPreparation?: boolean;
+      onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+    },
   ): Promise<string>;
   prepareTranslation(
     sourceLanguage: string,
     targetLanguage: string,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void>;
   translate(
     text: string,
@@ -207,7 +221,9 @@ export interface PromptService {
   getSelectedProviderId?(): string;
   setSelectedProvider?(providerId: string): Promise<AiProviderState[]>;
   checkAvailability(): Promise<PromptApiAvailability>;
-  preparePromptApi(options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  preparePromptApi(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void>;
   generateSlideTasksFromPrompt(
     prompt: string,
     options?: { targetLanguageHint?: string },

--- a/apps/editor/src/services/image-generation/bonsaiImageRuntime.ts
+++ b/apps/editor/src/services/image-generation/bonsaiImageRuntime.ts
@@ -1,7 +1,9 @@
+import type { ModelDownloadProgressDetails } from '../contracts/interfaces';
+
 export interface BonsaiImageRuntimeGenerateOptions {
   height: number;
   modelId: string;
-  onLoadProgress?: (progress: number) => void;
+  onLoadProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
   prompt: string;
   seed?: number;
   steps: number;
@@ -10,7 +12,10 @@ export interface BonsaiImageRuntimeGenerateOptions {
 }
 
 export interface BonsaiImageRuntime {
-  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  preload(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
   generate(options: BonsaiImageRuntimeGenerateOptions): Promise<Blob>;
 }
 
@@ -72,6 +77,7 @@ export type BonsaiImageWorkerRequest =
 
 export type BonsaiImageWorkerResponse =
   | {
+      details?: ModelDownloadProgressDetails;
       id: string;
       progress: number;
       type: 'progress';
@@ -99,7 +105,7 @@ interface WorkerBackedBonsaiImageRuntimeOptions {
 }
 
 interface PendingWorkerRequest {
-  onLoadProgress?: ((progress: number) => void) | undefined;
+  onLoadProgress?: ((progress: number, details?: ModelDownloadProgressDetails) => void) | undefined;
   onStep?: ((step: number, totalSteps: number) => void) | undefined;
   reject: (error: Error) => void;
   resolve: (blob?: Blob) => void;
@@ -130,25 +136,30 @@ async function deleteLegacyBonsaiModelCache() {
   }
 }
 
-function createBonsaiRuntimeProgressController(onProgress: (progress: number) => void) {
+function createBonsaiRuntimeProgressController(
+  onProgress: (progress: number, details?: ModelDownloadProgressDetails) => void,
+) {
   const componentProgress = new Map<string, { loaded: number; total: number }>();
   let estimateTimer: ReturnType<typeof setInterval> | undefined;
   let lastProgress = -1;
 
-  const emitProgress = (progress: number) => {
+  const emitProgress = (progress: number, details?: ModelDownloadProgressDetails) => {
     const nextProgress = Math.max(0, Math.min(100, Math.round(progress)));
     if (nextProgress <= lastProgress) return;
     lastProgress = nextProgress;
-    onProgress(nextProgress);
+    onProgress(nextProgress, details);
   };
 
   const reportComponentProgress = () => {
     const total = Object.values(BONSAI_COMPONENT_TOTALS).reduce((sum, value) => sum + value, 0);
-    const loaded = Object.entries(BONSAI_COMPONENT_TOTALS).reduce((sum, [component, fallbackTotal]) => {
-      const progress = componentProgress.get(component);
-      return sum + Math.min(progress?.loaded ?? 0, progress?.total ?? fallbackTotal);
-    }, 0);
-    emitProgress((loaded / total) * 100);
+    const loaded = Object.entries(BONSAI_COMPONENT_TOTALS).reduce(
+      (sum, [component, fallbackTotal]) => {
+        const progress = componentProgress.get(component);
+        return sum + Math.min(progress?.loaded ?? 0, progress?.total ?? fallbackTotal);
+      },
+      0,
+    );
+    emitProgress((loaded / total) * 100, { loadedBytes: loaded, totalBytes: total });
   };
 
   const reportRuntimeProgress = (progress: BonsaiRuntimeProgress) => {
@@ -163,7 +174,12 @@ function createBonsaiRuntimeProgressController(onProgress: (progress: number) =>
       emitProgress(componentFloor[progress.component] ?? 10);
     }
 
-    if (progress.component) {
+    if (
+      progress.component &&
+      Number.isFinite(progress.loaded) &&
+      Number.isFinite(progress.total) &&
+      (progress.total ?? 0) > 0
+    ) {
       const fallbackTotal = BONSAI_COMPONENT_TOTALS[progress.component] ?? progress.total ?? 1;
       componentProgress.set(progress.component, {
         loaded: Math.max(0, progress.loaded ?? 0),
@@ -173,8 +189,15 @@ function createBonsaiRuntimeProgressController(onProgress: (progress: number) =>
       return;
     }
 
-    if (Number.isFinite(progress.loaded) && Number.isFinite(progress.total) && (progress.total ?? 0) > 0) {
-      emitProgress(((progress.loaded ?? 0) / (progress.total ?? 1)) * 100);
+    if (
+      Number.isFinite(progress.loaded) &&
+      Number.isFinite(progress.total) &&
+      (progress.total ?? 0) > 0
+    ) {
+      emitProgress(((progress.loaded ?? 0) / (progress.total ?? 1)) * 100, {
+        loadedBytes: Math.max(0, progress.loaded ?? 0),
+        totalBytes: Math.max(1, progress.total ?? 1),
+      });
     }
   };
 
@@ -209,7 +232,10 @@ class BrowserBonsaiImageRuntime implements BonsaiImageRuntime {
 
   constructor(private readonly options: BrowserBonsaiImageRuntimeOptions = {}) {}
 
-  async preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  async preload(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     await this.loadPipeline(modelId, options?.onProgress ? { onProgress: options.onProgress } : {});
   }
 
@@ -234,10 +260,14 @@ class BrowserBonsaiImageRuntime implements BonsaiImageRuntime {
 
   private async loadPipeline(
     modelId: string,
-    options: { onProgress?: (progress: number) => void } = {},
+    options: {
+      onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+    } = {},
   ): Promise<BonsaiPipeline> {
     this.pipelinePromise ??= this.importRuntimeModule().then(async (module) => {
-      const progressReporter = options.onProgress ? createBonsaiRuntimeProgressController(options.onProgress) : undefined;
+      const progressReporter = options.onProgress
+        ? createBonsaiRuntimeProgressController(options.onProgress)
+        : undefined;
       const preloadOptions: {
         cacheName: string;
         onProgress?: (progress: BonsaiRuntimeProgress) => void;
@@ -275,7 +305,10 @@ class WorkerBackedBonsaiImageRuntime implements BonsaiImageRuntime {
 
   constructor(private readonly options: WorkerBackedBonsaiImageRuntimeOptions = {}) {}
 
-  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  preload(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     if (this.fallbackRuntime) return this.fallbackRuntime.preload(modelId, options);
     return this.request(
       {
@@ -352,7 +385,7 @@ class WorkerBackedBonsaiImageRuntime implements BonsaiImageRuntime {
     const pending = this.pendingRequests.get(response.id);
     if (!pending) return;
     if (response.type === 'progress') {
-      pending.onLoadProgress?.(response.progress);
+      pending.onLoadProgress?.(response.progress, response.details);
       return;
     }
     if (response.type === 'step') {
@@ -380,10 +413,12 @@ class WorkerBackedBonsaiImageRuntime implements BonsaiImageRuntime {
   ): Promise<Blob | undefined> {
     const fallback = this.getFallbackRuntime();
     if (request.type === 'preload') {
-      return fallback.preload(
-        request.modelId,
-        handlers.onLoadProgress ? { onProgress: handlers.onLoadProgress } : undefined,
-      ).then(() => undefined);
+      return fallback
+        .preload(
+          request.modelId,
+          handlers.onLoadProgress ? { onProgress: handlers.onLoadProgress } : undefined,
+        )
+        .then(() => undefined);
     }
     return fallback.generate({
       ...request.options,

--- a/apps/editor/src/services/image-generation/bonsaiImageRuntime.ts
+++ b/apps/editor/src/services/image-generation/bonsaiImageRuntime.ts
@@ -150,6 +150,22 @@ function createBonsaiRuntimeProgressController(
     onProgress(nextProgress, details);
   };
 
+  const getCompleteComponentDetails = () => {
+    const expectedComponents = Object.keys(BONSAI_COMPONENT_TOTALS);
+    if (!expectedComponents.every((component) => componentProgress.has(component))) return undefined;
+
+    const loadedBytes = expectedComponents.reduce((sum, component) => {
+      const progress = componentProgress.get(component);
+      return sum + Math.min(progress?.loaded ?? 0, progress?.total ?? 0);
+    }, 0);
+    const totalBytes = expectedComponents.reduce((sum, component) => {
+      const progress = componentProgress.get(component);
+      return sum + (progress?.total ?? 0);
+    }, 0);
+
+    return totalBytes > 0 ? { loadedBytes, totalBytes } : undefined;
+  };
+
   const reportComponentProgress = () => {
     const total = Object.values(BONSAI_COMPONENT_TOTALS).reduce((sum, value) => sum + value, 0);
     const loaded = Object.entries(BONSAI_COMPONENT_TOTALS).reduce(
@@ -159,7 +175,7 @@ function createBonsaiRuntimeProgressController(
       },
       0,
     );
-    emitProgress((loaded / total) * 100, { loadedBytes: loaded, totalBytes: total });
+    emitProgress((loaded / total) * 100, getCompleteComponentDetails());
   };
 
   const reportRuntimeProgress = (progress: BonsaiRuntimeProgress) => {

--- a/apps/editor/src/services/image-generation/bonsaiImageRuntime.worker.ts
+++ b/apps/editor/src/services/image-generation/bonsaiImageRuntime.worker.ts
@@ -7,6 +7,17 @@ function postResponse(response: BonsaiImageWorkerResponse) {
   self.postMessage(response);
 }
 
+type BonsaiProgressDetails = Extract<BonsaiImageWorkerResponse, { type: 'progress' }>['details'];
+
+function postProgress(id: string, progress: number, details: BonsaiProgressDetails | undefined) {
+  postResponse({
+    ...(details ? { details } : {}),
+    id,
+    progress,
+    type: 'progress',
+  });
+}
+
 self.onmessage = (event: MessageEvent<BonsaiImageWorkerRequest>) => {
   const request = event.data;
   void handleRequest(request);
@@ -16,8 +27,8 @@ async function handleRequest(request: BonsaiImageWorkerRequest) {
   try {
     if (request.type === 'preload') {
       await runtime.preload(request.modelId, {
-        onProgress: (progress) => {
-          postResponse({ id: request.id, progress, type: 'progress' });
+        onProgress: (progress, details) => {
+          postProgress(request.id, progress, details);
         },
       });
       postResponse({ id: request.id, type: 'result' });
@@ -26,8 +37,8 @@ async function handleRequest(request: BonsaiImageWorkerRequest) {
 
     const blob = await runtime.generate({
       ...request.options,
-      onLoadProgress: (progress) => {
-        postResponse({ id: request.id, progress, type: 'progress' });
+      onLoadProgress: (progress, details) => {
+        postProgress(request.id, progress, details);
       },
       onStep: (step, totalSteps) => {
         postResponse({ id: request.id, step, totalSteps, type: 'step' });

--- a/apps/editor/src/services/model-setup/modelSetupService.ts
+++ b/apps/editor/src/services/model-setup/modelSetupService.ts
@@ -18,7 +18,10 @@ const IMAGE_EDITING_DISPLAY_NAME = 'SlimSAM 77M';
 const IMAGE_EDITING_READY_KEY = 'ew-canvas-ai.model.image-editing-models.ready';
 
 export interface ImageEditingModelLoader {
-  loadImageEditingModel(): Promise<void>;
+  loadImageEditingModel(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void>;
+  removeImageEditingModel?(): Promise<void>;
 }
 
 export interface ImageGenerationModelLoader {
@@ -113,8 +116,14 @@ function getReadyKey(id: string) {
 class TransformersImageEditingModelLoader implements ImageEditingModelLoader {
   constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
 
-  async loadImageEditingModel(): Promise<void> {
-    await this.runtimeClient.preloadImageEditing();
+  async loadImageEditingModel(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void> {
+    await this.runtimeClient.preloadImageEditing(options);
+  }
+
+  async removeImageEditingModel(): Promise<void> {
+    await this.runtimeClient.removeImageEditing();
   }
 }
 
@@ -262,7 +271,9 @@ class BrowserModelSetupService implements ModelSetupService {
 
     try {
       if (id === IMAGE_EDITING_MODEL_ID) {
-        await this.imageEditingModelLoader.loadImageEditingModel();
+        await this.imageEditingModelLoader.loadImageEditingModel({
+          onProgress: reportProgress,
+        });
         this.storage?.setItem(IMAGE_EDITING_READY_KEY, 'true');
       }
       if (id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID) {
@@ -348,6 +359,7 @@ class BrowserModelSetupService implements ModelSetupService {
       );
     }
     if (id === IMAGE_EDITING_MODEL_ID) {
+      await this.imageEditingModelLoader.removeImageEditingModel?.();
       await this.modelCacheStorage.deleteModelArtifacts(IMAGE_EDITING_TRANSFORMERS_MODEL_ID);
     }
     if (id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID) {

--- a/apps/editor/src/services/model-setup/modelSetupService.ts
+++ b/apps/editor/src/services/model-setup/modelSetupService.ts
@@ -1,4 +1,8 @@
-import type { ModelSetupService, ModelState } from '../contracts/interfaces';
+import type {
+  ModelDownloadProgressDetails,
+  ModelSetupService,
+  ModelState,
+} from '../contracts/interfaces';
 import { aiModelCatalog } from './aiModelCatalog';
 import { imageGenerationModel } from '../image-generation/imageGenerationModel';
 import { bonsaiImageRuntime } from '../image-generation/bonsaiImageRuntime';
@@ -18,17 +22,25 @@ export interface ImageEditingModelLoader {
 }
 
 export interface ImageGenerationModelLoader {
-  loadImageGenerationModel(options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  loadImageGenerationModel(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void>;
 }
 
 export interface TextGenerationModelLoader {
-  loadTextGenerationModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  loadTextGenerationModel(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
   removeTextGenerationModel?(modelId: string): Promise<void>;
   releaseTextGenerationModel?(modelId: string): Promise<void> | void;
 }
 
 export interface LanguageDetectionModelLoader {
-  loadLanguageDetectionModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  loadLanguageDetectionModel(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
 }
 
 export interface ModelCacheStorage {
@@ -89,10 +101,12 @@ function cloneStates(states: ModelState[]) {
 
 function getReadyKey(id: string) {
   if (id === IMAGE_EDITING_MODEL_ID) return IMAGE_EDITING_READY_KEY;
-  if (id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID) return imageGenerationModel.IMAGE_GENERATION_READY_KEY;
+  if (id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID)
+    return imageGenerationModel.IMAGE_GENERATION_READY_KEY;
   if (id === aiModelCatalog.GEMMA_LLM_MODEL_ID) return aiModelCatalog.GEMMA_LLM_READY_KEY;
   if (id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID) return aiModelCatalog.TRANSLATEGEMMA_READY_KEY;
-  if (id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID) return aiModelCatalog.LANGUAGE_DETECTION_READY_KEY;
+  if (id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID)
+    return aiModelCatalog.LANGUAGE_DETECTION_READY_KEY;
   return undefined;
 }
 
@@ -105,15 +119,23 @@ class TransformersImageEditingModelLoader implements ImageEditingModelLoader {
 }
 
 class TransformersImageGenerationModelLoader implements ImageGenerationModelLoader {
-  async loadImageGenerationModel(options?: { onProgress?: (progress: number) => void }): Promise<void> {
-    await new bonsaiImageRuntime.WorkerBackedBonsaiImageRuntime().preload(imageGenerationModel.IMAGE_GENERATION_TRANSFORMERS_MODEL_ID, options);
+  async loadImageGenerationModel(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void> {
+    await new bonsaiImageRuntime.WorkerBackedBonsaiImageRuntime().preload(
+      imageGenerationModel.IMAGE_GENERATION_TRANSFORMERS_MODEL_ID,
+      options,
+    );
   }
 }
 
 class TransformersTextGenerationModelLoader implements TextGenerationModelLoader {
   constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
 
-  async loadTextGenerationModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  async loadTextGenerationModel(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     await this.runtimeClient.preloadTextGeneration(modelId, options);
   }
 
@@ -131,10 +153,20 @@ class TransformersLanguageDetectionModelLoader implements LanguageDetectionModel
 
   async loadLanguageDetectionModel(
     modelId: string,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void> {
     await this.runtimeClient.preloadLanguageDetection(modelId, options);
   }
+}
+
+function withoutProgressDetails(patch: Partial<ModelState>): Partial<ModelState> {
+  if (patch.status === 'downloading') return patch;
+  return {
+    ...patch,
+    estimatedRemainingMs: undefined,
+    loadedBytes: undefined,
+    totalBytes: undefined,
+  };
 }
 
 class BrowserTransformersModelCache implements ModelCacheStorage {
@@ -161,29 +193,35 @@ class BrowserModelSetupService implements ModelSetupService {
 
   constructor(
     private readonly imageEditingModelLoader: ImageEditingModelLoader = new TransformersImageEditingModelLoader(),
-    private readonly storage: BrowserKeyValueStorage | undefined = browserStorage.getBrowserLocalStorage(),
+    private readonly storage:
+      | BrowserKeyValueStorage
+      | undefined = browserStorage.getBrowserLocalStorage(),
     private readonly imageGenerationModelLoader: ImageGenerationModelLoader = new TransformersImageGenerationModelLoader(),
     private readonly textGenerationModelLoader: TextGenerationModelLoader = new TransformersTextGenerationModelLoader(),
     private readonly modelCacheStorage: ModelCacheStorage = new BrowserTransformersModelCache(),
     private readonly languageDetectionModelLoader: LanguageDetectionModelLoader = new TransformersLanguageDetectionModelLoader(),
   ) {
     const imageEditingModelReady = storage?.getItem(IMAGE_EDITING_READY_KEY) === 'true';
-    const imageGenerationModelReady = storage?.getItem(imageGenerationModel.IMAGE_GENERATION_READY_KEY) === 'true';
+    const imageGenerationModelReady =
+      storage?.getItem(imageGenerationModel.IMAGE_GENERATION_READY_KEY) === 'true';
     const gemmaLlmReady = storage?.getItem(aiModelCatalog.GEMMA_LLM_READY_KEY) === 'true';
-    const translateGemmaReady = storage?.getItem(aiModelCatalog.TRANSLATEGEMMA_READY_KEY) === 'true';
-    const languageDetectionReady = storage?.getItem(aiModelCatalog.LANGUAGE_DETECTION_READY_KEY) === 'true';
+    const translateGemmaReady =
+      storage?.getItem(aiModelCatalog.TRANSLATEGEMMA_READY_KEY) === 'true';
+    const languageDetectionReady =
+      storage?.getItem(aiModelCatalog.LANGUAGE_DETECTION_READY_KEY) === 'true';
     this.states = initialStates.map((state) =>
       state.id === aiModelCatalog.GEMMA_LLM_MODEL_ID && gemmaLlmReady
         ? { ...state, status: 'ready', progress: 100 }
         : state.id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID && translateGemmaReady
           ? { ...state, status: 'ready', progress: 100 }
-        : state.id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID && languageDetectionReady
-          ? { ...state, status: 'ready', progress: 100 }
-        : state.id === IMAGE_EDITING_MODEL_ID && imageEditingModelReady
-        ? { ...state, status: 'ready', progress: 100 }
-        : state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID && imageGenerationModelReady
-          ? { ...state, status: 'ready', progress: 100 }
-        : { ...state },
+          : state.id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID && languageDetectionReady
+            ? { ...state, status: 'ready', progress: 100 }
+            : state.id === IMAGE_EDITING_MODEL_ID && imageEditingModelReady
+              ? { ...state, status: 'ready', progress: 100 }
+              : state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID &&
+                  imageGenerationModelReady
+                ? { ...state, status: 'ready', progress: 100 }
+                : { ...state },
     );
   }
 
@@ -198,16 +236,26 @@ class BrowserModelSetupService implements ModelSetupService {
     return this.getModelStates();
   }
 
-  async downloadModel(id: string, options?: { onProgress?: (progress: number) => void }): Promise<ModelState> {
+  async downloadModel(
+    id: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<ModelState> {
     const current = this.states.find((state) => state.id === id);
     if (!current) throw new Error(`Unknown model: ${id}`);
     if (current.status === 'ready') return { ...current };
 
+    const startedAt = Date.now();
     this.setModelState(id, { status: 'downloading', progress: 10, error: undefined });
     const reportProgress = progress.createMonotonicProgressReporter(
-      (progress) => {
-        this.setModelState(id, { status: 'downloading', progress, error: undefined });
-        options?.onProgress?.(progress);
+      (progress, details) => {
+        const nextDetails = this.withRemainingTime(startedAt, details);
+        this.setModelState(id, {
+          status: 'downloading',
+          progress,
+          error: undefined,
+          ...nextDetails,
+        });
+        options?.onProgress?.(progress, nextDetails);
       },
       { initial: 10, min: 10, max: 99 },
     );
@@ -224,33 +272,50 @@ class BrowserModelSetupService implements ModelSetupService {
         this.storage?.setItem(imageGenerationModel.IMAGE_GENERATION_READY_KEY, 'true');
       }
       if (id === aiModelCatalog.GEMMA_LLM_MODEL_ID) {
-        await this.textGenerationModelLoader.loadTextGenerationModel(aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID, {
-          onProgress: reportProgress,
-        });
-        await this.textGenerationModelLoader.releaseTextGenerationModel?.(aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID);
+        await this.textGenerationModelLoader.loadTextGenerationModel(
+          aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+          {
+            onProgress: reportProgress,
+          },
+        );
+        await this.textGenerationModelLoader.releaseTextGenerationModel?.(
+          aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+        );
         this.storage?.setItem(aiModelCatalog.GEMMA_LLM_READY_KEY, 'true');
       }
       if (id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID) {
-        await this.textGenerationModelLoader.loadTextGenerationModel(aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID, {
-          onProgress: reportProgress,
-        });
-        await this.textGenerationModelLoader.releaseTextGenerationModel?.(aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID);
+        await this.textGenerationModelLoader.loadTextGenerationModel(
+          aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID,
+          {
+            onProgress: reportProgress,
+          },
+        );
+        await this.textGenerationModelLoader.releaseTextGenerationModel?.(
+          aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID,
+        );
         this.storage?.setItem(aiModelCatalog.TRANSLATEGEMMA_READY_KEY, 'true');
       }
       if (id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID) {
-        await this.languageDetectionModelLoader.loadLanguageDetectionModel(aiModelCatalog.LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID, {
-          onProgress: reportProgress,
-        });
+        await this.languageDetectionModelLoader.loadLanguageDetectionModel(
+          aiModelCatalog.LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID,
+          {
+            onProgress: reportProgress,
+          },
+        );
         this.storage?.setItem(aiModelCatalog.LANGUAGE_DETECTION_READY_KEY, 'true');
       }
       options?.onProgress?.(100);
       return this.setModelState(id, { status: 'ready', progress: 100, error: undefined });
     } catch (error) {
       if (id === IMAGE_EDITING_MODEL_ID) this.storage?.setItem(IMAGE_EDITING_READY_KEY, 'false');
-      if (id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID) this.storage?.setItem(imageGenerationModel.IMAGE_GENERATION_READY_KEY, 'false');
-      if (id === aiModelCatalog.GEMMA_LLM_MODEL_ID) this.storage?.setItem(aiModelCatalog.GEMMA_LLM_READY_KEY, 'false');
-      if (id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID) this.storage?.setItem(aiModelCatalog.TRANSLATEGEMMA_READY_KEY, 'false');
-      if (id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID) this.storage?.setItem(aiModelCatalog.LANGUAGE_DETECTION_READY_KEY, 'false');
+      if (id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID)
+        this.storage?.setItem(imageGenerationModel.IMAGE_GENERATION_READY_KEY, 'false');
+      if (id === aiModelCatalog.GEMMA_LLM_MODEL_ID)
+        this.storage?.setItem(aiModelCatalog.GEMMA_LLM_READY_KEY, 'false');
+      if (id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID)
+        this.storage?.setItem(aiModelCatalog.TRANSLATEGEMMA_READY_KEY, 'false');
+      if (id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID)
+        this.storage?.setItem(aiModelCatalog.LANGUAGE_DETECTION_READY_KEY, 'false');
       const message = error instanceof Error ? error.message : 'Model download failed.';
       return this.setModelState(id, { status: 'failed', progress: 0, error: message });
     }
@@ -267,26 +332,54 @@ class BrowserModelSetupService implements ModelSetupService {
     }
 
     if (id === aiModelCatalog.GEMMA_LLM_MODEL_ID) {
-      await this.textGenerationModelLoader.removeTextGenerationModel?.(aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID);
-      await this.modelCacheStorage.deleteModelArtifacts(aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID);
+      await this.textGenerationModelLoader.removeTextGenerationModel?.(
+        aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+      );
+      await this.modelCacheStorage.deleteModelArtifacts(
+        aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+      );
     }
     if (id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID) {
-      await this.textGenerationModelLoader.removeTextGenerationModel?.(aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID);
-      await this.modelCacheStorage.deleteModelArtifacts(aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID);
+      await this.textGenerationModelLoader.removeTextGenerationModel?.(
+        aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID,
+      );
+      await this.modelCacheStorage.deleteModelArtifacts(
+        aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID,
+      );
     }
     if (id === IMAGE_EDITING_MODEL_ID) {
       await this.modelCacheStorage.deleteModelArtifacts(IMAGE_EDITING_TRANSFORMERS_MODEL_ID);
     }
     if (id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID) {
-      await this.modelCacheStorage.deleteModelArtifacts(imageGenerationModel.IMAGE_GENERATION_TRANSFORMERS_MODEL_ID);
+      await this.modelCacheStorage.deleteModelArtifacts(
+        imageGenerationModel.IMAGE_GENERATION_TRANSFORMERS_MODEL_ID,
+      );
     }
 
     return this.setModelState(id, { status: 'needs-download', progress: 0, error: undefined });
   }
 
   private setModelState(id: string, patch: Partial<ModelState>) {
-    this.states = this.states.map((state) => (state.id === id ? { ...state, ...patch } : state));
+    this.states = this.states.map((state) =>
+      state.id === id ? { ...state, ...withoutProgressDetails(patch) } : state,
+    );
     return { ...this.states.find((state) => state.id === id)! };
+  }
+
+  private withRemainingTime(
+    startedAt: number,
+    details: ModelDownloadProgressDetails | undefined,
+  ): ModelDownloadProgressDetails | undefined {
+    if (!details) return undefined;
+    const estimatedRemainingMs = progress.estimateRemainingMs({
+      elapsedMs: Date.now() - startedAt,
+      loadedBytes: details.loadedBytes,
+      totalBytes: details.totalBytes,
+    });
+    return {
+      ...details,
+      estimatedRemainingMs,
+    };
   }
 }
 
@@ -304,7 +397,10 @@ class InMemoryModelSetupService implements ModelSetupService {
     return this.getModelStates();
   }
 
-  downloadModel(id: string, options?: { onProgress?: (progress: number) => void }): Promise<ModelState> {
+  downloadModel(
+    id: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<ModelState> {
     const current = this.states.find((state) => state.id === id);
     if (!current) throw new Error(`Unknown model: ${id}`);
 
@@ -320,7 +416,9 @@ class InMemoryModelSetupService implements ModelSetupService {
     if (!current) throw new Error(`Unknown model: ${id}`);
 
     this.states = this.states.map((state) =>
-      state.id === id ? { ...state, status: 'needs-download', progress: 0, error: undefined } : state,
+      state.id === id
+        ? { ...state, status: 'needs-download', progress: 0, error: undefined }
+        : state,
     );
     return Promise.resolve({ ...this.states.find((state) => state.id === id)! });
   }

--- a/apps/editor/src/services/model-setup/progress.ts
+++ b/apps/editor/src/services/model-setup/progress.ts
@@ -1,3 +1,5 @@
+import type { ModelDownloadProgressDetails } from '../contracts/interfaces';
+
 function clampProgress(progress: number, min = 0, max = 100) {
   return Math.max(min, Math.min(max, Math.round(progress)));
 }
@@ -7,17 +9,17 @@ function mapProgressToRange(progress: number, min: number, max: number) {
 }
 
 function createMonotonicProgressReporter(
-  onProgress: ((progress: number) => void) | undefined,
+  onProgress: ((progress: number, details?: ModelDownloadProgressDetails) => void) | undefined,
   options: { initial?: number; min?: number; max?: number } = {},
 ) {
   let latest = options.initial ?? options.min ?? 0;
   const min = options.min ?? 0;
   const max = options.max ?? 100;
 
-  return (progress: number) => {
+  return (progress: number, details?: ModelDownloadProgressDetails) => {
     const next = Math.max(latest, clampProgress(progress, min, max));
     latest = next;
-    onProgress?.(next);
+    onProgress?.(next, details);
     return next;
   };
 }
@@ -36,7 +38,7 @@ function isTransformersProgressEvent(event: unknown): event is TransformersProgr
 }
 
 function createTransformersProgressCallback(
-  onProgress: ((progress: number) => void) | undefined,
+  onProgress: ((progress: number, details?: ModelDownloadProgressDetails) => void) | undefined,
   options: { initial?: number; min?: number; max?: number } = {},
 ) {
   const reportProgress = createMonotonicProgressReporter(onProgress, options);
@@ -48,7 +50,7 @@ function createTransformersProgressCallback(
 
     if (event.status === 'progress_total' && typeof event.progress === 'number') {
       receivedAggregateProgress = true;
-      reportProgress(event.progress);
+      reportProgress(event.progress, getByteProgressDetails(event));
       return;
     }
 
@@ -68,7 +70,8 @@ function createTransformersProgressCallback(
       const totals = Array.from(fileProgress.values());
       const loaded = totals.reduce((sum, file) => sum + Math.min(file.loaded, file.total), 0);
       const total = totals.reduce((sum, file) => sum + file.total, 0);
-      if (total > 0) reportProgress((loaded / total) * 100);
+      if (total > 0)
+        reportProgress((loaded / total) * 100, { loadedBytes: loaded, totalBytes: total });
       return;
     }
 
@@ -76,6 +79,37 @@ function createTransformersProgressCallback(
       reportProgress(event.progress);
     }
   };
+}
+
+function getByteProgressDetails(
+  event: TransformersProgressEvent,
+): ModelDownloadProgressDetails | undefined {
+  if (typeof event.loaded !== 'number' || typeof event.total !== 'number' || event.total <= 0) {
+    return undefined;
+  }
+
+  return {
+    loadedBytes: Math.max(0, event.loaded),
+    totalBytes: Math.max(1, event.total),
+  };
+}
+
+function estimateRemainingMs({
+  elapsedMs,
+  loadedBytes,
+  totalBytes,
+}: {
+  elapsedMs: number;
+  loadedBytes?: number | undefined;
+  totalBytes?: number | undefined;
+}) {
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return undefined;
+  if (!Number.isFinite(loadedBytes) || !Number.isFinite(totalBytes)) return undefined;
+  if (!loadedBytes || !totalBytes || loadedBytes <= 0 || totalBytes <= loadedBytes)
+    return undefined;
+
+  const remainingMs = elapsedMs * ((totalBytes - loadedBytes) / loadedBytes);
+  return Number.isFinite(remainingMs) ? Math.round(remainingMs) : undefined;
 }
 function createEstimatedProgressTicker(
   onProgress: (progress: number) => void,
@@ -100,5 +134,6 @@ export const progress = {
   mapProgressToRange,
   createMonotonicProgressReporter,
   createTransformersProgressCallback,
+  estimateRemainingMs,
   createEstimatedProgressTicker,
 };

--- a/apps/editor/src/services/model-setup/transformersOperations.ts
+++ b/apps/editor/src/services/model-setup/transformersOperations.ts
@@ -1,5 +1,6 @@
 import { imageGenerationModel } from '../image-generation/imageGenerationModel';
 import { progress } from './progress';
+import type { ModelDownloadProgressDetails } from '../contracts/interfaces';
 
 const IMAGE_EDITING_TRANSFORMERS_MODEL_ID = 'Xenova/slimsam-77-uniform';
 
@@ -58,12 +59,18 @@ interface SegmentationResult extends EncodedAsset {
   scores: number[];
 }
 
-type TextGenerationPipeline = ((prompt: unknown, options?: TextGenerationOptions) => Promise<unknown>) & {
+type TextGenerationPipeline = ((
+  prompt: unknown,
+  options?: TextGenerationOptions,
+) => Promise<unknown>) & {
   dispose?: () => Promise<void> | void;
 };
 
 type TextClassificationResult = { label?: unknown; score?: unknown };
-type TextClassificationPipeline = ((text: string, options?: Record<string, unknown>) => Promise<unknown>) & {
+type TextClassificationPipeline = ((
+  text: string,
+  options?: Record<string, unknown>,
+) => Promise<unknown>) & {
   dispose?: () => Promise<void> | void;
 };
 
@@ -164,11 +171,18 @@ class DirectTransformersOperations {
   private languageDetectionPipelines = new Map<string, Promise<TextClassificationPipeline>>();
   private textGenerationPipelines = new Map<string, Promise<TextGenerationPipeline>>();
 
-  async preloadTextGeneration(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+  async preloadTextGeneration(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     await this.loadTextGenerationPipeline(modelId, options);
   }
 
-  async generateText(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions) {
+  async generateText(
+    modelId: string,
+    prompt: TextGenerationInput,
+    options?: TextGenerationOptions,
+  ) {
     const textGeneration = await this.loadTextGenerationPipeline(modelId);
     const generationOptions: TextGenerationOptions = {
       do_sample: false,
@@ -198,7 +212,10 @@ class DirectTransformersOperations {
     await pipeline?.dispose?.();
   }
 
-  async preloadLanguageDetection(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+  async preloadLanguageDetection(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     await this.loadLanguageDetectionPipeline(modelId, options);
   }
 
@@ -216,19 +233,30 @@ class DirectTransformersOperations {
     options?.onProgress?.(100);
   }
 
-  async prepareBackgroundRemoval(objectUrl: string, options?: { onProgress?: (progress: number) => void }) {
+  async prepareBackgroundRemoval(
+    objectUrl: string,
+    options?: { onProgress?: (progress: number) => void },
+  ) {
     await this.encodeAsset(objectUrl, options?.onProgress);
     options?.onProgress?.(100);
   }
 
-  async segmentBackgroundRemoval(objectUrl: string, points: SegmentationPoint[]): Promise<BackgroundSegmentationResult> {
+  async segmentBackgroundRemoval(
+    objectUrl: string,
+    points: SegmentationPoint[],
+  ): Promise<BackgroundSegmentationResult> {
     const positivePoints = points.filter((point) => point.positive);
     const promptPoints = positivePoints.length > 0 ? positivePoints : points;
-    const segmentations = await Promise.all(promptPoints.map((point) => this.segment(objectUrl, [point])));
-    if (segmentations.length === 0) throw new Error('At least one point is required for segmentation.');
+    const segmentations = await Promise.all(
+      promptPoints.map((point) => this.segment(objectUrl, [point])),
+    );
+    if (segmentations.length === 0)
+      throw new Error('At least one point is required for segmentation.');
     const firstSegmentation = segmentations[0];
     if (!firstSegmentation) throw new Error('At least one point is required for segmentation.');
-    const subjectData = new Uint8Array(firstSegmentation.mask.width * firstSegmentation.mask.height);
+    const subjectData = new Uint8Array(
+      firstSegmentation.mask.width * firstSegmentation.mask.height,
+    );
     let scoreTotal = 0;
 
     for (const segmentation of segmentations) {
@@ -254,7 +282,10 @@ class DirectTransformersOperations {
     };
   }
 
-  private loadTextGenerationPipeline(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+  private loadTextGenerationPipeline(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     const existingPipeline = this.textGenerationPipelines.get(modelId);
     if (existingPipeline) return existingPipeline;
 
@@ -271,7 +302,10 @@ class DirectTransformersOperations {
     return pipelinePromise;
   }
 
-  private loadLanguageDetectionPipeline(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+  private loadLanguageDetectionPipeline(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     const existingPipeline = this.languageDetectionPipelines.get(modelId);
     if (existingPipeline) return existingPipeline;
 
@@ -287,7 +321,10 @@ class DirectTransformersOperations {
     return pipelinePromise;
   }
 
-  private async segment(objectUrl: string, points: SegmentationPoint[]): Promise<SegmentationResult> {
+  private async segment(
+    objectUrl: string,
+    points: SegmentationPoint[],
+  ): Promise<SegmentationResult> {
     const { model, processor, RawImage, Tensor } = await this.loadBackgroundModel();
     const encodedAsset = await this.encodeAsset(objectUrl);
     const reshaped = encodedAsset.imageProcessed.reshaped_input_sizes[0]!;
@@ -358,7 +395,8 @@ class DirectTransformersOperations {
   }
 
   private async createBackgroundModel() {
-    const { AutoProcessor, RawImage, SamModel, Tensor, env } = await import('@huggingface/transformers');
+    const { AutoProcessor, RawImage, SamModel, Tensor, env } =
+      await import('@huggingface/transformers');
 
     env.useBrowserCache = true;
     env.cacheKey = imageGenerationModel.TRANSFORMERS_CACHE_KEY;
@@ -380,7 +418,10 @@ class DirectTransformersOperations {
   }
 
   private getBestMaskIndex(scores: number[]) {
-    return scores.reduce((bestIndex, score, index) => (score > scores[bestIndex]! ? index : bestIndex), 0);
+    return scores.reduce(
+      (bestIndex, score, index) => (score > scores[bestIndex]! ? index : bestIndex),
+      0,
+    );
   }
 }
 

--- a/apps/editor/src/services/model-setup/transformersOperations.ts
+++ b/apps/editor/src/services/model-setup/transformersOperations.ts
@@ -75,6 +75,7 @@ type TextClassificationPipeline = ((
 };
 
 interface SamRuntimeModel {
+  dispose?: () => Promise<void> | void;
   get_image_embeddings(image: SamProcessedImage): Promise<Record<string, unknown>>;
   (inputs: Record<string, unknown>): Promise<{
     pred_masks: unknown;
@@ -228,8 +229,10 @@ class DirectTransformersOperations {
     return extractDetectedLanguage(result);
   }
 
-  async preloadImageEditing(options?: { onProgress?: (progress: number) => void }) {
-    await this.loadBackgroundModel();
+  async preloadImageEditing(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }) {
+    await this.loadBackgroundModel(options);
     options?.onProgress?.(100);
   }
 
@@ -280,6 +283,15 @@ class DirectTransformersOperations {
         score: scoreTotal / segmentations.length,
       },
     };
+  }
+
+  async removeImageEditing() {
+    const backgroundModelPromise = this.backgroundModelPromise;
+    this.backgroundModelPromise = null;
+    this.encodedAssets.clear();
+
+    const backgroundModel = await backgroundModelPromise?.catch(() => undefined);
+    await backgroundModel?.model.dispose?.();
   }
 
   private loadTextGenerationPipeline(
@@ -389,14 +401,19 @@ class DirectTransformersOperations {
     return { imageInput, imageProcessed, imageEmbeddings };
   }
 
-  private async loadBackgroundModel() {
-    this.backgroundModelPromise ??= this.createBackgroundModel();
+  private async loadBackgroundModel(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }) {
+    this.backgroundModelPromise ??= this.createBackgroundModel(options);
     return this.backgroundModelPromise;
   }
 
-  private async createBackgroundModel() {
+  private async createBackgroundModel(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }) {
     const { AutoProcessor, RawImage, SamModel, Tensor, env } =
       await import('@huggingface/transformers');
+    const progressCallback = progress.createTransformersProgressCallback(options?.onProgress);
 
     env.useBrowserCache = true;
     env.cacheKey = imageGenerationModel.TRANSFORMERS_CACHE_KEY;
@@ -405,8 +422,11 @@ class DirectTransformersOperations {
       SamModel.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID, {
         dtype: 'fp16',
         device: 'webgpu',
+        progress_callback: progressCallback,
       }),
-      AutoProcessor.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID),
+      AutoProcessor.from_pretrained(IMAGE_EDITING_TRANSFORMERS_MODEL_ID, {
+        progress_callback: progressCallback,
+      }),
     ]);
 
     return {

--- a/apps/editor/src/services/model-setup/transformersRuntime.worker.ts
+++ b/apps/editor/src/services/model-setup/transformersRuntime.worker.ts
@@ -81,8 +81,14 @@ async function handleRequest(request: TransformersWorkerRequest) {
 
     if (request.type === 'preload-image-editing') {
       await operations.preloadImageEditing({
-        onProgress: (progress) => postResponse({ id: request.id, progress, type: 'progress' }),
+        onProgress: (progress, details) => postProgress(request.id, progress, details),
       });
+      postResponse({ id: request.id, type: 'result' });
+      return;
+    }
+
+    if (request.type === 'remove-image-editing') {
+      await operations.removeImageEditing();
       postResponse({ id: request.id, type: 'result' });
       return;
     }

--- a/apps/editor/src/services/model-setup/transformersRuntime.worker.ts
+++ b/apps/editor/src/services/model-setup/transformersRuntime.worker.ts
@@ -1,10 +1,31 @@
 import { transformersOperations } from './transformersOperations';
-import type { TransformersWorkerRequest, TransformersWorkerResponse } from './transformersRuntimeClient';
+import type {
+  TransformersWorkerRequest,
+  TransformersWorkerResponse,
+} from './transformersRuntimeClient';
 
 const operations = new transformersOperations.DirectTransformersOperations();
 
 function postResponse(response: TransformersWorkerResponse) {
   self.postMessage(response);
+}
+
+type TransformersProgressDetails = Extract<
+  TransformersWorkerResponse,
+  { type: 'progress' }
+>['details'];
+
+function postProgress(
+  id: string,
+  progress: number,
+  details: TransformersProgressDetails | undefined,
+) {
+  postResponse({
+    ...(details ? { details } : {}),
+    id,
+    progress,
+    type: 'progress',
+  });
 }
 
 self.onmessage = (event: MessageEvent<TransformersWorkerRequest>) => {
@@ -16,14 +37,18 @@ async function handleRequest(request: TransformersWorkerRequest) {
   try {
     if (request.type === 'preload-text-generation') {
       await operations.preloadTextGeneration(request.modelId, {
-        onProgress: (progress) => postResponse({ id: request.id, progress, type: 'progress' }),
+        onProgress: (progress, details) => postProgress(request.id, progress, details),
       });
       postResponse({ id: request.id, type: 'result' });
       return;
     }
 
     if (request.type === 'generate-text') {
-      const result = await operations.generateText(request.modelId, request.prompt, request.options);
+      const result = await operations.generateText(
+        request.modelId,
+        request.prompt,
+        request.options,
+      );
       postResponse({ id: request.id, result, type: 'result' });
       return;
     }
@@ -42,7 +67,7 @@ async function handleRequest(request: TransformersWorkerRequest) {
 
     if (request.type === 'preload-language-detection') {
       await operations.preloadLanguageDetection(request.modelId, {
-        onProgress: (progress) => postResponse({ id: request.id, progress, type: 'progress' }),
+        onProgress: (progress, details) => postProgress(request.id, progress, details),
       });
       postResponse({ id: request.id, type: 'result' });
       return;

--- a/apps/editor/src/services/model-setup/transformersRuntimeClient.ts
+++ b/apps/editor/src/services/model-setup/transformersRuntimeClient.ts
@@ -1,3 +1,4 @@
+import type { ModelDownloadProgressDetails } from '../contracts/interfaces';
 import type {
   BackgroundSegmentationResult,
   LanguageDetectionResult,
@@ -53,6 +54,7 @@ export type TransformersWorkerRequest =
 
 export type TransformersWorkerResponse =
   | {
+      details?: ModelDownloadProgressDetails;
       id: string;
       progress: number;
       type: 'progress';
@@ -69,9 +71,11 @@ export type TransformersWorkerResponse =
     };
 
 interface PendingTransformersRequest {
-  onProgress?: ((progress: number) => void) | undefined;
+  onProgress?: ((progress: number, details?: ModelDownloadProgressDetails) => void) | undefined;
   reject: (error: Error) => void;
-  resolve: (result: BackgroundSegmentationResult | LanguageDetectionResult | string | undefined) => void;
+  resolve: (
+    result: BackgroundSegmentationResult | LanguageDetectionResult | string | undefined,
+  ) => void;
 }
 
 interface TransformersRuntimeClientOptions {
@@ -81,14 +85,32 @@ interface TransformersRuntimeClientOptions {
 
 interface TransformersOperationsFallback {
   detectLanguage(modelId: string, text: string): Promise<LanguageDetectionResult>;
-  generateText(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string>;
-  preloadImageEditing(options?: { onProgress?: (progress: number) => void }): Promise<void>;
-  preloadLanguageDetection(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
-  preloadTextGeneration(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
-  prepareBackgroundRemoval(objectUrl: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  generateText(
+    modelId: string,
+    prompt: TextGenerationInput,
+    options?: TextGenerationOptions,
+  ): Promise<string>;
+  preloadImageEditing(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void>;
+  preloadLanguageDetection(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
+  preloadTextGeneration(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
+  prepareBackgroundRemoval(
+    objectUrl: string,
+    options?: { onProgress?: (progress: number) => void },
+  ): Promise<void>;
   releaseTextGeneration(modelId: string): Promise<void>;
   removeTextGeneration(modelId: string): Promise<void>;
-  segmentBackgroundRemoval(objectUrl: string, points: SegmentationPoint[]): Promise<BackgroundSegmentationResult>;
+  segmentBackgroundRemoval(
+    objectUrl: string,
+    points: SegmentationPoint[],
+  ): Promise<BackgroundSegmentationResult>;
 }
 
 export class TransformersRuntimeClient {
@@ -98,7 +120,10 @@ export class TransformersRuntimeClient {
 
   constructor(private readonly options: TransformersRuntimeClientOptions = {}) {}
 
-  preloadTextGeneration(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+  preloadTextGeneration(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     return this.request(
       {
         id: createRequestId(),
@@ -109,7 +134,11 @@ export class TransformersRuntimeClient {
     ).then(() => undefined);
   }
 
-  async generateText(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions) {
+  async generateText(
+    modelId: string,
+    prompt: TextGenerationInput,
+    options?: TextGenerationOptions,
+  ) {
     const result = await this.request({
       id: createRequestId(),
       modelId,
@@ -117,7 +146,8 @@ export class TransformersRuntimeClient {
       type: 'generate-text',
       ...(options ? { options } : {}),
     });
-    if (typeof result !== 'string') throw new Error('Transformers text worker did not return text.');
+    if (typeof result !== 'string')
+      throw new Error('Transformers text worker did not return text.');
     return result;
   }
 
@@ -137,7 +167,10 @@ export class TransformersRuntimeClient {
     }).then(() => undefined);
   }
 
-  preloadLanguageDetection(modelId: string, options?: { onProgress?: (progress: number) => void }) {
+  preloadLanguageDetection(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     return this.request(
       {
         id: createRequestId(),
@@ -161,7 +194,9 @@ export class TransformersRuntimeClient {
     return result;
   }
 
-  preloadImageEditing(options?: { onProgress?: (progress: number) => void }) {
+  preloadImageEditing(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }) {
     return this.request(
       {
         id: createRequestId(),
@@ -171,7 +206,10 @@ export class TransformersRuntimeClient {
     ).then(() => undefined);
   }
 
-  prepareBackgroundRemoval(objectUrl: string, options?: { onProgress?: (progress: number) => void }) {
+  prepareBackgroundRemoval(
+    objectUrl: string,
+    options?: { onProgress?: (progress: number) => void },
+  ) {
     return this.request(
       {
         id: createRequestId(),
@@ -195,18 +233,23 @@ export class TransformersRuntimeClient {
     return result;
   }
 
-  private request(request: TransformersWorkerRequest, options?: { onProgress?: (progress: number) => void }) {
+  private request(
+    request: TransformersWorkerRequest,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     const worker = this.getWorker();
     if (!worker) return this.executeFallbackRequest(request, options);
 
-    return new Promise<BackgroundSegmentationResult | LanguageDetectionResult | string | undefined>((resolve, reject) => {
-      this.pendingRequests.set(request.id, {
-        onProgress: options?.onProgress,
-        reject,
-        resolve,
-      });
-      worker.postMessage(request);
-    });
+    return new Promise<BackgroundSegmentationResult | LanguageDetectionResult | string | undefined>(
+      (resolve, reject) => {
+        this.pendingRequests.set(request.id, {
+          onProgress: options?.onProgress,
+          reject,
+          resolve,
+        });
+        worker.postMessage(request);
+      },
+    );
   }
 
   private getWorker() {
@@ -240,7 +283,7 @@ export class TransformersRuntimeClient {
     const pending = this.pendingRequests.get(response.id);
     if (!pending) return;
     if (response.type === 'progress') {
-      pending.onProgress?.(response.progress);
+      pending.onProgress?.(response.progress, response.details);
       return;
     }
     this.pendingRequests.delete(response.id);
@@ -260,7 +303,7 @@ export class TransformersRuntimeClient {
 
   private executeFallbackRequest(
     request: TransformersWorkerRequest,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ) {
     const operations = this.getFallbackOperations();
     switch (request.type) {
@@ -279,7 +322,9 @@ export class TransformersRuntimeClient {
       case 'preload-image-editing':
         return operations.preloadImageEditing(options).then(() => undefined);
       case 'prepare-background-removal':
-        return operations.prepareBackgroundRemoval(request.objectUrl, options).then(() => undefined);
+        return operations
+          .prepareBackgroundRemoval(request.objectUrl, options)
+          .then(() => undefined);
       case 'segment-background-removal':
         return operations.segmentBackgroundRemoval(request.objectUrl, request.points);
     }
@@ -303,17 +348,14 @@ function createDefaultTransformersWorker() {
 function isLanguageDetectionResult(value: unknown): value is LanguageDetectionResult {
   return Boolean(
     value &&
-      typeof value === 'object' &&
-      'language' in value &&
-      typeof (value as { language?: unknown }).language === 'string',
+    typeof value === 'object' &&
+    'language' in value &&
+    typeof (value as { language?: unknown }).language === 'string',
   );
 }
 
 function isBackgroundSegmentationResult(value: unknown): value is BackgroundSegmentationResult {
   return Boolean(
-    value &&
-      typeof value === 'object' &&
-      'imageInput' in value &&
-      'subjectMask' in value,
+    value && typeof value === 'object' && 'imageInput' in value && 'subjectMask' in value,
   );
 }

--- a/apps/editor/src/services/model-setup/transformersRuntimeClient.ts
+++ b/apps/editor/src/services/model-setup/transformersRuntimeClient.ts
@@ -42,6 +42,10 @@ export type TransformersWorkerRequest =
     }
   | {
       id: string;
+      type: 'remove-image-editing';
+    }
+  | {
+      id: string;
       objectUrl: string;
       type: 'prepare-background-removal';
     }
@@ -93,6 +97,7 @@ interface TransformersOperationsFallback {
   preloadImageEditing(options?: {
     onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
   }): Promise<void>;
+  removeImageEditing(): Promise<void>;
   preloadLanguageDetection(
     modelId: string,
     options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
@@ -204,6 +209,13 @@ export class TransformersRuntimeClient {
       },
       options,
     ).then(() => undefined);
+  }
+
+  removeImageEditing() {
+    return this.request({
+      id: createRequestId(),
+      type: 'remove-image-editing',
+    }).then(() => undefined);
   }
 
   prepareBackgroundRemoval(
@@ -321,6 +333,8 @@ export class TransformersRuntimeClient {
         return operations.detectLanguage(request.modelId, request.text);
       case 'preload-image-editing':
         return operations.preloadImageEditing(options).then(() => undefined);
+      case 'remove-image-editing':
+        return operations.removeImageEditing().then(() => undefined);
       case 'prepare-background-removal':
         return operations
           .prepareBackgroundRemoval(request.objectUrl, options)

--- a/apps/editor/src/services/prompting/browserPromptService.ts
+++ b/apps/editor/src/services/prompting/browserPromptService.ts
@@ -1,8 +1,18 @@
 import { generatedSlide } from '../../domain/generated-slides/generatedSlide';
-import type { GeneratedSlideElement, GeneratedSlideTask, GeneratedSlideTasksDocument } from '../../domain/generated-slides/generatedSlide';
+import type {
+  GeneratedSlideElement,
+  GeneratedSlideTask,
+  GeneratedSlideTasksDocument,
+} from '../../domain/generated-slides/generatedSlide';
 import { aiModelCatalog } from '../model-setup/aiModelCatalog';
 import { ChromePromptService } from './chromePromptService';
-import type { AiProviderState, ModelSetupService, PromptApiAvailability, PromptService } from '../contracts/interfaces';
+import type {
+  AiProviderState,
+  ModelDownloadProgressDetails,
+  ModelSetupService,
+  PromptApiAvailability,
+  PromptService,
+} from '../contracts/interfaces';
 import { providerSelection } from '../model-setup/providerSelection';
 import { progress as progressUtils } from '../model-setup/progress';
 import { buildSlideElementPrompt } from './slideElementPrompt';
@@ -22,7 +32,10 @@ interface PromptProvider {
   runtime: AiProviderState['runtime'];
   modelId?: string | undefined;
   checkAvailability(modelSetupService: ModelSetupService): Promise<PromptApiAvailability>;
-  prepare(modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  prepare(
+    modelSetupService: ModelSetupService,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
   generateSlideTasksFromPrompt(
     prompt: string,
     options?: { targetLanguageHint?: string },
@@ -50,7 +63,10 @@ class ChromePromptProvider implements PromptProvider {
     return this.chromePromptService.checkAvailability();
   }
 
-  prepare(_modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  prepare(
+    _modelSetupService: ModelSetupService,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     return this.chromePromptService.preparePromptApi(options);
   }
 
@@ -87,7 +103,10 @@ interface GemmaStructuredJsonOptions<T> {
   parse: (value: string) => T;
 }
 
-function createGemmaStructuredJsonMessages(prompt: string, responseSchema: unknown): TextGenerationInput {
+function createGemmaStructuredJsonMessages(
+  prompt: string,
+  responseSchema: unknown,
+): TextGenerationInput {
   return [
     {
       role: 'user',
@@ -141,11 +160,15 @@ class GemmaPromptProvider implements PromptProvider {
   runtime = 'webgpu-huggingface' as const;
   modelId = aiModelCatalog.GEMMA_LLM_MODEL_ID;
 
-  constructor(private readonly runtimeClient: TextGenerationRuntime = new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime()) {}
+  constructor(
+    private readonly runtimeClient: TextGenerationRuntime = new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime(),
+  ) {}
 
   async checkAvailability(modelSetupService: ModelSetupService): Promise<PromptApiAvailability> {
     if (!providerSelection.isWebGpuCompatible()) return 'unavailable';
-    const model = (await modelSetupService.getModelStates()).find((state) => state.id === aiModelCatalog.GEMMA_LLM_MODEL_ID);
+    const model = (await modelSetupService.getModelStates()).find(
+      (state) => state.id === aiModelCatalog.GEMMA_LLM_MODEL_ID,
+    );
     if (model?.status === 'ready') return 'ready';
     if (model?.status === 'downloading') return 'downloading';
     return 'downloadable';
@@ -153,11 +176,19 @@ class GemmaPromptProvider implements PromptProvider {
 
   async prepare(
     modelSetupService: ModelSetupService,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void> {
-    const reportProgress = progressUtils.createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
+    const reportProgress = progressUtils.createMonotonicProgressReporter(options?.onProgress, {
+      initial: 4,
+      min: 4,
+      max: 100,
+    });
     await modelSetupService.downloadModel(aiModelCatalog.GEMMA_LLM_MODEL_ID, {
-      onProgress: (nextProgress) => reportProgress(nextProgress >= 99 ? 99 : progressUtils.mapProgressToRange(nextProgress, 4, 99)),
+      onProgress: (nextProgress, details) =>
+        reportProgress(
+          nextProgress >= 99 ? 99 : progressUtils.mapProgressToRange(nextProgress, 4, 99),
+          details,
+        ),
     });
     reportProgress(100);
   }
@@ -243,7 +274,10 @@ class BrowserPromptService implements PromptService {
     private readonly storage = providerSelection.getBrowserProviderStorage(),
     textGenerationRuntime: TextGenerationRuntime = new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime(),
   ) {
-    this.providers = providers ?? [new ChromePromptProvider(), new GemmaPromptProvider(textGenerationRuntime)];
+    this.providers = providers ?? [
+      new ChromePromptProvider(),
+      new GemmaPromptProvider(textGenerationRuntime),
+    ];
     this.selectedProviderId = storage?.getItem(PROMPT_PROVIDER_STORAGE_KEY) ?? undefined;
   }
 
@@ -265,9 +299,12 @@ class BrowserPromptService implements PromptService {
     const states = await Promise.all(
       this.providers.map(async (provider) => {
         const availability = await provider.checkAvailability(this.modelSetupService);
-        const chromeUnavailable = provider.runtime === 'chrome-built-in' && availability === 'unavailable';
-        const webGpuUnavailable = provider.runtime === 'webgpu-huggingface' && !providerSelection.isWebGpuCompatible();
-        const compatibility = chromeUnavailable || webGpuUnavailable ? 'incompatible' : 'compatible';
+        const chromeUnavailable =
+          provider.runtime === 'chrome-built-in' && availability === 'unavailable';
+        const webGpuUnavailable =
+          provider.runtime === 'webgpu-huggingface' && !providerSelection.isWebGpuCompatible();
+        const compatibility =
+          chromeUnavailable || webGpuUnavailable ? 'incompatible' : 'compatible';
         return {
           id: provider.id,
           label: provider.label,
@@ -288,8 +325,8 @@ class BrowserPromptService implements PromptService {
                 : availability === 'unavailable'
                   ? 'unavailable'
                   : availability === 'downloading'
-                  ? 'downloading'
-                  : 'needs-download'
+                    ? 'downloading'
+                    : 'needs-download'
               : providerSelection.getModelReadiness(modelStates, provider.modelId),
           selected: false,
         } satisfies AiProviderState;
@@ -306,7 +343,9 @@ class BrowserPromptService implements PromptService {
     return this.getSelectedProvider().checkAvailability(this.modelSetupService);
   }
 
-  async preparePromptApi(options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  async preparePromptApi(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void> {
     await this.getSelectedProvider().prepare(this.modelSetupService, options);
   }
 

--- a/apps/editor/src/services/prompting/chromePromptService.ts
+++ b/apps/editor/src/services/prompting/chromePromptService.ts
@@ -1,6 +1,14 @@
 import { generatedSlide } from '../../domain/generated-slides/generatedSlide';
-import type { GeneratedSlideElement, GeneratedSlideTask, GeneratedSlideTasksDocument } from '../../domain/generated-slides/generatedSlide';
-import type { PromptApiAvailability, PromptService } from '../contracts/interfaces';
+import type {
+  GeneratedSlideElement,
+  GeneratedSlideTask,
+  GeneratedSlideTasksDocument,
+} from '../../domain/generated-slides/generatedSlide';
+import type {
+  ModelDownloadProgressDetails,
+  PromptApiAvailability,
+  PromptService,
+} from '../contracts/interfaces';
 import { buildSlideElementPrompt } from './slideElementPrompt';
 import { slideLayoutPresets } from './slideLayoutPresets';
 import { slideTaskPrompt } from './slideTaskPrompt';
@@ -19,7 +27,9 @@ interface ChromePromptSession {
 
 interface ChromeLanguageModelApi {
   availability?: () => Promise<ChromePromptAvailability>;
-  create?: (options?: { monitor?: (monitorTarget: EventTarget) => void }) => Promise<ChromePromptSession>;
+  create?: (options?: {
+    monitor?: (monitorTarget: EventTarget) => void;
+  }) => Promise<ChromePromptSession>;
 }
 
 function getLanguageModelApi() {
@@ -31,7 +41,9 @@ function getLanguageModelApi() {
   return globalWindow.LanguageModel ?? globalWindow.ai?.languageModel;
 }
 
-function normalizePromptAvailability(availability: ChromePromptAvailability | undefined): PromptApiAvailability {
+function normalizePromptAvailability(
+  availability: ChromePromptAvailability | undefined,
+): PromptApiAvailability {
   if (availability === 'available' || availability === 'readily') return 'ready';
   if (availability === 'downloadable') return 'downloadable';
   if (availability === 'downloading') return 'downloading';
@@ -48,7 +60,9 @@ export class ChromePromptService implements PromptService {
     return normalizePromptAvailability(availability);
   }
 
-  async preparePromptApi(options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  async preparePromptApi(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }): Promise<void> {
     const languageModel = getLanguageModelApi();
     if (!languageModel?.create) throw new Error('Chrome Prompt API is unavailable.');
 
@@ -81,7 +95,10 @@ export class ChromePromptService implements PromptService {
       generatedSlide.GENERATED_SLIDE_TASKS_RESPONSE_SCHEMA,
     );
     this.ready = true;
-    return slideLayoutPresets.normalizeSlideTasksForLayout(generatedSlide.parseGeneratedSlideTasksJson(response), prompt);
+    return slideLayoutPresets.normalizeSlideTasksForLayout(
+      generatedSlide.parseGeneratedSlideTasksJson(response),
+      prompt,
+    );
   }
 
   async generateSlideElementFromTask(
@@ -104,11 +121,14 @@ export class ChromePromptService implements PromptService {
       generatedSlide.GENERATED_SLIDE_ELEMENT_RESPONSE_SCHEMA,
     );
     this.ready = true;
-    return slideLayoutPresets.applySlideElementLayoutPreset(generatedSlide.parseGeneratedSlideElementJson(response), {
-      task,
-      allTasks: context.allTasks,
-      page: context.page,
-    });
+    return slideLayoutPresets.applySlideElementLayoutPreset(
+      generatedSlide.parseGeneratedSlideElementJson(response),
+      {
+        task,
+        allTasks: context.allTasks,
+        page: context.page,
+      },
+    );
   }
 
   private async promptWithStructuredOutput(prompt: string, responseConstraint: unknown) {

--- a/apps/editor/src/services/prompting/webGpuTextGenerationRuntime.ts
+++ b/apps/editor/src/services/prompting/webGpuTextGenerationRuntime.ts
@@ -1,19 +1,33 @@
 import { TransformersRuntimeClient } from '../model-setup/transformersRuntimeClient';
 import { transformersOperations } from '../model-setup/transformersOperations';
-import type { TextGenerationInput, TextGenerationOptions } from '../model-setup/transformersOperations';
+import type { ModelDownloadProgressDetails } from '../contracts/interfaces';
+import type {
+  TextGenerationInput,
+  TextGenerationOptions,
+} from '../model-setup/transformersOperations';
 
 export type { TextGenerationInput, TextGenerationOptions };
 
 export interface TextGenerationRuntime {
-  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
-  generate(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string>;
+  preload(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
+  generate(
+    modelId: string,
+    prompt: TextGenerationInput,
+    options?: TextGenerationOptions,
+  ): Promise<string>;
   removeTextGenerationModel?(modelId: string): Promise<void>;
 }
 
 class TransformersTextGenerationRuntime implements TextGenerationRuntime {
   constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
 
-  loadTextGenerationModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  loadTextGenerationModel(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     return this.preload(modelId, options);
   }
 
@@ -21,7 +35,10 @@ class TransformersTextGenerationRuntime implements TextGenerationRuntime {
     return this.runtimeClient.releaseTextGeneration(modelId);
   }
 
-  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  preload(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     return this.runtimeClient.preloadTextGeneration(modelId, options);
   }
 
@@ -29,7 +46,11 @@ class TransformersTextGenerationRuntime implements TextGenerationRuntime {
     return this.runtimeClient.removeTextGeneration(modelId);
   }
 
-  generate(modelId: string, prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string> {
+  generate(
+    modelId: string,
+    prompt: TextGenerationInput,
+    options?: TextGenerationOptions,
+  ): Promise<string> {
     return this.runtimeClient.generateText(modelId, prompt, options);
   }
 }

--- a/apps/editor/src/services/testing/inMemoryAiServices.ts
+++ b/apps/editor/src/services/testing/inMemoryAiServices.ts
@@ -4,6 +4,7 @@ import type {
   ImageGenerationOptions,
   ImageGenerationService,
   MagicEraserService,
+  ModelDownloadProgressDetails,
   PaletteService,
   SmartGrabService,
   TranslatorService,
@@ -21,7 +22,7 @@ class MockTranslatorService implements TranslatorService {
   prepareTranslation(
     sourceLanguage: string,
     targetLanguage: string,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void> {
     void sourceLanguage;
     void targetLanguage;
@@ -47,7 +48,12 @@ class MockImageGenerationService implements ImageGenerationService {
   generateImage(prompt: string, options?: ImageGenerationOptions): Promise<Asset> {
     void options;
     const safeName = prompt.trim() || 'Generated image';
-    const safeId = safeName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 32) || 'image';
+    const safeId =
+      safeName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 32) || 'image';
     return Promise.resolve({
       id: `asset-generated-${safeId}`,
       type: 'image',

--- a/apps/editor/src/services/translation/browserTranslatorService.ts
+++ b/apps/editor/src/services/translation/browserTranslatorService.ts
@@ -1,6 +1,11 @@
 import { aiModelCatalog } from '../model-setup/aiModelCatalog';
 import { chromeTranslatorService as chromeTranslator } from './chromeTranslatorService';
-import type { AiProviderState, ModelSetupService, TranslatorService } from '../contracts/interfaces';
+import type {
+  AiProviderState,
+  ModelDownloadProgressDetails,
+  ModelSetupService,
+  TranslatorService,
+} from '../contracts/interfaces';
 import { providerSelection } from '../model-setup/providerSelection';
 import { progress as progressUtils } from '../model-setup/progress';
 import { webGpuLanguageDetectionRuntime } from './webGpuLanguageDetectionRuntime';
@@ -21,14 +26,20 @@ interface TranslationProvider {
   description: string;
   runtime: AiProviderState['runtime'];
   modelId?: string | undefined;
-  checkCompatibility(): { compatible: boolean; disabledReason?: string | undefined } | Promise<{ compatible: boolean; disabledReason?: string | undefined }>;
+  checkCompatibility():
+    | { compatible: boolean; disabledReason?: string | undefined }
+    | Promise<{ compatible: boolean; disabledReason?: string | undefined }>;
   prepare(
     sourceLanguage: string,
     targetLanguage: string,
     modelSetupService: ModelSetupService,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void>;
-  translate(text: string, targetLanguage: string, options?: { sourceLanguage?: string }): Promise<string>;
+  translate(
+    text: string,
+    targetLanguage: string,
+    options?: { sourceLanguage?: string },
+  ): Promise<string>;
   detectLanguage?(text: string): Promise<string>;
 }
 
@@ -39,7 +50,10 @@ interface LanguageDetectionProvider {
   runtime: AiProviderState['runtime'];
   modelId?: string | undefined;
   checkCompatibility(): { compatible: boolean; disabledReason?: string | undefined };
-  prepare(modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  prepare(
+    modelSetupService: ModelSetupService,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
   detectLanguage(text: string): Promise<string>;
 }
 
@@ -91,7 +105,7 @@ const TRANSLATEGEMMA_LANGUAGE_ALIASES: Record<string, string> = {
   iw: 'he',
   pt: 'pt_BR',
   'pt-BR': 'pt_BR',
-  'pt_BR': 'pt_BR',
+  pt_BR: 'pt_BR',
   zh: 'zh',
   'zh-CN': 'zh',
   'zh-Hant': 'zh',
@@ -143,7 +157,9 @@ class ChromeTranslationProvider implements TranslationProvider {
   description = 'Uses Chrome built-in local translation support.';
   runtime = 'chrome-built-in' as const;
 
-  constructor(private readonly chromeTranslatorService = new chromeTranslator.ChromeTranslatorService()) {}
+  constructor(
+    private readonly chromeTranslatorService = new chromeTranslator.ChromeTranslatorService(),
+  ) {}
 
   async checkCompatibility() {
     const translator = getChromeTranslatorApi();
@@ -155,7 +171,10 @@ class ChromeTranslationProvider implements TranslationProvider {
     }
 
     try {
-      const availability = await translator.availability({ sourceLanguage: 'en', targetLanguage: 'pt' });
+      const availability = await translator.availability({
+        sourceLanguage: 'en',
+        targetLanguage: 'pt',
+      });
       return availability === 'unavailable'
         ? {
             compatible: false,
@@ -178,12 +197,16 @@ class ChromeTranslationProvider implements TranslationProvider {
     sourceLanguage: string,
     targetLanguage: string,
     _modelSetupService: ModelSetupService,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void> {
     return this.chromeTranslatorService.prepareTranslation(sourceLanguage, targetLanguage, options);
   }
 
-  translate(text: string, targetLanguage: string, options?: { sourceLanguage?: string }): Promise<string> {
+  translate(
+    text: string,
+    targetLanguage: string,
+    options?: { sourceLanguage?: string },
+  ): Promise<string> {
     return this.chromeTranslatorService.translate(text, targetLanguage, options);
   }
 }
@@ -195,7 +218,9 @@ class TranslateGemmaProvider implements TranslationProvider {
   runtime = 'webgpu-huggingface' as const;
   modelId = aiModelCatalog.TRANSLATEGEMMA_MODEL_ID;
 
-  constructor(private readonly runtimeClient: TextGenerationRuntime = new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime()) {}
+  constructor(
+    private readonly runtimeClient: TextGenerationRuntime = new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime(),
+  ) {}
 
   checkCompatibility() {
     return providerSelection.isWebGpuCompatible()
@@ -207,24 +232,40 @@ class TranslateGemmaProvider implements TranslationProvider {
     _sourceLanguage: string,
     _targetLanguage: string,
     modelSetupService: ModelSetupService,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void> {
-    const reportProgress = progressUtils.createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
+    const reportProgress = progressUtils.createMonotonicProgressReporter(options?.onProgress, {
+      initial: 4,
+      min: 4,
+      max: 100,
+    });
     await modelSetupService.downloadModel(aiModelCatalog.TRANSLATEGEMMA_MODEL_ID, {
-      onProgress: (nextProgress) => reportProgress(nextProgress >= 99 ? 99 : progressUtils.mapProgressToRange(nextProgress, 4, 99)),
+      onProgress: (nextProgress, details) =>
+        reportProgress(
+          nextProgress >= 99 ? 99 : progressUtils.mapProgressToRange(nextProgress, 4, 99),
+          details,
+        ),
     });
     reportProgress(100);
   }
 
-  async translate(text: string, targetLanguage: string, options?: { sourceLanguage?: string }): Promise<string> {
+  async translate(
+    text: string,
+    targetLanguage: string,
+    options?: { sourceLanguage?: string },
+  ): Promise<string> {
     const messages = createTranslateGemmaMessages({
       sourceLanguage: options?.sourceLanguage,
       targetLanguage,
       text,
     });
-    return this.runtimeClient.generate(aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID, messages, {
-      max_new_tokens: Math.max(64, Math.min(1024, Math.ceil(text.length * 2.5))),
-    });
+    return this.runtimeClient.generate(
+      aiModelCatalog.TRANSLATEGEMMA_TRANSFORMERS_MODEL_ID,
+      messages,
+      {
+        max_new_tokens: Math.max(64, Math.min(1024, Math.ceil(text.length * 2.5))),
+      },
+    );
   }
 }
 
@@ -234,15 +275,23 @@ class ChromeLanguageDetectionProvider implements LanguageDetectionProvider {
   description = 'Detect slide text language using Chrome Built-in AI.';
   runtime = 'chrome-built-in' as const;
 
-  constructor(private readonly chromeTranslatorService = new chromeTranslator.ChromeTranslatorService()) {}
+  constructor(
+    private readonly chromeTranslatorService = new chromeTranslator.ChromeTranslatorService(),
+  ) {}
 
   checkCompatibility() {
     return chromeTranslator.hasChromeLanguageDetector()
       ? { compatible: true }
-      : { compatible: false, disabledReason: 'Chrome Built-in LanguageDetector is unavailable in this browser.' };
+      : {
+          compatible: false,
+          disabledReason: 'Chrome Built-in LanguageDetector is unavailable in this browser.',
+        };
   }
 
-  prepare(_modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }) {
+  prepare(
+    _modelSetupService: ModelSetupService,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
     options?.onProgress?.(100);
     return Promise.resolve();
   }
@@ -259,24 +308,43 @@ class WebGpuLanguageDetectionProvider implements LanguageDetectionProvider {
   runtime = 'webgpu-huggingface' as const;
   modelId = aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID;
 
-  constructor(private readonly runtimeClient: LanguageDetectionRuntime = new webGpuLanguageDetectionRuntime.TransformersLanguageDetectionRuntime()) {}
+  constructor(
+    private readonly runtimeClient: LanguageDetectionRuntime = new webGpuLanguageDetectionRuntime.TransformersLanguageDetectionRuntime(),
+  ) {}
 
   checkCompatibility() {
     return providerSelection.isWebGpuCompatible()
       ? { compatible: true }
-      : { compatible: false, disabledReason: 'WebGPU is required for external language detection.' };
+      : {
+          compatible: false,
+          disabledReason: 'WebGPU is required for external language detection.',
+        };
   }
 
-  async prepare(modelSetupService: ModelSetupService, options?: { onProgress?: (progress: number) => void }) {
-    const reportProgress = progressUtils.createMonotonicProgressReporter(options?.onProgress, { initial: 4, min: 4, max: 100 });
+  async prepare(
+    modelSetupService: ModelSetupService,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ) {
+    const reportProgress = progressUtils.createMonotonicProgressReporter(options?.onProgress, {
+      initial: 4,
+      min: 4,
+      max: 100,
+    });
     await modelSetupService.downloadModel(aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID, {
-      onProgress: (nextProgress) => reportProgress(nextProgress >= 99 ? 99 : progressUtils.mapProgressToRange(nextProgress, 4, 99)),
+      onProgress: (nextProgress, details) =>
+        reportProgress(
+          nextProgress >= 99 ? 99 : progressUtils.mapProgressToRange(nextProgress, 4, 99),
+          details,
+        ),
     });
     reportProgress(100);
   }
 
   async detectLanguage(text: string) {
-    const result = await this.runtimeClient.detectLanguage(aiModelCatalog.LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID, text);
+    const result = await this.runtimeClient.detectLanguage(
+      aiModelCatalog.LANGUAGE_DETECTION_TRANSFORMERS_MODEL_ID,
+      text,
+    );
     return chromeTranslator.normalizeDetectedLanguageCode(result.language);
   }
 }
@@ -296,7 +364,10 @@ class BrowserTranslatorService implements TranslatorService {
     textGenerationRuntime: TextGenerationRuntime = new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime(),
     private readonly languageDetectionRuntime: LanguageDetectionRuntime = new webGpuLanguageDetectionRuntime.TransformersLanguageDetectionRuntime(),
   ) {
-    this.providers = providers ?? [new ChromeTranslationProvider(), new TranslateGemmaProvider(textGenerationRuntime)];
+    this.providers = providers ?? [
+      new ChromeTranslationProvider(),
+      new TranslateGemmaProvider(textGenerationRuntime),
+    ];
     this.languageDetectionProviders = [
       new ChromeLanguageDetectionProvider(),
       new WebGpuLanguageDetectionProvider(languageDetectionRuntime),
@@ -329,21 +400,27 @@ class BrowserTranslatorService implements TranslatorService {
         description: provider.description,
         capability: 'language-detection' as const,
         runtime: provider.runtime,
-        compatibility: compatibility.compatible ? 'compatible' as const : 'incompatible' as const,
+        compatibility: compatibility.compatible
+          ? ('compatible' as const)
+          : ('incompatible' as const),
         disabledReason: compatibility.disabledReason,
         modelId: provider.modelId,
         readiness:
           provider.runtime === 'chrome-built-in'
             ? compatibility.compatible
-              ? 'ready' as const
-              : 'unavailable' as const
+              ? ('ready' as const)
+              : ('unavailable' as const)
             : providerSelection.getModelReadiness(modelStates, provider.modelId),
         selected: false,
       } satisfies AiProviderState;
     });
-    const selected = providerSelection.selectDefaultProvider(states, this.selectedLanguageDetectionProviderId, {
-      forcePreferred: this.forceSelectedLanguageDetectionProvider,
-    });
+    const selected = providerSelection.selectDefaultProvider(
+      states,
+      this.selectedLanguageDetectionProviderId,
+      {
+        forcePreferred: this.forceSelectedLanguageDetectionProvider,
+      },
+    );
     this.selectedLanguageDetectionProviderId = selected?.id;
     return states.map((state) => ({ ...state, selected: state.id === selected?.id }));
   }
@@ -388,13 +465,18 @@ class BrowserTranslatorService implements TranslatorService {
     return states.map((state) => ({ ...state, selected: state.id === selected?.id }));
   }
 
-  async prepareLanguageDetection(options?: { onProgress?: (progress: number) => void }) {
+  async prepareLanguageDetection(options?: {
+    onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+  }) {
     await this.getSelectedLanguageDetectionProvider().prepare(this.modelSetupService, options);
   }
 
   async detectLanguage(
     text: string,
-    options?: { allowModelPreparation?: boolean; onProgress?: (progress: number) => void },
+    options?: {
+      allowModelPreparation?: boolean;
+      onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void;
+    },
   ): Promise<string> {
     const provider = this.getSelectedLanguageDetectionProvider();
     if (options?.allowModelPreparation === false && provider.runtime !== 'chrome-built-in') {
@@ -411,12 +493,21 @@ class BrowserTranslatorService implements TranslatorService {
   async prepareTranslation(
     sourceLanguage: string,
     targetLanguage: string,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void> {
-    await this.getSelectedProvider().prepare(sourceLanguage, targetLanguage, this.modelSetupService, options);
+    await this.getSelectedProvider().prepare(
+      sourceLanguage,
+      targetLanguage,
+      this.modelSetupService,
+      options,
+    );
   }
 
-  translate(text: string, targetLanguage: string, options?: { sourceLanguage?: string }): Promise<string> {
+  translate(
+    text: string,
+    targetLanguage: string,
+    options?: { sourceLanguage?: string },
+  ): Promise<string> {
     return this.getSelectedProvider().translate(text, targetLanguage, options);
   }
 
@@ -436,10 +527,14 @@ class BrowserTranslatorService implements TranslatorService {
 
     return (
       this.languageDetectionProviders.find(
-        (provider) => provider.id === CHROME_LANGUAGE_DETECTION_PROVIDER_ID && provider.checkCompatibility().compatible,
+        (provider) =>
+          provider.id === CHROME_LANGUAGE_DETECTION_PROVIDER_ID &&
+          provider.checkCompatibility().compatible,
       ) ??
       this.languageDetectionProviders.find(
-        (provider) => provider.id === WEBGPU_LANGUAGE_DETECTION_PROVIDER_ID && provider.checkCompatibility().compatible,
+        (provider) =>
+          provider.id === WEBGPU_LANGUAGE_DETECTION_PROVIDER_ID &&
+          provider.checkCompatibility().compatible,
       ) ??
       this.languageDetectionProviders[0]!
     );

--- a/apps/editor/src/services/translation/chromeTranslatorService.ts
+++ b/apps/editor/src/services/translation/chromeTranslatorService.ts
@@ -1,4 +1,4 @@
-import type { TranslatorService } from '../contracts/interfaces';
+import type { ModelDownloadProgressDetails, TranslatorService } from '../contracts/interfaces';
 
 type ChromeTranslationInstance = {
   ready?: Promise<void>;
@@ -15,7 +15,9 @@ type ChromeTranslatorApi = {
 };
 
 type ChromeLanguageDetectorApi = {
-  create?: () => Promise<{ detect: (text: string) => Promise<Array<{ detectedLanguage: string }>> }>;
+  create?: () => Promise<{
+    detect: (text: string) => Promise<Array<{ detectedLanguage: string }>>;
+  }>;
 };
 
 type ChromeAiWindow = Window &
@@ -60,7 +62,9 @@ function getTranslationKey(sourceLanguage: string, targetLanguage: string) {
 }
 
 function hasChromeLanguageDetector() {
-  return typeof window !== 'undefined' && Boolean((window as ChromeAiWindow).LanguageDetector?.create);
+  return (
+    typeof window !== 'undefined' && Boolean((window as ChromeAiWindow).LanguageDetector?.create)
+  );
 }
 
 function normalizeDetectedLanguageCode(language: string) {
@@ -83,7 +87,7 @@ class ChromeTranslatorService implements TranslatorService {
   async prepareTranslation(
     sourceLanguage: string,
     targetLanguage: string,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ): Promise<void> {
     const normalizedSourceLanguage = normalizeLanguageCode(sourceLanguage);
     const normalizedTargetLanguage = normalizeLanguageCode(targetLanguage);
@@ -95,7 +99,11 @@ class ChromeTranslatorService implements TranslatorService {
     await this.getTranslator(normalizedSourceLanguage, normalizedTargetLanguage, options);
   }
 
-  async translate(text: string, targetLanguage: string, options?: { sourceLanguage?: string }): Promise<string> {
+  async translate(
+    text: string,
+    targetLanguage: string,
+    options?: { sourceLanguage?: string },
+  ): Promise<string> {
     const sourceLanguage = options?.sourceLanguage
       ? normalizeLanguageCode(options.sourceLanguage)
       : await this.detectLanguage(text);
@@ -109,7 +117,7 @@ class ChromeTranslatorService implements TranslatorService {
   private async getTranslator(
     sourceLanguage: string,
     targetLanguage: string,
-    options?: { onProgress?: (progress: number) => void },
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
   ) {
     const translatorApi = (window as ChromeAiWindow).Translator;
     if (!translatorApi?.create) {
@@ -141,7 +149,9 @@ class ChromeTranslatorService implements TranslatorService {
         monitor: (monitorTarget) => {
           monitorTarget.addEventListener('downloadprogress', (event) => {
             const progressEvent = event as ProgressEvent;
-            options?.onProgress?.(Math.max(0, Math.min(100, Math.round(progressEvent.loaded * 100))));
+            options?.onProgress?.(
+              Math.max(0, Math.min(100, Math.round(progressEvent.loaded * 100))),
+            );
           });
         },
       })

--- a/apps/editor/src/services/translation/webGpuLanguageDetectionRuntime.ts
+++ b/apps/editor/src/services/translation/webGpuLanguageDetectionRuntime.ts
@@ -1,20 +1,30 @@
 import { TransformersRuntimeClient } from '../model-setup/transformersRuntimeClient';
 import { transformersOperations } from '../model-setup/transformersOperations';
+import type { ModelDownloadProgressDetails } from '../contracts/interfaces';
 import type { LanguageDetectionResult } from '../model-setup/transformersOperations';
 
 export interface LanguageDetectionRuntime {
-  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void>;
+  preload(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void>;
   detectLanguage(modelId: string, text: string): Promise<LanguageDetectionResult>;
 }
 
 class TransformersLanguageDetectionRuntime implements LanguageDetectionRuntime {
   constructor(private readonly runtimeClient = new TransformersRuntimeClient()) {}
 
-  loadLanguageDetectionModel(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  loadLanguageDetectionModel(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     return this.preload(modelId, options);
   }
 
-  preload(modelId: string, options?: { onProgress?: (progress: number) => void }): Promise<void> {
+  preload(
+    modelId: string,
+    options?: { onProgress?: (progress: number, details?: ModelDownloadProgressDetails) => void },
+  ): Promise<void> {
     return this.runtimeClient.preloadLanguageDetection(modelId, options);
   }
 

--- a/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
@@ -1,7 +1,11 @@
 import { Download, ImagePlus, Languages, ScanSearch, X } from 'lucide-react';
 import { aiModelCatalog } from '../../../services/model-setup/aiModelCatalog';
 import { imageGenerationModel } from '../../../services/image-generation/imageGenerationModel';
-import type { AiProviderState, ModelState } from '../../../services/contracts/interfaces';
+import type {
+  AiProviderState,
+  ModelDownloadProgressDetails,
+  ModelState,
+} from '../../../services/contracts/interfaces';
 import { modelSetupService } from '../../../services/model-setup/modelSetupService';
 import { IconButton } from '../../components/IconButton';
 import { StatusPill } from '../../components/StatusPill';
@@ -9,7 +13,9 @@ import type { CreateImagePromptOptions } from '../media/imagePromptOptions';
 import { imagePromptOptions } from '../media/imagePromptOptions';
 
 interface AiToolsPanelProps {
-  activeSlideLanguage?: { code: string; displayCode: string; flag: string; label: string } | undefined;
+  activeSlideLanguage?:
+    | { code: string; displayCode: string; flag: string; label: string }
+    | undefined;
   modelStates: ModelState[];
   attentionModelId?: string | undefined;
   createImageOptions?: CreateImagePromptOptions;
@@ -17,13 +23,31 @@ interface AiToolsPanelProps {
   translationProviderStates?: AiProviderState[] | undefined;
   languageDetectionProviderStates?: AiProviderState[] | undefined;
   translationLanguageOptions?: Array<{ code: string; flag: string; label: string }> | undefined;
-  languageDetectionPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' } | undefined;
-  translationPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' } | undefined;
+  languageDetectionPreparation?:
+    | (ModelDownloadProgressDetails & {
+        progress: number;
+        sourceLanguage?: string;
+        status: 'idle' | 'downloading' | 'ready' | 'failed';
+      })
+    | undefined;
+  translationPreparation?:
+    | (ModelDownloadProgressDetails & {
+        progress: number;
+        sourceLanguage?: string;
+        status: 'idle' | 'downloading' | 'ready' | 'failed';
+      })
+    | undefined;
   translationTargetAttention?: boolean | undefined;
   translationTargetLanguage?: string | undefined;
   promptApiAttention?: boolean | undefined;
   promptApiNotice?: string | undefined;
-  promptPreparation?: { availability: string; progress: number; status: 'idle' | 'downloading' | 'ready' | 'failed' } | undefined;
+  promptPreparation?:
+    | (ModelDownloadProgressDetails & {
+        availability: string;
+        progress: number;
+        status: 'idle' | 'downloading' | 'ready' | 'failed';
+      })
+    | undefined;
   onDownloadModel?: ((id: string) => Promise<void>) | undefined;
   onRemoveModel?: ((id: string) => Promise<void>) | undefined;
   onCreateImageOptionsChange?: ((options: CreateImagePromptOptions) => void) | undefined;
@@ -53,7 +77,8 @@ function getPreparationStatus(
   provider: AiProviderState | undefined,
   preparationStatus: 'idle' | 'downloading' | 'ready' | 'failed',
 ) {
-  if (preparationStatus === 'downloading' || preparationStatus === 'failed') return preparationStatus;
+  if (preparationStatus === 'downloading' || preparationStatus === 'failed')
+    return preparationStatus;
   if (provider?.readiness === 'ready') return 'ready';
   return 'idle';
 }
@@ -65,22 +90,97 @@ function getPreparationLabel(status: 'idle' | 'downloading' | 'ready' | 'failed'
   return 'Pending';
 }
 
-function getProgressText(status: 'idle' | 'downloading' | 'ready' | 'failed', progress: number) {
-  if (status === 'ready') return undefined;
-  if (status === 'idle') return undefined;
-  if (status === 'downloading' && progress >= 98) return 'Finalizing...';
-  return `${progress}%`;
-}
-
 function getPreparationTone(status: 'idle' | 'downloading' | 'ready' | 'failed') {
   if (status === 'ready') return 'success';
   if (status === 'downloading') return 'warning';
   return 'neutral';
 }
 
+function hasByteProgress(details: ModelDownloadProgressDetails) {
+  return (
+    typeof details.loadedBytes === 'number' &&
+    typeof details.totalBytes === 'number' &&
+    Number.isFinite(details.loadedBytes) &&
+    Number.isFinite(details.totalBytes) &&
+    details.totalBytes > 0
+  );
+}
+
+function formatGigabytes(bytes: number) {
+  return `${(bytes / 1_000_000_000).toFixed(1)} GB`;
+}
+
+function formatRemainingTime(estimatedRemainingMs: number | undefined) {
+  if (
+    typeof estimatedRemainingMs !== 'number' ||
+    !Number.isFinite(estimatedRemainingMs) ||
+    estimatedRemainingMs <= 0
+  ) {
+    return undefined;
+  }
+
+  const totalSeconds = Math.max(1, Math.ceil(estimatedRemainingMs / 1_000));
+  if (totalSeconds < 60) return 'Less than 1 min remaining';
+
+  const minutes = Math.ceil(totalSeconds / 60);
+  return `About ${minutes} min remaining`;
+}
+
+function getPrimaryProgressText(
+  status: 'idle' | 'downloading' | 'ready' | 'failed',
+  details: ModelDownloadProgressDetails & { progress: number },
+) {
+  if (status !== 'downloading') return undefined;
+  const progress = Math.max(0, Math.min(100, Math.round(details.progress)));
+  if (hasByteProgress(details)) {
+    return `${formatGigabytes(details.loadedBytes!)} / ${formatGigabytes(details.totalBytes!)} (${progress}%)`;
+  }
+  if (status === 'downloading' && progress >= 98) return undefined;
+  return `${progress}%`;
+}
+
+function getModelProgressStatus(
+  status: ModelState['status'],
+): 'idle' | 'downloading' | 'ready' | 'failed' {
+  if (status === 'downloading') return 'downloading';
+  if (status === 'ready') return 'ready';
+  if (status === 'failed') return 'failed';
+  return 'idle';
+}
+
+function getSecondaryProgressText(
+  status: 'idle' | 'downloading' | 'ready' | 'failed',
+  details: ModelDownloadProgressDetails & { progress: number },
+) {
+  if (status !== 'downloading') return undefined;
+  if (details.progress >= 98) return 'Finalizing...';
+  return formatRemainingTime(details.estimatedRemainingMs);
+}
+
+function DownloadProgressCopy({
+  details,
+  status,
+}: {
+  details: ModelDownloadProgressDetails & { progress: number };
+  status: 'idle' | 'downloading' | 'ready' | 'failed';
+}) {
+  const primary = getPrimaryProgressText(status, details);
+  const secondary = getSecondaryProgressText(status, details);
+  if (!primary && !secondary) return null;
+
+  return (
+    <span className="download-progress-copy">
+      {primary ? <span className="download-progress-primary">{primary}</span> : null}
+      {secondary ? <span className="download-progress-secondary">{secondary}</span> : null}
+    </span>
+  );
+}
+
 function getFixedModelDisplayName(modelId: string, fallback: string) {
-  if (modelId === modelSetupService.IMAGE_EDITING_MODEL_ID) return modelSetupService.IMAGE_EDITING_DISPLAY_NAME;
-  if (modelId === imageGenerationModel.IMAGE_GENERATION_MODEL_ID) return imageGenerationModel.IMAGE_GENERATION_DISPLAY_NAME;
+  if (modelId === modelSetupService.IMAGE_EDITING_MODEL_ID)
+    return modelSetupService.IMAGE_EDITING_DISPLAY_NAME;
+  if (modelId === imageGenerationModel.IMAGE_GENERATION_MODEL_ID)
+    return imageGenerationModel.IMAGE_GENERATION_DISPLAY_NAME;
   return fallback;
 }
 
@@ -142,7 +242,10 @@ export function AiToolsPanel({
             capability: 'prompt' as const,
             runtime: 'chrome-built-in' as const,
             compatibility: 'compatible' as const,
-            readiness: promptPreparation.status === 'ready' ? 'ready' as const : 'needs-download' as const,
+            readiness:
+              promptPreparation.status === 'ready'
+                ? ('ready' as const)
+                : ('needs-download' as const),
             selected: true,
           },
         ];
@@ -157,7 +260,10 @@ export function AiToolsPanel({
             capability: 'translation' as const,
             runtime: 'chrome-built-in' as const,
             compatibility: 'compatible' as const,
-            readiness: translationPreparation.status === 'ready' ? 'ready' as const : 'needs-download' as const,
+            readiness:
+              translationPreparation.status === 'ready'
+                ? ('ready' as const)
+                : ('needs-download' as const),
             selected: true,
           },
         ];
@@ -176,33 +282,43 @@ export function AiToolsPanel({
             selected: true,
           },
         ];
-  const selectedPromptProvider = promptProviders.find((provider) => provider.selected) ?? promptProviders[0];
-  const selectedTranslationProvider = translationProviders.find((provider) => provider.selected) ?? translationProviders[0];
+  const selectedPromptProvider =
+    promptProviders.find((provider) => provider.selected) ?? promptProviders[0];
+  const selectedTranslationProvider =
+    translationProviders.find((provider) => provider.selected) ?? translationProviders[0];
   const selectedLanguageDetectionProvider =
-    languageDetectionProviders.find((provider) => provider.selected) ?? languageDetectionProviders[0];
+    languageDetectionProviders.find((provider) => provider.selected) ??
+    languageDetectionProviders[0];
   const promptStatus = getPreparationStatus(selectedPromptProvider, promptPreparation.status);
   const promptProgress = promptStatus === 'ready' ? 100 : promptPreparation.progress;
-  const promptProgressText = getProgressText(promptStatus, promptProgress);
   const languageDetectionStatus = getPreparationStatus(
     selectedLanguageDetectionProvider,
     languageDetectionPreparation.status,
   );
   const languageDetectionProgress =
     languageDetectionStatus === 'ready' ? 100 : languageDetectionPreparation.progress;
-  const translationProviderStatus = getPreparationStatus(selectedTranslationProvider, translationPreparation.status);
-  const translationProviderProgress = translationProviderStatus === 'ready' ? 100 : translationPreparation.progress;
-  const translationProviderProgressText = getProgressText(translationProviderStatus, translationProviderProgress);
-  const displayedSourceLanguage = activeSlideLanguage?.code ?? translationPreparation.sourceLanguage;
+  const translationProviderStatus = getPreparationStatus(
+    selectedTranslationProvider,
+    translationPreparation.status,
+  );
+  const translationProviderProgress =
+    translationProviderStatus === 'ready' ? 100 : translationPreparation.progress;
+  const displayedSourceLanguage =
+    activeSlideLanguage?.code ?? translationPreparation.sourceLanguage;
   const selectedPromptNeedsDownload =
-    selectedPromptProvider?.readiness === 'needs-download' || selectedPromptProvider?.readiness === 'failed';
+    selectedPromptProvider?.readiness === 'needs-download' ||
+    selectedPromptProvider?.readiness === 'failed';
   const selectedTranslationNeedsDownload =
-    selectedTranslationProvider?.readiness === 'needs-download' || selectedTranslationProvider?.readiness === 'failed';
+    selectedTranslationProvider?.readiness === 'needs-download' ||
+    selectedTranslationProvider?.readiness === 'failed';
   const selectedLanguageDetectionNeedsDownload =
     selectedLanguageDetectionProvider?.readiness === 'needs-download' ||
     selectedLanguageDetectionProvider?.readiness === 'failed';
-  const selectedPromptCanRemove = selectedPromptProvider?.modelId && selectedPromptProvider.readiness === 'ready';
+  const selectedPromptCanRemove =
+    selectedPromptProvider?.modelId && selectedPromptProvider.readiness === 'ready';
   const selectedLanguageDetectionCanRemove =
-    selectedLanguageDetectionProvider?.modelId && selectedLanguageDetectionProvider.readiness === 'ready';
+    selectedLanguageDetectionProvider?.modelId &&
+    selectedLanguageDetectionProvider.readiness === 'ready';
   const selectedTranslationCanRemove =
     selectedTranslationProvider?.modelId && selectedTranslationProvider.readiness === 'ready';
   const visibleModelStates = modelStates.filter(
@@ -215,414 +331,468 @@ export function AiToolsPanel({
   return (
     <div className="panel-stack">
       <div className="tool-card-list">
-          <article
-            className={promptApiAttention ? 'tool-card tool-card-attention' : 'tool-card'}
-            aria-label="LLM Model"
-          >
-            <div className="tool-card-heading">
-              <ImagePlus size={18} />
-              <strong>LLM Model</strong>
-              <StatusPill
-                label={selectedPromptProvider?.runtime === 'chrome-built-in' ? 'CHROME' : 'EXTERNAL'}
-                tone={selectedPromptProvider?.compatibility === 'compatible' ? 'success' : 'neutral'}
-              />
-              {promptStatus === 'downloading' ? null : selectedPromptNeedsDownload ? (
-                <IconButton
-                  label="Download LLM Model"
-                  attention
-                  disabled={selectedPromptProvider?.compatibility === 'incompatible'}
-                  onClick={() => {
-                    void onPreparePromptApi?.();
-                  }}
-                >
-                  <Download size={14} />
-                </IconButton>
-              ) : selectedPromptCanRemove ? (
-                <IconButton
-                  label="Remove LLM Model"
-                  tone="danger"
-                  onClick={() => {
-                    void onRemoveModel?.(selectedPromptProvider.modelId!);
-                  }}
-                >
-                  <X size={14} />
-                </IconButton>
-              ) : null}
-            </div>
-            <p>Choose the local model used for prompt-to-slides.</p>
-            <label className="translation-target-control">
-              <span className="translation-target-label">Model</span>
-              <select
-                aria-label="LLM Model"
-                disabled={promptPreparation.status === 'downloading'}
-                value={selectedPromptProvider?.id ?? ''}
-                onChange={(event) => onPromptProviderChange?.(event.target.value)}
-              >
-                {promptProviders.map((provider) => (
-                  <option
-                    key={provider.id}
-                    value={provider.id}
-                    disabled={provider.compatibility === 'incompatible'}
-                  >
-                    {provider.label}
-                    {provider.compatibility === 'incompatible' ? ' - unavailable' : ''}
-                  </option>
-                ))}
-              </select>
-              {selectedPromptProvider?.disabledReason ? (
-                <span className="translation-source-note">{selectedPromptProvider.disabledReason}</span>
-              ) : null}
-            </label>
-            <div className="translation-target-control">
-              <div className="translation-preparation" aria-label="LLM preparation">
-                <div className="translation-preparation-meta">
-                  <StatusPill
-                    label={getPreparationLabel(promptStatus)}
-                    tone={getPreparationTone(promptStatus)}
-                  />
-                  {promptProgressText ? <span>{promptProgressText}</span> : null}
-                </div>
-                {promptStatus === 'downloading' ? (
-                  <>
-                    <div className="model-progress">
-                      <span style={{ width: `${promptProgress}%` }} />
-                    </div>
-                    <span className="translation-source-note">
-                      {promptApiNotice ?? `Availability: ${promptPreparation.availability}`}
-                    </span>
-                  </>
-                ) : null}
-              </div>
-            </div>
-          </article>
-
-          <article className="tool-card" aria-label="Language Detection">
-            <div className="tool-card-heading">
-              <ScanSearch size={18} />
-              <strong>Language Detection</strong>
-              <StatusPill
-                label={selectedLanguageDetectionProvider?.runtime === 'chrome-built-in' ? 'CHROME' : 'EXTERNAL'}
-                tone={selectedLanguageDetectionProvider?.compatibility === 'compatible' ? 'success' : 'neutral'}
-              />
-              {languageDetectionStatus === 'downloading' ? null : selectedLanguageDetectionNeedsDownload ? (
-                <IconButton
-                  label="Download Language Detection Model"
-                  attention
-                  disabled={selectedLanguageDetectionProvider?.compatibility === 'incompatible'}
-                  onClick={() => {
-                    void onPrepareLanguageDetectionProvider?.();
-                  }}
-                >
-                  <Download size={14} />
-                </IconButton>
-              ) : selectedLanguageDetectionCanRemove ? (
-                <IconButton
-                  label="Remove Language Detection Model"
-                  tone="danger"
-                  onClick={() => {
-                    void onRemoveModel?.(selectedLanguageDetectionProvider.modelId!);
-                  }}
-                >
-                  <X size={14} />
-                </IconButton>
-              ) : null}
-            </div>
-            <p>Choose how LocalStudio.dev detects source text language before translation.</p>
-            <label className="translation-target-control">
-              <span className="translation-target-label">Detection Model</span>
-              <select
-                aria-label="Language Detection Model"
-                disabled={languageDetectionPreparation.status === 'downloading'}
-                value={selectedLanguageDetectionProvider?.id ?? ''}
-                onChange={(event) => onLanguageDetectionProviderChange?.(event.target.value)}
-              >
-                {languageDetectionProviders.map((provider) => (
-                  <option
-                    key={provider.id}
-                    value={provider.id}
-                    disabled={provider.compatibility === 'incompatible'}
-                  >
-                    {provider.label}
-                    {provider.compatibility === 'incompatible' ? ' - unavailable' : ''}
-                  </option>
-                ))}
-              </select>
-              {selectedLanguageDetectionProvider?.disabledReason ? (
-                <span className="translation-source-note">{selectedLanguageDetectionProvider.disabledReason}</span>
-              ) : null}
-            </label>
-            <div className="translation-target-control">
-              <div className="translation-preparation" aria-label="Language detection preparation">
-                <div className="translation-preparation-meta">
-                  <StatusPill
-                    label={getPreparationLabel(languageDetectionStatus)}
-                    tone={getPreparationTone(languageDetectionStatus)}
-                  />
-                  {languageDetectionStatus === 'downloading' ? <span>{languageDetectionProgress}%</span> : null}
-                </div>
-                {languageDetectionStatus === 'downloading' ? (
-                  <div className="model-progress">
-                    <span style={{ width: `${languageDetectionProgress}%` }} />
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          </article>
-
-          <article
-            className={translationTargetAttention ? 'tool-card tool-card-attention' : 'tool-card'}
-            aria-label="Translate Design"
-          >
-            <div className="tool-card-heading">
-              <Languages size={18} />
-              <strong>Translate Design</strong>
-              <StatusPill
-                label={selectedTranslationProvider?.runtime === 'chrome-built-in' ? 'CHROME' : 'EXTERNAL'}
-                tone={selectedTranslationProvider?.compatibility === 'compatible' ? 'success' : 'neutral'}
-              />
-              {translationProviderStatus === 'downloading' ? null : selectedTranslationNeedsDownload ? (
-                <IconButton
-                  label="Download Translation Model"
-                  attention
-                  disabled={selectedTranslationProvider?.compatibility === 'incompatible'}
-                  onClick={() => {
-                    void onPrepareTranslationProvider?.();
-                  }}
-                >
-                  <Download size={14} />
-                </IconButton>
-              ) : selectedTranslationCanRemove ? (
-                <IconButton
-                  label="Remove Translation Model"
-                  tone="danger"
-                  onClick={() => {
-                    void onRemoveModel?.(selectedTranslationProvider.modelId!);
-                  }}
-                >
-                  <X size={14} />
-                </IconButton>
-              ) : null}
-            </div>
-            <p>Translate visible text using the selected local translation model.</p>
-            <label className="translation-target-control">
-              <span className="translation-target-label">Translation Model</span>
-              <select
-                aria-label="Translation Model"
-                disabled={translationPreparation.status === 'downloading'}
-                value={selectedTranslationProvider?.id ?? ''}
-                onChange={(event) => onTranslationProviderChange?.(event.target.value)}
-              >
-                {translationProviders.map((provider) => (
-                  <option
-                    key={provider.id}
-                    value={provider.id}
-                    disabled={provider.compatibility === 'incompatible'}
-                  >
-                    {provider.label}
-                    {provider.compatibility === 'incompatible' ? ' - unavailable' : ''}
-                  </option>
-                ))}
-              </select>
-              {selectedTranslationProvider?.disabledReason ? (
-                <span className="translation-source-note">{selectedTranslationProvider.disabledReason}</span>
-              ) : null}
-            </label>
-            {selectedTranslationProvider?.modelId ? (
-              <div className="translation-target-control">
-                <div className="translation-preparation" aria-label="Translation model preparation">
-                  <div className="translation-preparation-meta">
-                    <StatusPill
-                      label={getPreparationLabel(translationProviderStatus)}
-                      tone={getPreparationTone(translationProviderStatus)}
-                    />
-                    {translationProviderStatus === 'downloading' ? <span>{translationProviderProgress}%</span> : null}
-                  </div>
-                  {translationProviderStatus === 'downloading' ? (
-                    <div className="model-progress">
-                      <span style={{ width: `${translationProviderProgress}%` }} />
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            ) : null}
-            <label className="translation-target-control">
-              <span className="translation-target-label">
-                Translate to:
-                <ToolHelp
-                  id="translation-target-tooltip"
-                  text="Choose the language that will be used for all translations in this deck."
-                />
-              </span>
-              <select
-                aria-label="Translate to"
-                aria-describedby="translation-target-tooltip"
-                disabled={translationPreparation.status === 'downloading'}
-                value={translationTargetLanguage}
-                onChange={(event) => {
-                  onTranslationTargetLanguageChange?.(event.target.value);
+        <article
+          className={promptApiAttention ? 'tool-card tool-card-attention' : 'tool-card'}
+          aria-label="LLM Model"
+        >
+          <div className="tool-card-heading">
+            <ImagePlus size={18} />
+            <strong>LLM Model</strong>
+            <StatusPill
+              label={selectedPromptProvider?.runtime === 'chrome-built-in' ? 'CHROME' : 'EXTERNAL'}
+              tone={selectedPromptProvider?.compatibility === 'compatible' ? 'success' : 'neutral'}
+            />
+            {promptStatus === 'downloading' ? null : selectedPromptNeedsDownload ? (
+              <IconButton
+                label="Download LLM Model"
+                attention
+                disabled={selectedPromptProvider?.compatibility === 'incompatible'}
+                onClick={() => {
+                  void onPreparePromptApi?.();
                 }}
               >
-                <option value="">Choose language</option>
-                {translationLanguageOptions.map((language) => (
-                  <option key={language.code} value={language.code}>
-                    {language.label} ({language.code}) {language.flag}
-                  </option>
-                ))}
-              </select>
-              {translationTargetLanguage ? (
-                <div className="translation-preparation" aria-label="Translation language preparation">
-                  <div className="translation-preparation-meta">
-                    <StatusPill
-                      label={getPreparationLabel(translationProviderStatus)}
-                      tone={getPreparationTone(translationProviderStatus)}
-                    />
-                    {translationProviderProgressText ? <span>{translationProviderProgressText}</span> : null}
+                <Download size={14} />
+              </IconButton>
+            ) : selectedPromptCanRemove ? (
+              <IconButton
+                label="Remove LLM Model"
+                tone="danger"
+                onClick={() => {
+                  void onRemoveModel?.(selectedPromptProvider.modelId!);
+                }}
+              >
+                <X size={14} />
+              </IconButton>
+            ) : null}
+          </div>
+          <p>Choose the local model used for prompt-to-slides.</p>
+          <label className="translation-target-control">
+            <span className="translation-target-label">Model</span>
+            <select
+              aria-label="LLM Model"
+              disabled={promptPreparation.status === 'downloading'}
+              value={selectedPromptProvider?.id ?? ''}
+              onChange={(event) => onPromptProviderChange?.(event.target.value)}
+            >
+              {promptProviders.map((provider) => (
+                <option
+                  key={provider.id}
+                  value={provider.id}
+                  disabled={provider.compatibility === 'incompatible'}
+                >
+                  {provider.label}
+                  {provider.compatibility === 'incompatible' ? ' - unavailable' : ''}
+                </option>
+              ))}
+            </select>
+            {selectedPromptProvider?.disabledReason ? (
+              <span className="translation-source-note">
+                {selectedPromptProvider.disabledReason}
+              </span>
+            ) : null}
+          </label>
+          <div className="translation-target-control">
+            <div className="translation-preparation" aria-label="LLM preparation">
+              <div className="translation-preparation-meta">
+                <StatusPill
+                  label={getPreparationLabel(promptStatus)}
+                  tone={getPreparationTone(promptStatus)}
+                />
+                <DownloadProgressCopy
+                  details={{ ...promptPreparation, progress: promptProgress }}
+                  status={promptStatus}
+                />
+              </div>
+              {promptStatus === 'downloading' ? (
+                <>
+                  <div className="model-progress">
+                    <span style={{ width: `${promptProgress}%` }} />
                   </div>
-                  {translationProviderStatus === 'downloading' ? (
-                    <div className="model-progress">
-                      <span style={{ width: `${translationProviderProgress}%` }} />
-                    </div>
-                  ) : null}
-                  {displayedSourceLanguage ? (
-                    <span className="translation-source-note">
-                      Pair: {displayedSourceLanguage} → {translationTargetLanguage}
-                    </span>
-                  ) : null}
+                  <span className="translation-source-note">
+                    {promptApiNotice ?? `Availability: ${promptPreparation.availability}`}
+                  </span>
+                </>
+              ) : null}
+            </div>
+          </div>
+        </article>
+
+        <article className="tool-card" aria-label="Language Detection">
+          <div className="tool-card-heading">
+            <ScanSearch size={18} />
+            <strong>Language Detection</strong>
+            <StatusPill
+              label={
+                selectedLanguageDetectionProvider?.runtime === 'chrome-built-in'
+                  ? 'CHROME'
+                  : 'EXTERNAL'
+              }
+              tone={
+                selectedLanguageDetectionProvider?.compatibility === 'compatible'
+                  ? 'success'
+                  : 'neutral'
+              }
+            />
+            {languageDetectionStatus ===
+            'downloading' ? null : selectedLanguageDetectionNeedsDownload ? (
+              <IconButton
+                label="Download Language Detection Model"
+                attention
+                disabled={selectedLanguageDetectionProvider?.compatibility === 'incompatible'}
+                onClick={() => {
+                  void onPrepareLanguageDetectionProvider?.();
+                }}
+              >
+                <Download size={14} />
+              </IconButton>
+            ) : selectedLanguageDetectionCanRemove ? (
+              <IconButton
+                label="Remove Language Detection Model"
+                tone="danger"
+                onClick={() => {
+                  void onRemoveModel?.(selectedLanguageDetectionProvider.modelId!);
+                }}
+              >
+                <X size={14} />
+              </IconButton>
+            ) : null}
+          </div>
+          <p>Choose how LocalStudio.dev detects source text language before translation.</p>
+          <label className="translation-target-control">
+            <span className="translation-target-label">Detection Model</span>
+            <select
+              aria-label="Language Detection Model"
+              disabled={languageDetectionPreparation.status === 'downloading'}
+              value={selectedLanguageDetectionProvider?.id ?? ''}
+              onChange={(event) => onLanguageDetectionProviderChange?.(event.target.value)}
+            >
+              {languageDetectionProviders.map((provider) => (
+                <option
+                  key={provider.id}
+                  value={provider.id}
+                  disabled={provider.compatibility === 'incompatible'}
+                >
+                  {provider.label}
+                  {provider.compatibility === 'incompatible' ? ' - unavailable' : ''}
+                </option>
+              ))}
+            </select>
+            {selectedLanguageDetectionProvider?.disabledReason ? (
+              <span className="translation-source-note">
+                {selectedLanguageDetectionProvider.disabledReason}
+              </span>
+            ) : null}
+          </label>
+          <div className="translation-target-control">
+            <div className="translation-preparation" aria-label="Language detection preparation">
+              <div className="translation-preparation-meta">
+                <StatusPill
+                  label={getPreparationLabel(languageDetectionStatus)}
+                  tone={getPreparationTone(languageDetectionStatus)}
+                />
+                <DownloadProgressCopy
+                  details={{ ...languageDetectionPreparation, progress: languageDetectionProgress }}
+                  status={languageDetectionStatus}
+                />
+              </div>
+              {languageDetectionStatus === 'downloading' ? (
+                <div className="model-progress">
+                  <span style={{ width: `${languageDetectionProgress}%` }} />
                 </div>
               ) : null}
-            </label>
-          </article>
+            </div>
+          </div>
+        </article>
 
-          {visibleModelStates.map((model) => {
-            const needsAttention = attentionModelId === model.id && model.status !== 'ready';
-            return (
-              <article
-                aria-label={model.label}
-                className={needsAttention ? 'model-row model-row-attention' : 'model-row'}
-                key={model.id}
+        <article
+          className={translationTargetAttention ? 'tool-card tool-card-attention' : 'tool-card'}
+          aria-label="Translate Design"
+        >
+          <div className="tool-card-heading">
+            <Languages size={18} />
+            <strong>Translate Design</strong>
+            <StatusPill
+              label={
+                selectedTranslationProvider?.runtime === 'chrome-built-in' ? 'CHROME' : 'EXTERNAL'
+              }
+              tone={
+                selectedTranslationProvider?.compatibility === 'compatible' ? 'success' : 'neutral'
+              }
+            />
+            {translationProviderStatus ===
+            'downloading' ? null : selectedTranslationNeedsDownload ? (
+              <IconButton
+                label="Download Translation Model"
+                attention
+                disabled={selectedTranslationProvider?.compatibility === 'incompatible'}
+                onClick={() => {
+                  void onPrepareTranslationProvider?.();
+                }}
               >
-                <div className="model-row-main">
-                  <ScanSearch size={17} />
-                  <div className="model-row-title">
-                    <strong>{model.label}</strong>
-                    {model.description ? <span>{model.description}</span> : null}
-                  </div>
-                  {model.status === 'ready' ? (
-                    <IconButton
-                      label={`Remove ${model.label}`}
-                      tone="danger"
-                      onClick={() => {
-                        void onRemoveModel?.(model.id);
-                      }}
-                    >
-                      <X size={14} />
-                    </IconButton>
-                  ) : (
-                    <IconButton
-                      label={`Download ${model.label}`}
-                      attention={needsAttention || model.status === 'needs-download' || model.status === 'failed'}
-                      disabled={model.status === 'downloading'}
-                      onClick={() => {
-                        void onDownloadModel?.(model.id);
-                      }}
-                    >
-                      <Download size={14} />
-                    </IconButton>
-                  )}
+                <Download size={14} />
+              </IconButton>
+            ) : selectedTranslationCanRemove ? (
+              <IconButton
+                label="Remove Translation Model"
+                tone="danger"
+                onClick={() => {
+                  void onRemoveModel?.(selectedTranslationProvider.modelId!);
+                }}
+              >
+                <X size={14} />
+              </IconButton>
+            ) : null}
+          </div>
+          <p>Translate visible text using the selected local translation model.</p>
+          <label className="translation-target-control">
+            <span className="translation-target-label">Translation Model</span>
+            <select
+              aria-label="Translation Model"
+              disabled={translationPreparation.status === 'downloading'}
+              value={selectedTranslationProvider?.id ?? ''}
+              onChange={(event) => onTranslationProviderChange?.(event.target.value)}
+            >
+              {translationProviders.map((provider) => (
+                <option
+                  key={provider.id}
+                  value={provider.id}
+                  disabled={provider.compatibility === 'incompatible'}
+                >
+                  {provider.label}
+                  {provider.compatibility === 'incompatible' ? ' - unavailable' : ''}
+                </option>
+              ))}
+            </select>
+            {selectedTranslationProvider?.disabledReason ? (
+              <span className="translation-source-note">
+                {selectedTranslationProvider.disabledReason}
+              </span>
+            ) : null}
+          </label>
+          {selectedTranslationProvider?.modelId ? (
+            <div className="translation-target-control">
+              <div className="translation-preparation" aria-label="Translation model preparation">
+                <div className="translation-preparation-meta">
+                  <StatusPill
+                    label={getPreparationLabel(translationProviderStatus)}
+                    tone={getPreparationTone(translationProviderStatus)}
+                  />
+                  <DownloadProgressCopy
+                    details={{ ...translationPreparation, progress: translationProviderProgress }}
+                    status={translationProviderStatus}
+                  />
                 </div>
-                <label className="translation-target-control model-row-selector">
-                  <span className="translation-target-label">Model</span>
-                  <select aria-label={`${model.label} model`} value={model.id} onChange={() => undefined}>
-                    <option value={model.id}>{getFixedModelDisplayName(model.id, model.label)}</option>
-                  </select>
-                </label>
-                <div className="model-row-meta">
-                  <StatusPill label={formatStatus(model.status)} tone={statusTone(model.status)} />
-                  {model.status === 'ready' ? null : <span>{model.progress}%</span>}
-                </div>
-                {model.status === 'ready' ? null : (
-                  <div className="model-progress" aria-label={`${model.label} progress`}>
-                    <span style={{ width: `${model.progress}%` }} />
+                {translationProviderStatus === 'downloading' ? (
+                  <div className="model-progress">
+                    <span style={{ width: `${translationProviderProgress}%` }} />
                   </div>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+          <label className="translation-target-control">
+            <span className="translation-target-label">
+              Translate to:
+              <ToolHelp
+                id="translation-target-tooltip"
+                text="Choose the language that will be used for all translations in this deck."
+              />
+            </span>
+            <select
+              aria-label="Translate to"
+              aria-describedby="translation-target-tooltip"
+              disabled={translationPreparation.status === 'downloading'}
+              value={translationTargetLanguage}
+              onChange={(event) => {
+                onTranslationTargetLanguageChange?.(event.target.value);
+              }}
+            >
+              <option value="">Choose language</option>
+              {translationLanguageOptions.map((language) => (
+                <option key={language.code} value={language.code}>
+                  {language.label} ({language.code}) {language.flag}
+                </option>
+              ))}
+            </select>
+            {translationTargetLanguage ? (
+              <div
+                className="translation-preparation"
+                aria-label="Translation language preparation"
+              >
+                <div className="translation-preparation-meta">
+                  <StatusPill
+                    label={getPreparationLabel(translationProviderStatus)}
+                    tone={getPreparationTone(translationProviderStatus)}
+                  />
+                  <DownloadProgressCopy
+                    details={{ ...translationPreparation, progress: translationProviderProgress }}
+                    status={translationProviderStatus}
+                  />
+                </div>
+                {translationProviderStatus === 'downloading' ? (
+                  <div className="model-progress">
+                    <span style={{ width: `${translationProviderProgress}%` }} />
+                  </div>
+                ) : null}
+                {displayedSourceLanguage ? (
+                  <span className="translation-source-note">
+                    Pair: {displayedSourceLanguage} → {translationTargetLanguage}
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+          </label>
+        </article>
+
+        {visibleModelStates.map((model) => {
+          const needsAttention = attentionModelId === model.id && model.status !== 'ready';
+          return (
+            <article
+              aria-label={model.label}
+              className={needsAttention ? 'model-row model-row-attention' : 'model-row'}
+              key={model.id}
+            >
+              <div className="model-row-main">
+                <ScanSearch size={17} />
+                <div className="model-row-title">
+                  <strong>{model.label}</strong>
+                  {model.description ? <span>{model.description}</span> : null}
+                </div>
+                {model.status === 'ready' ? (
+                  <IconButton
+                    label={`Remove ${model.label}`}
+                    tone="danger"
+                    onClick={() => {
+                      void onRemoveModel?.(model.id);
+                    }}
+                  >
+                    <X size={14} />
+                  </IconButton>
+                ) : (
+                  <IconButton
+                    label={`Download ${model.label}`}
+                    attention={
+                      needsAttention ||
+                      model.status === 'needs-download' ||
+                      model.status === 'failed'
+                    }
+                    disabled={model.status === 'downloading'}
+                    onClick={() => {
+                      void onDownloadModel?.(model.id);
+                    }}
+                  >
+                    <Download size={14} />
+                  </IconButton>
                 )}
-                {model.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID ? (
-                  <div className="image-generation-settings" aria-label="Image generation settings">
-                    <div className="image-generation-setting">
-                      <span className="translation-target-label">Size</span>
-                      <div className="image-size-presets" role="group" aria-label="Image size">
-                        {imagePromptOptions.imageSizePresets.map((preset) => (
-                          <button
-                            key={preset.label}
-                            aria-pressed={imagePromptOptions.getImageSizeLabel(createImageOptions) === preset.label}
-                            className="image-size-preset"
-                            type="button"
-                            onClick={() => {
-                              updateCreateImageOptions({ width: preset.width, height: preset.height });
-                            }}
-                          >
-                            {preset.label}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                    <label className="image-generation-setting image-generation-range">
-                      <span className="translation-target-label">
-                        Steps
-                        <ToolHelp
-                          id="image-steps-tooltip"
-                          text="Steps control how many generation passes the model runs. Lower is faster; higher can add detail but takes longer. Use 4 for quick drafts."
-                        />
-                      </span>
-                      <input
-                        type="range"
-                        min={1}
-                        max={8}
-                        step={1}
-                        value={createImageOptions.steps}
-                        onChange={(event) => {
-                          updateCreateImageOptions({ steps: Number(event.target.value) });
-                        }}
-                      />
-                      <strong>{createImageOptions.steps}</strong>
-                    </label>
-                    <label className="image-generation-setting">
-                      <span className="translation-target-label">
-                        Seed
-                        <ToolHelp
-                          id="image-seed-tooltip"
-                          text="Seed controls randomness. Leave it random for new variations, or reuse the same number to recreate a similar image from the same prompt and options."
-                        />
-                      </span>
-                      <input
-                        aria-label="Image seed"
-                        className="image-generation-seed-input"
-                        inputMode="numeric"
-                        pattern="[0-9]*"
-                        placeholder="random"
-                        type="text"
-                        value={createImageOptions.seed?.toString() ?? ''}
-                        onChange={(event) => {
-                          const nextValue = event.target.value.replace(/\D/g, '').slice(0, 10);
-                          if (!nextValue) {
-                            onCreateImageOptionsChange?.({
-                              width: createImageOptions.width,
-                              height: createImageOptions.height,
-                              steps: createImageOptions.steps,
-                            });
-                            return;
+              </div>
+              <label className="translation-target-control model-row-selector">
+                <span className="translation-target-label">Model</span>
+                <select
+                  aria-label={`${model.label} model`}
+                  value={model.id}
+                  onChange={() => undefined}
+                >
+                  <option value={model.id}>
+                    {getFixedModelDisplayName(model.id, model.label)}
+                  </option>
+                </select>
+              </label>
+              <div className="model-row-meta">
+                <StatusPill label={formatStatus(model.status)} tone={statusTone(model.status)} />
+                <DownloadProgressCopy
+                  details={model}
+                  status={getModelProgressStatus(model.status)}
+                />
+              </div>
+              {model.status === 'ready' ? null : (
+                <div className="model-progress" aria-label={`${model.label} progress`}>
+                  <span style={{ width: `${model.progress}%` }} />
+                </div>
+              )}
+              {model.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID ? (
+                <div className="image-generation-settings" aria-label="Image generation settings">
+                  <div className="image-generation-setting">
+                    <span className="translation-target-label">Size</span>
+                    <div className="image-size-presets" role="group" aria-label="Image size">
+                      {imagePromptOptions.imageSizePresets.map((preset) => (
+                        <button
+                          key={preset.label}
+                          aria-pressed={
+                            imagePromptOptions.getImageSizeLabel(createImageOptions) ===
+                            preset.label
                           }
-                          updateCreateImageOptions({ seed: Number.parseInt(nextValue, 10) });
-                        }}
-                      />
-                    </label>
+                          className="image-size-preset"
+                          type="button"
+                          onClick={() => {
+                            updateCreateImageOptions({
+                              width: preset.width,
+                              height: preset.height,
+                            });
+                          }}
+                        >
+                          {preset.label}
+                        </button>
+                      ))}
+                    </div>
                   </div>
-                ) : null}
-                {model.status === 'failed' && model.error ? (
-                  <span className="translation-source-note">{model.error}</span>
-                ) : null}
-              </article>
-            );
-          })}
+                  <label className="image-generation-setting image-generation-range">
+                    <span className="translation-target-label">
+                      Steps
+                      <ToolHelp
+                        id="image-steps-tooltip"
+                        text="Steps control how many generation passes the model runs. Lower is faster; higher can add detail but takes longer. Use 4 for quick drafts."
+                      />
+                    </span>
+                    <input
+                      type="range"
+                      min={1}
+                      max={8}
+                      step={1}
+                      value={createImageOptions.steps}
+                      onChange={(event) => {
+                        updateCreateImageOptions({ steps: Number(event.target.value) });
+                      }}
+                    />
+                    <strong>{createImageOptions.steps}</strong>
+                  </label>
+                  <label className="image-generation-setting">
+                    <span className="translation-target-label">
+                      Seed
+                      <ToolHelp
+                        id="image-seed-tooltip"
+                        text="Seed controls randomness. Leave it random for new variations, or reuse the same number to recreate a similar image from the same prompt and options."
+                      />
+                    </span>
+                    <input
+                      aria-label="Image seed"
+                      className="image-generation-seed-input"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      placeholder="random"
+                      type="text"
+                      value={createImageOptions.seed?.toString() ?? ''}
+                      onChange={(event) => {
+                        const nextValue = event.target.value.replace(/\D/g, '').slice(0, 10);
+                        if (!nextValue) {
+                          onCreateImageOptionsChange?.({
+                            width: createImageOptions.width,
+                            height: createImageOptions.height,
+                            steps: createImageOptions.steps,
+                          });
+                          return;
+                        }
+                        updateCreateImageOptions({ seed: Number.parseInt(nextValue, 10) });
+                      }}
+                    />
+                  </label>
+                </div>
+              ) : null}
+              {model.status === 'failed' && model.error ? (
+                <span className="translation-source-note">{model.error}</span>
+              ) : null}
+            </article>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
@@ -321,6 +321,7 @@ export function AiToolsPanel({
     selectedLanguageDetectionProvider.readiness === 'ready';
   const selectedTranslationCanRemove =
     selectedTranslationProvider?.modelId && selectedTranslationProvider.readiness === 'ready';
+  const shouldShowTranslationLanguageProgress = !selectedTranslationProvider?.modelId;
   const visibleModelStates = modelStates.filter(
     (model) =>
       model.id !== aiModelCatalog.GEMMA_LLM_MODEL_ID &&
@@ -619,20 +620,27 @@ export function AiToolsPanel({
                 className="translation-preparation"
                 aria-label="Translation language preparation"
               >
-                <div className="translation-preparation-meta">
-                  <StatusPill
-                    label={getPreparationLabel(translationProviderStatus)}
-                    tone={getPreparationTone(translationProviderStatus)}
-                  />
-                  <DownloadProgressCopy
-                    details={{ ...translationPreparation, progress: translationProviderProgress }}
-                    status={translationProviderStatus}
-                  />
-                </div>
-                {translationProviderStatus === 'downloading' ? (
-                  <div className="model-progress">
-                    <span style={{ width: `${translationProviderProgress}%` }} />
-                  </div>
+                {shouldShowTranslationLanguageProgress ? (
+                  <>
+                    <div className="translation-preparation-meta">
+                      <StatusPill
+                        label={getPreparationLabel(translationProviderStatus)}
+                        tone={getPreparationTone(translationProviderStatus)}
+                      />
+                      <DownloadProgressCopy
+                        details={{
+                          ...translationPreparation,
+                          progress: translationProviderProgress,
+                        }}
+                        status={translationProviderStatus}
+                      />
+                    </div>
+                    {translationProviderStatus === 'downloading' ? (
+                      <div className="model-progress">
+                        <span style={{ width: `${translationProviderProgress}%` }} />
+                      </div>
+                    ) : null}
+                  </>
                 ) : null}
                 {displayedSourceLanguage ? (
                   <span className="translation-source-note">

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -29,6 +29,7 @@ import type {
   AiProviderState,
   MirrorProjectSummary,
   MirrorState,
+  ModelDownloadProgressDetails,
   ModelState,
   PromptApiAvailability,
   VersionHistoryEntry,
@@ -81,13 +82,13 @@ interface BackgroundSelectionPoint {
   positive: boolean;
 }
 
-interface TranslationPreparationState {
+interface TranslationPreparationState extends ModelDownloadProgressDetails {
   progress: number;
   sourceLanguage?: string;
   status: 'idle' | 'downloading' | 'ready' | 'failed';
 }
 
-interface PromptPreparationState {
+interface PromptPreparationState extends ModelDownloadProgressDetails {
   availability: PromptApiAvailability;
   progress: number;
   status: 'idle' | 'downloading' | 'ready' | 'failed';
@@ -96,6 +97,18 @@ interface PromptPreparationState {
 interface ElementClipboardState {
   assets: ProjectDocument['assets'];
   elements: DesignElement[];
+}
+
+function getDownloadProgressPatch(
+  progress: number,
+  details: ModelDownloadProgressDetails | undefined,
+): ModelDownloadProgressDetails & { progress: number } {
+  return {
+    estimatedRemainingMs: details?.estimatedRemainingMs,
+    loadedBytes: details?.loadedBytes,
+    progress,
+    totalBytes: details?.totalBytes,
+  };
 }
 
 export type RemoteImportStatus =
@@ -799,10 +812,12 @@ export function useEditorViewModel(services: AppServices) {
       ),
     );
     const next = await services.modelSetupService.downloadModel(id, {
-      onProgress: (progress) => {
+      onProgress: (progress, details) => {
         setModelStates((currentStates) =>
           currentStates.map((state) =>
-            state.id === id ? { ...state, status: 'downloading', progress } : state,
+            state.id === id
+              ? { ...state, status: 'downloading', ...getDownloadProgressPatch(progress, details) }
+              : state,
           ),
         );
       },
@@ -914,11 +929,14 @@ export function useEditorViewModel(services: AppServices) {
     }));
     try {
       await services.promptService.preparePromptApi({
-        onProgress: (progress) => {
+        onProgress: (progress, details) => {
           setPromptPreparation((current) => ({
             ...current,
             availability: progress >= 100 ? 'ready' : current.availability,
-            progress: Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+            ...getDownloadProgressPatch(
+              Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+              details,
+            ),
             status: progress >= 100 ? 'ready' : 'downloading',
           }));
         },
@@ -1008,9 +1026,12 @@ export function useEditorViewModel(services: AppServices) {
     setLanguageDetectionPreparation({ progress: 4, status: 'downloading' });
     try {
       await services.translatorService.prepareLanguageDetection?.({
-        onProgress: (progress) => {
+        onProgress: (progress, details) => {
           setLanguageDetectionPreparation((current) => ({
-            progress: Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+            ...getDownloadProgressPatch(
+              Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+              details,
+            ),
             status: progress >= 100 ? 'ready' : 'downloading',
           }));
         },
@@ -1040,9 +1061,12 @@ export function useEditorViewModel(services: AppServices) {
           'en',
           translationTargetLanguage || 'en',
           {
-            onProgress: (progress) => {
+            onProgress: (progress, details) => {
               setTranslationPreparation((current) => ({
-                progress: Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+                ...getDownloadProgressPatch(
+                  Math.max(current.progress, 4, Math.min(100, Math.round(progress))),
+                  details,
+                ),
                 status: progress >= 100 ? 'ready' : 'downloading',
               }));
             },
@@ -2099,9 +2123,12 @@ export function useEditorViewModel(services: AppServices) {
     try {
       const sourceLanguage = translationLanguageUtils.normalizeLanguageCode(
         await services.translatorService.detectLanguage(sampleText, {
-          onProgress: (progress) => {
+          onProgress: (progress, details) => {
             setTranslationPreparation((current) => ({
-              progress: Math.max(current.progress, 4, Math.min(45, Math.round(progress * 0.45))),
+              ...getDownloadProgressPatch(
+                Math.max(current.progress, 4, Math.min(45, Math.round(progress * 0.45))),
+                details,
+              ),
               status: 'downloading',
             }));
           },
@@ -2116,9 +2143,12 @@ export function useEditorViewModel(services: AppServices) {
       if (shouldPrepareLanguagePair) {
         setTranslationPreparation({ progress: 8, sourceLanguage, status: 'downloading' });
         await services.translatorService.prepareTranslation(sourceLanguage, nextLanguage, {
-          onProgress: (progress) => {
+          onProgress: (progress, details) => {
             setTranslationPreparation((current) => ({
-              progress: Math.max(current.progress, 8, Math.min(100, Math.round(progress))),
+              ...getDownloadProgressPatch(
+                Math.max(current.progress, 8, Math.min(100, Math.round(progress))),
+                details,
+              ),
               sourceLanguage,
               status: progress >= 100 ? 'ready' : 'downloading',
             }));

--- a/apps/editor/tests/unit/services/browserImageGenerationService.test.ts
+++ b/apps/editor/tests/unit/services/browserImageGenerationService.test.ts
@@ -76,6 +76,7 @@ describe('bonsaiImageRuntime.BrowserBonsaiImageRuntime', () => {
       return Promise.resolve(pipeline);
     });
     const progress: number[] = [];
+    const progressDetails: Array<unknown> = [];
 
     await new bonsaiImageRuntime.BrowserBonsaiImageRuntime({
       cacheName: 'test-cache',
@@ -86,7 +87,10 @@ describe('bonsaiImageRuntime.BrowserBonsaiImageRuntime', () => {
           },
         }),
     }).preload('prism-ml/bonsai-image-ternary-4B-mlx-2bit', {
-      onProgress: (value) => progress.push(Math.round(value)),
+      onProgress: (value, details) => {
+        progress.push(Math.round(value));
+        progressDetails.push(details);
+      },
     });
 
     expect(fromPretrained).toHaveBeenCalledWith(
@@ -94,6 +98,11 @@ describe('bonsaiImageRuntime.BrowserBonsaiImageRuntime', () => {
       expect.objectContaining({ cacheName: 'test-cache' }),
     );
     expect(progress).toEqual([3, 27, 55, 97, 100]);
+    expect(progressDetails.slice(0, 4).every((details) => details === undefined)).toBe(true);
+    expect(progressDetails[4]).toEqual({
+      loadedBytes: 3_095_000_000,
+      totalBytes: 3_095_000_000,
+    });
   });
 
   it('imports the vendored runtime-only module without DOM side effects or cleanup hooks', async () => {

--- a/apps/editor/tests/unit/services/modelSetupService.test.ts
+++ b/apps/editor/tests/unit/services/modelSetupService.test.ts
@@ -72,16 +72,32 @@ describe('modelSetupService.BrowserModelSetupService', () => {
   }
 
   it('downloads and marks the image editing model as browser cached', async () => {
-    const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
+    const loadImageEditingModel = vi.fn(
+      (options?: {
+        onProgress?: (
+          progress: number,
+          details?: { loadedBytes?: number; totalBytes?: number },
+        ) => void;
+      }) => {
+        options?.onProgress?.(64, {
+          loadedBytes: 120_000_000,
+          totalBytes: 190_000_000,
+        });
+        return Promise.resolve();
+      },
+    );
     const loader: ImageEditingModelLoader = {
       loadImageEditingModel,
     };
     const storage = createStorage();
     const service = new modelSetupService.BrowserModelSetupService(loader, storage);
 
-    const state = await service.downloadModel('image-editing-models');
+    const progressDetails: Array<ModelDownloadProgressDetails | undefined> = [];
+    const state = await service.downloadModel('image-editing-models', {
+      onProgress: (_value, details) => progressDetails.push(details),
+    });
 
-    expect(loadImageEditingModel).toHaveBeenCalledTimes(1);
+    expect(loadImageEditingModel).toHaveBeenCalledWith(expect.any(Object));
     expect(state).toMatchObject({ status: 'ready', progress: 100 });
     const states = await service.getModelStates();
     expect(states.find((item) => item.id === 'image-editing-models')).toMatchObject({
@@ -93,6 +109,10 @@ describe('modelSetupService.BrowserModelSetupService', () => {
     ).toMatchObject({
       status: 'needs-download',
       progress: 0,
+    });
+    expect(progressDetails[0]).toMatchObject({
+      loadedBytes: 120_000_000,
+      totalBytes: 190_000_000,
     });
   });
 
@@ -350,6 +370,29 @@ describe('modelSetupService.BrowserModelSetupService', () => {
     expect(deleteModelArtifacts).toHaveBeenCalledWith(
       'onnx-community/translategemma-text-4b-it-ONNX',
     );
+  });
+
+  it('releases image editing runtime state when removing the image editing model', async () => {
+    const removeImageEditingModel = vi.fn().mockResolvedValue(undefined);
+    const deleteModelArtifacts = vi.fn().mockResolvedValue(undefined);
+    const imageEditingLoader: ImageEditingModelLoader & {
+      removeImageEditingModel: () => Promise<void>;
+    } = {
+      loadImageEditingModel: vi.fn().mockResolvedValue(undefined),
+      removeImageEditingModel,
+    };
+    const service = new modelSetupService.BrowserModelSetupService(
+      imageEditingLoader,
+      createStorage({ 'ew-canvas-ai.model.image-editing-models.ready': 'true' }),
+      undefined,
+      undefined,
+      { deleteModelArtifacts },
+    );
+
+    await service.removeModel('image-editing-models');
+
+    expect(removeImageEditingModel).toHaveBeenCalledTimes(1);
+    expect(deleteModelArtifacts).toHaveBeenCalledWith('Xenova/slimsam-77-uniform');
   });
 
   it('removes matching Transformers.js cache entries for a model id', async () => {

--- a/apps/editor/tests/unit/services/modelSetupService.test.ts
+++ b/apps/editor/tests/unit/services/modelSetupService.test.ts
@@ -1,7 +1,14 @@
 import { vi } from 'vitest';
+import type { ModelDownloadProgressDetails } from '../../../src/services/contracts/interfaces';
 import { aiModelCatalog } from '../../../src/services/model-setup/aiModelCatalog';
 import { modelSetupService } from '../../../src/services/model-setup/modelSetupService';
-import type { ImageEditingModelLoader, ImageGenerationModelLoader, LanguageDetectionModelLoader, ModelCacheStorage, TextGenerationModelLoader } from '../../../src/services/model-setup/modelSetupService';
+import type {
+  ImageEditingModelLoader,
+  ImageGenerationModelLoader,
+  LanguageDetectionModelLoader,
+  ModelCacheStorage,
+  TextGenerationModelLoader,
+} from '../../../src/services/model-setup/modelSetupService';
 import { imageGenerationModel } from '../../../src/services/image-generation/imageGenerationModel';
 
 describe('modelSetupService.InMemoryModelSetupService', () => {
@@ -10,19 +17,25 @@ describe('modelSetupService.InMemoryModelSetupService', () => {
     await service.downloadRequiredModels();
 
     const states = await service.getModelStates();
-    expect(states.filter((state) => state.required).every((state) => state.status === 'ready')).toBe(true);
+    expect(
+      states.filter((state) => state.required).every((state) => state.status === 'ready'),
+    ).toBe(true);
     expect(states).toHaveLength(5);
     expect(states.find((state) => state.id === aiModelCatalog.GEMMA_LLM_MODEL_ID)).toMatchObject({
       label: aiModelCatalog.GEMMA_LLM_DISPLAY_NAME,
       required: false,
       status: 'needs-download',
     });
-    expect(states.find((state) => state.id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID)).toMatchObject({
+    expect(
+      states.find((state) => state.id === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID),
+    ).toMatchObject({
       label: aiModelCatalog.TRANSLATEGEMMA_DISPLAY_NAME,
       required: false,
       status: 'needs-download',
     });
-    expect(states.find((state) => state.id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID)).toMatchObject({
+    expect(
+      states.find((state) => state.id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID),
+    ).toMatchObject({
       label: aiModelCatalog.LANGUAGE_DETECTION_DISPLAY_NAME,
       required: false,
       status: 'needs-download',
@@ -32,7 +45,9 @@ describe('modelSetupService.InMemoryModelSetupService', () => {
       label: 'Image Editing Models',
       description: 'Segmentation model for image editing.',
     });
-    expect(states.find((state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID)).toMatchObject({
+    expect(
+      states.find((state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID),
+    ).toMatchObject({
       id: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
       label: 'Image Generation Models',
       description: 'Text-to-image model for generated slide assets.',
@@ -69,8 +84,13 @@ describe('modelSetupService.BrowserModelSetupService', () => {
     expect(loadImageEditingModel).toHaveBeenCalledTimes(1);
     expect(state).toMatchObject({ status: 'ready', progress: 100 });
     const states = await service.getModelStates();
-    expect(states.find((item) => item.id === 'image-editing-models')).toMatchObject({ status: 'ready', progress: 100 });
-    expect(states.find((item) => item.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID)).toMatchObject({
+    expect(states.find((item) => item.id === 'image-editing-models')).toMatchObject({
+      status: 'ready',
+      progress: 100,
+    });
+    expect(
+      states.find((item) => item.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID),
+    ).toMatchObject({
       status: 'needs-download',
       progress: 0,
     });
@@ -78,17 +98,23 @@ describe('modelSetupService.BrowserModelSetupService', () => {
 
   it('downloads image generation models independently', async () => {
     const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
-    const loadImageGenerationModel = vi.fn((options?: { onProgress?: (progress: number) => void }) => {
-      options?.onProgress?.(55);
-      return Promise.resolve();
-    });
+    const loadImageGenerationModel = vi.fn(
+      (options?: { onProgress?: (progress: number) => void }) => {
+        options?.onProgress?.(55);
+        return Promise.resolve();
+      },
+    );
     const imageEditingLoader: ImageEditingModelLoader = {
       loadImageEditingModel,
     };
     const imageGenerationLoader: ImageGenerationModelLoader = {
       loadImageGenerationModel,
     };
-    const service = new modelSetupService.BrowserModelSetupService(imageEditingLoader, createStorage(), imageGenerationLoader);
+    const service = new modelSetupService.BrowserModelSetupService(
+      imageEditingLoader,
+      createStorage(),
+      imageGenerationLoader,
+    );
 
     const progress: number[] = [];
     const state = await service.downloadModel(imageGenerationModel.IMAGE_GENERATION_MODEL_ID, {
@@ -97,20 +123,64 @@ describe('modelSetupService.BrowserModelSetupService', () => {
 
     expect(loadImageGenerationModel).toHaveBeenCalledTimes(1);
     expect(loadImageEditingModel).not.toHaveBeenCalled();
-    expect(state).toMatchObject({ id: imageGenerationModel.IMAGE_GENERATION_MODEL_ID, status: 'ready', progress: 100 });
+    expect(state).toMatchObject({
+      id: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
+      status: 'ready',
+      progress: 100,
+    });
     expect(progress).toEqual([55, 100]);
+  });
+
+  it('adds remaining time details to byte-aware model download progress', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValueOnce(0).mockReturnValueOnce(60_000);
+    const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
+    const loadImageGenerationModel = vi.fn(
+      (options?: {
+        onProgress?: (
+          progress: number,
+          details?: { loadedBytes?: number; totalBytes?: number },
+        ) => void;
+      }) => {
+        options?.onProgress?.(64, {
+          loadedBytes: 1_200_000_000,
+          totalBytes: 3_800_000_000,
+        });
+        return Promise.resolve();
+      },
+    );
+    const service = new modelSetupService.BrowserModelSetupService(
+      { loadImageEditingModel },
+      createStorage(),
+      { loadImageGenerationModel },
+    );
+
+    const progressDetails: Array<ModelDownloadProgressDetails | undefined> = [];
+    await service.downloadModel(imageGenerationModel.IMAGE_GENERATION_MODEL_ID, {
+      onProgress: (_value, details) => progressDetails.push(details),
+    });
+
+    expect(progressDetails[0]).toMatchObject({
+      loadedBytes: 1_200_000_000,
+      totalBytes: 3_800_000_000,
+      estimatedRemainingMs: 130_000,
+    });
+    expect(loadImageGenerationModel).toHaveBeenCalledTimes(1);
+    now.mockRestore();
   });
 
   it('keeps text model progress monotonic when loaders report per-file progress', async () => {
     const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
     const loadImageGenerationModel = vi.fn().mockResolvedValue(undefined);
-    const loadTextGenerationModel = vi.fn((_, options?: { onProgress?: (progress: number) => void }) => {
-      options?.onProgress?.(8);
-      options?.onProgress?.(18);
-      options?.onProgress?.(10);
-      options?.onProgress?.(55);
-      return Promise.resolve();
-    });
+    const loadTextGenerationModel = vi.fn(
+      (_, options?: { onProgress?: (progress: number) => void }) => {
+        options?.onProgress?.(8);
+        options?.onProgress?.(18);
+        options?.onProgress?.(10);
+        options?.onProgress?.(55);
+        return Promise.resolve();
+      },
+    );
     const textGenerationLoader: TextGenerationModelLoader = {
       loadTextGenerationModel,
     };
@@ -126,7 +196,11 @@ describe('modelSetupService.BrowserModelSetupService', () => {
       onProgress: (value) => progress.push(value),
     });
 
-    expect(state).toMatchObject({ id: aiModelCatalog.GEMMA_LLM_MODEL_ID, status: 'ready', progress: 100 });
+    expect(state).toMatchObject({
+      id: aiModelCatalog.GEMMA_LLM_MODEL_ID,
+      status: 'ready',
+      progress: 100,
+    });
     expect(progress).toEqual([10, 18, 18, 55, 100]);
   });
 
@@ -150,18 +224,25 @@ describe('modelSetupService.BrowserModelSetupService', () => {
 
     await service.downloadModel(aiModelCatalog.GEMMA_LLM_MODEL_ID);
 
-    expect(loadTextGenerationModel).toHaveBeenCalledWith(aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID, expect.any(Object));
-    expect(releaseTextGenerationModel).toHaveBeenCalledWith(aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID);
+    expect(loadTextGenerationModel).toHaveBeenCalledWith(
+      aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+      expect.any(Object),
+    );
+    expect(releaseTextGenerationModel).toHaveBeenCalledWith(
+      aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+    );
   });
 
   it('downloads the language detection model independently', async () => {
     const loadImageEditingModel = vi.fn().mockResolvedValue(undefined);
     const loadImageGenerationModel = vi.fn().mockResolvedValue(undefined);
     const loadTextGenerationModel = vi.fn().mockResolvedValue(undefined);
-    const loadLanguageDetectionModel = vi.fn((_, options?: { onProgress?: (progress: number) => void }) => {
-      options?.onProgress?.(42);
-      return Promise.resolve();
-    });
+    const loadLanguageDetectionModel = vi.fn(
+      (_, options?: { onProgress?: (progress: number) => void }) => {
+        options?.onProgress?.(42);
+        return Promise.resolve();
+      },
+    );
     const languageDetectionLoader: LanguageDetectionModelLoader = {
       loadLanguageDetectionModel,
     };
@@ -179,7 +260,11 @@ describe('modelSetupService.BrowserModelSetupService', () => {
       onProgress: (value) => progress.push(value),
     });
 
-    expect(state).toMatchObject({ id: aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID, status: 'ready', progress: 100 });
+    expect(state).toMatchObject({
+      id: aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID,
+      status: 'ready',
+      progress: 100,
+    });
     expect(progress).toEqual([42, 100]);
     expect(loadLanguageDetectionModel).toHaveBeenCalledTimes(1);
     expect(loadTextGenerationModel).not.toHaveBeenCalled();
@@ -201,7 +286,9 @@ describe('modelSetupService.BrowserModelSetupService', () => {
       status: 'ready',
       progress: 100,
     });
-    expect(states.find((state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID)).toMatchObject({
+    expect(
+      states.find((state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID),
+    ).toMatchObject({
       status: 'needs-download',
       progress: 0,
     });
@@ -219,7 +306,9 @@ describe('modelSetupService.BrowserModelSetupService', () => {
 
     const states = await service.getModelStates();
 
-    expect(states.find((state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID)).toMatchObject({
+    expect(
+      states.find((state) => state.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID),
+    ).toMatchObject({
       id: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
       status: 'ready',
       progress: 100,
@@ -255,8 +344,12 @@ describe('modelSetupService.BrowserModelSetupService', () => {
       progress: 0,
     });
     expect(storage.getItem('localstudio.ai.model.translategemma-webgpu.ready')).toBe('false');
-    expect(removeTextGenerationModel).toHaveBeenCalledWith('onnx-community/translategemma-text-4b-it-ONNX');
-    expect(deleteModelArtifacts).toHaveBeenCalledWith('onnx-community/translategemma-text-4b-it-ONNX');
+    expect(removeTextGenerationModel).toHaveBeenCalledWith(
+      'onnx-community/translategemma-text-4b-it-ONNX',
+    );
+    expect(deleteModelArtifacts).toHaveBeenCalledWith(
+      'onnx-community/translategemma-text-4b-it-ONNX',
+    );
   });
 
   it('removes matching Transformers.js cache entries for a model id', async () => {
@@ -264,9 +357,15 @@ describe('modelSetupService.BrowserModelSetupService', () => {
     const cache = {
       keys: vi.fn(() =>
         Promise.resolve([
-          new Request('https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/config.json'),
-          new Request('https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/onnx/model_q4.onnx'),
-          new Request('https://huggingface.co/onnx-community/translategemma-text-4b-it-ONNX/resolve/main/config.json'),
+          new Request(
+            'https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/config.json',
+          ),
+          new Request(
+            'https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/onnx/model_q4.onnx',
+          ),
+          new Request(
+            'https://huggingface.co/onnx-community/translategemma-text-4b-it-ONNX/resolve/main/config.json',
+          ),
         ]),
       ),
       delete: vi.fn((request: Request) => {
@@ -281,7 +380,9 @@ describe('modelSetupService.BrowserModelSetupService', () => {
       }),
     });
 
-    await new modelSetupService.BrowserTransformersModelCache().deleteModelArtifacts('onnx-community/gemma-4-E2B-it-ONNX');
+    await new modelSetupService.BrowserTransformersModelCache().deleteModelArtifacts(
+      'onnx-community/gemma-4-E2B-it-ONNX',
+    );
 
     expect(deletedRequests).toEqual([
       'https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX/resolve/main/config.json',
@@ -297,7 +398,9 @@ describe('modelSetupService.BrowserModelSetupService', () => {
 
     const states = await service.getModelStates();
 
-    expect(states.find((state) => state.id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID)).toMatchObject({
+    expect(
+      states.find((state) => state.id === aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID),
+    ).toMatchObject({
       id: aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID,
       status: 'ready',
       progress: 100,

--- a/apps/editor/tests/unit/services/progress.test.ts
+++ b/apps/editor/tests/unit/services/progress.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import type { ModelDownloadProgressDetails } from '../../../src/services/contracts/interfaces';
 import { progress } from '../../../src/services/model-setup/progress';
 
 describe('progress.createTransformersProgressCallback', () => {
   it('prefers Transformers.js aggregate progress over raw per-file progress', () => {
     const reportedProgress: number[] = [];
-    const onProgress = progress.createTransformersProgressCallback((value) => reportedProgress.push(value));
+    const onProgress = progress.createTransformersProgressCallback((value) =>
+      reportedProgress.push(value),
+    );
 
     onProgress({
       file: 'model_q4.onnx',
@@ -26,9 +29,31 @@ describe('progress.createTransformersProgressCallback', () => {
     expect(reportedProgress).toEqual([18]);
   });
 
+  it('reports aggregate byte progress details when Transformers.js provides them', () => {
+    const reportedProgress: Array<[number, ModelDownloadProgressDetails | undefined]> = [];
+    const onProgress = progress.createTransformersProgressCallback((value, details) =>
+      reportedProgress.push([value, details]),
+    );
+
+    onProgress({
+      file: 'model_q4.onnx',
+      loaded: 1_200_000_000,
+      name: 'onnx-community/gemma',
+      progress: 64,
+      status: 'progress_total',
+      total: 3_800_000_000,
+    });
+
+    expect(reportedProgress).toEqual([
+      [64, { loadedBytes: 1_200_000_000, totalBytes: 3_800_000_000 }],
+    ]);
+  });
+
   it('aggregates per-file progress when aggregate progress is unavailable', () => {
-    const reportedProgress: number[] = [];
-    const onProgress = progress.createTransformersProgressCallback((value) => reportedProgress.push(value));
+    const reportedProgress: Array<[number, ModelDownloadProgressDetails | undefined]> = [];
+    const onProgress = progress.createTransformersProgressCallback((value, details) =>
+      reportedProgress.push([value, details]),
+    );
 
     onProgress({
       file: 'a.onnx',
@@ -45,6 +70,38 @@ describe('progress.createTransformersProgressCallback', () => {
       total: 100,
     });
 
-    expect(reportedProgress).toEqual([50, 50]);
+    expect(reportedProgress).toEqual([
+      [50, { loadedBytes: 50, totalBytes: 100 }],
+      [50, { loadedBytes: 75, totalBytes: 200 }],
+    ]);
+  });
+});
+
+describe('progress.estimateRemainingMs', () => {
+  it('calculates remaining time from elapsed time and downloaded bytes', () => {
+    expect(
+      progress.estimateRemainingMs({
+        elapsedMs: 60_000,
+        loadedBytes: 1_200_000_000,
+        totalBytes: 3_800_000_000,
+      }),
+    ).toBe(130_000);
+  });
+
+  it('omits remaining time when byte totals are not usable', () => {
+    expect(
+      progress.estimateRemainingMs({
+        elapsedMs: 60_000,
+        loadedBytes: 0,
+        totalBytes: 3_800_000_000,
+      }),
+    ).toBeUndefined();
+    expect(
+      progress.estimateRemainingMs({
+        elapsedMs: 60_000,
+        loadedBytes: 3_800_000_000,
+        totalBytes: 3_800_000_000,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/apps/editor/tests/unit/services/transformersOperations.test.ts
+++ b/apps/editor/tests/unit/services/transformersOperations.test.ts
@@ -1,0 +1,113 @@
+import { vi } from 'vitest';
+import { transformersOperations } from '../../../src/services/model-setup/transformersOperations';
+import type { ModelDownloadProgressDetails } from '../../../src/services/contracts/interfaces';
+
+const mockProcessor = Object.assign(
+  vi.fn(() =>
+    Promise.resolve({
+      original_sizes: [],
+      reshaped_input_sizes: [[1, 1]],
+    }),
+  ),
+  {
+    post_process_masks: vi.fn(() => Promise.resolve([[{}]])),
+  },
+);
+
+const mockModel = Object.assign(
+  vi.fn(() =>
+    Promise.resolve({
+      pred_masks: {},
+      iou_scores: { data: [1] },
+    }),
+  ),
+  {
+    dispose: vi.fn(() => Promise.resolve()),
+    get_image_embeddings: vi.fn(() => Promise.resolve({})),
+  },
+);
+
+const fromPretrainedSamModel = vi.fn(
+  (_modelId: string, options?: { progress_callback?: (event: unknown) => void }) => {
+    options?.progress_callback?.({
+      file: 'onnx/model_fp16.onnx',
+      loaded: 120_000_000,
+      progress: 64,
+      status: 'progress',
+      total: 190_000_000,
+    });
+    return Promise.resolve(mockModel);
+  },
+);
+
+const fromPretrainedProcessor = vi.fn(
+  (_modelId: string, options?: { progress_callback?: (event: unknown) => void }) => {
+    options?.progress_callback?.({
+      file: 'preprocessor_config.json',
+      loaded: 20_000,
+      progress: 100,
+      status: 'progress',
+      total: 20_000,
+    });
+    return Promise.resolve(mockProcessor);
+  },
+);
+
+vi.mock('@huggingface/transformers', () => ({
+  AutoProcessor: {
+    from_pretrained: fromPretrainedProcessor,
+  },
+  RawImage: {
+    fromTensor: vi.fn(() => ({ data: new Uint8Array([1]), width: 1, height: 1 })),
+    fromURL: vi.fn(() =>
+      Promise.resolve({
+        data: new Uint8Array([255, 0, 0, 255]),
+        width: 1,
+        height: 1,
+        channels: 4,
+      }),
+    ),
+  },
+  SamModel: {
+    from_pretrained: fromPretrainedSamModel,
+  },
+  Tensor: class Tensor {
+    constructor(
+      readonly type: string,
+      readonly data: Array<number | bigint>,
+      readonly dims: number[],
+    ) {}
+  },
+  env: {},
+}));
+
+describe('transformersOperations.DirectTransformersOperations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports byte-aware progress while preloading image editing models', async () => {
+    const operations = new transformersOperations.DirectTransformersOperations();
+    const details: Array<ModelDownloadProgressDetails | undefined> = [];
+
+    await operations.preloadImageEditing({
+      onProgress: (_progress, nextDetails) => details.push(nextDetails),
+    });
+
+    expect(fromPretrainedSamModel.mock.calls[0]?.[0]).toBe('Xenova/slimsam-77-uniform');
+    expect(typeof fromPretrainedSamModel.mock.calls[0]?.[1]?.progress_callback).toBe('function');
+    expect(fromPretrainedProcessor.mock.calls[0]?.[0]).toBe('Xenova/slimsam-77-uniform');
+    expect(typeof fromPretrainedProcessor.mock.calls[0]?.[1]?.progress_callback).toBe('function');
+    expect(details.some((item) => item?.loadedBytes === 120_000_000)).toBe(true);
+    expect(details.some((item) => item?.totalBytes === 190_000_000)).toBe(true);
+  });
+
+  it('disposes the loaded image editing model when removed', async () => {
+    const operations = new transformersOperations.DirectTransformersOperations();
+
+    await operations.preloadImageEditing();
+    await operations.removeImageEditing();
+
+    expect(mockModel.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
@@ -119,6 +119,83 @@ describe('AiToolsPanel', () => {
     expect(within(translationCard).queryByText(/elapsed/i)).not.toBeInTheDocument();
   });
 
+  it('does not duplicate translation model download progress under the target language', () => {
+    render(
+      <AiToolsPanel
+        activeSlideLanguage={{ code: 'pt', displayCode: 'PT', flag: '🇧🇷', label: 'Portuguese' }}
+        modelStates={[]}
+        translationProviderStates={[translateGemmaProvider]}
+        translationLanguageOptions={[{ code: 'pt', flag: '🇧🇷', label: 'Portuguese' }]}
+        translationPreparation={{
+          estimatedRemainingMs: 180_000,
+          loadedBytes: 1_200_000_000,
+          progress: 64,
+          status: 'downloading',
+          totalBytes: 3_800_000_000,
+        }}
+        translationTargetLanguage="pt"
+      />,
+    );
+
+    const translationCard = screen.getByRole('article', { name: 'Translate Design' });
+
+    expect(within(translationCard).getAllByText('1.2 GB / 3.8 GB (64%)')).toHaveLength(1);
+    expect(within(translationCard).getAllByText('About 3 min remaining')).toHaveLength(1);
+    expect(within(translationCard).getByText('Pair: pt → pt')).toBeInTheDocument();
+  });
+
+  it('renders model-specific byte totals for each AI tools item', () => {
+    const imageGenerationState: ModelState = {
+      id: 'image-generation-models',
+      label: 'Image Generation Models',
+      description: 'Text-to-image model for generated slide assets.',
+      estimatedRemainingMs: 75_000,
+      loadedBytes: 1_200_000_000,
+      progress: 64,
+      provider: 'transformers',
+      required: false,
+      status: 'downloading',
+      totalBytes: 3_800_000_000,
+    };
+
+    render(
+      <AiToolsPanel
+        languageDetectionProviderStates={[languageDetectionProvider]}
+        languageDetectionPreparation={{
+          estimatedRemainingMs: 20_000,
+          loadedBytes: 40_000_000,
+          progress: 40,
+          status: 'downloading',
+          totalBytes: 100_000_000,
+        }}
+        modelStates={[imageGenerationState]}
+        promptProviderStates={[gemmaProvider]}
+        promptPreparation={{
+          availability: 'downloading',
+          estimatedRemainingMs: 90_000,
+          loadedBytes: 600_000_000,
+          progress: 30,
+          status: 'downloading',
+          totalBytes: 2_000_000_000,
+        }}
+        translationProviderStates={[translateGemmaProvider]}
+        translationLanguageOptions={[{ code: 'pt', flag: '🇧🇷', label: 'Portuguese' }]}
+        translationPreparation={{
+          estimatedRemainingMs: 180_000,
+          loadedBytes: 1_200_000_000,
+          progress: 64,
+          status: 'downloading',
+          totalBytes: 3_100_000_000,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('0.6 GB / 2.0 GB (30%)')).toBeInTheDocument();
+    expect(screen.getByText('0.0 GB / 0.1 GB (40%)')).toBeInTheDocument();
+    expect(screen.getByText('1.2 GB / 3.1 GB (64%)')).toBeInTheDocument();
+    expect(screen.getByText('1.2 GB / 3.8 GB (64%)')).toBeInTheDocument();
+  });
+
   it('shows remove actions for cached external providers', () => {
     render(
       <AiToolsPanel
@@ -175,14 +252,30 @@ describe('AiToolsPanel', () => {
       status: 'downloading',
       totalBytes: 3_800_000_000,
     };
+    const imageEditingState: ModelState = {
+      id: 'image-editing-models',
+      label: 'Image Editing Models',
+      description: 'Segmentation model for image editing.',
+      estimatedRemainingMs: 40_000,
+      loadedBytes: 120_000_000,
+      progress: 64,
+      provider: 'transformers',
+      required: true,
+      status: 'downloading',
+      totalBytes: 190_000_000,
+    };
 
-    render(<AiToolsPanel modelStates={[imageGenerationState]} />);
+    render(<AiToolsPanel modelStates={[imageGenerationState, imageEditingState]} />);
 
-    const modelCard = screen.getByRole('article', { name: 'Image Generation Models' });
+    const generationCard = screen.getByRole('article', { name: 'Image Generation Models' });
+    const editingCard = screen.getByRole('article', { name: 'Image Editing Models' });
 
-    expect(within(modelCard).getByText('1.2 GB / 3.8 GB (64%)')).toBeInTheDocument();
-    expect(within(modelCard).getByText('About 2 min remaining')).toBeInTheDocument();
-    expect(within(modelCard).queryByText(/elapsed/i)).not.toBeInTheDocument();
+    expect(within(generationCard).getByText('1.2 GB / 3.8 GB (64%)')).toBeInTheDocument();
+    expect(within(generationCard).getByText('About 2 min remaining')).toBeInTheDocument();
+    expect(within(generationCard).queryByText(/elapsed/i)).not.toBeInTheDocument();
+    expect(within(editingCard).getByText('0.1 GB / 0.2 GB (64%)')).toBeInTheDocument();
+    expect(within(editingCard).getByText('Less than 1 min remaining')).toBeInTheDocument();
+    expect(within(editingCard).queryByText(/elapsed/i)).not.toBeInTheDocument();
   });
 
   it('shows the same configurable model controls for language detection', () => {

--- a/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import { aiModelCatalog } from '../../../../src/services/model-setup/aiModelCatalog';
-import type { AiProviderState } from '../../../../src/services/contracts/interfaces';
+import type { AiProviderState, ModelState } from '../../../../src/services/contracts/interfaces';
 import { AiToolsPanel } from '../../../../src/ui/editor/panels/AiToolsPanel';
 
 const gemmaProvider: AiProviderState = {
@@ -72,7 +72,9 @@ describe('AiToolsPanel', () => {
     expect(within(translationCard).queryByText('Ready')).not.toBeInTheDocument();
     expect(within(translationCard).getAllByText('Pending').length).toBeGreaterThanOrEqual(1);
     expect(within(translationCard).queryByText('100%')).not.toBeInTheDocument();
-    expect(within(translationCard).getByRole('button', { name: 'Download Translation Model' })).toBeInTheDocument();
+    expect(
+      within(translationCard).getByRole('button', { name: 'Download Translation Model' }),
+    ).toBeInTheDocument();
   });
 
   it('shows translation model download progress even before a target language is selected', () => {
@@ -88,8 +90,33 @@ describe('AiToolsPanel', () => {
     const translationCard = screen.getByRole('article', { name: 'Translate Design' });
 
     expect(within(translationCard).getByLabelText('Translation Model')).toBeDisabled();
-    expect(within(translationCard).getByLabelText('Translation model preparation')).toHaveTextContent('Downloading');
+    expect(
+      within(translationCard).getByLabelText('Translation model preparation'),
+    ).toHaveTextContent('Downloading');
     expect(within(translationCard).getByText('64%')).toBeInTheDocument();
+  });
+
+  it('shows byte progress and remaining time for downloading provider models', () => {
+    render(
+      <AiToolsPanel
+        modelStates={[]}
+        translationProviderStates={[translateGemmaProvider]}
+        translationLanguageOptions={[{ code: 'pt', flag: '🇧🇷', label: 'Portuguese' }]}
+        translationPreparation={{
+          estimatedRemainingMs: 180_000,
+          loadedBytes: 1_200_000_000,
+          progress: 64,
+          status: 'downloading',
+          totalBytes: 3_800_000_000,
+        }}
+      />,
+    );
+
+    const translationCard = screen.getByRole('article', { name: 'Translate Design' });
+
+    expect(within(translationCard).getByText('1.2 GB / 3.8 GB (64%)')).toBeInTheDocument();
+    expect(within(translationCard).getByText('About 3 min remaining')).toBeInTheDocument();
+    expect(within(translationCard).queryByText(/elapsed/i)).not.toBeInTheDocument();
   });
 
   it('shows remove actions for cached external providers', () => {
@@ -107,7 +134,9 @@ describe('AiToolsPanel', () => {
     expect(screen.getByRole('button', { name: 'Remove LLM Model' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Remove Translation Model' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Download LLM Model' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Download Translation Model' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Download Translation Model' }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows finalizing copy instead of a stuck high percentage during model preparation', () => {
@@ -115,14 +144,45 @@ describe('AiToolsPanel', () => {
       <AiToolsPanel
         modelStates={[]}
         promptProviderStates={[gemmaProvider]}
-        promptPreparation={{ availability: 'downloading', progress: 99, status: 'downloading' }}
+        promptPreparation={{
+          estimatedRemainingMs: 2_000,
+          loadedBytes: 1_180_000_000,
+          availability: 'downloading',
+          progress: 99,
+          status: 'downloading',
+          totalBytes: 1_200_000_000,
+        }}
       />,
     );
 
     const llmCard = screen.getByRole('article', { name: 'LLM Model' });
 
     expect(within(llmCard).getByText('Finalizing...')).toBeInTheDocument();
-    expect(within(llmCard).queryByText('99%')).not.toBeInTheDocument();
+    expect(within(llmCard).getByText('1.2 GB / 1.2 GB (99%)')).toBeInTheDocument();
+    expect(within(llmCard).queryByText(/remaining/i)).not.toBeInTheDocument();
+  });
+
+  it('shows byte progress and remaining time for fixed model rows', () => {
+    const imageGenerationState: ModelState = {
+      id: 'image-generation-models',
+      label: 'Image Generation Models',
+      description: 'Text-to-image model for generated slide assets.',
+      estimatedRemainingMs: 75_000,
+      loadedBytes: 1_200_000_000,
+      progress: 64,
+      provider: 'transformers',
+      required: false,
+      status: 'downloading',
+      totalBytes: 3_800_000_000,
+    };
+
+    render(<AiToolsPanel modelStates={[imageGenerationState]} />);
+
+    const modelCard = screen.getByRole('article', { name: 'Image Generation Models' });
+
+    expect(within(modelCard).getByText('1.2 GB / 3.8 GB (64%)')).toBeInTheDocument();
+    expect(within(modelCard).getByText('About 2 min remaining')).toBeInTheDocument();
+    expect(within(modelCard).queryByText(/elapsed/i)).not.toBeInTheDocument();
   });
 
   it('shows the same configurable model controls for language detection', () => {
@@ -140,6 +200,8 @@ describe('AiToolsPanel', () => {
       'language-detection-webgpu',
     );
     expect(within(detectionCard).getByText('Pending')).toBeInTheDocument();
-    expect(within(detectionCard).getByRole('button', { name: 'Download Language Detection Model' })).toBeInTheDocument();
+    expect(
+      within(detectionCard).getByRole('button', { name: 'Download Language Detection Model' }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Add progress contracts and helpers that carry estimated remaining time alongside percentage updates.
- Thread ETA-capable progress reporting through model setup, image generation, prompting, and translation runtimes.
- Update the editor AI tools panel and view model to surface richer progress feedback to users.
- Extend in-memory test doubles and unit coverage for progress calculations and AI tools UI behavior.

## Testing
- Added and updated unit tests for progress helpers, model setup service behavior, and the AI tools panel.
- Performed local validation of the editor flow to confirm progress updates render and propagate correctly.