### PR TITLE
Allow sharing UI without remote storage and gate only public link creation

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -4605,8 +4605,12 @@ button {
 }
 
 .share-copy-link-button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.72;
+}
+
+.share-copy-link-button[data-loading='true']:disabled {
+  cursor: wait;
 }
 
 .share-link-fields {

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -45,7 +45,8 @@ export function EditorShell({ services }: EditorShellProps) {
     vm.project.pages.findIndex((page) => page.id === vm.activePageId),
   );
   const publicSharingAvailable = vm.mirrorState.enabled && vm.mirrorState.status === 'synced';
-  const publicSharingUnavailableReason = vm.mirrorState.error ?? 'Public sharing requires active external storage.';
+  const publicSharingUnavailableReason =
+    'Public links cannot be created without remote storage.';
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -278,8 +279,6 @@ export function EditorShell({ services }: EditorShellProps) {
         canUndo={!isHistoryReadOnly && vm.canUndo}
         hasSelection={!isHistoryReadOnly && hasSelection}
         persistenceEnabled={vm.persistenceEnabled}
-        publicSharingAvailable={publicSharingAvailable}
-        publicSharingUnavailableReason={publicSharingUnavailableReason}
         mirrorState={vm.mirrorState}
         mirrorDisabledBySettings={vm.mirrorDisabledBySettings}
         persistenceAttention={vm.persistenceAttention}
@@ -622,6 +621,9 @@ export function EditorShell({ services }: EditorShellProps) {
             setSharePanelOpen(false);
           }}
           onCopyLink={copyPublicShareLink}
+          publicLinkUnavailableReason={
+            publicSharingAvailable ? undefined : publicSharingUnavailableReason
+          }
           onDownload={exportCurrentPageAsPng}
           onPresent={presentFromSharePanel}
         />

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -12,8 +12,6 @@ interface TopToolbarProps {
   hasSelection?: boolean;
   persistenceEnabled?: boolean;
   persistenceAvailable?: boolean;
-  publicSharingAvailable?: boolean;
-  publicSharingUnavailableReason?: string;
   lastEditedAt?: string | undefined;
   mirrorState?: MirrorState;
   mirrorDisabledBySettings?: boolean;
@@ -115,8 +113,6 @@ export function TopToolbar({
   hasSelection = false,
   persistenceEnabled = false,
   persistenceAvailable = true,
-  publicSharingAvailable = true,
-  publicSharingUnavailableReason = 'Public sharing requires active external storage.',
   lastEditedAt,
   mirrorState = { enabled: false, status: 'disabled' },
   mirrorDisabledBySettings = false,
@@ -163,7 +159,6 @@ export function TopToolbar({
   }, [isEditingProjectName]);
 
   function triggerShare() {
-    if (!publicSharingAvailable) return;
     onShare?.();
   }
 
@@ -193,7 +188,7 @@ export function TopToolbar({
       { label: 'New Project', disabled: !onNewProject, onSelect: onNewProject },
       { label: 'Import Project', disabled: !onImportProject, onSelect: onImportProject },
       { label: 'Import Remote', disabled: !onImportRemoteMirror, onSelect: onImportRemoteMirror },
-      { label: 'Share', disabled: !publicSharingAvailable, onSelect: triggerShare },
+      { label: 'Share', disabled: !onShare, onSelect: triggerShare },
       { kind: 'separator', label: 'File storage actions' },
       { label: 'Save', disabled: !onSaveLocal, onSelect: onSaveLocal },
       { label: 'Save As...', disabled: !onSaveLocalAs, onSelect: onSaveLocalAs },
@@ -280,7 +275,7 @@ export function TopToolbar({
   ]
     .filter(Boolean)
     .join(' ');
-  const shareTitle = publicSharingAvailable ? 'Share' : publicSharingUnavailableReason;
+  const shareTitle = 'Share';
 
   return (
     <header className="top-toolbar">
@@ -544,7 +539,7 @@ export function TopToolbar({
         </a>
         <button
           className="export-button font-orbitron"
-          disabled={!publicSharingAvailable}
+          disabled={!onShare}
           title={shareTitle}
           type="button"
           onClick={triggerShare}

--- a/apps/editor/src/ui/share/SharePanel.tsx
+++ b/apps/editor/src/ui/share/SharePanel.tsx
@@ -82,6 +82,7 @@ export function SharePanel({
       <button
         className="share-copy-link-button font-orbitron"
         type="button"
+        data-loading={isCopying ? 'true' : 'false'}
         disabled={isCopying || publicLinkUnavailable}
         title={publicLinkUnavailableReason}
         onClick={() => {

--- a/apps/editor/src/ui/share/SharePanel.tsx
+++ b/apps/editor/src/ui/share/SharePanel.tsx
@@ -4,6 +4,7 @@ import type { ShareMetadata } from '../../services/contracts/interfaces';
 interface SharePanelProps {
   projectName: string;
   share?: ShareMetadata | undefined;
+  publicLinkUnavailableReason?: string | undefined;
   onClose: () => void;
   onCopyLink: () => Promise<ShareMetadata>;
   onDownload: () => void;
@@ -22,6 +23,7 @@ function getStatusLabel(share: ShareMetadata | undefined, isCopying: boolean) {
 export function SharePanel({
   projectName,
   share,
+  publicLinkUnavailableReason,
   onClose,
   onCopyLink,
   onDownload,
@@ -30,9 +32,17 @@ export function SharePanel({
   const [currentShare, setCurrentShare] = useState<ShareMetadata | undefined>(share);
   const [isCopying, setIsCopying] = useState(false);
   const [copyError, setCopyError] = useState<string | undefined>();
+  const publicLinkUnavailable = Boolean(publicLinkUnavailableReason);
   const statusLabel = getStatusLabel(currentShare, isCopying);
+  const shareAccessDescription =
+    copyError ??
+    publicLinkUnavailableReason ??
+    (currentShare
+      ? 'Unlisted: anyone with the link can view.'
+      : 'Create a public view link for this deck.');
 
   async function handleCopyLink() {
+    if (publicLinkUnavailable) return;
     setIsCopying(true);
     setCopyError(undefined);
     try {
@@ -66,18 +76,14 @@ export function SharePanel({
 
       <section className="share-access-block" aria-label="Share access">
         <span className="share-status-pill">{copyError ? 'Share failed' : statusLabel}</span>
-        <p>
-          {copyError ??
-            (currentShare
-              ? 'Unlisted: anyone with the link can view.'
-              : 'Create a public view link for this deck.')}
-        </p>
+        <p>{shareAccessDescription}</p>
       </section>
 
       <button
         className="share-copy-link-button font-orbitron"
         type="button"
-        disabled={isCopying}
+        disabled={isCopying || publicLinkUnavailable}
+        title={publicLinkUnavailableReason}
         onClick={() => {
           void handleCopyLink();
         }}

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -1855,10 +1855,19 @@ describe('EditorShell', () => {
     expect(screen.getByRole('button', { name: 'BG Remover' })).toBeInTheDocument();
   });
 
-  it('keeps Share disabled until the MinIO mirror is synced', () => {
+  it('opens Share before MinIO is synced and disables only public link creation', async () => {
+    const user = userEvent.setup();
     render(<EditorShell services={createAppServices()} />);
 
-    expect(screen.getByRole('button', { name: 'Share' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Share' }));
+
+    expect(screen.getByRole('heading', { name: 'Share design' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Public links cannot be created without remote storage.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy link' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Download' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Present' })).not.toBeDisabled();
   });
 
   it('exports the current slide as a PNG file', async () => {

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -240,7 +240,7 @@ describe('TopToolbar', () => {
     expect(screen.getByText('Mirroring')).toBeInTheDocument();
   });
 
-  it('disables sharing until MinIO external storage is ready', async () => {
+  it('opens sharing even when MinIO external storage is not ready', async () => {
     const user = userEvent.setup();
     const onShare = vi.fn();
 
@@ -248,19 +248,19 @@ describe('TopToolbar', () => {
       <TopToolbar
         project={sampleProject.createSampleProject()}
         language="PT-BR"
-        publicSharingAvailable={false}
-        publicSharingUnavailableReason="Public sharing requires active external storage."
         onShare={onShare}
       />,
     );
 
     const shareButton = screen.getByRole('button', { name: 'Share' });
-    expect(shareButton).toBeDisabled();
-    expect(shareButton).toHaveAttribute('title', 'Public sharing requires active external storage.');
+    expect(shareButton).not.toBeDisabled();
+    expect(shareButton).toHaveAttribute('title', 'Share');
+    await user.click(shareButton);
+    expect(onShare).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByRole('button', { name: 'File' }));
-    expect(screen.getByRole('menuitem', { name: 'Share' })).toBeDisabled();
-    expect(onShare).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('menuitem', { name: 'Share' }));
+    expect(onShare).toHaveBeenCalledTimes(2);
   });
 
   it('does not show stale share fallback UI when no share handler is provided', async () => {

--- a/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
@@ -67,6 +67,7 @@ describe('SharePanel', () => {
     const copyButton = screen.getByRole('button', { name: 'Copy link' });
     expect(copyButton).toBeDisabled();
     expect(copyButton).toHaveAttribute('title', message);
+    expect(copyButton).toHaveAttribute('data-loading', 'false');
 
     await user.click(screen.getByRole('button', { name: 'Download' }));
     await user.click(screen.getByRole('button', { name: 'Present' }));

--- a/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
@@ -45,6 +45,37 @@ describe('SharePanel', () => {
     expect(screen.getByRole('button', { name: 'Embed code' })).toBeDisabled();
   });
 
+  it('disables only public link creation when remote storage is unavailable', async () => {
+    const user = userEvent.setup();
+    const onCopyLink = vi.fn();
+    const onDownload = vi.fn();
+    const onPresent = vi.fn();
+    const message = 'Public links cannot be created without remote storage.';
+
+    render(
+      <SharePanel
+        projectName="Untitled AI Deck"
+        publicLinkUnavailableReason={message}
+        onClose={vi.fn()}
+        onCopyLink={onCopyLink}
+        onDownload={onDownload}
+        onPresent={onPresent}
+      />,
+    );
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+    const copyButton = screen.getByRole('button', { name: 'Copy link' });
+    expect(copyButton).toBeDisabled();
+    expect(copyButton).toHaveAttribute('title', message);
+
+    await user.click(screen.getByRole('button', { name: 'Download' }));
+    await user.click(screen.getByRole('button', { name: 'Present' }));
+
+    expect(onCopyLink).not.toHaveBeenCalled();
+    expect(onDownload).toHaveBeenCalledTimes(1);
+    expect(onPresent).toHaveBeenCalledTimes(1);
+  });
+
   it('creates a share and copies the public URL', async () => {
     const user = userEvent.setup();
     const onCopyLink = vi.fn().mockResolvedValue(createShareMetadata({ status: 'copied' }));


### PR DESCRIPTION
## Summary
- Keep the Share entrypoint available even when remote storage is unavailable.
- Restrict only public link creation in the share panel and show a clear unavailability message.
- Update button states and cursor styling so disabled loading vs unavailable states are distinguished.
- Adjust tests to cover opening Share without MinIO sync and verify Download/Present remain usable.

## Testing
- Added unit coverage for `EditorShell`, `TopToolbar`, and `SharePanel`.
- Validated the new behavior at the component level: Share opens without remote storage, copy-link is blocked, and other share actions still work.