### PR TITLE
Add Safari-compatible OPFS setup and project storage flow

### DIFF
--- a/apps/editor/src/app/composition.ts
+++ b/apps/editor/src/app/composition.ts
@@ -9,6 +9,7 @@ import type {
   MirrorService,
   ModelSetupService,
   PaletteService,
+  PersistenceStorageMode,
   PromptService,
   ProjectRepository,
   SmartGrabService,
@@ -23,6 +24,7 @@ import { BrowserBackgroundRemovalService } from '../services/background-removal/
 import { BrowserImageGenerationService } from '../services/image-generation/browserImageGenerationService';
 import { BrowserFileSystemProjectRepository } from '../services/storage/browserFileSystemProjectRepository';
 import { DisabledProjectRepository } from '../services/storage/disabledProjectRepository';
+import { OpfsProjectRepository } from '../services/storage/opfsProjectRepository';
 import { localSetupService } from '../services/browser/localSetupService';
 import { modelSetupService } from '../services/model-setup/modelSetupService';
 import { BrowserShareService } from '../services/sharing/shareService';
@@ -36,6 +38,7 @@ export interface AppServices {
   skipStoredProjectLoad: boolean;
   storedProjectName?: string;
   persistenceAvailable: boolean;
+  persistenceMode: PersistenceStorageMode;
   projectRepository: ProjectRepository;
   exportService: ExportService;
   shareService: ShareService;
@@ -60,7 +63,8 @@ interface CreateAppServicesOptions {
 export function createAppServices(options: CreateAppServicesOptions = {}): AppServices {
   const textGenerationRuntime = new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime();
   const languageDetectionRuntime = new webGpuLanguageDetectionRuntime.TransformersLanguageDetectionRuntime();
-  const persistenceAvailable = isFileSystemAccessAvailable();
+  const persistenceMode = getPersistenceStorageMode();
+  const persistenceAvailable = persistenceMode !== 'none';
   const mirrorService = new minioMirrorService.MinioMirrorService();
   const browserModelSetupService = new modelSetupService.BrowserModelSetupService(
     undefined,
@@ -75,7 +79,8 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
     skipStoredProjectLoad: options.skipStoredProjectLoad ?? false,
     ...(options.storedProjectName ? { storedProjectName: options.storedProjectName } : {}),
     persistenceAvailable,
-    projectRepository: createProjectRepository(persistenceAvailable),
+    persistenceMode,
+    projectRepository: createProjectRepository(persistenceMode),
     exportService: new BrowserExportService(),
     shareService: new BrowserShareService({ mirrorService }),
     localSetupService: new localSetupService.BrowserLocalSetupService(),
@@ -102,16 +107,32 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
   };
 }
 
-function isFileSystemAccessAvailable() {
-  return (
+function getPersistenceStorageMode(): PersistenceStorageMode {
+  if (
     typeof window !== 'undefined' &&
     typeof (window as Window & { showDirectoryPicker?: unknown }).showDirectoryPicker === 'function'
-  );
+  ) {
+    return 'directory';
+  }
+  if (
+    typeof navigator !== 'undefined' &&
+    typeof (
+      navigator as Navigator & {
+        storage?: StorageManager & { getDirectory?: unknown };
+      }
+    ).storage?.getDirectory === 'function'
+  ) {
+    return 'opfs';
+  }
+  return 'none';
 }
 
-function createProjectRepository(persistenceAvailable: boolean): ProjectRepository {
-  if (persistenceAvailable) {
+function createProjectRepository(persistenceMode: PersistenceStorageMode): ProjectRepository {
+  if (persistenceMode === 'directory') {
     return new BrowserFileSystemProjectRepository();
+  }
+  if (persistenceMode === 'opfs') {
+    return new OpfsProjectRepository();
   }
   return new DisabledProjectRepository();
 }

--- a/apps/editor/src/services/browser/localSetupService.ts
+++ b/apps/editor/src/services/browser/localSetupService.ts
@@ -15,6 +15,12 @@ type SetupWindow = Window &
     Translator?: TranslatorApi;
   };
 
+type SetupNavigator = Navigator & {
+  storage?: StorageManager & {
+    getDirectory?: unknown;
+  };
+};
+
 class BrowserLocalSetupService implements LocalSetupService {
   async checkReadiness(): Promise<LocalSetupState> {
     return {
@@ -41,10 +47,19 @@ class BrowserLocalSetupService implements LocalSetupService {
       };
     }
 
+    const browserNavigator = navigator as SetupNavigator;
+    if (typeof browserNavigator.storage?.getDirectory === 'function') {
+      return {
+        label: 'Project Files',
+        status: 'ready',
+        detail: 'Browser-private project storage is supported.',
+      };
+    }
+
     return {
       label: 'Project Files',
       status: 'unavailable',
-      detail: 'Chrome File System Access API is required.',
+      detail: 'Local project persistence is not available in this browser.',
     };
   }
 

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -168,6 +168,7 @@ export interface ModelSetupService {
 }
 
 export type SetupCapabilityStatus = 'unavailable' | 'needs-setup' | 'ready';
+export type PersistenceStorageMode = 'directory' | 'opfs' | 'none';
 
 export interface SetupCapabilityState {
   label: string;

--- a/apps/editor/src/services/storage/opfsProjectRepository.ts
+++ b/apps/editor/src/services/storage/opfsProjectRepository.ts
@@ -1,0 +1,428 @@
+import type { ProjectDocument } from '../../domain/documents/model';
+import type {
+  MirrorFile,
+  ProjectRepository,
+  VersionHistoryEntry,
+  VersionHistoryManifest,
+  VersionSnapshotMetadata,
+} from '../contracts/interfaces';
+import { browserStorage, type BrowserKeyValueStorage } from '../browser/browserStorage';
+import { assetFileUtils } from './assetFileUtils';
+import { projectVersionHistoryUtils } from './projectVersionHistoryUtils';
+
+interface OpfsProjectRepositoryOptions {
+  getRootDirectory?: () => Promise<FileSystemDirectoryHandle>;
+  storage?: BrowserKeyValueStorage;
+}
+
+interface HydrateProjectAssetsOptions {
+  allowMissingAssetFiles?: boolean;
+}
+
+type NavigatorWithOpfs = Navigator & {
+  storage?: StorageManager & {
+    getDirectory?: () => Promise<FileSystemDirectoryHandle>;
+  };
+};
+
+const PROJECTS_DIRECTORY_NAME = 'projects';
+const PROJECT_FILE_NAME = 'project.json';
+const PROJECT_CONFIG_FILE_NAME = 'localstudio.json';
+const VERSION_HISTORY_FILE_NAME = 'manifest.json';
+const VERSION_HISTORY_LIMIT = 100;
+const LAST_PROJECT_NAME_KEY = 'localstudio.ai.opfs.last-project-name';
+
+async function createFileBackedProjectSnapshot(
+  project: ProjectDocument,
+  assetsDirectory: FileSystemDirectoryHandle,
+): Promise<ProjectDocument> {
+  const projectAssets = project.assets;
+  const projectForDisk: ProjectDocument = {
+    ...project,
+    assets: { ...projectAssets },
+  };
+
+  for (const [assetId, asset] of Object.entries(projectAssets)) {
+    if (asset.storage === 'file' && asset.fileName) {
+      const assetForDisk = { ...asset };
+      delete assetForDisk.objectUrl;
+      projectForDisk.assets[assetId] = assetForDisk;
+      continue;
+    }
+
+    if (!assetFileUtils.isReadableObjectUrl(asset.objectUrl)) continue;
+    const fileName = asset.fileName ?? `${assetId}.${assetFileUtils.getAssetFileExtension(asset.mimeType)}`;
+    await writeBlobFileToDirectory(
+      assetsDirectory,
+      fileName,
+      await assetFileUtils.objectUrlToBlob(asset.objectUrl),
+    );
+    const assetForDisk = { ...asset };
+    delete assetForDisk.objectUrl;
+    projectForDisk.assets[assetId] = {
+      ...assetForDisk,
+      fileName,
+      storage: 'file',
+    };
+  }
+
+  return projectForDisk;
+}
+
+async function writeBlobFileToDirectory(
+  directoryHandle: FileSystemDirectoryHandle,
+  fileName: string,
+  value: Blob,
+) {
+  const fileHandle = await directoryHandle.getFileHandle(fileName, { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(value);
+  await writable.close();
+}
+
+async function readProjectNameFromMirrorFiles(files: MirrorFile[]) {
+  const projectFile = files.find((file) => file.path === PROJECT_FILE_NAME);
+  if (!projectFile) return undefined;
+  const project = JSON.parse(await projectFile.blob.text()) as ProjectDocument;
+  return project.name.trim() || undefined;
+}
+
+function isNotFoundError(error: unknown) {
+  return error instanceof DOMException && error.name === 'NotFoundError';
+}
+
+function normalizeProjectDirectoryName(projectName: string | undefined) {
+  const normalizedName = projectName?.trim();
+  if (!normalizedName) return 'untitled-project';
+  return encodeURIComponent(normalizedName).replaceAll('.', '%2E');
+}
+
+export class OpfsProjectRepository implements ProjectRepository {
+  private directoryHandle: FileSystemDirectoryHandle | null = null;
+  private projectDirectoryName: string | null = null;
+  private readonly storage: BrowserKeyValueStorage | undefined;
+
+  constructor(private readonly options: OpfsProjectRepositoryOptions = {}) {
+    this.storage = options.storage ?? browserStorage.getBrowserLocalStorage();
+  }
+
+  async importMirrorFiles(files: MirrorFile[]): Promise<ProjectDocument> {
+    const mirrorFiles = Array.isArray(files) ? files : [files];
+    const projectDirectoryName = normalizeProjectDirectoryName(
+      await readProjectNameFromMirrorFiles(mirrorFiles),
+    );
+    const projectsDirectory = await this.getProjectsDirectory();
+    this.directoryHandle = await projectsDirectory.getDirectoryHandle(projectDirectoryName, {
+      create: true,
+    });
+    this.projectDirectoryName = projectDirectoryName;
+    for (const file of mirrorFiles) {
+      await this.writeMirrorFile(this.directoryHandle, file);
+    }
+    const project = await this.readProjectFromDirectory(this.directoryHandle, {
+      allowMissingAssetFiles: true,
+    });
+    if (!project) throw new Error('The mirrored project did not include project.json.');
+    this.rememberProject(project.name);
+    return project;
+  }
+
+  async loadProject(options?: { projectName?: string }): Promise<ProjectDocument | null> {
+    const projectName = options?.projectName ?? this.storage?.getItem(LAST_PROJECT_NAME_KEY) ?? undefined;
+    if (!projectName) return null;
+    const projectsDirectory = await this.getProjectsDirectory();
+    const projectDirectoryName = normalizeProjectDirectoryName(projectName);
+    try {
+      this.directoryHandle = await projectsDirectory.getDirectoryHandle(projectDirectoryName);
+      this.projectDirectoryName = projectDirectoryName;
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
+    }
+    return this.readProjectFromDirectory(this.directoryHandle);
+  }
+
+  async saveProject(
+    project: ProjectDocument,
+    options?: { projectDirectoryName?: string },
+  ): Promise<void> {
+    const previousProjectDirectoryName = this.projectDirectoryName;
+    const directoryHandle = await this.ensureProjectDirectory(
+      options?.projectDirectoryName ?? project.name,
+    );
+    const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
+    await Promise.all([
+      directoryHandle.getDirectoryHandle('cache', { create: true }),
+      directoryHandle.getDirectoryHandle('config', { create: true }),
+    ]);
+
+    const projectForDisk = await createFileBackedProjectSnapshot(project, assetsDirectory);
+    const retainedAssetFileNames = new Set(
+      Object.values(projectForDisk.assets)
+        .map((asset) => asset.fileName)
+        .filter((fileName): fileName is string => Boolean(fileName)),
+    );
+
+    await this.removeUnretainedAssetFiles(assetsDirectory, retainedAssetFileNames);
+    await this.writeJsonFile(directoryHandle, PROJECT_FILE_NAME, projectForDisk);
+    const configDirectory = await directoryHandle.getDirectoryHandle('config', { create: true });
+    await this.writeJsonFile(configDirectory, PROJECT_CONFIG_FILE_NAME, {
+      app: 'LocalStudio.dev',
+      projectId: project.id,
+      schemaVersion: 1,
+      savedAt: new Date().toISOString(),
+      storage: 'opfs',
+    });
+    if (
+      previousProjectDirectoryName &&
+      previousProjectDirectoryName !== this.projectDirectoryName
+    ) {
+      const projectsDirectory = await this.getProjectsDirectory();
+      await projectsDirectory
+        .removeEntry(previousProjectDirectoryName, { recursive: true })
+        .catch(() => undefined);
+    }
+    this.rememberProject(project.name);
+  }
+
+  async saveProjectAs(
+    project: ProjectDocument,
+    options?: { projectDirectoryName?: string },
+  ): Promise<void> {
+    this.directoryHandle = null;
+    this.projectDirectoryName = null;
+    await this.saveProject(project, options);
+  }
+
+  async getVersionHistory(): Promise<VersionHistoryEntry[]> {
+    const directoryHandle = await this.ensureProjectDirectory();
+    const manifest = await this.readVersionHistoryManifest(directoryHandle);
+    return manifest.versions;
+  }
+
+  async saveVersion(
+    project: ProjectDocument,
+    metadata: VersionSnapshotMetadata,
+  ): Promise<VersionHistoryEntry> {
+    const directoryHandle = await this.ensureProjectDirectory(project.name);
+    const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
+    const historyDirectory = await directoryHandle.getDirectoryHandle('history', { create: true });
+    const versionsDirectory = await historyDirectory.getDirectoryHandle('versions', {
+      create: true,
+    });
+    const manifest = await this.readVersionHistoryManifest(directoryHandle, project.id);
+    const createdAt = new Date().toISOString();
+    const id = projectVersionHistoryUtils.createVersionId(new Date(createdAt));
+    const fileName = `${id}.json`;
+    const changeSummary = projectVersionHistoryUtils.createChangeSummary(project, metadata.previousProject);
+    const entry: VersionHistoryEntry = {
+      id,
+      createdAt,
+      authorName: 'Local user',
+      projectName: project.name,
+      summary: changeSummary.summary,
+      changeCount: changeSummary.changeCount,
+      fileName,
+      ...(changeSummary.firstChangedPageId
+        ? { firstChangedPageId: changeSummary.firstChangedPageId }
+        : {}),
+      ...(changeSummary.firstChangedElementId
+        ? { firstChangedElementId: changeSummary.firstChangedElementId }
+        : {}),
+    };
+
+    const projectForHistory = await createFileBackedProjectSnapshot(project, assetsDirectory);
+    await this.writeJsonFile(
+      versionsDirectory,
+      fileName,
+      projectVersionHistoryUtils.cloneProjectForHistory(projectForHistory),
+    );
+    const nextVersions = [entry, ...manifest.versions.filter((version) => version.id !== entry.id)];
+    const retainedVersions = nextVersions.slice(0, VERSION_HISTORY_LIMIT);
+    await this.removePrunedVersionFiles(
+      versionsDirectory,
+      nextVersions.slice(VERSION_HISTORY_LIMIT),
+    );
+    await this.writeJsonFile(historyDirectory, VERSION_HISTORY_FILE_NAME, {
+      schemaVersion: 1,
+      projectId: project.id,
+      latestVersionId: entry.id,
+      versions: retainedVersions,
+    } satisfies VersionHistoryManifest);
+    this.rememberProject(project.name);
+    return entry;
+  }
+
+  async loadVersion(versionId: string): Promise<ProjectDocument | null> {
+    const directoryHandle = await this.ensureProjectDirectory();
+    const manifest = await this.readVersionHistoryManifest(directoryHandle);
+    const entry = manifest.versions.find((version) => version.id === versionId);
+    if (!entry) return null;
+    try {
+      const historyDirectory = await directoryHandle.getDirectoryHandle('history');
+      const versionsDirectory = await historyDirectory.getDirectoryHandle('versions');
+      const fileHandle = await versionsDirectory.getFileHandle(entry.fileName);
+      const file = await fileHandle.getFile();
+      return this.hydrateProjectAssets(JSON.parse(await file.text()) as ProjectDocument, {
+        allowMissingAssetFiles: true,
+      });
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
+    }
+  }
+
+  private async getProjectsDirectory() {
+    const rootDirectory = await this.getRootDirectory();
+    return rootDirectory.getDirectoryHandle(PROJECTS_DIRECTORY_NAME, { create: true });
+  }
+
+  private async getRootDirectory() {
+    if (this.options.getRootDirectory) return this.options.getRootDirectory();
+    const browserNavigator =
+      typeof navigator === 'undefined' ? undefined : (navigator as NavigatorWithOpfs);
+    if (!browserNavigator?.storage?.getDirectory) {
+      throw new Error('Browser storage is not available in this browser.');
+    }
+    return browserNavigator.storage.getDirectory();
+  }
+
+  private async ensureProjectDirectory(projectName?: string): Promise<FileSystemDirectoryHandle> {
+    const requestedProjectDirectoryName = normalizeProjectDirectoryName(
+      projectName ?? this.storage?.getItem(LAST_PROJECT_NAME_KEY) ?? undefined,
+    );
+    if (!this.directoryHandle || requestedProjectDirectoryName !== this.projectDirectoryName) {
+      const projectsDirectory = await this.getProjectsDirectory();
+      this.directoryHandle = await projectsDirectory.getDirectoryHandle(requestedProjectDirectoryName, {
+        create: true,
+      });
+      this.projectDirectoryName = requestedProjectDirectoryName;
+    }
+    return this.directoryHandle;
+  }
+
+  private async writeJsonFile(
+    directoryHandle: FileSystemDirectoryHandle,
+    fileName: string,
+    value: unknown,
+  ) {
+    const temporaryFileName = `${fileName}.tmp`;
+    await this.writeTextFile(directoryHandle, temporaryFileName, JSON.stringify(value, null, 2));
+    await this.writeTextFile(directoryHandle, fileName, JSON.stringify(value, null, 2));
+    await directoryHandle.removeEntry(temporaryFileName).catch(() => undefined);
+  }
+
+  private async writeTextFile(
+    directoryHandle: FileSystemDirectoryHandle,
+    fileName: string,
+    value: string,
+  ) {
+    const fileHandle = await directoryHandle.getFileHandle(fileName, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(value);
+    await writable.close();
+  }
+
+  private async removeUnretainedAssetFiles(
+    directoryHandle: FileSystemDirectoryHandle,
+    retainedAssetFileNames: Set<string>,
+  ) {
+    const entries = (directoryHandle as unknown as {
+      entries?: () => AsyncIterable<[string, { kind?: string }]>;
+    }).entries;
+    if (!entries) return;
+
+    const removals: Array<Promise<void>> = [];
+    for await (const [name, handle] of entries.call(directoryHandle)) {
+      if (handle.kind !== 'file' || retainedAssetFileNames.has(name)) continue;
+      removals.push(directoryHandle.removeEntry(name).catch(() => undefined));
+    }
+    await Promise.all(removals);
+  }
+
+  private async writeMirrorFile(directoryHandle: FileSystemDirectoryHandle, file: MirrorFile) {
+    const pathParts = file.path.split('/').filter(Boolean);
+    const fileName = pathParts.pop();
+    if (!fileName) return;
+    let currentDirectory = directoryHandle;
+    for (const directoryName of pathParts) {
+      currentDirectory = await currentDirectory.getDirectoryHandle(directoryName, { create: true });
+    }
+    await writeBlobFileToDirectory(currentDirectory, fileName, file.blob);
+  }
+
+  private async removePrunedVersionFiles(
+    directoryHandle: FileSystemDirectoryHandle,
+    entries: VersionHistoryEntry[],
+  ) {
+    await Promise.all(
+      entries.map((entry) => directoryHandle.removeEntry(entry.fileName).catch(() => undefined)),
+    );
+  }
+
+  private async readVersionHistoryManifest(
+    directoryHandle: FileSystemDirectoryHandle,
+    projectId = 'unknown-project',
+  ): Promise<VersionHistoryManifest> {
+    const historyDirectory = await directoryHandle.getDirectoryHandle('history', { create: true });
+    try {
+      const fileHandle = await historyDirectory.getFileHandle(VERSION_HISTORY_FILE_NAME);
+      const file = await fileHandle.getFile();
+      return JSON.parse(await file.text()) as VersionHistoryManifest;
+    } catch (error) {
+      if (!isNotFoundError(error)) throw error;
+      return { schemaVersion: 1, projectId, versions: [] };
+    }
+  }
+
+  private async readProjectFromDirectory(
+    directoryHandle: FileSystemDirectoryHandle,
+    options: HydrateProjectAssetsOptions = {},
+  ): Promise<ProjectDocument | null> {
+    let file: File;
+    try {
+      const fileHandle = await directoryHandle.getFileHandle(PROJECT_FILE_NAME);
+      file = await fileHandle.getFile();
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      throw error;
+    }
+
+    const project = JSON.parse(await file.text()) as ProjectDocument;
+    return this.hydrateProjectAssets(project, options);
+  }
+
+  private async hydrateProjectAssets(
+    project: ProjectDocument,
+    options: HydrateProjectAssetsOptions = {},
+  ): Promise<ProjectDocument> {
+    if (!this.directoryHandle) return project;
+    const assets: ProjectDocument['assets'] = {};
+    let assetsDirectory: FileSystemDirectoryHandle | undefined;
+
+    for (const [assetId, asset] of Object.entries(project.assets)) {
+      if (asset.storage !== 'file' || !asset.fileName) {
+        assets[assetId] = asset;
+        continue;
+      }
+      try {
+        assetsDirectory ??= await this.directoryHandle.getDirectoryHandle('assets');
+        const fileHandle = await assetsDirectory.getFileHandle(asset.fileName);
+        const file = await fileHandle.getFile();
+        assets[assetId] = {
+          ...asset,
+          objectUrl: URL.createObjectURL(file),
+        };
+      } catch (error) {
+        if (!isNotFoundError(error) || !options.allowMissingAssetFiles) throw error;
+        assets[assetId] = asset;
+      }
+    }
+
+    return { ...project, assets };
+  }
+
+  private rememberProject(projectName: string) {
+    this.storage?.setItem(LAST_PROJECT_NAME_KEY, projectName);
+  }
+}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -47,6 +47,7 @@ export function EditorShell({ services }: EditorShellProps) {
   const publicSharingAvailable = vm.mirrorState.enabled && vm.mirrorState.status === 'synced';
   const publicSharingUnavailableReason =
     'Public links cannot be created without remote storage.';
+  const hasDirectoryPersistence = services.persistenceMode === 'directory';
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -319,14 +320,19 @@ export function EditorShell({ services }: EditorShellProps) {
         saveAnimationKey={vm.saveAnimationKey}
         canTranslateDeck={vm.canTranslateDeck}
         persistenceAvailable={services.persistenceAvailable}
+        persistenceMode={services.persistenceMode}
         onDelete={isHistoryReadOnly ? undefined : vm.deleteSelectedElement}
         onDuplicate={isHistoryReadOnly ? undefined : vm.duplicateSelectedElement}
         onImportRemoteMirror={() => {
           void vm.importRemoteMirror();
         }}
-        onImportProject={() => {
-          void vm.importProject();
-        }}
+        onImportProject={
+          hasDirectoryPersistence
+            ? () => {
+                void vm.importProject();
+              }
+            : undefined
+        }
         onMirrorNow={() => {
           vm.requestMirrorNow();
         }}
@@ -353,9 +359,13 @@ export function EditorShell({ services }: EditorShellProps) {
         onSaveLocal={() => {
           void vm.saveLocalNow();
         }}
-        onSaveLocalAs={() => {
-          void vm.saveLocalAs();
-        }}
+        onSaveLocalAs={
+          hasDirectoryPersistence
+            ? () => {
+                void vm.saveLocalAs();
+              }
+            : undefined
+        }
         onTranslateDeck={
           isHistoryReadOnly
             ? undefined

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -1406,6 +1406,11 @@ export function useEditorViewModel(services: AppServices) {
       return;
     }
 
+    if (services.persistenceMode === 'opfs') {
+      void reenablePersistence();
+      return;
+    }
+
     setLocalProjectSetupOpen(true);
   }
 

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { ProjectDocument } from '../../../domain/documents/model';
-import type { MirrorState } from '../../../services/contracts/interfaces';
+import type { MirrorState, PersistenceStorageMode } from '../../../services/contracts/interfaces';
 
 interface TopToolbarProps {
   project: ProjectDocument;
@@ -12,6 +12,7 @@ interface TopToolbarProps {
   hasSelection?: boolean;
   persistenceEnabled?: boolean;
   persistenceAvailable?: boolean;
+  persistenceMode?: PersistenceStorageMode;
   lastEditedAt?: string | undefined;
   mirrorState?: MirrorState;
   mirrorDisabledBySettings?: boolean;
@@ -113,6 +114,7 @@ export function TopToolbar({
   hasSelection = false,
   persistenceEnabled = false,
   persistenceAvailable = true,
+  persistenceMode = persistenceAvailable ? 'directory' : 'none',
   lastEditedAt,
   mirrorState = { enabled: false, status: 'disabled' },
   mirrorDisabledBySettings = false,
@@ -234,14 +236,22 @@ export function TopToolbar({
     : 'No saved versions yet';
   const persistenceLabel = !persistenceAvailable
     ? 'Persistence unavailable'
+    : persistenceMode === 'opfs'
+      ? persistenceEnabled
+        ? 'Browser storage enabled'
+        : 'Browser storage disabled'
     : persistenceEnabled
       ? 'Persistence enabled'
       : 'Persistence disabled';
   const persistenceTitle = !persistenceAvailable
-    ? 'Local project persistence is not available in this browser. Use a browser with File System Access support.'
+    ? 'Local project persistence is not available in this browser.'
+    : persistenceMode === 'opfs'
+      ? persistenceEnabled
+        ? 'Browser-private project storage is enabled. Files are stored by this browser profile and are not visible in Finder.'
+        : 'Save this deck in browser-private storage. Files are scoped to this browser profile and are not visible in Finder.'
     : persistenceEnabled
-      ? 'Persistence enabled'
-      : 'Persistence disabled';
+      ? 'Local folder persistence is enabled'
+      : 'Save this deck to a local folder';
   const mirrorLabel = !persistenceEnabled
     ? 'Unsaved deck'
     : !mirrorState.enabled

--- a/apps/editor/tests/unit/app/composition.test.ts
+++ b/apps/editor/tests/unit/app/composition.test.ts
@@ -3,15 +3,21 @@ import { sampleProject } from '../../../src/domain/projects/sampleProject';
 import { BrowserFileSystemProjectRepository } from '../../../src/services/storage/browserFileSystemProjectRepository';
 import { BrowserImageGenerationService } from '../../../src/services/image-generation/browserImageGenerationService';
 import { DisabledProjectRepository } from '../../../src/services/storage/disabledProjectRepository';
+import { OpfsProjectRepository } from '../../../src/services/storage/opfsProjectRepository';
 
 describe('createAppServices', () => {
   const testWindow = window as Window & { showDirectoryPicker?: unknown };
   const originalShowDirectoryPicker = testWindow.showDirectoryPicker;
+  const originalStorage = navigator.storage;
 
   afterEach(() => {
     Object.defineProperty(window, 'showDirectoryPicker', {
       configurable: true,
       value: originalShowDirectoryPicker,
+    });
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: originalStorage,
     });
   });
 
@@ -23,17 +29,39 @@ describe('createAppServices', () => {
 
     const services = createAppServices();
     expect(services.persistenceAvailable).toBe(true);
+    expect(services.persistenceMode).toBe('directory');
     expect(services.projectRepository).toBeInstanceOf(BrowserFileSystemProjectRepository);
   });
 
-  it('uses disabled persistence when the File System Access API is unavailable', () => {
+  it('uses OPFS-backed project storage when only browser-private storage is available', () => {
     Object.defineProperty(window, 'showDirectoryPicker', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: { getDirectory: () => Promise.resolve({}) },
+    });
+
+    const services = createAppServices();
+    expect(services.persistenceAvailable).toBe(true);
+    expect(services.persistenceMode).toBe('opfs');
+    expect(services.projectRepository).toBeInstanceOf(OpfsProjectRepository);
+  });
+
+  it('uses disabled persistence when no filesystem storage API is available', () => {
+    Object.defineProperty(window, 'showDirectoryPicker', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(navigator, 'storage', {
       configurable: true,
       value: undefined,
     });
 
     const services = createAppServices();
     expect(services.persistenceAvailable).toBe(false);
+    expect(services.persistenceMode).toBe('none');
     expect(services.projectRepository).toBeInstanceOf(DisabledProjectRepository);
   });
 

--- a/apps/editor/tests/unit/services/localSetupService.test.ts
+++ b/apps/editor/tests/unit/services/localSetupService.test.ts
@@ -2,8 +2,14 @@ import { vi } from 'vitest';
 import { localSetupService } from '../../../src/services/browser/localSetupService';
 
 describe('localSetupService.BrowserLocalSetupService', () => {
+  const originalStorage = navigator.storage;
+
   afterEach(() => {
     vi.unstubAllGlobals();
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: originalStorage,
+    });
     Object.defineProperty(navigator, 'gpu', {
       configurable: true,
       value: undefined,
@@ -29,6 +35,10 @@ describe('localSetupService.BrowserLocalSetupService', () => {
   it('reports missing browser capabilities as unavailable', async () => {
     vi.stubGlobal('showDirectoryPicker', undefined);
     vi.stubGlobal('Translator', undefined);
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: undefined,
+    });
     const service = new localSetupService.BrowserLocalSetupService();
 
     const state = await service.checkReadiness();
@@ -36,6 +46,21 @@ describe('localSetupService.BrowserLocalSetupService', () => {
     expect(state.fileSystem.status).toBe('unavailable');
     expect(state.chromeTranslation.status).toBe('unavailable');
     expect(state.chromeTranslation.detail).toBe('No compatible local AI provider was found in this browser.');
+  });
+
+  it('reports OPFS browser storage as ready when folder picking is unavailable', async () => {
+    vi.stubGlobal('showDirectoryPicker', undefined);
+    vi.stubGlobal('Translator', undefined);
+    Object.defineProperty(navigator, 'storage', {
+      configurable: true,
+      value: { getDirectory: vi.fn() },
+    });
+    const service = new localSetupService.BrowserLocalSetupService();
+
+    const state = await service.checkReadiness();
+
+    expect(state.fileSystem.status).toBe('ready');
+    expect(state.fileSystem.detail).toBe('Browser-private project storage is supported.');
   });
 
   it('uses WebGPU provider compatibility when Chrome AI needs setup', async () => {

--- a/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
@@ -1,0 +1,226 @@
+import type { BrowserKeyValueStorage } from '../../../src/services/browser/browserStorage';
+import type { ProjectDocument } from '../../../src/domain/documents/model';
+import { sampleProject } from '../../../src/domain/projects/sampleProject';
+import { OpfsProjectRepository } from '../../../src/services/storage/opfsProjectRepository';
+import { vi } from 'vitest';
+
+class MockWritable {
+  constructor(private readonly onClose: (value: string | Blob) => void) {}
+
+  private value: string | Blob = '';
+
+  write(value: string | Blob): Promise<void> {
+    this.value = value;
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this.onClose(this.value);
+    return Promise.resolve();
+  }
+}
+
+class MockFileHandle {
+  constructor(
+    private readonly name: string,
+    private readonly files: Map<string, string | Blob>,
+  ) {}
+
+  createWritable(): Promise<MockWritable> {
+    return Promise.resolve(
+      new MockWritable((value) => {
+        this.files.set(this.name, value);
+      }),
+    );
+  }
+
+  getFile(): Promise<{ text: () => Promise<string>; type: string }> {
+    const value = this.files.get(this.name);
+    if (value === undefined) return Promise.reject(new DOMException('Not found', 'NotFoundError'));
+    if (typeof value === 'string') {
+      return Promise.resolve({ text: () => Promise.resolve(value), type: 'application/json' });
+    }
+    return Promise.resolve(value);
+  }
+}
+
+class MockDirectoryHandle {
+  constructor(readonly name = 'root') {}
+
+  readonly files = new Map<string, string | Blob>();
+  readonly directories = new Map<string, MockDirectoryHandle>();
+
+  getFileHandle(name: string, options?: { create?: boolean }): Promise<MockFileHandle> {
+    if (!options?.create && !this.files.has(name)) {
+      throw new DOMException('Not found', 'NotFoundError');
+    }
+    return Promise.resolve(new MockFileHandle(name, this.files));
+  }
+
+  getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<MockDirectoryHandle> {
+    if (!this.directories.has(name)) {
+      if (!options?.create) throw new DOMException('Not found', 'NotFoundError');
+      this.directories.set(name, new MockDirectoryHandle(name));
+    }
+    return Promise.resolve(this.directories.get(name)!);
+  }
+
+  removeEntry(name: string): Promise<void> {
+    this.files.delete(name);
+    this.directories.delete(name);
+    return Promise.resolve();
+  }
+
+  async *entries(): AsyncIterableIterator<[string, { kind: 'file' | 'directory'; name: string }]> {
+    for (const name of this.files.keys()) yield [name, { kind: 'file', name }];
+    for (const name of this.directories.keys()) yield [name, { kind: 'directory', name }];
+  }
+}
+
+class MemoryStorage implements BrowserKeyValueStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+async function readMockText(value: string | Blob) {
+  return typeof value === 'string' ? value : value.text();
+}
+
+async function getProjectDirectory(root: MockDirectoryHandle, projectName: string) {
+  const projects = root.directories.get('projects');
+  if (!projects) throw new Error('Missing projects directory.');
+  const projectDirectory = projects.directories.get(encodeURIComponent(projectName));
+  if (!projectDirectory) throw new Error(`Missing ${projectName} project directory.`);
+  return projectDirectory;
+}
+
+describe('OpfsProjectRepository', () => {
+  it('creates OPFS project structure and writes project metadata', async () => {
+    const root = new MockDirectoryHandle();
+    const storage = new MemoryStorage();
+    const repository = new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage,
+    });
+    const project = sampleProject.createSampleProject();
+
+    await repository.saveProject(project);
+
+    const projectDirectory = await getProjectDirectory(root, project.name);
+    expect(projectDirectory.directories.has('assets')).toBe(true);
+    expect(projectDirectory.directories.has('cache')).toBe(true);
+    expect(projectDirectory.directories.has('config')).toBe(true);
+    expect(JSON.parse(await readMockText(projectDirectory.files.get('project.json')!))).toMatchObject({
+      id: project.id,
+      name: project.name,
+    });
+    expect(
+      JSON.parse(
+        await readMockText(
+          projectDirectory.directories.get('config')!.files.get('localstudio.json')!,
+        ),
+      ),
+    ).toMatchObject({ app: 'LocalStudio.dev', projectId: project.id, storage: 'opfs' });
+    expect(storage.getItem('localstudio.ai.opfs.last-project-name')).toBe(project.name);
+  });
+
+  it('loads the remembered OPFS project and hydrates file-backed assets', async () => {
+    const root = new MockDirectoryHandle();
+    const storage = new MemoryStorage();
+    const repository = new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage,
+    });
+    const project: ProjectDocument = {
+      ...sampleProject.createSampleProject(),
+      assets: {
+        asset1: {
+          id: 'asset1',
+          type: 'image',
+          name: 'hero.png',
+          mimeType: 'image/png',
+          fileName: 'hero.png',
+          storage: 'file',
+        },
+      },
+    };
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:hero');
+
+    await repository.saveProject(project);
+    const projectDirectory = await getProjectDirectory(root, project.name);
+    projectDirectory.directories.get('assets')!.files.set('hero.png', new Blob(['image'], { type: 'image/png' }));
+
+    const loaded = await new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage,
+    }).loadProject();
+
+    expect(loaded?.assets.asset1?.objectUrl).toBe('blob:hero');
+    expect(createObjectUrl).toHaveBeenCalled();
+  });
+
+  it('updates project JSON during autosave', async () => {
+    const root = new MockDirectoryHandle();
+    const repository = new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage: new MemoryStorage(),
+    });
+    const project = sampleProject.createSampleProject();
+
+    await repository.saveProject(project);
+    await repository.saveProject({ ...project, name: 'Renamed Deck' });
+
+    const projectDirectory = await getProjectDirectory(root, 'Renamed Deck');
+    expect(JSON.parse(await readMockText(projectDirectory.files.get('project.json')!))).toMatchObject({
+      name: 'Renamed Deck',
+    });
+  });
+
+  it('writes and reads OPFS version history', async () => {
+    const root = new MockDirectoryHandle();
+    const repository = new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage: new MemoryStorage(),
+    });
+    const project = sampleProject.createSampleProject();
+
+    await repository.saveProject(project);
+    const version = await repository.saveVersion(
+      { ...project, name: 'Versioned Deck' },
+      { previousProject: project },
+    );
+
+    const history = await repository.getVersionHistory();
+    const loadedVersion = await repository.loadVersion(version.id);
+    const projectDirectory = await getProjectDirectory(root, 'Versioned Deck');
+    const historyDirectory = projectDirectory.directories.get('history')!;
+
+    expect(history).toHaveLength(1);
+    expect(JSON.parse(await readMockText(historyDirectory.files.get('manifest.json')!))).toMatchObject({
+      latestVersionId: version.id,
+    });
+    expect(loadedVersion?.name).toBe('Versioned Deck');
+  });
+
+  it('surfaces unavailable OPFS errors without creating fallback state', async () => {
+    const repository = new OpfsProjectRepository({
+      getRootDirectory: () => Promise.reject(new DOMException('Private browsing', 'SecurityError')),
+      storage: new MemoryStorage(),
+    });
+
+    await expect(repository.saveProject(sampleProject.createSampleProject())).rejects.toMatchObject({
+      name: 'SecurityError',
+    });
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -115,13 +115,37 @@ describe('TopToolbar', () => {
     expect(persistenceButton).toBeDisabled();
     expect(persistenceButton).toHaveAttribute(
       'title',
-      'Local project persistence is not available in this browser. Use a browser with File System Access support.',
+      'Local project persistence is not available in this browser.',
     );
     expect(persistenceButton).toHaveTextContent('×');
 
     await user.click(screen.getByRole('button', { name: 'File' }));
     expect(screen.queryByRole('menuitem', { name: 'Save Local' })).not.toBeInTheDocument();
     expect(onPersistenceToggle).not.toHaveBeenCalled();
+  });
+
+  it('labels OPFS persistence as browser storage', async () => {
+    const user = userEvent.setup();
+    const onPersistenceToggle = vi.fn();
+
+    render(
+      <TopToolbar
+        project={sampleProject.createSampleProject()}
+        language="PT-BR"
+        persistenceMode="opfs"
+        onPersistenceToggle={onPersistenceToggle}
+      />,
+    );
+
+    const persistenceButton = screen.getByRole('button', { name: 'Browser storage disabled' });
+    expect(persistenceButton).toHaveAttribute(
+      'title',
+      'Save this deck in browser-private storage. Files are scoped to this browser profile and are not visible in Finder.',
+    );
+
+    await user.click(persistenceButton);
+
+    expect(onPersistenceToggle).toHaveBeenCalledWith(true);
   });
 
   it('shows mirror status beside persistence and syncs when clicked', async () => {


### PR DESCRIPTION
## Summary
- Add Safari-safe initialization for local editor storage when the File System Access API is unavailable
- Route project persistence through OPFS-backed repository and updated service contracts
- Update editor shell, toolbar, and view model wiring to reflect the new local setup path
- Cover the behavior with unit tests for composition, local setup, OPFS repository, and toolbar state

## Testing
- Unit tests added/updated for service composition, local setup, repository behavior, and toolbar interactions
- Not run (not requested)