### PR TITLE
Add Unsplash and Giphy tabs to the editor media flow

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@giphy/js-fetch-api": "^5.8.0",
     "@huggingface/transformers": "^4.2.0",
     "@localstudio/brand": "*",
     "jspdf": "^4.2.1",
@@ -19,6 +20,7 @@
     "lucide-react": "^1.21.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-konva": "^19.2.5"
+    "react-konva": "^19.2.5",
+    "unsplash-js": "^8.0.0"
   }
 }

--- a/apps/editor/src/app/composition.ts
+++ b/apps/editor/src/app/composition.ts
@@ -14,6 +14,7 @@ import type {
   ProjectRepository,
   SmartGrabService,
   ShareService,
+  StockMediaService,
   TranslatorService,
 } from '../services/contracts/interfaces';
 import { inMemoryAiServices } from '../services/testing/inMemoryAiServices';
@@ -28,6 +29,7 @@ import { OpfsProjectRepository } from '../services/storage/opfsProjectRepository
 import { localSetupService } from '../services/browser/localSetupService';
 import { modelSetupService } from '../services/model-setup/modelSetupService';
 import { BrowserShareService } from '../services/sharing/shareService';
+import { BrowserStockMediaService } from '../services/stock-media/stockMediaService';
 import { webGpuLanguageDetectionRuntime } from '../services/translation/webGpuLanguageDetectionRuntime';
 import { webGpuTextGenerationRuntime } from '../services/prompting/webGpuTextGenerationRuntime';
 import { minioMirrorService } from '../services/mirror/minioMirrorService';
@@ -42,6 +44,7 @@ export interface AppServices {
   projectRepository: ProjectRepository;
   exportService: ExportService;
   shareService: ShareService;
+  stockMediaService: StockMediaService;
   localSetupService: LocalSetupService;
   modelSetupService: ModelSetupService;
   translatorService: TranslatorService;
@@ -83,6 +86,7 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
     projectRepository: createProjectRepository(persistenceMode),
     exportService: new BrowserExportService(),
     shareService: new BrowserShareService({ mirrorService }),
+    stockMediaService: new BrowserStockMediaService(),
     localSetupService: new localSetupService.BrowserLocalSetupService(),
     modelSetupService: browserModelSetupService,
     translatorService: new browserTranslatorService.BrowserTranslatorService(

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -2620,6 +2620,10 @@ button {
   width: min(280px, calc(100vw - 32px));
 }
 
+.media-integration-settings-panel {
+  width: min(420px, calc(100vw - 32px));
+}
+
 .remote-import-panel {
   width: min(360px, calc(100vw - 32px));
 }
@@ -2647,6 +2651,17 @@ button {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+}
+
+.settings-panel-title-row {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.settings-panel-back-button {
+  flex: 0 0 auto;
 }
 
 .settings-panel-header h2,
@@ -2700,6 +2715,66 @@ button {
 
 .settings-panel-header p {
   margin: 4px 0 0;
+}
+
+.media-integration-form,
+.media-key-field {
+  display: grid;
+  gap: 10px;
+}
+
+.media-key-field {
+  color: var(--ew-muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.media-key-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.media-key-label a {
+  color: var(--ew-green);
+  font-weight: 800;
+  letter-spacing: 0;
+  text-decoration: none;
+}
+
+.media-key-label a::before {
+  color: rgba(255, 255, 255, 0.42);
+  content: '(';
+}
+
+.media-key-label a::after {
+  color: rgba(255, 255, 255, 0.42);
+  content: ')';
+}
+
+.media-key-label a:hover,
+.media-key-label a:focus-visible {
+  text-decoration: underline;
+}
+
+.media-key-field input {
+  height: 38px;
+  padding: 0 10px;
+}
+
+.media-key-field small {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.media-integration-actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
 }
 
 .mirror-settings-grid {
@@ -4107,13 +4182,207 @@ button {
 
 .elements-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-columns: calc((100% - 30px) / 4);
+  grid-auto-flow: column;
   gap: 10px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  padding-bottom: 4px;
+  scroll-snap-type: x mandatory;
+  scrollbar-color: rgba(255, 255, 255, 0.24) transparent;
+  scrollbar-width: thin;
+}
+
+.element-section {
+  display: grid;
+  gap: 10px;
+}
+
+.element-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.element-section-heading h3 {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.element-section-see-all {
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.64);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+}
+
+.element-section-see-all:hover,
+.element-section-see-all:focus-visible {
+  color: #d7ffe2;
+  outline: none;
+}
+
+.media-search-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 36px;
+  gap: 8px;
+}
+
+.media-search-row input,
+.media-key-field input {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 8px;
+  background: #111418;
+  color: var(--ew-text);
+  font: inherit;
+  outline: none;
+}
+
+.media-search-row input {
+  height: 36px;
+  padding: 0 10px;
+}
+
+.media-search-row button {
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(55, 253, 118, 0.28);
+  border-radius: 8px;
+  background: rgba(55, 253, 118, 0.1);
+  color: #d7ffe2;
+  cursor: pointer;
+}
+
+.media-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stock-media-tile {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: #191c20;
+  color: #ffffff;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.stock-media-tile img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.stock-media-source,
+.stock-media-credit {
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  z-index: 1;
+}
+
+.stock-media-source {
+  top: 6px;
+  width: max-content;
+  max-width: calc(100% - 12px);
+  border-radius: 999px;
+  background: rgba(5, 13, 16, 0.76);
+  color: #d7ffe2;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  padding: 3px 6px;
+  text-transform: uppercase;
+}
+
+.stock-media-credit {
+  bottom: 0;
+  display: block;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(5, 13, 16, 0), rgba(5, 13, 16, 0.88));
+  color: rgba(255, 255, 255, 0.84);
+  font-size: 10px;
+  line-height: 1.2;
+  padding: 16px 0 6px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stock-media-tile:hover,
+.stock-media-tile:focus-visible {
+  border-color: rgba(55, 253, 118, 0.5);
+  box-shadow: 0 0 18px rgba(55, 253, 118, 0.12);
+  outline: none;
+}
+
+.media-pagination {
+  display: grid;
+  grid-template-columns: 32px 1fr 32px;
+  align-items: center;
+  gap: 8px;
+}
+
+.media-pagination-button {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 8px;
+  background: #111418;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+}
+
+.media-pagination-button:hover:not(:disabled),
+.media-pagination-button:focus-visible {
+  border-color: rgba(55, 253, 118, 0.42);
+  color: #d7ffe2;
+  outline: none;
+}
+
+.media-pagination-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.media-pagination-count {
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 11px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.provider-disabled-callout {
+  display: grid;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 10px;
+}
+
+.provider-disabled-callout p,
+.stock-media-error {
+  margin: 0;
 }
 
 .element-tile {
   position: relative;
   aspect-ratio: 1;
+  min-width: 0;
   display: grid;
   place-items: center;
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -4128,6 +4397,7 @@ button {
     box-shadow 140ms ease,
     color 140ms ease,
     transform 140ms ease;
+  scroll-snap-align: start;
 }
 
 .element-tile:hover {

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -157,6 +157,48 @@ export interface ShareService {
   getEmbedHtml(shareId: string): string;
 }
 
+export type StockMediaProvider = 'giphy' | 'unsplash';
+export type StockMediaKind = 'gif' | 'image';
+
+export interface StockMediaConfig {
+  giphyApiKey: string;
+  unsplashAccessKey: string;
+}
+
+export interface StockMediaProviderStatus {
+  configured: boolean;
+  provider: StockMediaProvider;
+}
+
+export interface StockMediaProviderState {
+  gifs: StockMediaProviderStatus;
+  images: StockMediaProviderStatus;
+}
+
+export interface StockMediaItem {
+  id: string;
+  provider: StockMediaProvider;
+  kind: StockMediaKind;
+  title: string;
+  authorName?: string | undefined;
+  authorUrl?: string | undefined;
+  thumbnailUrl: string;
+  mediaUrl: string;
+  width: number;
+  height: number;
+  downloadLocation?: string | undefined;
+}
+
+export interface StockMediaService {
+  loadConfig(): StockMediaConfig | null;
+  saveConfig(config: StockMediaConfig): void;
+  clearConfig(): void;
+  getProviderState(): StockMediaProviderState;
+  searchImages(query: string): Promise<StockMediaItem[]>;
+  searchGifs(query: string): Promise<StockMediaItem[]>;
+  trackImageDownload(item: StockMediaItem): Promise<void>;
+}
+
 export interface ModelSetupService {
   getModelStates(): Promise<ModelState[]>;
   downloadRequiredModels(): Promise<ModelState[]>;

--- a/apps/editor/src/services/stock-media/stockMediaService.ts
+++ b/apps/editor/src/services/stock-media/stockMediaService.ts
@@ -1,0 +1,235 @@
+import type {
+  StockMediaConfig,
+  StockMediaItem,
+  StockMediaProviderState,
+  StockMediaService,
+} from '../contracts/interfaces';
+import { browserStorage, type BrowserKeyValueStorage } from '../browser/browserStorage';
+import { GiphyFetch } from '@giphy/js-fetch-api';
+import { createApi } from 'unsplash-js';
+
+const CONFIG_STORAGE_KEY = 'localstudio.ai.stock-media-config';
+const DEFAULT_LIMIT = 30;
+
+interface BrowserStockMediaServiceOptions {
+  fetch?: typeof fetch;
+  storage?: BrowserKeyValueStorage;
+}
+
+interface UnsplashPhotoResponse {
+  id?: unknown;
+  alt_description?: unknown;
+  description?: unknown;
+  width?: unknown;
+  height?: unknown;
+  urls?: {
+    regular?: unknown;
+    small?: unknown;
+    thumb?: unknown;
+  };
+  links?: {
+    download_location?: unknown;
+  };
+  user?: {
+    name?: unknown;
+    links?: {
+      html?: unknown;
+    };
+  };
+}
+
+interface GiphyResponse {
+  id?: unknown;
+  title?: unknown;
+  username?: unknown;
+  url?: unknown;
+  images?: {
+    downsized_medium?: GiphyImageResponse;
+    original?: GiphyImageResponse;
+    fixed_width?: GiphyImageResponse;
+    preview_gif?: GiphyImageResponse;
+  };
+}
+
+interface GiphyImageResponse {
+  url?: unknown;
+  width?: unknown;
+  height?: unknown;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function readString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readPositiveNumber(value: unknown, fallback: number) {
+  const parsed = typeof value === 'number' ? value : Number.parseInt(readString(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isSafeRemoteUrl(value: unknown): value is string {
+  if (!isNonEmptyString(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function readConfigFromStorage(storage: BrowserKeyValueStorage | undefined) {
+  const rawValue = storage?.getItem(CONFIG_STORAGE_KEY);
+  if (!rawValue) return null;
+  try {
+    const parsed = JSON.parse(rawValue) as Partial<StockMediaConfig>;
+    const giphyApiKey = readString(parsed.giphyApiKey);
+    const unsplashAccessKey = readString(parsed.unsplashAccessKey);
+    if (!giphyApiKey && !unsplashAccessKey) return null;
+    return { giphyApiKey, unsplashAccessKey };
+  } catch {
+    return null;
+  }
+}
+
+function mapUnsplashPhoto(photo: UnsplashPhotoResponse): StockMediaItem | null {
+  const mediaUrl = photo.urls?.regular;
+  const thumbnailUrl = photo.urls?.small ?? photo.urls?.thumb ?? mediaUrl;
+  if (!isNonEmptyString(photo.id) || !isSafeRemoteUrl(mediaUrl) || !isSafeRemoteUrl(thumbnailUrl))
+    return null;
+
+  return {
+    id: photo.id,
+    provider: 'unsplash',
+    kind: 'image',
+    title:
+      readString(photo.alt_description) ||
+      readString(photo.description) ||
+      `Unsplash photo ${photo.id}`,
+    authorName: readString(photo.user?.name) || undefined,
+    authorUrl: isSafeRemoteUrl(photo.user?.links?.html) ? photo.user?.links?.html : undefined,
+    thumbnailUrl,
+    mediaUrl,
+    width: readPositiveNumber(photo.width, 1200),
+    height: readPositiveNumber(photo.height, 800),
+    downloadLocation: isSafeRemoteUrl(photo.links?.download_location)
+      ? photo.links?.download_location
+      : undefined,
+  };
+}
+
+function mapGiphyGif(gif: GiphyResponse): StockMediaItem | null {
+  const media = gif.images?.downsized_medium ?? gif.images?.original;
+  const thumbnail = gif.images?.fixed_width ?? gif.images?.preview_gif ?? media;
+  if (!isNonEmptyString(gif.id) || !isSafeRemoteUrl(media?.url) || !isSafeRemoteUrl(thumbnail?.url))
+    return null;
+
+  return {
+    id: gif.id,
+    provider: 'giphy',
+    kind: 'gif',
+    title: readString(gif.title) || `GIPHY GIF ${gif.id}`,
+    authorName: readString(gif.username) || undefined,
+    authorUrl: isSafeRemoteUrl(gif.url) ? gif.url : undefined,
+    thumbnailUrl: thumbnail.url,
+    mediaUrl: media.url,
+    width: readPositiveNumber(media.width, 480),
+    height: readPositiveNumber(media.height, 270),
+  };
+}
+
+export class BrowserStockMediaService implements StockMediaService {
+  private readonly requestFetch: typeof fetch;
+  private readonly storage: BrowserKeyValueStorage | undefined;
+
+  constructor(options: BrowserStockMediaServiceOptions = {}) {
+    this.requestFetch = options.fetch ?? fetch;
+    this.storage = options.storage ?? browserStorage.getBrowserLocalStorage();
+  }
+
+  loadConfig(): StockMediaConfig | null {
+    return readConfigFromStorage(this.storage);
+  }
+
+  saveConfig(config: StockMediaConfig): void {
+    const normalizedConfig: StockMediaConfig = {
+      giphyApiKey: config.giphyApiKey.trim(),
+      unsplashAccessKey: config.unsplashAccessKey.trim(),
+    };
+    this.storage?.setItem(CONFIG_STORAGE_KEY, JSON.stringify(normalizedConfig));
+  }
+
+  clearConfig(): void {
+    this.storage?.removeItem?.(CONFIG_STORAGE_KEY);
+  }
+
+  getProviderState(): StockMediaProviderState {
+    const config = this.loadConfig();
+    return {
+      gifs: { configured: Boolean(config?.giphyApiKey), provider: 'giphy' },
+      images: { configured: Boolean(config?.unsplashAccessKey), provider: 'unsplash' },
+    };
+  }
+
+  async searchImages(query: string): Promise<StockMediaItem[]> {
+    const accessKey = this.loadConfig()?.unsplashAccessKey;
+    if (!accessKey) return [];
+
+    const normalizedQuery = query.trim();
+    const unsplash = createApi({ accessKey, fetch: this.requestFetch });
+    const result = normalizedQuery
+      ? await unsplash.GET('/search/photos', {
+          params: { query: { query: normalizedQuery, page: 1, per_page: DEFAULT_LIMIT } },
+        })
+      : await unsplash.GET('/photos', {
+          params: { query: { page: 1, per_page: DEFAULT_LIMIT } },
+        });
+    if (result.error) throw new Error('Unsplash image search failed.');
+
+    const payload = result.data as
+      | { results?: UnsplashPhotoResponse[] }
+      | UnsplashPhotoResponse[]
+      | undefined;
+    const photos = Array.isArray(payload) ? payload : (payload?.results ?? []);
+    return photos.map(mapUnsplashPhoto).filter((item): item is StockMediaItem => Boolean(item));
+  }
+
+  async searchGifs(query: string): Promise<StockMediaItem[]> {
+    const apiKey = this.loadConfig()?.giphyApiKey;
+    if (!apiKey) return [];
+
+    const normalizedQuery = query.trim();
+    const giphy = new GiphyFetch(apiKey);
+    const payload = await this.withConfiguredFetch(() =>
+      normalizedQuery
+        ? giphy.search(normalizedQuery, { limit: DEFAULT_LIMIT, rating: 'g' })
+        : giphy.trending({ limit: DEFAULT_LIMIT, rating: 'g' }),
+    );
+    return (payload.data ?? []).map(mapGiphyGif).filter((item): item is StockMediaItem => Boolean(item));
+  }
+
+  private async withConfiguredFetch<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.requestFetch === globalThis.fetch) return operation();
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = this.requestFetch;
+    try {
+      return await operation();
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  }
+
+  async trackImageDownload(item: StockMediaItem): Promise<void> {
+    const accessKey = this.loadConfig()?.unsplashAccessKey;
+    if (!accessKey || item.provider !== 'unsplash' || !isSafeRemoteUrl(item.downloadLocation)) {
+      return;
+    }
+    const unsplash = createApi({ accessKey, fetch: this.requestFetch });
+    const result = await unsplash.GET('/photos/{id}/download', {
+      params: { path: { id: item.id } },
+    });
+    if (result.error) throw new Error('Unsplash download tracking failed.');
+  }
+}

--- a/apps/editor/src/ui/editor/panels/ElementsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/ElementsPanel.tsx
@@ -10,12 +10,13 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import type { RefObject } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { ShapeKind } from '../../../domain/documents/model';
 import type {
   StockMediaItem,
   StockMediaProviderState,
 } from '../../../services/contracts/interfaces';
+import type { StockMediaErrorState } from '../state/useEditorViewModel';
 
 const elementShapeCatalog: Array<{
   icon?: LucideIcon;
@@ -47,11 +48,6 @@ interface ElementsPanelProps {
   recentStockMedia?: StockMediaItem[] | undefined;
   stockMediaError?: StockMediaErrorState | undefined;
   stockMediaProviderState?: StockMediaProviderState | undefined;
-}
-
-interface StockMediaErrorState {
-  gifs?: string | undefined;
-  images?: string | undefined;
 }
 
 const defaultProviderState: StockMediaProviderState = {
@@ -91,6 +87,7 @@ export function ElementsPanel({
       <ShapeGrid gridRef={shapeGridRef} onInsertShape={onInsertShape} />
       {recentStockMedia.length > 0 ? (
         <MediaSection
+          key={getMediaItemsKey(recentStockMedia)}
           items={recentStockMedia}
           title="Recently used"
           onInsertStockMedia={onInsertStockMedia}
@@ -103,6 +100,7 @@ export function ElementsPanel({
         items={imageResults}
         loading={loadingImages}
         providerLabel="Unsplash"
+        searchPlaceholder="search images"
         title="Images"
         typeLabel="image"
         onConfigureStockMedia={onConfigureStockMedia}
@@ -116,6 +114,7 @@ export function ElementsPanel({
         items={gifResults}
         loading={loadingGifs}
         providerLabel="GIPHY"
+        searchPlaceholder="search gifs"
         title="GIFs"
         typeLabel="GIF"
         onConfigureStockMedia={onConfigureStockMedia}
@@ -189,6 +188,7 @@ function MediaProviderSection({
   items,
   loading,
   providerLabel,
+  searchPlaceholder,
   title,
   typeLabel,
   onConfigureStockMedia,
@@ -201,6 +201,7 @@ function MediaProviderSection({
   items: StockMediaItem[];
   loading: boolean;
   providerLabel: string;
+  searchPlaceholder: string;
   title: string;
   typeLabel: 'GIF' | 'image';
   onConfigureStockMedia?: (() => void) | undefined;
@@ -235,7 +236,7 @@ function MediaProviderSection({
         <input
           aria-label={inputLabel}
           value={query}
-          placeholder={`Search ${providerLabel}`}
+          placeholder={searchPlaceholder}
           onChange={(event) => {
             setQuery(event.target.value);
           }}
@@ -254,6 +255,7 @@ function MediaProviderSection({
         />
       ) : (
         <MediaSection
+          key={getMediaItemsKey(items)}
           emptyLabel={loading ? `Loading ${title.toLowerCase()}...` : `No ${title.toLowerCase()} found.`}
           items={items}
           title={title}
@@ -306,10 +308,6 @@ function MediaSection({
     pageIndex * MEDIA_PAGE_SIZE,
     pageIndex * MEDIA_PAGE_SIZE + MEDIA_PAGE_SIZE,
   );
-
-  useEffect(() => {
-    setPageIndex(0);
-  }, [items]);
 
   if (items.length === 0) return <p className="panel-muted">{emptyLabel}</p>;
   return (
@@ -365,6 +363,10 @@ function MediaSection({
       ) : null}
     </>
   );
+}
+
+function getMediaItemsKey(items: StockMediaItem[]) {
+  return items.map((item) => `${item.provider}:${item.id}`).join('|');
 }
 function getMediaButtonLabel(item: StockMediaItem, typeLabel?: 'GIF' | 'image') {
   if (item.kind === 'gif' || typeLabel === 'GIF') return `Insert GIF ${item.title}`;

--- a/apps/editor/src/ui/editor/panels/ElementsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/ElementsPanel.tsx
@@ -9,7 +9,13 @@ import {
   Triangle,
   type LucideIcon,
 } from 'lucide-react';
+import type { RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ShapeKind } from '../../../domain/documents/model';
+import type {
+  StockMediaItem,
+  StockMediaProviderState,
+} from '../../../services/contracts/interfaces';
 
 const elementShapeCatalog: Array<{
   icon?: LucideIcon;
@@ -29,37 +35,344 @@ const elementShapeCatalog: Array<{
 ];
 
 interface ElementsPanelProps {
-  onInsertShape?: (shape: ShapeKind) => void;
+  gifResults?: StockMediaItem[] | undefined;
+  imageResults?: StockMediaItem[] | undefined;
+  loadingGifs?: boolean | undefined;
+  loadingImages?: boolean | undefined;
+  onInsertShape?: ((shape: ShapeKind) => void) | undefined;
+  onConfigureStockMedia?: (() => void) | undefined;
+  onInsertStockMedia?: ((item: StockMediaItem) => void) | undefined;
+  onSearchStockGifs?: ((query: string) => void) | undefined;
+  onSearchStockImages?: ((query: string) => void) | undefined;
+  recentStockMedia?: StockMediaItem[] | undefined;
+  stockMediaError?: StockMediaErrorState | undefined;
+  stockMediaProviderState?: StockMediaProviderState | undefined;
 }
 
-export function ElementsPanel({ onInsertShape }: ElementsPanelProps) {
+interface StockMediaErrorState {
+  gifs?: string | undefined;
+  images?: string | undefined;
+}
+
+const defaultProviderState: StockMediaProviderState = {
+  gifs: { configured: false, provider: 'giphy' },
+  images: { configured: false, provider: 'unsplash' },
+};
+const MEDIA_PAGE_SIZE = 10;
+
+export function ElementsPanel({
+  gifResults = [],
+  imageResults = [],
+  loadingGifs = false,
+  loadingImages = false,
+  onConfigureStockMedia,
+  onInsertShape,
+  onInsertStockMedia,
+  onSearchStockGifs,
+  onSearchStockImages,
+  recentStockMedia = [],
+  stockMediaError,
+  stockMediaProviderState = defaultProviderState,
+}: ElementsPanelProps) {
+  const shapeGridRef = useRef<HTMLDivElement>(null);
+
+  const scrollShapes = () => {
+    const grid = shapeGridRef.current;
+    grid?.scrollBy({ behavior: 'smooth', left: grid.clientWidth || 220 });
+  };
+
   return (
     <section className="panel-stack" aria-label="Elements tools">
-      <div className="panel-section">
+      <div className="panel-section element-section">
         <h2 className="panel-heading">Elements</h2>
-        <p className="panel-muted">Add editable shapes to the current slide.</p>
+        <p className="panel-muted">Add shapes, images, and GIFs to the current slide.</p>
       </div>
-      <div className="elements-grid" aria-label="Shape elements">
-        {elementShapeCatalog.map((item) => {
-          const Icon = item.icon;
-          return (
-            <button
-              aria-label={`Add ${item.label}`}
-              className="element-tile"
-              key={item.shape}
-              type="button"
-              onClick={() => {
-                onInsertShape?.(item.shape);
-              }}
-            >
-              <ShapeTilePreview shape={item.shape} />
-              {Icon ? <Icon aria-hidden="true" className="element-tile-icon" size={24} strokeWidth={2.2} /> : null}
-            </button>
-          );
-        })}
-      </div>
+      <ElementSectionHeader title="Shapes" seeAllLabel="See all Shapes" onSeeAll={scrollShapes} />
+      <ShapeGrid gridRef={shapeGridRef} onInsertShape={onInsertShape} />
+      {recentStockMedia.length > 0 ? (
+        <MediaSection
+          items={recentStockMedia}
+          title="Recently used"
+          onInsertStockMedia={onInsertStockMedia}
+        />
+      ) : null}
+      <MediaProviderSection
+        configured={stockMediaProviderState.images.configured}
+        inputLabel="Search Unsplash images"
+        error={stockMediaError?.images}
+        items={imageResults}
+        loading={loadingImages}
+        providerLabel="Unsplash"
+        title="Images"
+        typeLabel="image"
+        onConfigureStockMedia={onConfigureStockMedia}
+        onInsertStockMedia={onInsertStockMedia}
+        onSearch={onSearchStockImages}
+      />
+      <MediaProviderSection
+        configured={stockMediaProviderState.gifs.configured}
+        inputLabel="Search GIPHY GIFs"
+        error={stockMediaError?.gifs}
+        items={gifResults}
+        loading={loadingGifs}
+        providerLabel="GIPHY"
+        title="GIFs"
+        typeLabel="GIF"
+        onConfigureStockMedia={onConfigureStockMedia}
+        onInsertStockMedia={onInsertStockMedia}
+        onSearch={onSearchStockGifs}
+      />
     </section>
   );
+}
+
+function ShapeGrid({
+  gridRef,
+  onInsertShape,
+}: {
+  gridRef: RefObject<HTMLDivElement | null>;
+  onInsertShape?: ((shape: ShapeKind) => void) | undefined;
+}) {
+  return (
+    <div className="elements-grid" ref={gridRef} aria-label="Shape elements">
+      {elementShapeCatalog.map((item) => {
+        const Icon = item.icon;
+        return (
+          <button
+            aria-label={`Add ${item.label}`}
+            className="element-tile"
+            key={item.shape}
+            type="button"
+            onClick={() => {
+              onInsertShape?.(item.shape);
+            }}
+          >
+            <ShapeTilePreview shape={item.shape} />
+            {Icon ? <Icon aria-hidden="true" className="element-tile-icon" size={24} strokeWidth={2.2} /> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ElementSectionHeader({
+  seeAllLabel,
+  title,
+  onSeeAll,
+}: {
+  seeAllLabel?: string | undefined;
+  title: string;
+  onSeeAll?: (() => void) | undefined;
+}) {
+  return (
+    <div className="element-section-heading">
+      <h3>{title}</h3>
+      {onSeeAll ? (
+        <button
+          aria-label={seeAllLabel ?? `See all ${title}`}
+          className="element-section-see-all"
+          type="button"
+          onClick={onSeeAll}
+        >
+          See all
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function MediaProviderSection({
+  configured,
+  error,
+  inputLabel,
+  items,
+  loading,
+  providerLabel,
+  title,
+  typeLabel,
+  onConfigureStockMedia,
+  onInsertStockMedia,
+  onSearch,
+}: {
+  configured: boolean;
+  error?: string | undefined;
+  inputLabel: string;
+  items: StockMediaItem[];
+  loading: boolean;
+  providerLabel: string;
+  title: string;
+  typeLabel: 'GIF' | 'image';
+  onConfigureStockMedia?: (() => void) | undefined;
+  onInsertStockMedia?: ((item: StockMediaItem) => void) | undefined;
+  onSearch?: ((query: string) => void) | undefined;
+}) {
+  const [query, setQuery] = useState('');
+
+  if (!configured) {
+    return (
+      <section className="element-section" aria-label={title}>
+        <ElementSectionHeader title={title} />
+        <ProviderConfigurationCallout
+          buttonLabel="Configure media integrations"
+          message={`${providerLabel} is not configured.`}
+          onConfigureStockMedia={onConfigureStockMedia}
+        />
+      </section>
+    );
+  }
+
+  return (
+    <section className="element-section" aria-label={title}>
+      <ElementSectionHeader title={title} />
+      <form
+        className="media-search-row"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSearch?.(query.trim());
+        }}
+      >
+        <input
+          aria-label={inputLabel}
+          value={query}
+          placeholder={`Search ${providerLabel}`}
+          onChange={(event) => {
+            setQuery(event.target.value);
+          }}
+        />
+        <button type="submit" aria-label={`${inputLabel} submit`}>
+          <span className="material-symbols-outlined" aria-hidden="true">
+            search
+          </span>
+        </button>
+      </form>
+      {error ? (
+        <ProviderConfigurationCallout
+          buttonLabel="Configure media integrations"
+          message={error}
+          onConfigureStockMedia={onConfigureStockMedia}
+        />
+      ) : (
+        <MediaSection
+          emptyLabel={loading ? `Loading ${title.toLowerCase()}...` : `No ${title.toLowerCase()} found.`}
+          items={items}
+          title={title}
+          typeLabel={typeLabel}
+          onInsertStockMedia={onInsertStockMedia}
+        />
+      )}
+    </section>
+  );
+}
+
+function ProviderConfigurationCallout({
+  buttonLabel,
+  message,
+  onConfigureStockMedia,
+}: {
+  buttonLabel: string;
+  message: string;
+  onConfigureStockMedia?: (() => void) | undefined;
+}) {
+  return (
+    <div className="provider-disabled-callout">
+      <p>{message}</p>
+      <button className="compact-action compact-action-full" type="button" onClick={onConfigureStockMedia}>
+        <span className="material-symbols-outlined" aria-hidden="true">
+          key
+        </span>
+        {buttonLabel}
+      </button>
+    </div>
+  );
+}
+
+function MediaSection({
+  emptyLabel = 'No media yet.',
+  items,
+  title,
+  typeLabel,
+  onInsertStockMedia,
+}: {
+  emptyLabel?: string | undefined;
+  items: StockMediaItem[];
+  title: string;
+  typeLabel?: 'GIF' | 'image' | undefined;
+  onInsertStockMedia?: ((item: StockMediaItem) => void) | undefined;
+}) {
+  const [pageIndex, setPageIndex] = useState(0);
+  const pageCount = Math.max(1, Math.ceil(items.length / MEDIA_PAGE_SIZE));
+  const visibleItems = items.slice(
+    pageIndex * MEDIA_PAGE_SIZE,
+    pageIndex * MEDIA_PAGE_SIZE + MEDIA_PAGE_SIZE,
+  );
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [items]);
+
+  if (items.length === 0) return <p className="panel-muted">{emptyLabel}</p>;
+  return (
+    <>
+      <div className="media-grid" aria-label={`${title} results`}>
+        {visibleItems.map((item) => (
+          <button
+            aria-label={getMediaButtonLabel(item, typeLabel)}
+            className="stock-media-tile"
+            key={`${item.provider}-${item.id}`}
+            type="button"
+            title={getMediaCredit(item)}
+            onClick={() => {
+              onInsertStockMedia?.(item);
+            }}
+          >
+            <img alt="" src={item.thumbnailUrl} />
+            <span className="stock-media-source">{item.provider === 'unsplash' ? 'Unsplash' : 'GIPHY'}</span>
+            <span className="stock-media-credit">{getMediaCredit(item)}</span>
+          </button>
+        ))}
+      </div>
+      {items.length > MEDIA_PAGE_SIZE ? (
+        <div className="media-pagination" aria-label={`${title} pagination`}>
+          <button
+            aria-label={`Previous ${title} page`}
+            className="media-pagination-button"
+            type="button"
+            disabled={pageIndex === 0}
+            onClick={() => {
+              setPageIndex((current) => Math.max(0, current - 1));
+            }}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              chevron_left
+            </span>
+          </button>
+          <span className="media-pagination-count">{pageIndex + 1} / {pageCount}</span>
+          <button
+            aria-label={`Next ${title} page`}
+            className="media-pagination-button"
+            type="button"
+            disabled={pageIndex >= pageCount - 1}
+            onClick={() => {
+              setPageIndex((current) => Math.min(pageCount - 1, current + 1));
+            }}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              chevron_right
+            </span>
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
+}
+function getMediaButtonLabel(item: StockMediaItem, typeLabel?: 'GIF' | 'image') {
+  if (item.kind === 'gif' || typeLabel === 'GIF') return `Insert GIF ${item.title}`;
+  return item.authorName ? `Insert image by ${item.authorName}` : `Insert image ${item.title}`;
+}
+
+function getMediaCredit(item: StockMediaItem) {
+  return item.authorName ? `${item.title} by ${item.authorName}` : item.title;
 }
 
 function ShapeTilePreview({ shape }: { shape: ShapeKind }) {

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -24,7 +24,7 @@ import { ElementsPanel } from './ElementsPanel';
 import type { CreateImagePromptOptions } from '../media/imagePromptOptions';
 import { LayersPanel } from './LayersPanel';
 import { TextPanel } from './TextPanel';
-import type { RightPanelTab, TextPreset } from '../state/useEditorViewModel';
+import type { RightPanelTab, StockMediaErrorState, TextPreset } from '../state/useEditorViewModel';
 
 interface LeftToolPanelProps {
   activeTab: RightPanelTab;
@@ -99,11 +99,6 @@ interface LeftToolPanelProps {
   onClearElementAnimationBuild?: ((elementId: string) => void) | undefined;
   onReorderElementAnimationBuild?: ((elementId: string, targetIndex: number) => void) | undefined;
   onPlayAnimationPreview?: (() => void) | undefined;
-}
-
-interface StockMediaErrorState {
-  gifs?: string | undefined;
-  images?: string | undefined;
 }
 
 const menuItems: Array<{ id: RightPanelTab; label: string; icon: typeof Layers3 }> = [

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -11,7 +11,12 @@ import type {
   SlideTransition,
 } from '../../../domain/documents/model';
 import type { ElementStylePatch, MediaPlaybackPatch } from '../../../domain/commands/elements/basicCommands';
-import type { AiProviderState, ModelState } from '../../../services/contracts/interfaces';
+import type {
+  AiProviderState,
+  ModelState,
+  StockMediaItem,
+  StockMediaProviderState,
+} from '../../../services/contracts/interfaces';
 import { AiToolsPanel } from './AiToolsPanel';
 import { AnimationPanel } from './AnimationPanel';
 import { DesignPanel } from './DesignPanel';
@@ -54,11 +59,22 @@ interface LeftToolPanelProps {
   onDownloadModel?: ((id: string) => Promise<void>) | undefined;
   onRemoveModel?: ((id: string) => Promise<void>) | undefined;
   onCreateImageOptionsChange?: ((options: CreateImagePromptOptions) => void) | undefined;
+  stockGifResults?: StockMediaItem[];
+  stockImageResults?: StockMediaItem[];
+  stockMediaError?: StockMediaErrorState | undefined;
+  stockMediaProviderState?: StockMediaProviderState;
+  stockMediaRecentItems?: StockMediaItem[];
+  stockMediaSearchingGifs?: boolean;
+  stockMediaSearchingImages?: boolean;
+  onConfigureStockMedia?: (() => void) | undefined;
   onImportImage?: ((file: File) => void) | undefined;
   onRemoveAsset?: ((assetId: string) => void) | undefined;
   onImportMedia?: ((file: File) => void) | undefined;
+  onInsertStockMedia?: ((item: StockMediaItem) => void) | undefined;
   onInsertText?: ((preset: TextPreset) => void) | undefined;
   onInsertShape?: ((shape: ShapeKind) => void) | undefined;
+  onSearchStockGifs?: ((query: string) => void) | undefined;
+  onSearchStockImages?: ((query: string) => void) | undefined;
   onPreparePromptApi?: (() => Promise<void>) | undefined;
   onPrepareLanguageDetectionProvider?: (() => Promise<void>) | undefined;
   onPrepareTranslationProvider?: (() => Promise<void>) | undefined;
@@ -83,6 +99,11 @@ interface LeftToolPanelProps {
   onClearElementAnimationBuild?: ((elementId: string) => void) | undefined;
   onReorderElementAnimationBuild?: ((elementId: string, targetIndex: number) => void) | undefined;
   onPlayAnimationPreview?: (() => void) | undefined;
+}
+
+interface StockMediaErrorState {
+  gifs?: string | undefined;
+  images?: string | undefined;
 }
 
 const menuItems: Array<{ id: RightPanelTab; label: string; icon: typeof Layers3 }> = [
@@ -119,11 +140,22 @@ export function LeftToolPanel({
   onDownloadModel,
   onRemoveModel,
   onCreateImageOptionsChange,
+  stockGifResults,
+  stockImageResults,
+  stockMediaError,
+  stockMediaProviderState,
+  stockMediaRecentItems,
+  stockMediaSearchingGifs,
+  stockMediaSearchingImages,
+  onConfigureStockMedia,
   onImportImage,
   onRemoveAsset,
   onImportMedia,
+  onInsertStockMedia,
   onInsertText,
   onInsertShape,
+  onSearchStockGifs,
+  onSearchStockImages,
   onPreparePromptApi,
   onPrepareLanguageDetectionProvider,
   onPrepareTranslationProvider,
@@ -220,7 +252,20 @@ export function LeftToolPanel({
           <TextPanel {...(onInsertText ? { onInsertText } : {})} />
         ) : null}
         {panelOpen && activeTab === 'elements' ? (
-          <ElementsPanel {...(onInsertShape ? { onInsertShape } : {})} />
+          <ElementsPanel
+            {...(onInsertShape ? { onInsertShape } : {})}
+            {...(onConfigureStockMedia ? { onConfigureStockMedia } : {})}
+            {...(onInsertStockMedia ? { onInsertStockMedia } : {})}
+            {...(onSearchStockGifs ? { onSearchStockGifs } : {})}
+            {...(onSearchStockImages ? { onSearchStockImages } : {})}
+            gifResults={stockGifResults}
+            imageResults={stockImageResults}
+            loadingGifs={stockMediaSearchingGifs}
+            loadingImages={stockMediaSearchingImages}
+            recentStockMedia={stockMediaRecentItems}
+            stockMediaError={stockMediaError}
+            stockMediaProviderState={stockMediaProviderState}
+          />
         ) : null}
         {panelOpen && activeTab === 'animations' ? (
           <AnimationPanel

--- a/apps/editor/src/ui/editor/panels/MediaIntegrationSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MediaIntegrationSettingsPanel.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import type { StockMediaConfig } from '../../../services/contracts/interfaces';
+
+interface MediaIntegrationSettingsPanelProps {
+  config: StockMediaConfig | null;
+  onBack?: () => void;
+  onClear?: () => void;
+  onClose: () => void;
+  onSave: (config: StockMediaConfig) => void;
+}
+
+export function MediaIntegrationSettingsPanel({
+  config,
+  onBack,
+  onClear,
+  onClose,
+  onSave,
+}: MediaIntegrationSettingsPanelProps) {
+  const [unsplashAccessKey, setUnsplashAccessKey] = useState(config?.unsplashAccessKey ?? '');
+  const [giphyApiKey, setGiphyApiKey] = useState(config?.giphyApiKey ?? '');
+  const [unsplashVisible, setUnsplashVisible] = useState(false);
+  const [giphyVisible, setGiphyVisible] = useState(false);
+  const unsplashConfigured = Boolean(config?.unsplashAccessKey);
+  const giphyConfigured = Boolean(config?.giphyApiKey);
+
+  return (
+    <aside
+      className="settings-panel media-integration-settings-panel"
+      role="dialog"
+      aria-modal="false"
+      aria-label="Media integrations"
+    >
+      <div className="settings-panel-header">
+        <div className="settings-panel-title-row">
+          {onBack ? (
+            <button
+              className="stitch-icon-button settings-panel-back-button"
+              type="button"
+              aria-label="Back to settings"
+              onClick={onBack}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                arrow_back
+              </span>
+            </button>
+          ) : null}
+          <div>
+            <h2>Media integrations</h2>
+            <p>Connect Unsplash images and GIPHY GIFs in the Elements panel.</p>
+          </div>
+        </div>
+        <button className="stitch-icon-button" type="button" aria-label="Close media integrations" onClick={onClose}>
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
+        </button>
+      </div>
+      <form
+        className="media-integration-form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSave({
+            giphyApiKey: giphyApiKey.trim(),
+            unsplashAccessKey: unsplashAccessKey.trim(),
+          });
+        }}
+      >
+        <label className="media-key-field">
+          <span className="media-key-label">
+            <span>Unsplash access key</span>
+            <a
+              href="https://unsplash.com/documentation?utm_source=localstudio.dev#creating-a-developer-account"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="See how to get an Unsplash access key"
+            >
+              See how
+            </a>
+          </span>
+          <span className="mirror-secret-control">
+            <input
+              aria-label="Unsplash access key"
+              autoComplete="off"
+              type={unsplashVisible ? 'text' : 'password'}
+              value={unsplashAccessKey}
+              placeholder="Paste Unsplash access key"
+              onChange={(event) => {
+                setUnsplashAccessKey(event.target.value);
+              }}
+            />
+            <button
+              className="stitch-icon-button mirror-secret-toggle"
+              type="button"
+              aria-label={unsplashVisible ? 'Hide Unsplash access key' : 'Show Unsplash access key'}
+              onClick={() => setUnsplashVisible((current) => !current)}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                {unsplashVisible ? 'visibility_off' : 'visibility'}
+              </span>
+            </button>
+          </span>
+          <small>{unsplashConfigured ? 'Unsplash configured' : 'Unsplash not configured'}</small>
+        </label>
+        <label className="media-key-field">
+          <span className="media-key-label">
+            <span>GIPHY API key</span>
+            <a
+              href="https://developers.giphy.com/docs/api/?utm_source=localstudio.dev#quick-start-guide"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="See how to get a GIPHY API key"
+            >
+              See how
+            </a>
+          </span>
+          <span className="mirror-secret-control">
+            <input
+              aria-label="GIPHY API key"
+              autoComplete="off"
+              type={giphyVisible ? 'text' : 'password'}
+              value={giphyApiKey}
+              placeholder="Paste GIPHY API key"
+              onChange={(event) => {
+                setGiphyApiKey(event.target.value);
+              }}
+            />
+            <button
+              className="stitch-icon-button mirror-secret-toggle"
+              type="button"
+              aria-label={giphyVisible ? 'Hide GIPHY API key' : 'Show GIPHY API key'}
+              onClick={() => setGiphyVisible((current) => !current)}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                {giphyVisible ? 'visibility_off' : 'visibility'}
+              </span>
+            </button>
+          </span>
+          <small>{giphyConfigured ? 'GIPHY configured' : 'GIPHY not configured'}</small>
+        </label>
+        <div className="mirror-settings-help">
+          <p>Provider keys stay in this browser profile.</p>
+        </div>
+        <div className="media-integration-actions">
+          <button className="export-button font-orbitron" type="submit">
+            Save media integrations
+          </button>
+          <button
+            className="compact-action compact-action-secondary"
+            type="button"
+            disabled={!config || (!unsplashConfigured && !giphyConfigured)}
+            onClick={() => {
+              onClear?.();
+              setUnsplashAccessKey('');
+              setGiphyApiKey('');
+              setUnsplashVisible(false);
+              setGiphyVisible(false);
+            }}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              key_off
+            </span>
+            Clear media integrations
+          </button>
+        </div>
+      </form>
+    </aside>
+  );
+}

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -6,6 +6,7 @@ interface MirrorSettingsPanelProps {
   config: MinioMirrorConfig;
   mirrorState: MirrorState;
   mirrorDisabledBySettings?: boolean;
+  onBack?: () => void;
   onClose: () => void;
   onEnabledChange: (enabled: boolean) => void;
   onSave: (config: MinioMirrorConfig) => void;
@@ -16,6 +17,7 @@ export function MirrorSettingsPanel({
   config,
   mirrorState,
   mirrorDisabledBySettings = false,
+  onBack,
   onClose,
   onEnabledChange,
   onSave,
@@ -81,9 +83,23 @@ export function MirrorSettingsPanel({
       aria-label="Mirror settings"
     >
       <div className="mirror-settings-header">
-        <div>
-          <h2>Mirror settings</h2>
-          <p>Sync this local project folder to MinIO.</p>
+        <div className="settings-panel-title-row">
+          {onBack ? (
+            <button
+              className="stitch-icon-button settings-panel-back-button"
+              type="button"
+              aria-label="Back to settings"
+              onClick={onBack}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                arrow_back
+              </span>
+            </button>
+          ) : null}
+          <div>
+            <h2>Mirror settings</h2>
+            <p>Sync this local project folder to MinIO.</p>
+          </div>
         </div>
         <button
           className="stitch-icon-button"

--- a/apps/editor/src/ui/editor/panels/SettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/SettingsPanel.tsx
@@ -1,9 +1,10 @@
 interface SettingsPanelProps {
   onClose: () => void;
+  onOpenMediaSettings: () => void;
   onOpenMirrorSettings: () => void;
 }
 
-export function SettingsPanel({ onClose, onOpenMirrorSettings }: SettingsPanelProps) {
+export function SettingsPanel({ onClose, onOpenMediaSettings, onOpenMirrorSettings }: SettingsPanelProps) {
   return (
     <aside className="settings-panel" role="dialog" aria-modal="false" aria-label="Settings">
       <div className="settings-panel-header">
@@ -19,6 +20,12 @@ export function SettingsPanel({ onClose, onOpenMirrorSettings }: SettingsPanelPr
           cloud_sync
         </span>
         <span>Mirror settings</span>
+      </button>
+      <button className="settings-panel-row" type="button" onClick={onOpenMediaSettings}>
+        <span className="material-symbols-outlined" aria-hidden="true">
+          image_search
+        </span>
+        <span>Media integrations</span>
       </button>
     </aside>
   );

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -12,6 +12,7 @@ import {
 import { EditorFooter } from './EditorFooter';
 import { LeftToolPanel } from '../panels/LeftToolPanel';
 import { LocalProjectSetupPanel } from '../panels/LocalProjectSetupPanel';
+import { MediaIntegrationSettingsPanel } from '../panels/MediaIntegrationSettingsPanel';
 import { MirrorSettingsPanel } from '../panels/MirrorSettingsPanel';
 import { PagesPanel } from '../panels/PagesPanel';
 import { PromptBar } from '../prompting/PromptBar';
@@ -432,10 +433,25 @@ export function EditorShell({ services }: EditorShellProps) {
                   void vm.importImageFile(file);
                 }
           }
+          stockGifResults={vm.stockGifResults}
+          stockImageResults={vm.stockImageResults}
+          stockMediaError={vm.stockMediaError}
+          stockMediaProviderState={vm.stockMediaProviderState}
+          stockMediaRecentItems={vm.stockMediaRecentItems}
+          stockMediaSearchingGifs={vm.stockMediaSearching.gifs}
+          stockMediaSearchingImages={vm.stockMediaSearching.images}
+          onConfigureStockMedia={vm.openMediaSettings}
           onRemoveAsset={isHistoryReadOnly ? undefined : vm.removeAsset}
           onImportMedia={isHistoryReadOnly ? undefined : importMediaFile}
+          onInsertStockMedia={isHistoryReadOnly ? undefined : vm.insertStockMedia}
           onInsertText={isHistoryReadOnly ? undefined : vm.insertTextElement}
           onInsertShape={isHistoryReadOnly ? undefined : vm.insertShapeElement}
+          onSearchStockGifs={(query) => {
+            void vm.searchStockGifs(query);
+          }}
+          onSearchStockImages={(query) => {
+            void vm.searchStockImages(query);
+          }}
           modelStates={vm.modelStates}
           attentionModelId={
             vm.aiToolsAttentionModelId ??
@@ -681,13 +697,33 @@ export function EditorShell({ services }: EditorShellProps) {
         />
       ) : null}
       {vm.settingsOpen ? (
-        <SettingsPanel onClose={vm.closeSettings} onOpenMirrorSettings={vm.openMirrorSettings} />
+        <SettingsPanel
+          onClose={vm.closeSettings}
+          onOpenMediaSettings={vm.openMediaSettings}
+          onOpenMirrorSettings={vm.openMirrorSettings}
+        />
+      ) : null}
+      {vm.mediaSettingsOpen ? (
+        <MediaIntegrationSettingsPanel
+          config={vm.stockMediaConfig}
+          onClear={vm.clearStockMediaConfig}
+          onBack={() => {
+            vm.closeMediaSettings();
+            vm.openSettings();
+          }}
+          onClose={vm.closeMediaSettings}
+          onSave={vm.saveStockMediaConfig}
+        />
       ) : null}
       {vm.mirrorSettingsOpen ? (
         <MirrorSettingsPanel
           config={vm.mirrorConfig}
           mirrorState={vm.mirrorState}
           mirrorDisabledBySettings={vm.mirrorDisabledBySettings}
+          onBack={() => {
+            vm.closeMirrorSettings();
+            vm.openSettings();
+          }}
           onClose={vm.closeMirrorSettings}
           onEnabledChange={vm.setMirrorEnabledFromSettings}
           onSave={vm.saveMirrorConfig}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -32,6 +32,9 @@ import type {
   ModelDownloadProgressDetails,
   ModelState,
   PromptApiAvailability,
+  StockMediaConfig,
+  StockMediaItem,
+  StockMediaProviderState,
   VersionHistoryEntry,
 } from '../../../services/contracts/interfaces';
 import { minioMirrorService } from '../../../services/mirror/minioMirrorService';
@@ -99,6 +102,16 @@ interface ElementClipboardState {
   elements: DesignElement[];
 }
 
+interface StockMediaSearchState {
+  gifs: boolean;
+  images: boolean;
+}
+
+interface StockMediaErrorState {
+  gifs?: string | undefined;
+  images?: string | undefined;
+}
+
 function getDownloadProgressPatch(
   progress: number,
   details: ModelDownloadProgressDetails | undefined,
@@ -127,6 +140,7 @@ const IMAGE_PROMPT_MODE_REQUIRED_MESSAGE = 'Use Create image from the + menu to 
 const IMAGE_GENERATION_DIMENSION_MULTIPLE = 16;
 const BACKGROUND_PREVIEW_DEBOUNCE_MS = 120;
 const PASTED_ELEMENT_OFFSET = 32;
+const STOCK_MEDIA_RECENT_LIMIT = 12;
 
 function normalizeImageGenerationDimension(value: number) {
   return Math.max(
@@ -462,6 +476,21 @@ export function useEditorViewModel(services: AppServices) {
   }));
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [mirrorSettingsOpen, setMirrorSettingsOpen] = useState(false);
+  const [mediaSettingsOpen, setMediaSettingsOpen] = useState(false);
+  const [stockMediaConfig, setStockMediaConfig] = useState<StockMediaConfig | null>(() =>
+    services.stockMediaService.loadConfig(),
+  );
+  const [stockMediaProviderState, setStockMediaProviderState] = useState<StockMediaProviderState>(
+    () => services.stockMediaService.getProviderState(),
+  );
+  const [stockImageResults, setStockImageResults] = useState<StockMediaItem[]>([]);
+  const [stockGifResults, setStockGifResults] = useState<StockMediaItem[]>([]);
+  const [stockMediaRecentItems, setStockMediaRecentItems] = useState<StockMediaItem[]>([]);
+  const [stockMediaSearching, setStockMediaSearching] = useState<StockMediaSearchState>({
+    gifs: false,
+    images: false,
+  });
+  const [stockMediaError, setStockMediaError] = useState<StockMediaErrorState>({});
   const [mirrorDisabledBySettings, setMirrorDisabledBySettings] = useState(false);
   const [remoteImportOpen, setRemoteImportOpen] = useState(false);
   const [localProjectSetupOpen, setLocalProjectSetupOpen] = useState(false);
@@ -507,6 +536,19 @@ export function useEditorViewModel(services: AppServices) {
     const element = project.elements[selectedElementIds[0] ?? ''];
     return element?.type === 'image' ? element : undefined;
   }, [project.elements, selectedElementIds]);
+  useEffect(() => {
+    if (stockMediaProviderState.images.configured && stockImageResults.length === 0) {
+      void searchStockImages('');
+    }
+    if (stockMediaProviderState.gifs.configured && stockGifResults.length === 0) {
+      void searchStockGifs('');
+    }
+  }, [
+    stockGifResults.length,
+    stockImageResults.length,
+    stockMediaProviderState.gifs.configured,
+    stockMediaProviderState.images.configured,
+  ]);
   const activeSlideLanguage = useMemo(() => {
     const option = translationLanguageUtils.getLanguageOption(pageLanguageCodes[activePageId]);
     return {
@@ -1591,6 +1633,15 @@ export function useEditorViewModel(services: AppServices) {
     setSettingsOpen(false);
   }
 
+  function openMediaSettings() {
+    setSettingsOpen(false);
+    setMediaSettingsOpen(true);
+  }
+
+  function closeMediaSettings() {
+    setMediaSettingsOpen(false);
+  }
+
   function openMirrorSettings() {
     setSettingsOpen(false);
     setMirrorSettingsOpen(true);
@@ -1613,6 +1664,27 @@ export function useEditorViewModel(services: AppServices) {
     setMirrorState({ enabled: true, status: 'idle' });
     setMirrorSettingsOpen(false);
     void syncMirrorNow();
+  }
+
+  function refreshStockMediaConfig() {
+    setStockMediaConfig(services.stockMediaService.loadConfig());
+    setStockMediaProviderState(services.stockMediaService.getProviderState());
+  }
+
+  function saveStockMediaConfig(config: StockMediaConfig) {
+    services.stockMediaService.saveConfig(config);
+    refreshStockMediaConfig();
+    setMediaSettingsOpen(false);
+    void searchStockImages('');
+    void searchStockGifs('');
+  }
+
+  function clearStockMediaConfig() {
+    services.stockMediaService.clearConfig();
+    refreshStockMediaConfig();
+    setStockImageResults([]);
+    setStockGifResults([]);
+    setStockMediaError({});
   }
 
   function setMirrorEnabled(enabled: boolean, options?: { fromSettings?: boolean }) {
@@ -3154,6 +3226,149 @@ export function useEditorViewModel(services: AppServices) {
     );
   }
 
+  function addRecentStockMedia(item: StockMediaItem) {
+    setStockMediaRecentItems((currentItems) => [
+      item,
+      ...currentItems.filter(
+        (currentItem) => currentItem.provider !== item.provider || currentItem.id !== item.id,
+      ),
+    ].slice(0, STOCK_MEDIA_RECENT_LIMIT));
+  }
+
+  async function searchStockImages(query: string) {
+    setStockMediaSearching((current) => ({ ...current, images: true }));
+    setStockMediaError((current) => ({ ...current, images: undefined }));
+    try {
+      const results = await services.stockMediaService.searchImages(query);
+      setStockImageResults(results);
+      setStockMediaError((current) => ({ ...current, images: undefined }));
+    } catch (error) {
+      setStockImageResults([]);
+      setStockMediaError((current) => ({
+        ...current,
+        images: error instanceof Error ? error.message : 'Unsplash search failed.',
+      }));
+    } finally {
+      setStockMediaSearching((current) => ({ ...current, images: false }));
+    }
+  }
+
+  async function searchStockGifs(query: string) {
+    setStockMediaSearching((current) => ({ ...current, gifs: true }));
+    setStockMediaError((current) => ({ ...current, gifs: undefined }));
+    try {
+      const results = await services.stockMediaService.searchGifs(query);
+      setStockGifResults(results);
+      setStockMediaError((current) => ({ ...current, gifs: undefined }));
+    } catch (error) {
+      setStockGifResults([]);
+      setStockMediaError((current) => ({
+        ...current,
+        gifs: error instanceof Error ? error.message : 'GIPHY search failed.',
+      }));
+    } finally {
+      setStockMediaSearching((current) => ({ ...current, gifs: false }));
+    }
+  }
+
+  async function insertRemoteImage(item: StockMediaItem) {
+    if (item.kind !== 'image') return;
+    const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
+    if (!page) return;
+    await services.stockMediaService.trackImageDownload(item).catch(() => undefined);
+
+    const assetId = createPrefixedId('asset');
+    const elementId = createPrefixedId('image');
+    const fittedMedia = fitImageWithinPage({
+      imageWidth: item.width,
+      imageHeight: item.height,
+      pageWidth: page.width,
+      pageHeight: page.height,
+    });
+
+    commitProject(
+      (currentProject) =>
+        new basicCommands.AddImageElementCommand(activePageId, {
+          asset: {
+            id: assetId,
+            type: 'image',
+            name: item.title,
+            mimeType: 'image/jpeg',
+            objectUrl: item.mediaUrl,
+            storage: 'remote',
+          },
+          element: {
+            id: elementId,
+            type: 'image',
+            assetId,
+            x: fittedMedia.x,
+            y: fittedMedia.y,
+            width: fittedMedia.width,
+            height: fittedMedia.height,
+            rotation: 0,
+            locked: false,
+            visible: true,
+            opacity: 1,
+          },
+        }).execute(currentProject),
+      { selectedElementIds: [elementId] },
+    );
+    addRecentStockMedia(item);
+  }
+
+  async function insertRemoteGif(item: StockMediaItem) {
+    if (item.kind !== 'gif') return;
+    const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
+    if (!page) return;
+
+    const assetId = createPrefixedId('asset');
+    const elementId = createPrefixedId('gif');
+    const fittedMedia = fitImageWithinPage({
+      imageWidth: item.width,
+      imageHeight: item.height,
+      pageWidth: page.width,
+      pageHeight: page.height,
+    });
+
+    commitProject(
+      (currentProject) =>
+        new basicCommands.AddMediaElementCommand(activePageId, {
+          asset: {
+            id: assetId,
+            type: 'gif',
+            name: item.title,
+            mimeType: 'image/gif',
+            objectUrl: item.mediaUrl,
+            storage: 'remote',
+          },
+          element: {
+            id: elementId,
+            type: 'gif',
+            assetId,
+            x: fittedMedia.x,
+            y: fittedMedia.y,
+            width: fittedMedia.width,
+            height: fittedMedia.height,
+            rotation: 0,
+            locked: false,
+            visible: true,
+            opacity: 1,
+            playing: true,
+          },
+        }).execute(currentProject),
+      { selectedElementIds: [elementId] },
+    );
+    addRecentStockMedia(item);
+  }
+
+  function insertStockMedia(item: StockMediaItem) {
+    if (item.kind === 'gif') {
+      void insertRemoteGif(item);
+      return;
+    }
+    void insertRemoteImage(item);
+  }
+
   function updateMediaPlayback(elementId: string, patch: MediaPlaybackPatch) {
     commitProject((currentProject) =>
       new basicCommands.UpdateMediaPlaybackCommand(elementId, patch).execute(currentProject),
@@ -3175,6 +3390,14 @@ export function useEditorViewModel(services: AppServices) {
     mirrorConfig,
     settingsOpen,
     mirrorSettingsOpen,
+    mediaSettingsOpen,
+    stockMediaConfig,
+    stockMediaProviderState,
+    stockImageResults,
+    stockGifResults,
+    stockMediaRecentItems,
+    stockMediaSearching,
+    stockMediaError,
     localProjectSetupOpen,
     remoteImportOpen,
     remoteImportStatus,
@@ -3208,8 +3431,15 @@ export function useEditorViewModel(services: AppServices) {
     confirmLocalProjectSetup,
     openSettings,
     closeSettings,
+    openMediaSettings,
+    closeMediaSettings,
     openMirrorSettings,
     closeMirrorSettings,
+    saveStockMediaConfig,
+    clearStockMediaConfig,
+    searchStockImages,
+    searchStockGifs,
+    insertStockMedia,
     saveMirrorConfig,
     testMirrorConnection,
     syncMirrorNow,

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -107,7 +107,7 @@ interface StockMediaSearchState {
   images: boolean;
 }
 
-interface StockMediaErrorState {
+export interface StockMediaErrorState {
   gifs?: string | undefined;
   images?: string | undefined;
 }
@@ -989,7 +989,7 @@ export function useEditorViewModel(services: AppServices) {
         setPromptProviderStates(await services.promptService.getProviderStates());
       }
       setPromptApiNotice('Prompt API ready');
-    } catch (error) {
+    } catch (error: unknown) {
       const selectedProvider = promptProviderStates.find((provider) => provider.selected);
       if (selectedProvider?.modelId) {
         await services.modelSetupService.removeModel?.(selectedProvider.modelId);
@@ -1085,7 +1085,7 @@ export function useEditorViewModel(services: AppServices) {
           await services.translatorService.getLanguageDetectionProviderStates(),
         );
       }
-    } catch (error) {
+    } catch (error: unknown) {
       setLanguageDetectionPreparation({ progress: 0, status: 'failed' });
       setTranslationNotice(
         error instanceof Error ? error.message : 'Language detection model could not be prepared.',
@@ -1225,7 +1225,7 @@ export function useEditorViewModel(services: AppServices) {
         ...current,
         [pageId]: translationLanguageUtils.normalizeLanguageCode(generatedTasks.language),
       }));
-    } catch (error) {
+    } catch (error: unknown) {
       if (!isCurrentRun()) return;
       setPromptGenerationNotice(
         error instanceof Error ? error.message : 'Prompt API could not generate the slide.',
@@ -1317,7 +1317,7 @@ export function useEditorViewModel(services: AppServices) {
           }).execute(currentProject),
         { selectedElementIds: [elementId] },
       );
-    } catch (error) {
+    } catch (error: unknown) {
       if (!isCurrentRun()) return;
       setCreateImageNotice(error instanceof Error ? error.message : 'Image generation failed.');
     } finally {
@@ -1711,7 +1711,7 @@ export function useEditorViewModel(services: AppServices) {
     try {
       await services.mirrorService.listProjects(config);
       setMirrorState({ enabled: true, status: 'idle' });
-    } catch (error) {
+    } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'MinIO connection failed.';
       setMirrorState({
         enabled: true,
@@ -1768,7 +1768,7 @@ export function useEditorViewModel(services: AppServices) {
       }
       lastMirroredProjectNameRef.current = projectToSync.name;
       setMirrorState(nextState);
-    } catch (error) {
+    } catch (error: unknown) {
       setMirrorState({
         enabled: true,
         status: 'failed',
@@ -1818,7 +1818,7 @@ export function useEditorViewModel(services: AppServices) {
       }
       setRemoteImportProjects(mirrors);
       setRemoteImportStatus('ready');
-    } catch (error) {
+    } catch (error: unknown) {
       setRemoteImportStatus('failed');
       setRemoteImportError(
         error instanceof Error ? error.message : 'Could not list mirrored projects.',
@@ -1865,7 +1865,7 @@ export function useEditorViewModel(services: AppServices) {
       editorPreferences.writePersistencePreference(true);
       setMirrorState({ enabled: true, status: 'synced', lastSyncedAt: new Date().toISOString() });
       setRemoteImportOpen(false);
-    } catch (error) {
+    } catch (error: unknown) {
       setRemoteImportStatus('failed');
       setRemoteImportError(error instanceof Error ? error.message : 'MinIO mirror import failed.');
       setMirrorState({
@@ -3242,11 +3242,11 @@ export function useEditorViewModel(services: AppServices) {
       const results = await services.stockMediaService.searchImages(query);
       setStockImageResults(results);
       setStockMediaError((current) => ({ ...current, images: undefined }));
-    } catch (error) {
+    } catch {
       setStockImageResults([]);
       setStockMediaError((current) => ({
         ...current,
-        images: error instanceof Error ? error.message : 'Unsplash search failed.',
+        images: 'API Key is invalid',
       }));
     } finally {
       setStockMediaSearching((current) => ({ ...current, images: false }));
@@ -3260,11 +3260,11 @@ export function useEditorViewModel(services: AppServices) {
       const results = await services.stockMediaService.searchGifs(query);
       setStockGifResults(results);
       setStockMediaError((current) => ({ ...current, gifs: undefined }));
-    } catch (error) {
+    } catch {
       setStockGifResults([]);
       setStockMediaError((current) => ({
         ...current,
-        gifs: error instanceof Error ? error.message : 'GIPHY search failed.',
+        gifs: 'API Key is invalid',
       }));
     } finally {
       setStockMediaSearching((current) => ({ ...current, gifs: false }));
@@ -3316,7 +3316,7 @@ export function useEditorViewModel(services: AppServices) {
     addRecentStockMedia(item);
   }
 
-  async function insertRemoteGif(item: StockMediaItem) {
+  function insertRemoteGif(item: StockMediaItem) {
     if (item.kind !== 'gif') return;
     const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
     if (!page) return;
@@ -3363,7 +3363,7 @@ export function useEditorViewModel(services: AppServices) {
 
   function insertStockMedia(item: StockMediaItem) {
     if (item.kind === 'gif') {
-      void insertRemoteGif(item);
+      insertRemoteGif(item);
       return;
     }
     void insertRemoteImage(item);

--- a/apps/editor/tests/unit/app/composition.test.ts
+++ b/apps/editor/tests/unit/app/composition.test.ts
@@ -4,6 +4,7 @@ import { BrowserFileSystemProjectRepository } from '../../../src/services/storag
 import { BrowserImageGenerationService } from '../../../src/services/image-generation/browserImageGenerationService';
 import { DisabledProjectRepository } from '../../../src/services/storage/disabledProjectRepository';
 import { OpfsProjectRepository } from '../../../src/services/storage/opfsProjectRepository';
+import { BrowserStockMediaService } from '../../../src/services/stock-media/stockMediaService';
 
 describe('createAppServices', () => {
   const testWindow = window as Window & { showDirectoryPicker?: unknown };
@@ -67,6 +68,10 @@ describe('createAppServices', () => {
 
   it('wires the browser image generation service', () => {
     expect(createAppServices().imageGenerationService).toBeInstanceOf(BrowserImageGenerationService);
+  });
+
+  it('wires the browser stock media service', () => {
+    expect(createAppServices().stockMediaService).toBeInstanceOf(BrowserStockMediaService);
   });
 
   it('starts new app services with a blank project by default', () => {

--- a/apps/editor/tests/unit/services/stockMediaService.test.ts
+++ b/apps/editor/tests/unit/services/stockMediaService.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BrowserStockMediaService } from '../../../src/services/stock-media/stockMediaService';
+
+function getRequestUrl(input: RequestInfo | URL) {
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return input;
+}
+
+describe('BrowserStockMediaService', () => {
+  it('stores media integration keys in localStorage', () => {
+    const service = new BrowserStockMediaService();
+
+    service.saveConfig({ giphyApiKey: 'giphy-key', unsplashAccessKey: 'unsplash-key' });
+
+    expect(service.loadConfig()).toEqual({
+      giphyApiKey: 'giphy-key',
+      unsplashAccessKey: 'unsplash-key',
+    });
+
+    service.clearConfig();
+
+    expect(service.loadConfig()).toBeNull();
+  });
+
+  it('reports provider readiness from saved config', () => {
+    const service = new BrowserStockMediaService();
+
+    expect(service.getProviderState()).toEqual({
+      gifs: { configured: false, provider: 'giphy' },
+      images: { configured: false, provider: 'unsplash' },
+    });
+
+    service.saveConfig({ giphyApiKey: 'giphy-key', unsplashAccessKey: 'unsplash-key' });
+
+    expect(service.getProviderState()).toEqual({
+      gifs: { configured: true, provider: 'giphy' },
+      images: { configured: true, provider: 'unsplash' },
+    });
+  });
+
+  it('maps Unsplash search results and tracks the photo download URL', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      const headers = input instanceof Request ? input.headers : undefined;
+      if (url.startsWith('https://api.unsplash.com/search/photos')) {
+        expect(headers?.get('authorization')).toBe('Client-ID unsplash-key');
+        return Promise.resolve(
+          Response.json({
+            results: [
+              {
+                id: 'photo-1',
+                alt_description: 'Mountain sunset',
+                width: 2400,
+                height: 1600,
+                urls: {
+                  regular: 'https://images.unsplash.com/photo-1?ixid=abc&fm=jpg&w=1080',
+                  small: 'https://images.unsplash.com/photo-1?ixid=abc&fm=jpg&w=400',
+                },
+                links: {
+                  download_location: 'https://api.unsplash.com/photos/photo-1/download',
+                },
+                user: {
+                  name: 'Ada Photo',
+                  links: { html: 'https://unsplash.com/@ada' },
+                },
+              },
+            ],
+          }),
+        );
+      }
+      if (url === 'https://api.unsplash.com/photos/photo-1/download') {
+        expect(headers?.get('authorization')).toBe('Client-ID unsplash-key');
+        return Promise.resolve(Response.json({ url: 'https://images.unsplash.com/downloaded' }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new BrowserStockMediaService({ fetch: fetchMock });
+    service.saveConfig({ unsplashAccessKey: 'unsplash-key', giphyApiKey: '' });
+
+    const results = await service.searchImages('mountain');
+
+    expect(results).toEqual([
+      {
+        id: 'photo-1',
+        provider: 'unsplash',
+        kind: 'image',
+        title: 'Mountain sunset',
+        authorName: 'Ada Photo',
+        authorUrl: 'https://unsplash.com/@ada',
+        thumbnailUrl: 'https://images.unsplash.com/photo-1?ixid=abc&fm=jpg&w=400',
+        mediaUrl: 'https://images.unsplash.com/photo-1?ixid=abc&fm=jpg&w=1080',
+        width: 2400,
+        height: 1600,
+        downloadLocation: 'https://api.unsplash.com/photos/photo-1/download',
+      },
+    ]);
+
+    await service.trackImageDownload(results[0]!);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps GIPHY search results to animated GIF media', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(getRequestUrl(input));
+      expect(url.origin).toBe('https://api.giphy.com');
+      expect(url.pathname).toBe('/v1/gifs/search');
+      expect(url.searchParams.get('api_key')).toBe('giphy-key');
+      expect(url.searchParams.get('limit')).toBe('30');
+      expect(url.searchParams.get('q')).toBe('launch');
+      return Promise.resolve(
+        Response.json({
+          data: [
+            {
+              id: 'gif-1',
+              title: 'Launch GIF',
+              username: 'Motion Studio',
+              url: 'https://giphy.com/gifs/gif-1',
+              images: {
+                downsized_medium: {
+                  url: 'https://media.giphy.com/media/gif-1/giphy.gif',
+                  width: '480',
+                  height: '270',
+                },
+                fixed_width: {
+                  url: 'https://media.giphy.com/media/gif-1/200w.gif',
+                  width: '200',
+                  height: '113',
+                },
+              },
+            },
+          ],
+          meta: { response_id: 'response-1', status: 200, msg: 'OK' },
+        }),
+      );
+    });
+    const service = new BrowserStockMediaService({ fetch: fetchMock });
+    service.saveConfig({ unsplashAccessKey: '', giphyApiKey: 'giphy-key' });
+
+    await expect(service.searchGifs('launch')).resolves.toEqual([
+      {
+        id: 'gif-1',
+        provider: 'giphy',
+        kind: 'gif',
+        title: 'Launch GIF',
+        authorName: 'Motion Studio',
+        authorUrl: 'https://giphy.com/gifs/gif-1',
+        thumbnailUrl: 'https://media.giphy.com/media/gif-1/200w.gif',
+        mediaUrl: 'https://media.giphy.com/media/gif-1/giphy.gif',
+        width: 480,
+        height: 270,
+      },
+    ]);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -130,6 +130,12 @@ class ReadyStockMediaService implements StockMediaService {
   }
 }
 
+class InvalidImageStockMediaService extends ReadyStockMediaService {
+  override searchImages(): Promise<StockMediaItem[]> {
+    return Promise.reject(new Error('Unsplash image search failed with 401 Unauthorized.'));
+  }
+}
+
 class RejectingProjectRepository implements ProjectRepository {
   loadProject(): Promise<ProjectDocument | null> {
     return Promise.resolve(null);
@@ -615,6 +621,23 @@ describe('EditorShell', () => {
         expect.stringMatching(/^gif-/),
       );
     });
+  });
+
+  it('shows a generic API key error when stock image search is rejected', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    services.stockMediaService = new InvalidImageStockMediaService();
+
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'Elements');
+
+    expect(await screen.findByText('API Key is invalid')).toBeInTheDocument();
+    expect(screen.queryByText('Unsplash image search failed with 401 Unauthorized.')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Configure media integrations' }));
+
+    expect(screen.getByRole('dialog', { name: 'Media integrations' })).toBeInTheDocument();
   });
 
   it('keeps the Animations panel open after media integration settings are saved', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -14,6 +14,10 @@ import type {
   ShareMetadata,
   ShareRecord,
   ShareService,
+  StockMediaConfig,
+  StockMediaItem,
+  StockMediaProviderState,
+  StockMediaService,
   TranslatorService,
 } from '../../../../src/services/contracts/interfaces';
 import type { MinioMirrorConfig } from '../../../../src/services/mirror/minioMirrorService';
@@ -62,6 +66,67 @@ class InstantBackgroundRemovalService implements BackgroundRemovalService {
 
   removeBackground(asset: Asset): Promise<{ asset: Asset }> {
     return Promise.resolve({ asset });
+  }
+}
+
+const stockImage: StockMediaItem = {
+  id: 'photo-1',
+  provider: 'unsplash',
+  kind: 'image',
+  title: 'Mountain sunset',
+  authorName: 'Ada Photo',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1?w=400',
+  mediaUrl: 'https://images.unsplash.com/photo-1?w=1080',
+  width: 1200,
+  height: 800,
+  downloadLocation: 'https://api.unsplash.com/photos/photo-1/download',
+};
+
+const stockGif: StockMediaItem = {
+  id: 'gif-1',
+  provider: 'giphy',
+  kind: 'gif',
+  title: 'Launch GIF',
+  authorName: 'Motion Studio',
+  thumbnailUrl: 'https://media.giphy.com/media/gif-1/200w.gif',
+  mediaUrl: 'https://media.giphy.com/media/gif-1/giphy.gif',
+  width: 480,
+  height: 270,
+};
+
+class ReadyStockMediaService implements StockMediaService {
+  trackedItems: StockMediaItem[] = [];
+
+  loadConfig(): StockMediaConfig {
+    return { giphyApiKey: 'giphy-key', unsplashAccessKey: 'unsplash-key' };
+  }
+
+  saveConfig(): void {
+    return undefined;
+  }
+
+  clearConfig(): void {
+    return undefined;
+  }
+
+  getProviderState(): StockMediaProviderState {
+    return {
+      gifs: { configured: true, provider: 'giphy' },
+      images: { configured: true, provider: 'unsplash' },
+    };
+  }
+
+  searchImages(): Promise<StockMediaItem[]> {
+    return Promise.resolve([stockImage]);
+  }
+
+  searchGifs(): Promise<StockMediaItem[]> {
+    return Promise.resolve([stockGif]);
+  }
+
+  trackImageDownload(item: StockMediaItem): Promise<void> {
+    this.trackedItems.push(item);
+    return Promise.resolve();
   }
 }
 
@@ -512,6 +577,68 @@ describe('EditorShell', () => {
       'aria-pressed',
       'true',
     );
+  });
+
+  it('inserts and selects an Unsplash image from the Elements panel', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const stockMediaService = new ReadyStockMediaService();
+    services.stockMediaService = stockMediaService;
+
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'Elements');
+    await user.click(await screen.findByRole('button', { name: 'Insert image by Ada Photo' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-selected-elements',
+        expect.stringMatching(/^image-/),
+      );
+    });
+    expect(stockMediaService.trackedItems).toEqual([stockImage]);
+  });
+
+  it('inserts and selects a GIPHY GIF from the Elements panel', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    services.stockMediaService = new ReadyStockMediaService();
+
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'Elements');
+    await user.click(await screen.findByRole('button', { name: 'Insert GIF Launch GIF' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-selected-elements',
+        expect.stringMatching(/^gif-/),
+      );
+    });
+  });
+
+  it('keeps the Animations panel open after media integration settings are saved', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    services.stockMediaService = new ReadyStockMediaService();
+
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'Animate');
+    expect(screen.getByRole('tab', { name: 'Animate' })).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
+    await user.click(
+      within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+        name: 'Media integrations',
+      }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Save media integrations' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Media integrations' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('tab', { name: 'Animate' })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('switches to the layout panel from the header view menu', async () => {

--- a/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
@@ -473,7 +473,10 @@ describe('LeftToolPanel', () => {
   it('scrolls the shape strip from the Shapes see all action', async () => {
     const user = userEvent.setup();
     const scrollBy = vi.fn();
-    const originalScrollBy = HTMLElement.prototype.scrollBy;
+    const originalScrollByDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollBy',
+    );
     Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
       configurable: true,
       value: scrollBy,
@@ -494,12 +497,14 @@ describe('LeftToolPanel', () => {
 
       await user.click(screen.getByRole('button', { name: 'See all Shapes' }));
 
-      expect(scrollBy).toHaveBeenCalledWith({ behavior: 'smooth', left: expect.any(Number) });
+      const firstScrollCall = scrollBy.mock.calls.at(0) as [ScrollToOptions] | undefined;
+      const scrollOptions = firstScrollCall?.[0];
+      expect(scrollOptions).toMatchObject({ behavior: 'smooth' });
+      expect(typeof scrollOptions?.left).toBe('number');
     } finally {
-      Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
-        configurable: true,
-        value: originalScrollBy,
-      });
+      if (originalScrollByDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollBy', originalScrollByDescriptor);
+      }
     }
   });
 
@@ -543,7 +548,7 @@ describe('LeftToolPanel', () => {
         activePageId="page-1"
         selection={{ pageId: 'page-1', elementIds: [] }}
         modelStates={modelStates}
-        stockMediaError={{ images: 'Unsplash image search failed.' }}
+        stockMediaError={{ images: 'API Key is invalid' }}
         stockMediaProviderState={{
           gifs: { configured: true, provider: 'giphy' },
           images: { configured: true, provider: 'unsplash' },
@@ -552,7 +557,7 @@ describe('LeftToolPanel', () => {
       />,
     );
 
-    expect(screen.getByText('Unsplash image search failed.')).toBeInTheDocument();
+    expect(screen.getByText('API Key is invalid')).toBeInTheDocument();
     expect(screen.queryByText('No images found.')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Configure media integrations' }));
@@ -586,6 +591,9 @@ describe('LeftToolPanel', () => {
         onSearchStockImages={onSearchStockImages}
       />,
     );
+
+    expect(screen.getByPlaceholderText('search images')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('search gifs')).toBeInTheDocument();
 
     await user.type(screen.getByLabelText('Search Unsplash images'), 'mountain{Enter}');
     await user.type(screen.getByLabelText('Search GIPHY GIFs'), 'launch{Enter}');

--- a/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
+import type { StockMediaItem } from '../../../../src/services/contracts/interfaces';
 import { LeftToolPanel } from '../../../../src/ui/editor/panels/LeftToolPanel';
 import type { RightPanelTab } from '../../../../src/ui/editor/state/useEditorViewModel';
 
@@ -17,6 +18,49 @@ const modelStates = [
     required: true,
   },
 ];
+
+const stockImage: StockMediaItem = {
+  id: 'photo-1',
+  provider: 'unsplash',
+  kind: 'image',
+  title: 'Mountain sunset',
+  authorName: 'Ada Photo',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1?w=400',
+  mediaUrl: 'https://images.unsplash.com/photo-1?w=1080',
+  width: 1200,
+  height: 800,
+  downloadLocation: 'https://api.unsplash.com/photos/photo-1/download',
+};
+
+const stockGif: StockMediaItem = {
+  id: 'gif-1',
+  provider: 'giphy',
+  kind: 'gif',
+  title: 'Launch GIF',
+  authorName: 'Motion Studio',
+  thumbnailUrl: 'https://media.giphy.com/media/gif-1/200w.gif',
+  mediaUrl: 'https://media.giphy.com/media/gif-1/giphy.gif',
+  width: 480,
+  height: 270,
+};
+
+function createStockImages(count: number): StockMediaItem[] {
+  return Array.from({ length: count }, (_, index) => {
+    const itemNumber = index + 1;
+    return {
+      id: `photo-${itemNumber}`,
+      provider: 'unsplash',
+      kind: 'image',
+      title: `Mountain sunset ${itemNumber}`,
+      authorName: `Photo Author ${itemNumber}`,
+      thumbnailUrl: `https://images.unsplash.com/photo-${itemNumber}?w=400`,
+      mediaUrl: `https://images.unsplash.com/photo-${itemNumber}?w=1080`,
+      width: 1200,
+      height: 800,
+      downloadLocation: `https://api.unsplash.com/photos/photo-${itemNumber}/download`,
+    };
+  });
+}
 
 describe('LeftToolPanel', () => {
   it('opens panel content on click and closes it when clicking the active item again', async () => {
@@ -424,5 +468,166 @@ describe('LeftToolPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Add triangle' }));
 
     expect(onInsertShape).toHaveBeenCalledWith('triangle');
+  });
+
+  it('scrolls the shape strip from the Shapes see all action', async () => {
+    const user = userEvent.setup();
+    const scrollBy = vi.fn();
+    const originalScrollBy = HTMLElement.prototype.scrollBy;
+    Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
+      configurable: true,
+      value: scrollBy,
+    });
+
+    try {
+      render(
+        <LeftToolPanel
+          activeTab="elements"
+          open
+          onTabChange={vi.fn()}
+          project={sampleProject.createSampleProject()}
+          activePageId="page-1"
+          selection={{ pageId: 'page-1', elementIds: [] }}
+          modelStates={modelStates}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'See all Shapes' }));
+
+      expect(scrollBy).toHaveBeenCalledWith({ behavior: 'smooth', left: expect.any(Number) });
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, 'scrollBy', {
+        configurable: true,
+        value: originalScrollBy,
+      });
+    }
+  });
+
+  it('shows configure actions when stock media providers are missing keys', () => {
+    const onConfigureStockMedia = vi.fn();
+
+    render(
+      <LeftToolPanel
+        activeTab="elements"
+        open
+        onTabChange={vi.fn()}
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        modelStates={modelStates}
+        stockMediaProviderState={{
+          gifs: { configured: false, provider: 'giphy' },
+          images: { configured: false, provider: 'unsplash' },
+        }}
+        onConfigureStockMedia={onConfigureStockMedia}
+      />,
+    );
+
+    expect(screen.getByText('Images')).toBeInTheDocument();
+    expect(screen.getByText('GIFs')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Configure media integrations' })).toHaveLength(
+      2,
+    );
+  });
+
+  it('shows media settings action when a configured provider search fails', async () => {
+    const user = userEvent.setup();
+    const onConfigureStockMedia = vi.fn();
+
+    render(
+      <LeftToolPanel
+        activeTab="elements"
+        open
+        onTabChange={vi.fn()}
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        modelStates={modelStates}
+        stockMediaError={{ images: 'Unsplash image search failed.' }}
+        stockMediaProviderState={{
+          gifs: { configured: true, provider: 'giphy' },
+          images: { configured: true, provider: 'unsplash' },
+        }}
+        onConfigureStockMedia={onConfigureStockMedia}
+      />,
+    );
+
+    expect(screen.getByText('Unsplash image search failed.')).toBeInTheDocument();
+    expect(screen.queryByText('No images found.')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Configure media integrations' }));
+
+    expect(onConfigureStockMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it('searches and inserts configured stock media results', async () => {
+    const user = userEvent.setup();
+    const onSearchStockImages = vi.fn();
+    const onSearchStockGifs = vi.fn();
+    const onInsertStockMedia = vi.fn();
+
+    render(
+      <LeftToolPanel
+        activeTab="elements"
+        open
+        onTabChange={vi.fn()}
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        modelStates={modelStates}
+        stockImageResults={[stockImage]}
+        stockGifResults={[stockGif]}
+        stockMediaProviderState={{
+          gifs: { configured: true, provider: 'giphy' },
+          images: { configured: true, provider: 'unsplash' },
+        }}
+        onInsertStockMedia={onInsertStockMedia}
+        onSearchStockGifs={onSearchStockGifs}
+        onSearchStockImages={onSearchStockImages}
+      />,
+    );
+
+    await user.type(screen.getByLabelText('Search Unsplash images'), 'mountain{Enter}');
+    await user.type(screen.getByLabelText('Search GIPHY GIFs'), 'launch{Enter}');
+    await user.click(screen.getByRole('button', { name: 'Insert image by Ada Photo' }));
+    await user.click(screen.getByRole('button', { name: 'Insert GIF Launch GIF' }));
+
+    expect(onSearchStockImages).toHaveBeenCalledWith('mountain');
+    expect(onSearchStockGifs).toHaveBeenCalledWith('launch');
+    expect(onInsertStockMedia).toHaveBeenCalledWith(stockImage);
+    expect(onInsertStockMedia).toHaveBeenCalledWith(stockGif);
+  });
+
+  it('paginates stock media results in groups of ten', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LeftToolPanel
+        activeTab="elements"
+        open
+        onTabChange={vi.fn()}
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        modelStates={modelStates}
+        stockImageResults={createStockImages(12)}
+        stockMediaProviderState={{
+          gifs: { configured: false, provider: 'giphy' },
+          images: { configured: true, provider: 'unsplash' },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Insert image by Photo Author 1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Insert image by Photo Author 10' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Insert image by Photo Author 11' })).not.toBeInTheDocument();
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Next Images page' }));
+
+    expect(screen.queryByRole('button', { name: 'Insert image by Photo Author 1' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Insert image by Photo Author 11' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Insert image by Photo Author 12' })).toBeInTheDocument();
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
   });
 });

--- a/apps/editor/tests/unit/ui/editor/MediaIntegrationSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MediaIntegrationSettingsPanel.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { MediaIntegrationSettingsPanel } from '../../../../src/ui/editor/panels/MediaIntegrationSettingsPanel';
+
+describe('MediaIntegrationSettingsPanel', () => {
+  it('shows saved keys as masked fields and lets users reveal and save them', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <MediaIntegrationSettingsPanel
+        config={{ giphyApiKey: 'saved-giphy-key', unsplashAccessKey: 'saved-unsplash-key' }}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByText('Unsplash configured')).toBeInTheDocument();
+    expect(screen.getByText('GIPHY configured')).toBeInTheDocument();
+    expect(screen.getByLabelText('Unsplash access key')).toHaveValue('saved-unsplash-key');
+    expect(screen.getByLabelText('Unsplash access key')).toHaveAttribute('type', 'password');
+    expect(screen.getByLabelText('GIPHY API key')).toHaveValue('saved-giphy-key');
+    expect(screen.getByLabelText('GIPHY API key')).toHaveAttribute('type', 'password');
+    expect(screen.getByRole('button', { name: 'Save media integrations' })).toHaveClass(
+      'export-button',
+      'font-orbitron',
+    );
+    expect(screen.getByText('Unsplash access key')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'See how to get an Unsplash access key' })).toHaveTextContent(
+      'See how',
+    );
+    expect(screen.getByRole('link', { name: 'See how to get an Unsplash access key' })).toHaveAttribute(
+      'href',
+      'https://unsplash.com/documentation?utm_source=localstudio.dev#creating-a-developer-account',
+    );
+    expect(screen.getByText('GIPHY API key')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'See how to get a GIPHY API key' })).toHaveTextContent(
+      'See how',
+    );
+    expect(screen.getByRole('link', { name: 'See how to get a GIPHY API key' })).toHaveAttribute(
+      'href',
+      'https://developers.giphy.com/docs/api/?utm_source=localstudio.dev#quick-start-guide',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Show Unsplash access key' }));
+    await user.click(screen.getByRole('button', { name: 'Show GIPHY API key' }));
+    expect(screen.getByLabelText('Unsplash access key')).toHaveAttribute('type', 'text');
+    expect(screen.getByLabelText('GIPHY API key')).toHaveAttribute('type', 'text');
+
+    await user.clear(screen.getByLabelText('Unsplash access key'));
+    await user.type(screen.getByLabelText('Unsplash access key'), 'new-unsplash-key');
+    await user.clear(screen.getByLabelText('GIPHY API key'));
+    await user.type(screen.getByLabelText('GIPHY API key'), 'new-giphy-key');
+    await user.click(screen.getByRole('button', { name: 'Save media integrations' }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      giphyApiKey: 'new-giphy-key',
+      unsplashAccessKey: 'new-unsplash-key',
+    });
+  });
+
+  it('returns to the settings list from the back button', async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+
+    render(
+      <MediaIntegrationSettingsPanel
+        config={null}
+        onBack={onBack}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Back to settings' }));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears saved API keys', async () => {
+    const user = userEvent.setup();
+    const onClear = vi.fn();
+
+    render(
+      <MediaIntegrationSettingsPanel
+        config={{ giphyApiKey: 'saved-giphy-key', unsplashAccessKey: 'saved-unsplash-key' }}
+        onClear={onClear}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Clear media integrations' }));
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -91,6 +91,27 @@ describe('MirrorSettingsPanel', () => {
     expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ prefix: 'public-projects' }));
   });
 
+  it('returns to the settings list from the back button', async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+
+    render(
+      <MirrorSettingsPanel
+        config={config}
+        mirrorState={{ enabled: true, status: 'idle' }}
+        onBack={onBack}
+        onClose={vi.fn()}
+        onEnabledChange={vi.fn()}
+        onSave={vi.fn()}
+        onTestConnection={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Back to settings' }));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
   it('lets users disable mirroring from settings and keeps saving settings disabled while off', async () => {
     const user = userEvent.setup();
     const onEnabledChange = vi.fn();

--- a/apps/editor/tests/unit/ui/editor/SettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/SettingsPanel.test.tsx
@@ -8,12 +8,38 @@ describe('SettingsPanel', () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
     const onOpenMirrorSettings = vi.fn();
+    const onOpenMediaSettings = vi.fn();
 
-    render(<SettingsPanel onClose={onClose} onOpenMirrorSettings={onOpenMirrorSettings} />);
+    render(
+      <SettingsPanel
+        onClose={onClose}
+        onOpenMediaSettings={onOpenMediaSettings}
+        onOpenMirrorSettings={onOpenMirrorSettings}
+      />,
+    );
 
     expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
 
     expect(onOpenMirrorSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens media integration settings from the settings list', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onOpenMediaSettings = vi.fn();
+    const onOpenMirrorSettings = vi.fn();
+
+    render(
+      <SettingsPanel
+        onClose={onClose}
+        onOpenMediaSettings={onOpenMediaSettings}
+        onOpenMirrorSettings={onOpenMirrorSettings}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Media integrations' }));
+
+    expect(onOpenMediaSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "name": "@localstudio/editor",
       "version": "0.1.0",
       "dependencies": {
+        "@giphy/js-fetch-api": "^5.8.0",
         "@huggingface/transformers": "^4.2.0",
         "@localstudio/brand": "*",
         "jspdf": "^4.2.1",
@@ -44,7 +45,8 @@
         "lucide-react": "^1.21.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-konva": "^19.2.5"
+        "react-konva": "^19.2.5",
+        "unsplash-js": "^8.0.0"
       }
     },
     "apps/landing": {
@@ -694,6 +696,32 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@giphy/js-fetch-api": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-fetch-api/-/js-fetch-api-5.8.0.tgz",
+      "integrity": "sha512-DWdNauYaBSLPeAe/O+uzXtPIoUvmSnYV8Q49p+cPjEQ7Ncj1mDg1fuSKyl0OmPxCm6fzGJ4kuJjsWzyWn9ubbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/js-types": "*",
+        "@giphy/js-util": "*"
+      }
+    },
+    "node_modules/@giphy/js-types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-types/-/js-types-5.1.0.tgz",
+      "integrity": "sha512-BZYCDtYNRR7cUWkbDLB4wmm3qmWMsVCQdUiBNOfmZ3yAazCgygKJoDI/5Rq4CK5MBaOc5LVdF8viC2WtoBdaPA==",
+      "license": "MIT"
+    },
+    "node_modules/@giphy/js-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-util/-/js-util-5.2.0.tgz",
+      "integrity": "sha512-Qt7pGh2cqiNmXLeWAgb459wK8+BuMLtIxTfg4ZksnPHPsLthiHT9hhzs2QhqUh7Pp/HOq+Cbv2etGDfnq+xiKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/js-types": "*",
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/@huggingface/jinja": {
@@ -4232,6 +4260,21 @@
       "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5180,6 +5223,18 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
+    "node_modules/unsplash-js": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/unsplash-js/-/unsplash-js-8.0.0.tgz",
+      "integrity": "sha512-WJQD4lIcwv66+hhSvcX4j1XsHl0jTEhEHXrChBJnMvMnmPV5nvLcX2hh50h7hMYlwGh5sRM/LUO++xUH0Y+s0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-fetch": "^0.17.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -5229,6 +5284,20 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {


### PR DESCRIPTION
## Summary
- Adds Unsplash and Giphy integration tabs to the editor media workflow.
- Updates editor shell, panels, and composition wiring to expose the new media sources in the UI.
- Extends stock media service contracts and implementation to support the new integration paths.
- Covers the new behavior with unit tests across composition, services, and editor panels.

## Testing
- Unit tests added and updated for composition, stock media service, editor shell, left tool panel, settings panels, and media integration settings.
- Not run (not requested).