### PR TITLE
Filter CI workflow runs by app and package file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,30 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'apps/**'
+      - 'packages/**'
+      - 'scripts/**'
+      - 'eslint.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'prettier.config.cjs'
+      - 'tsconfig.json'
+      - '!**/*.md'
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'apps/**'
+      - 'packages/**'
+      - 'scripts/**'
+      - 'eslint.config.js'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'prettier.config.cjs'
+      - 'tsconfig.json'
+      - '!**/*.md'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Restricts CI triggers to relevant repository changes under `apps/`, `packages/`, and shared config files.
- Excludes markdown-only edits from automatically starting CI on push and pull request events.
- Keeps manual `workflow_dispatch` runs available.

## Testing
- Not run (not requested)