### PR TITLE
Add presenter view mode to the editor

### DIFF
--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -9,6 +9,9 @@ const EditorShell = lazy(() =>
 const PublicDeckViewer = lazy(() =>
   import('./ui/share/PublicDeckViewer').then((module) => ({ default: module.PublicDeckViewer })),
 );
+const PresenterView = lazy(() =>
+  import('./ui/presenter/PresenterView').then((module) => ({ default: module.PresenterView })),
+);
 const WebMcpShowcasePage = lazy(() =>
   import('./ui/webmcp/WebMcpShowcasePage').then((module) => ({
     default: module.WebMcpShowcasePage,
@@ -21,6 +24,15 @@ function normalizeRoutePath(pathname: string) {
 
 export function App() {
   const pathname = normalizeRoutePath(window.location.pathname);
+  const presenterSessionId = getPresenterSessionId();
+  if (presenterSessionId) {
+    return (
+      <Suspense fallback={null}>
+        <PresenterView sessionId={presenterSessionId} />
+      </Suspense>
+    );
+  }
+
   const shareRoute = getShareRoute(window.location.pathname);
   if (shareRoute) {
     const services = createAppServices();
@@ -45,6 +57,12 @@ export function App() {
   }
 
   return <EditorApp />;
+}
+
+function getPresenterSessionId() {
+  const url = new URL(window.location.href);
+  if (url.searchParams.get('presenter') !== '1') return undefined;
+  return url.searchParams.get('presenterSession') ?? undefined;
 }
 
 function getShareRoute(pathname: string) {

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -6522,6 +6522,318 @@ button {
   display: none;
 }
 
+.workspace-column-cursor-hidden,
+.workspace-column-cursor-hidden * {
+  cursor: none !important;
+}
+
+.keyboard-shortcuts-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(5, 13, 16, 0.78);
+  backdrop-filter: blur(8px);
+}
+
+.keyboard-shortcuts-dialog {
+  position: relative;
+  width: min(980px, calc(100vw - 48px));
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  display: grid;
+  gap: 22px;
+  padding: 28px 34px 34px;
+  border: 1px solid var(--ew-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(55, 253, 118, 0.05), transparent 38%),
+    var(--ew-black);
+  color: var(--ew-text);
+  box-shadow:
+    0 28px 80px rgba(0, 0, 0, 0.56),
+    0 0 24px rgba(55, 253, 118, 0.1);
+}
+
+.keyboard-shortcuts-popover {
+  position: fixed;
+  top: 70px;
+  right: 18px;
+  z-index: 120;
+  width: min(360px, calc(100vw - 36px));
+  max-height: min(640px, calc(100vh - 92px));
+  overflow: auto;
+  display: grid;
+  gap: 14px;
+  padding: 14px 0 16px;
+  border: 1px solid var(--ew-border);
+  border-radius: 8px;
+  background: var(--ew-black);
+  color: var(--ew-text);
+  box-shadow:
+    0 22px 64px rgba(0, 0, 0, 0.54),
+    0 0 18px rgba(55, 253, 118, 0.1);
+}
+
+.keyboard-shortcuts-close {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+}
+
+.keyboard-shortcuts-popover .keyboard-shortcuts-close {
+  top: 10px;
+  right: 10px;
+  left: auto;
+}
+
+.keyboard-shortcuts-dialog h2,
+.keyboard-shortcuts-popover h2 {
+  margin: 0;
+  font-family: var(--ls-font-display);
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 30px;
+  text-align: center;
+}
+
+.keyboard-shortcuts-popover h2 {
+  padding: 0 44px 0 16px;
+  font-size: 14px;
+  line-height: 24px;
+  text-align: left;
+}
+
+.keyboard-shortcuts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 54px;
+  row-gap: 22px;
+}
+
+.keyboard-shortcuts-popover .keyboard-shortcuts-grid {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+}
+
+.keyboard-shortcuts-group {
+  min-width: 0;
+}
+
+.keyboard-shortcuts-popover .keyboard-shortcuts-group {
+  padding: 12px 14px 0;
+  border-top: 1px solid var(--ew-border);
+}
+
+.keyboard-shortcuts-popover .keyboard-shortcuts-group:first-child {
+  border-top: 0;
+}
+
+.keyboard-shortcuts-group h3 {
+  margin: 0 0 12px;
+  color: var(--ew-green-fixed);
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 20px;
+}
+
+.keyboard-shortcuts-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.keyboard-shortcuts-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  border: 0;
+  border-radius: 6px;
+  padding: 2px 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.keyboard-shortcuts-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.keyboard-shortcuts-row:focus-visible {
+  outline: 2px solid var(--ew-green-fixed);
+  outline-offset: 2px;
+}
+
+.keyboard-shortcuts-popover .keyboard-shortcuts-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 32px;
+}
+
+.keyboard-shortcuts-popover .keyboard-shortcuts-keys {
+  order: 2;
+  justify-content: flex-end;
+}
+
+.keyboard-shortcuts-popover .keyboard-shortcuts-label {
+  order: 1;
+  font-size: 13px;
+}
+
+.keyboard-shortcuts-keys {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.keyboard-shortcuts-label {
+  margin: 0;
+  color: var(--ew-text);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 19px;
+}
+
+.keyboard-shortcuts-row kbd {
+  min-width: 24px;
+  min-height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 7px;
+  border: 1px solid rgba(193, 201, 189, 0.22);
+  border-radius: 4px;
+  background: var(--ew-raised);
+  color: var(--ew-text);
+  font-family: var(--ls-font-body);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.32);
+}
+
+.presentation-slide-navigator {
+  position: absolute;
+  top: 72px;
+  right: 24px;
+  z-index: 115;
+  width: min(340px, calc(100vw - 48px));
+  max-height: min(560px, calc(100vh - 120px));
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  border: 1px solid var(--ew-border);
+  border-radius: 8px;
+  background: var(--ew-black);
+  color: var(--ew-text);
+  box-shadow:
+    0 22px 64px rgba(0, 0, 0, 0.52),
+    0 0 18px rgba(55, 253, 118, 0.1);
+}
+
+.presentation-slide-navigator-header {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 12px 0 16px;
+  border-bottom: 1px solid var(--ew-border);
+}
+
+.presentation-slide-navigator-header h2 {
+  margin: 0;
+  font-family: var(--ls-font-display);
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 20px;
+}
+
+.presentation-slide-navigator-list {
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+}
+
+.presentation-slide-navigator-item {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--ew-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.presentation-slide-navigator-item span {
+  color: var(--ew-muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.presentation-slide-navigator-item strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.presentation-slide-navigator-item-active {
+  border-color: rgba(55, 253, 118, 0.38);
+  background: rgba(55, 253, 118, 0.12);
+}
+
+.presentation-blank-screen {
+  position: absolute;
+  inset: 0;
+  z-index: 112;
+}
+
+.presentation-blank-screen-black {
+  background: #000000;
+}
+
+.presentation-blank-screen-white {
+  background: #ffffff;
+}
+
+.presentation-slide-number {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  z-index: 113;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 14px;
+  border: 1px solid var(--ew-border);
+  border-radius: 6px;
+  background: var(--ew-black);
+  color: var(--ew-green-fixed);
+  font-size: 14px;
+  font-weight: 800;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.42);
+}
+
 .presenter-view {
   min-height: 100vh;
   display: grid;

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -1467,6 +1467,7 @@ button {
 }
 
 .left-tool-panel {
+  position: relative;
   min-height: 0;
   display: grid;
   grid-template-columns: 78px 0;
@@ -1480,8 +1481,12 @@ button {
 }
 
 .left-tool-panel-open {
-  grid-template-columns: 78px 266px;
-  width: 344px;
+  grid-template-columns: 78px var(--left-tool-content-width, 266px);
+  width: calc(78px + var(--left-tool-content-width, 266px));
+}
+
+.left-tool-panel-resizing {
+  user-select: none;
 }
 
 .left-tool-rail {
@@ -1532,6 +1537,38 @@ button {
   overflow-x: hidden;
   overflow-y: auto;
   padding: 18px;
+}
+
+.left-tool-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  bottom: 0;
+  z-index: 20;
+  width: 8px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  cursor: ew-resize;
+  padding: 0;
+}
+
+.left-tool-resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: rgba(55, 253, 118, 0.34);
+}
+
+.left-tool-resize-handle:hover::before,
+.left-tool-panel-resizing .left-tool-resize-handle::before {
+  left: 2px;
+  width: 3px;
+  background: var(--ew-green);
+  box-shadow: 0 0 18px rgba(55, 253, 118, 0.34);
 }
 
 .left-tool-panel:not(.left-tool-panel-open) .left-tool-content {
@@ -3817,6 +3854,10 @@ button {
     width: min(348px, calc(100vw - 24px));
   }
 
+  .left-tool-resize-handle {
+    display: none;
+  }
+
   .left-tool-rail {
     padding: 10px 7px;
   }
@@ -4207,6 +4248,10 @@ button {
   .left-tool-panel-open {
     height: min(58dvh, 460px);
     grid-template-rows: minmax(0, 1fr) 64px;
+  }
+
+  .left-tool-resize-handle {
+    display: none;
   }
 
   .left-tool-rail {

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -5840,6 +5840,288 @@ button {
   cursor: default;
 }
 
+.movie-inspector-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  min-height: 42px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.movie-inspector-tab {
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ew-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.movie-inspector-tab-active {
+  background: var(--ew-green);
+  color: #050d10;
+}
+
+.movie-panel-section {
+  display: grid;
+  gap: 10px;
+  padding: 14px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.movie-panel-section h3 {
+  margin: 0;
+  color: var(--ew-text);
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 20px;
+}
+
+.movie-file-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  color: var(--ew-text);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.movie-file-row span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.movie-controls-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+}
+
+.movie-controls-row button {
+  width: 42px;
+  height: 42px;
+  display: inline-grid;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--ew-text);
+  cursor: pointer;
+}
+
+.movie-controls-row .movie-play-button {
+  width: 54px;
+  height: 54px;
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.movie-controls-row button:hover {
+  background: rgba(55, 253, 118, 0.18);
+}
+
+.movie-volume-row,
+.movie-trim-control,
+.movie-poster-control,
+.movie-select-control {
+  display: grid;
+  gap: 8px;
+  color: var(--ew-text);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.movie-volume-row {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.movie-volume-row input,
+.movie-poster-control input,
+.movie-trim-track input {
+  width: 100%;
+  min-width: 0;
+  accent-color: var(--ew-green);
+}
+
+.movie-trim-track {
+  position: relative;
+  min-height: 28px;
+}
+
+.movie-trim-track input {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.movie-trim-track input::-webkit-slider-thumb {
+  pointer-events: auto;
+}
+
+.movie-trim-track input::-moz-range-thumb {
+  pointer-events: auto;
+}
+
+.movie-time-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--ew-text);
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.movie-poster-control strong {
+  color: var(--ew-text);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.movie-select-control select {
+  width: 100%;
+  min-height: 40px;
+  border: 0;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--ew-text);
+  font: inherit;
+  font-weight: 800;
+  padding: 0 12px;
+}
+
+.movie-checkbox-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  min-height: 34px;
+  color: var(--ew-text);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.movie-checkbox-row input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--ew-green);
+}
+
+.movie-checkbox-row-disabled {
+  color: var(--ew-muted);
+  opacity: 0.58;
+}
+
+.movie-arrange-grid,
+.movie-lock-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.movie-arrange-grid button,
+.movie-lock-grid button,
+.movie-full-button,
+.movie-arrange-select-row button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--ew-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 850;
+}
+
+.movie-arrange-grid button {
+  display: grid;
+  grid-template-rows: auto auto;
+  place-items: center;
+  min-height: 56px;
+  gap: 2px;
+}
+
+.movie-arrange-grid button:hover,
+.movie-lock-grid button:hover,
+.movie-full-button:hover,
+.movie-arrange-select-row button:hover {
+  background: rgba(55, 253, 118, 0.18);
+}
+
+.movie-arrange-grid button:disabled,
+.movie-lock-grid button:disabled,
+.movie-full-button:disabled,
+.movie-arrange-select-row button:disabled {
+  color: var(--ew-muted);
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.movie-arrange-select-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.movie-arrange-select-row select {
+  width: 100%;
+  min-height: 40px;
+  border: 0;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--ew-text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 850;
+  padding: 0 12px;
+}
+
+.movie-number-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.movie-number-grid label {
+  display: grid;
+  gap: 5px;
+  color: var(--ew-text);
+  font-size: 12px;
+  font-weight: 850;
+  text-align: center;
+}
+
+.movie-number-grid input {
+  width: 100%;
+  min-width: 0;
+  min-height: 40px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--ew-text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 850;
+  padding: 0 10px;
+  text-align: center;
+}
+
+.movie-number-grid input:focus,
+.movie-arrange-select-row select:focus {
+  border-color: var(--ew-green);
+  box-shadow: 0 0 0 2px rgba(55, 253, 118, 0.14);
+  outline: none;
+}
+
 .palette-row {
   display: grid;
   grid-template-columns: repeat(5, 1fr);

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -693,12 +693,15 @@ button {
 .project-group {
   gap: 8px;
   min-width: 0;
+  flex: 0 0 auto;
 }
 
 .project-play-shell {
   position: relative;
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
+  z-index: 1;
 }
 
 .project-title {
@@ -2913,6 +2916,7 @@ button {
 
 .editor-footer-left {
   min-width: 32px;
+  gap: 8px;
 }
 
 .footer-settings-button {
@@ -6019,7 +6023,10 @@ button {
 .download-models-button:focus-visible,
 .icon-button:focus-visible,
 .compact-action:focus-visible,
-.color-swatch:focus-visible {
+.color-swatch:focus-visible,
+.speaker-notes-actions button:focus-visible,
+.audience-fullscreen-close:focus-visible,
+.audience-fullscreen-primary:focus-visible {
   outline: 2px solid rgba(55, 253, 118, 0.8);
   outline-offset: 2px;
 }
@@ -6301,4 +6308,495 @@ button {
 .share-action-button-accent .share-action-icon {
   color: #fff;
   background: #ff5f0a;
+}
+
+.speaker-notes-editor {
+  position: absolute;
+  left: 20px;
+  bottom: 10px;
+  z-index: 55;
+  width: min(360px, calc(100% - 40px));
+  height: calc(100% - 28px);
+  max-height: 760px;
+  pointer-events: none;
+}
+
+.speaker-notes-card {
+  height: 100%;
+  min-height: 360px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  color: var(--ew-text);
+  background: linear-gradient(180deg, rgba(55, 253, 118, 0.04), transparent 42%), var(--ew-panel);
+  border: 1px solid var(--ew-border);
+  border-radius: 6px;
+  box-shadow:
+    0 20px 52px rgba(0, 0, 0, 0.42),
+    0 0 18px rgba(55, 253, 118, 0.08);
+  pointer-events: auto;
+}
+
+.speaker-notes-header {
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 16px;
+}
+
+.speaker-notes-header h2 {
+  margin: 0;
+  min-width: 0;
+  color: var(--ew-text);
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.speaker-notes-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.speaker-notes-actions button {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ew-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.speaker-notes-actions button:hover {
+  color: var(--ew-green-fixed);
+  background: var(--ew-raised);
+}
+
+.speaker-notes-actions .material-symbols-outlined {
+  font-size: 20px;
+}
+
+.speaker-notes-card textarea {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  color: var(--ew-text);
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: 21px;
+  line-height: 1.4;
+  resize: none;
+  padding: 0 18px 16px;
+}
+
+.speaker-notes-card textarea::placeholder {
+  color: var(--ew-dim);
+}
+
+.speaker-notes-card textarea:focus {
+  outline: 0;
+}
+
+.speaker-notes-count {
+  justify-self: end;
+  color: var(--ew-muted);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 18px 14px;
+}
+
+.presenter-view-error {
+  margin: -8px 24px 18px;
+  color: #8f1f1f;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.audience-fullscreen-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 90;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(5, 13, 16, 0.68);
+  backdrop-filter: blur(7px);
+  pointer-events: auto;
+}
+
+.audience-fullscreen-dialog {
+  position: relative;
+  width: min(544px, calc(100vw - 48px));
+  display: grid;
+  gap: 16px;
+  padding: 30px 32px 32px;
+  border: 1px solid var(--ew-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(55, 253, 118, 0.05), transparent 42%),
+    var(--ew-black);
+  color: var(--ew-text);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.48),
+    0 0 24px rgba(55, 253, 118, 0.08);
+}
+
+.audience-fullscreen-dialog h2 {
+  margin: 0;
+  font-family: var(--ls-font-display);
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 30px;
+}
+
+.audience-fullscreen-dialog p {
+  max-width: 410px;
+  margin: 0;
+  color: var(--ew-muted);
+  font-size: 14px;
+  line-height: 22px;
+}
+
+.audience-fullscreen-close {
+  position: absolute;
+  top: 0;
+  right: -50px;
+  width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--ew-border);
+  border-radius: 4px;
+  background: var(--ew-panel);
+  color: var(--ew-text);
+  cursor: pointer;
+}
+
+.audience-fullscreen-close:hover {
+  color: var(--ew-green-fixed);
+  background: var(--ew-raised);
+}
+
+.audience-fullscreen-primary {
+  justify-self: end;
+  min-height: 40px;
+  padding: 0 18px;
+  border: 1px solid rgba(55, 253, 118, 0.6);
+  border-radius: 6px;
+  background: var(--ew-green);
+  color: var(--ew-on-primary);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 800;
+  transition:
+    background-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+}
+
+.audience-fullscreen-primary:hover {
+  background: var(--ew-green-hover);
+  box-shadow: 0 0 18px rgba(55, 253, 118, 0.24);
+}
+
+.workspace-column:fullscreen .speaker-notes-editor,
+.workspace-column:fullscreen .presenter-view-error,
+.workspace-column:fullscreen .audience-fullscreen-backdrop {
+  display: none;
+}
+
+.presenter-view {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 364px;
+  color: var(--ew-text);
+  background: var(--ew-bg);
+  overflow: hidden;
+}
+
+.presenter-view-disconnected {
+  display: grid;
+  place-items: center;
+  color: var(--ew-muted);
+  font-size: 18px;
+}
+
+.presenter-main {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: 82px 58px minmax(0, 1fr) 164px;
+  border-right: 1px solid var(--ew-border);
+}
+
+.presenter-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 20px;
+}
+
+.presenter-clock-group {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+  font-family: var(--ls-font-display);
+  font-size: 34px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.presenter-clock {
+  color: var(--ls-cyan);
+}
+
+.presenter-timer {
+  color: var(--ew-text);
+}
+
+.presenter-divider {
+  width: 1px;
+  height: 40px;
+  background: var(--ew-border);
+}
+
+.presenter-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.presenter-control-button,
+.presenter-notes-zoom-button {
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--ew-border);
+  background: var(--ew-panel);
+}
+
+.presenter-status-row {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 44px 12px;
+  color: var(--ew-text);
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 26px;
+}
+
+.presenter-status-item {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.presenter-stage {
+  min-height: 0;
+  padding: 0 44px;
+}
+
+.presenter-stage .canvas-workspace {
+  height: 100%;
+}
+
+.presenter-stage .canvas-frame {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.presenter-slide-strip {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 260px;
+  gap: 18px;
+  overflow-x: auto;
+  padding: 18px 20px;
+}
+
+.presenter-thumb {
+  min-width: 0;
+  padding: 0;
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.presenter-thumb-active {
+  border-color: var(--ew-green);
+  box-shadow: 0 0 16px rgba(55, 253, 118, 0.18);
+}
+
+.presenter-thumb-canvas {
+  container-type: inline-size;
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: 6px;
+}
+
+.presenter-thumb-bg,
+.presenter-thumb-element {
+  position: absolute;
+  object-fit: cover;
+}
+
+.presenter-thumb-bg {
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.presenter-thumb-text {
+  overflow: hidden;
+  line-height: 0.95;
+  white-space: pre-wrap;
+}
+
+.presenter-notes-panel {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: 86px minmax(0, 1fr) 72px;
+  background: var(--ew-panel);
+}
+
+.presenter-notes-tabs {
+  display: flex;
+  justify-content: center;
+  align-items: end;
+  padding: 0 18px;
+  color: var(--ew-muted);
+}
+
+.presenter-notes-tab-active {
+  min-width: 156px;
+  padding: 0 0 12px;
+  color: var(--ew-text);
+  font-size: 13px;
+  font-weight: 800;
+  text-align: center;
+  border-bottom: 3px solid var(--ew-green);
+}
+
+.presenter-notes-textarea {
+  min-width: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  color: var(--ew-text);
+  background: transparent;
+  border: 0;
+  font-family: var(--ls-font-body);
+  line-height: 1.24;
+  resize: none;
+  padding: 22px 18px;
+}
+
+.presenter-notes-textarea::placeholder,
+.presenter-notes-empty {
+  color: var(--ew-dim);
+}
+
+.presenter-notes-textarea:focus {
+  outline: 2px solid var(--ew-green);
+  outline-offset: -2px;
+}
+
+.presenter-notes-zoom {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0;
+  padding: 14px;
+}
+
+.presenter-notes-zoom span {
+  height: 40px;
+  min-width: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ew-text);
+  border-top: 1px solid var(--ew-border);
+  border-bottom: 1px solid var(--ew-border);
+  font-weight: 800;
+}
+
+.presenter-intro-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  background: rgba(5, 13, 16, 0.72);
+  backdrop-filter: blur(8px);
+}
+
+.presenter-intro-dialog {
+  width: min(512px, calc(100vw - 40px));
+  display: grid;
+  gap: 18px;
+  color: var(--ew-text);
+  background: var(--ew-black);
+  border: 1px solid var(--ew-border);
+  border-radius: 8px;
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.42);
+  padding: 34px 30px;
+}
+
+.presenter-intro-dialog h1 {
+  margin: 0;
+  font-family: var(--ls-font-display);
+  font-size: 24px;
+  letter-spacing: 0;
+}
+
+.presenter-intro-dialog p {
+  margin: 0;
+  color: var(--ew-muted);
+  line-height: 1.45;
+}
+
+.presenter-intro-dialog label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ew-text);
+  font-size: 14px;
+}
+
+.presenter-intro-dialog button {
+  justify-self: end;
+  min-width: 82px;
+  min-height: 40px;
+  color: var(--ew-on-primary);
+  background: var(--ew-green);
+  border: 1px solid rgba(55, 253, 118, 0.6);
+  border-radius: 6px;
+  font-weight: 800;
+  padding: 0 18px;
+  cursor: pointer;
 }

--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -26,7 +26,21 @@ export type ElementFramePatch = Partial<
 export type ImageCropPatch = ElementFramePatch & { crop: NonNullable<ImageElement['crop']> };
 export type GifPlaybackPatch = Partial<Pick<GifElement, 'playing'>>;
 export type VideoPlaybackPatch = Partial<
-  Pick<VideoElement, 'autoplayInPreview' | 'controls' | 'loop' | 'muted' | 'trimStartSeconds'>
+  Pick<
+    VideoElement,
+    | 'autoplayInPreview'
+    | 'controls'
+    | 'loop'
+    | 'muted'
+    | 'playAcrossSlides'
+    | 'playbackPositionSeconds'
+    | 'playing'
+    | 'posterFrameSeconds'
+    | 'repeatMode'
+    | 'startOnClick'
+    | 'trimStartSeconds'
+    | 'volume'
+  >
 > & {
   trimEndSeconds?: number | undefined;
 };

--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -578,6 +578,49 @@ class ReplaceImageAssetCommand implements EditorCommand {
   }
 }
 
+class ReplaceVideoAssetCommand implements EditorCommand {
+  readonly description = 'Replace video asset';
+
+  constructor(
+    private readonly elementId: string,
+    private readonly asset: Asset,
+    private readonly metadata: { durationSeconds?: number } = {},
+  ) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    const element = project.elements[this.elementId];
+    if (!element || element.type !== 'video' || element.locked) return project;
+
+    const nextElement: VideoElement = {
+      ...element,
+      assetId: this.asset.id,
+      playbackPositionSeconds: 0,
+      playing: false,
+      trimStartSeconds: 0,
+    };
+    delete nextElement.durationSeconds;
+    delete nextElement.posterFrameSeconds;
+    delete nextElement.trimEndSeconds;
+    if (this.metadata.durationSeconds !== undefined) {
+      nextElement.durationSeconds = this.metadata.durationSeconds;
+      nextElement.trimEndSeconds = this.metadata.durationSeconds;
+    }
+
+    return {
+      ...project,
+      assets: {
+        ...project.assets,
+        [this.asset.id]: this.asset,
+      },
+      elements: {
+        ...project.elements,
+        [this.elementId]: nextElement,
+      },
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
 class AddElementsCommand implements EditorCommand {
   readonly description = 'Add elements';
 
@@ -1034,6 +1077,7 @@ export const basicCommands = {
   UpdateTextContentCommand,
   UpdateElementStyleCommand,
   ToggleImageFlipCommand,
+  ReplaceVideoAssetCommand,
   UpdateImageCropCommand,
   UpdatePageBackgroundCommand,
   SetPageTransitionCommand,

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -153,6 +153,8 @@ export interface GifElement extends BaseElement {
   playing: boolean;
 }
 
+export type VideoRepeatMode = 'loop' | 'loop-back-and-forth' | 'none';
+
 export interface VideoElement extends BaseElement {
   type: 'video';
   assetId: string;
@@ -160,8 +162,16 @@ export interface VideoElement extends BaseElement {
   controls: boolean;
   muted: boolean;
   autoplayInPreview: boolean;
+  playing?: boolean;
+  playbackPositionSeconds?: number;
   trimStartSeconds: number;
   trimEndSeconds?: number;
+  durationSeconds?: number;
+  playAcrossSlides?: boolean;
+  posterFrameSeconds?: number;
+  repeatMode?: VideoRepeatMode;
+  startOnClick?: boolean;
+  volume?: number;
 }
 
 export interface ShapeElement extends BaseElement {

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -42,6 +42,7 @@ export interface Page {
   elementIds: string[];
   transition?: SlideTransition;
   animationBuilds?: ElementAnimationBuild[];
+  speakerNotes?: string;
   visible?: boolean;
 }
 

--- a/apps/editor/src/services/automation/editorAutomationController.ts
+++ b/apps/editor/src/services/automation/editorAutomationController.ts
@@ -57,13 +57,20 @@ type SnapshotElement = Pick<
   assetId?: string;
   autoplayInPreview?: boolean;
   controls?: boolean;
+  durationSeconds?: number;
   fill?: string;
   loop?: boolean;
   muted?: boolean;
+  playAcrossSlides?: boolean;
+  playbackPositionSeconds?: number;
   playing?: boolean;
+  posterFrameSeconds?: number;
+  repeatMode?: string;
+  startOnClick?: boolean;
   text?: string;
   trimEndSeconds?: number | undefined;
   trimStartSeconds?: number;
+  volume?: number;
 };
 
 const VALID_TRANSLATION_SCOPES: TranslationScope[] = ['selection', 'slide', 'deck'];
@@ -119,8 +126,24 @@ function compactElement(element: DesignElement): SnapshotElement {
       controls: element.controls,
       loop: element.loop,
       muted: element.muted,
-      trimEndSeconds: element.trimEndSeconds,
       trimStartSeconds: element.trimStartSeconds,
+      ...(element.durationSeconds !== undefined
+        ? { durationSeconds: element.durationSeconds }
+        : {}),
+      ...(element.playbackPositionSeconds !== undefined
+        ? { playbackPositionSeconds: element.playbackPositionSeconds }
+        : {}),
+      ...(element.playAcrossSlides !== undefined
+        ? { playAcrossSlides: element.playAcrossSlides }
+        : {}),
+      ...(element.playing !== undefined ? { playing: element.playing } : {}),
+      ...(element.posterFrameSeconds !== undefined
+        ? { posterFrameSeconds: element.posterFrameSeconds }
+        : {}),
+      ...(element.repeatMode !== undefined ? { repeatMode: element.repeatMode } : {}),
+      ...(element.startOnClick !== undefined ? { startOnClick: element.startOnClick } : {}),
+      ...(element.trimEndSeconds !== undefined ? { trimEndSeconds: element.trimEndSeconds } : {}),
+      ...(element.volume !== undefined ? { volume: element.volume } : {}),
     };
   }
   return {

--- a/apps/editor/src/services/presenter/presenterSessionService.ts
+++ b/apps/editor/src/services/presenter/presenterSessionService.ts
@@ -1,0 +1,123 @@
+import type {
+  PresenterCommandMessage,
+  PresenterStateMessage,
+  PresenterStatePayload,
+  PresenterWindowCommand,
+} from './presenterSessionTypes';
+
+type OpenPresenterWindow = (url: string, target: string, features: string) => Window | null;
+
+interface BrowserPresenterSessionServiceOptions {
+  href?: string;
+  openWindow?: OpenPresenterWindow;
+  randomId?: () => string;
+  targetWindow?: Window;
+}
+
+type PresenterWindowOpenResult =
+  | { status: 'blocked'; sessionId: string }
+  | { status: 'opened'; sessionId: string };
+
+function createSessionId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  return `presenter-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isPresenterCommandMessage(value: unknown): value is PresenterCommandMessage {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record.source === 'localstudio-presenter-window' &&
+    record.type === 'command' &&
+    typeof record.sessionId === 'string' &&
+    typeof record.command === 'string'
+  );
+}
+
+export class BrowserPresenterSessionService {
+  private readonly href: string;
+  private readonly openWindow: OpenPresenterWindow;
+  private readonly origin: string;
+  private readonly randomId: () => string;
+  private readonly targetWindow: Window;
+  private popupWindow: Window | null = null;
+  private sessionId: string | undefined;
+
+  constructor(options: BrowserPresenterSessionServiceOptions = {}) {
+    const targetWindow = options.targetWindow ?? window;
+    this.targetWindow = targetWindow;
+    this.href = options.href ?? targetWindow.location.href;
+    this.origin = new URL(this.href).origin;
+    this.openWindow =
+      options.openWindow ??
+      ((url, target, features) => targetWindow.open(url, target, features));
+    this.randomId = options.randomId ?? createSessionId;
+  }
+
+  openPresenterWindow(): PresenterWindowOpenResult {
+    const sessionId = this.randomId();
+    const url = new URL(this.href);
+    url.searchParams.set('presenter', '1');
+    url.searchParams.set('presenterSession', sessionId);
+    const popupWindow = this.openWindow(
+      '',
+      `localstudio-presenter-${sessionId}`,
+      'popup,width=1280,height=760',
+    );
+    if (!popupWindow || popupWindow === this.targetWindow) {
+      this.sessionId = sessionId;
+      this.popupWindow = null;
+      return { status: 'blocked', sessionId };
+    }
+    popupWindow.location.href = url.toString();
+    this.sessionId = sessionId;
+    this.popupWindow = popupWindow;
+    return { status: 'opened', sessionId };
+  }
+
+  publishState(payload: PresenterStatePayload) {
+    if (!this.sessionId || !this.popupWindow || this.popupWindow.closed) return;
+    const message: PresenterStateMessage = {
+      payload,
+      sessionId: this.sessionId,
+      source: 'localstudio-presenter-main',
+      type: 'state',
+    };
+    this.popupWindow.postMessage(message, this.origin);
+  }
+
+  closePresenterWindow() {
+    if (this.popupWindow && !this.popupWindow.closed) this.popupWindow.close();
+    this.popupWindow = null;
+    this.sessionId = undefined;
+  }
+
+  subscribeToCommands(handler: (command: PresenterWindowCommand) => void) {
+    const listener = (event: MessageEvent) => {
+      if (event.origin !== this.origin) return;
+      if (!isPresenterCommandMessage(event.data)) return;
+      if (!this.sessionId || event.data.sessionId !== this.sessionId) return;
+      const { command } = event.data;
+      if (command === 'update-notes') {
+        if (typeof event.data.pageId !== 'string' || typeof event.data.notes !== 'string') return;
+        handler({ command, notes: event.data.notes, pageId: event.data.pageId });
+        return;
+      }
+      if (
+        command === 'close' ||
+        command === 'next' ||
+        command === 'pause-timer' ||
+        command === 'previous' ||
+        command === 'request-state' ||
+        command === 'reset-timer' ||
+        command === 'resume-timer'
+      ) {
+        handler({ command });
+      }
+    };
+    this.targetWindow.addEventListener('message', listener);
+    return () => {
+      this.targetWindow.removeEventListener('message', listener);
+    };
+  }
+}

--- a/apps/editor/src/services/presenter/presenterSessionTypes.ts
+++ b/apps/editor/src/services/presenter/presenterSessionTypes.ts
@@ -1,0 +1,31 @@
+import type { ProjectDocument } from '../../domain/documents/model';
+import type { AnimationPreviewState } from '../../ui/editor/animation/useAnimationPreviewController';
+
+export interface PresenterStatePayload {
+  activePageId: string;
+  animationPreview: AnimationPreviewState | undefined;
+  project: ProjectDocument;
+}
+
+export type PresenterWindowCommand =
+  | { command: 'close' }
+  | { command: 'next' }
+  | { command: 'pause-timer' }
+  | { command: 'previous' }
+  | { command: 'request-state' }
+  | { command: 'reset-timer' }
+  | { command: 'resume-timer' }
+  | { command: 'update-notes'; notes: string; pageId: string };
+
+export interface PresenterStateMessage {
+  payload: PresenterStatePayload;
+  sessionId: string;
+  source: 'localstudio-presenter-main';
+  type: 'state';
+}
+
+export type PresenterCommandMessage = PresenterWindowCommand & {
+  sessionId: string;
+  source: 'localstudio-presenter-window';
+  type: 'command';
+};

--- a/apps/editor/src/services/presenter/presenterSessionTypes.ts
+++ b/apps/editor/src/services/presenter/presenterSessionTypes.ts
@@ -9,6 +9,7 @@ export interface PresenterStatePayload {
 
 export type PresenterWindowCommand =
   | { command: 'close' }
+  | { command: 'go-to-page'; pageId: string }
   | { command: 'next' }
   | { command: 'pause-timer' }
   | { command: 'previous' }

--- a/apps/editor/src/ui/components/KeyboardShortcutsDialog.tsx
+++ b/apps/editor/src/ui/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,167 @@
+interface KeyboardShortcutsDialogProps {
+  onShortcutAction?: (action: KeyboardShortcutAction) => void;
+  onClose: () => void;
+  supportedActions?: readonly KeyboardShortcutAction[];
+  title?: string;
+  variant?: 'dialog' | 'popover';
+}
+
+export type KeyboardShortcutAction =
+  | 'black-screen'
+  | 'close-slide-navigator'
+  | 'cursor-toggle'
+  | 'decrease-notes'
+  | 'fast-forward-movie'
+  | 'first-slide'
+  | 'increase-notes'
+  | 'jump-movie-end'
+  | 'jump-movie-start'
+  | 'last-slide'
+  | 'next-build'
+  | 'next-navigator-slide'
+  | 'next-slide'
+  | 'open-slide-navigator'
+  | 'pause-presentation'
+  | 'play-pause-movie'
+  | 'previous-build'
+  | 'previous-navigator-slide'
+  | 'previous-slide'
+  | 'quit-presentation'
+  | 'reset-timer'
+  | 'rewind-movie'
+  | 'select-navigator-slide'
+  | 'shortcut-toggle'
+  | 'show-slide-number'
+  | 'white-screen'
+  | 'scroll-notes-up'
+  | 'scroll-notes-down';
+
+const shortcutGroups = [
+  {
+    title: 'Navigation',
+    items: [
+      { action: 'next-build', keys: ['→', '↓'], label: 'Advance to next build' },
+      { action: 'previous-build', keys: ['['], label: 'Go back to previous build' },
+      { action: 'next-build', keys: [']'], label: 'Advance and skip build' },
+      { action: 'next-slide', keys: ['Shift', '↓'], label: 'Advance to next slide' },
+      { action: 'previous-slide', keys: ['←', '↑'], label: 'Go back to previous slide' },
+      { action: 'first-slide', keys: ['Home'], label: 'Go to first slide' },
+      { action: 'last-slide', keys: ['End'], label: 'Go to last slide' },
+    ],
+  },
+  {
+    title: 'Other',
+    items: [
+      { action: 'quit-presentation', keys: ['Esc'], label: 'Quit presentation mode' },
+      { action: 'shortcut-toggle', keys: ['?'], label: 'Show or hide Keyboard Shortcuts window' },
+      { action: 'pause-presentation', keys: ['F'], label: 'Pause presentation; press any key to resume' },
+      { action: 'black-screen', keys: ['B'], label: 'Pause presentation and show black screen' },
+      { action: 'white-screen', keys: ['W'], label: 'Pause presentation and show white screen' },
+      { action: 'cursor-toggle', keys: ['C'], label: 'Show or hide the pointer cursor' },
+      { action: 'show-slide-number', keys: ['S'], label: 'Display the current slide number' },
+    ],
+  },
+  {
+    title: 'Slide Navigator',
+    items: [
+      { action: 'open-slide-navigator', keys: ['#'], label: 'Open the slide navigator' },
+      { action: 'next-navigator-slide', keys: ['+'], label: 'Go to the next slide in the slide navigator' },
+      { action: 'previous-navigator-slide', keys: ['-'], label: 'Go to the previous slide in the slide navigator' },
+      { action: 'select-navigator-slide', keys: ['Return'], label: 'Go to the current slide in the slide navigator' },
+      { action: 'close-slide-navigator', keys: ['Esc'], label: 'Close the slide navigator' },
+    ],
+  },
+  {
+    title: 'Presenter Display',
+    items: [
+      { action: 'reset-timer', keys: ['R'], label: 'Reset timer' },
+      { action: 'scroll-notes-up', keys: ['U'], label: 'Scroll notes up' },
+      { action: 'scroll-notes-down', keys: ['D'], label: 'Scroll notes down' },
+      { action: 'increase-notes', keys: ['⌘', '+'], label: 'Increase note font size' },
+      { action: 'decrease-notes', keys: ['⌘', '-'], label: 'Decrease note font size' },
+    ],
+  },
+  {
+    title: 'Movies',
+    items: [
+      { action: 'play-pause-movie', keys: ['K'], label: 'Pause/Play movie' },
+      { action: 'rewind-movie', keys: ['J'], label: 'Rewind movie (by frame, if paused)' },
+      { action: 'fast-forward-movie', keys: ['L'], label: 'Fast forward movie (by frame, if paused)' },
+      { action: 'jump-movie-start', keys: ['I'], label: 'Jump to beginning of movie' },
+      { action: 'jump-movie-end', keys: ['O'], label: 'Jump to end of movie' },
+    ],
+  },
+] satisfies {
+  title: string;
+  items: { action: KeyboardShortcutAction; keys: string[]; label: string }[];
+}[];
+
+export function KeyboardShortcutsDialog({
+  onShortcutAction,
+  onClose,
+  supportedActions,
+  title = 'Keyboard Shortcuts',
+  variant = 'dialog',
+}: KeyboardShortcutsDialogProps) {
+  const supportedActionSet = supportedActions ? new Set(supportedActions) : undefined;
+  const visibleGroups = shortcutGroups
+    .map((group) => ({
+      ...group,
+      items: supportedActionSet
+        ? group.items.filter((item) => supportedActionSet.has(item.action))
+        : group.items,
+    }))
+    .filter((group) => group.items.length > 0);
+  const content = (
+      <section
+        className={variant === 'popover' ? 'keyboard-shortcuts-popover' : 'keyboard-shortcuts-dialog'}
+        role="dialog"
+        aria-modal={variant === 'dialog'}
+        aria-labelledby="keyboard-shortcuts-title"
+      >
+        <button
+          className="stitch-icon-button keyboard-shortcuts-close"
+          type="button"
+          aria-label="Close keyboard shortcuts"
+          onClick={onClose}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
+        </button>
+        <h2 id="keyboard-shortcuts-title">{title}</h2>
+        <div className="keyboard-shortcuts-grid">
+          {visibleGroups.map((group) => (
+            <section className="keyboard-shortcuts-group" key={group.title}>
+              <h3>{group.title}</h3>
+              <div className="keyboard-shortcuts-list">
+                {group.items.map((item) => (
+                  <button
+                    className="keyboard-shortcuts-row"
+                    key={`${group.title}-${item.label}`}
+                    type="button"
+                    onClick={() => onShortcutAction?.(item.action)}
+                  >
+                    <span className="keyboard-shortcuts-keys">
+                        {item.keys.map((key) => (
+                          <kbd key={key}>{key}</kbd>
+                        ))}
+                    </span>
+                    <span className="keyboard-shortcuts-label">{item.label}</span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </section>
+  );
+
+  if (variant === 'popover') return content;
+
+  return (
+    <div className="keyboard-shortcuts-backdrop" role="presentation">
+      {content}
+    </div>
+  );
+}

--- a/apps/editor/src/ui/components/KeyboardShortcutsDialog.tsx
+++ b/apps/editor/src/ui/components/KeyboardShortcutsDialog.tsx
@@ -85,8 +85,8 @@ const shortcutGroups = [
     title: 'Movies',
     items: [
       { action: 'play-pause-movie', keys: ['K'], label: 'Pause/Play movie' },
-      { action: 'rewind-movie', keys: ['J'], label: 'Rewind movie (by frame, if paused)' },
-      { action: 'fast-forward-movie', keys: ['L'], label: 'Fast forward movie (by frame, if paused)' },
+      { action: 'rewind-movie', keys: ['J'], label: 'Hold to rewind movie' },
+      { action: 'fast-forward-movie', keys: ['L'], label: 'Hold to fast forward movie' },
       { action: 'jump-movie-start', keys: ['I'], label: 'Jump to beginning of movie' },
       { action: 'jump-movie-end', keys: ['O'], label: 'Jump to end of movie' },
     ],

--- a/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
+++ b/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
@@ -245,7 +245,55 @@ export function useAnimationPreviewController({
     return goToPresentationPage(1);
   }
 
+  function getPreviewBuilds(pageId: string) {
+    const page = projectRef.current.pages.find((item) => item.id === pageId);
+    if (!page) return [];
+    return (page.animationBuilds ?? []).filter((build) => page.elementIds.includes(build.elementId));
+  }
+
+  function getCurrentBuildIndex(builds: ElementAnimationBuild[]) {
+    if (!animationPreview) return -1;
+    if (animationPreview.phase === 'complete') return builds.length;
+    if (animationPreview.activeBuild) {
+      const activeBuildIndex = builds.findIndex((build) => build.id === animationPreview.activeBuild?.id);
+      if (activeBuildIndex >= 0) return activeBuildIndex;
+    }
+    const nextBuild = animationPreviewQueueRef.current[0];
+    if (!nextBuild) return builds.length;
+    return builds.findIndex((build) => build.id === nextBuild.id);
+  }
+
+  function rewindAnimationPreviewBuild() {
+    if (!animationPreview) return false;
+    const builds = getPreviewBuilds(animationPreview.pageId);
+    if (builds.length === 0) return false;
+    const currentBuildIndex = getCurrentBuildIndex(builds);
+    const targetBuildIndex = currentBuildIndex - 1;
+    if (targetBuildIndex < 0) return false;
+    const targetBuild = builds[targetBuildIndex];
+    if (!targetBuild) return false;
+    clearAnimationPreviewTimers();
+    animationPreviewQueueRef.current = builds.slice(targetBuildIndex);
+    setAnimationPreview((current) =>
+      current
+        ? {
+            ...current,
+            activeBuild: undefined,
+            activeBuildElementId: targetBuild.elementId,
+            animationProgress: 0,
+            hiddenElementIds: builds
+              .slice(targetBuildIndex)
+              .map((build) => build.elementId),
+            phase: 'waiting',
+            waitingForClick: true,
+          }
+        : current,
+    );
+    return true;
+  }
+
   function rewindPresentationPreview() {
+    if (rewindAnimationPreviewBuild()) return true;
     return goToPresentationPage(-1);
   }
 

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -1667,7 +1667,13 @@ function CanvasVideoElement({
   const videoRef = useRef<HTMLVideoElement>(null);
   const reverseIntervalRef = useRef<number | undefined>(undefined);
   const previousTrimRef = useRef<
-    { assetUrl: string | undefined; end: number | undefined; start: number } | undefined
+    | {
+        assetUrl: string | undefined;
+        end: number | undefined;
+        poster: number | undefined;
+        start: number;
+      }
+    | undefined
   >(undefined);
   const repeatMode = element.repeatMode ?? (element.loop ? 'loop' : 'none');
   const autoplay = previewMode && element.autoplayInPreview && !element.startOnClick;
@@ -1701,15 +1707,20 @@ function CanvasVideoElement({
           : undefined;
     const previousTrim = previousTrimRef.current;
     const assetChanged = previousTrim?.assetUrl !== assetUrl;
+    const poster =
+      element.posterFrameSeconds !== undefined
+        ? Math.max(0, element.posterFrameSeconds)
+        : undefined;
+    const posterChanged = previousTrim?.poster !== poster;
     video.volume = Math.min(1, Math.max(0, element.volume ?? 1));
-    if (assetChanged && element.posterFrameSeconds !== undefined) {
-      video.currentTime = Math.max(0, element.posterFrameSeconds);
+    if (posterChanged && poster !== undefined) {
+      video.currentTime = poster;
     } else if (assetChanged || previousTrim?.start !== start) {
       video.currentTime = start;
     } else if (previousTrim?.end !== end && end !== undefined) {
       video.currentTime = end;
     }
-    previousTrimRef.current = { assetUrl, end, start };
+    previousTrimRef.current = { assetUrl, end, poster, start };
   }, [
     assetUrl,
     element.posterFrameSeconds,

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -1665,10 +1665,29 @@ function CanvasVideoElement({
   scale,
 }: CanvasVideoElementProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const reverseIntervalRef = useRef<number | undefined>(undefined);
   const previousTrimRef = useRef<
     { assetUrl: string | undefined; end: number | undefined; start: number } | undefined
   >(undefined);
-  const autoplay = previewMode && element.autoplayInPreview;
+  const repeatMode = element.repeatMode ?? (element.loop ? 'loop' : 'none');
+  const autoplay = previewMode && element.autoplayInPreview && !element.startOnClick;
+
+  function stopReversePlayback() {
+    if (reverseIntervalRef.current === undefined) return;
+    window.clearInterval(reverseIntervalRef.current);
+    reverseIntervalRef.current = undefined;
+  }
+
+  function getTrimStart() {
+    return Math.max(0, element.trimStartSeconds);
+  }
+
+  function getTrimEnd(video: HTMLVideoElement) {
+    if (element.trimEndSeconds !== undefined && element.trimEndSeconds > 0) {
+      return Math.max(0, element.trimEndSeconds);
+    }
+    return Number.isFinite(video.duration) ? video.duration : undefined;
+  }
 
   useEffect(() => {
     const video = videoRef.current;
@@ -1677,23 +1696,80 @@ function CanvasVideoElement({
     const end =
       element.trimEndSeconds !== undefined && element.trimEndSeconds > 0
         ? Math.max(0, element.trimEndSeconds)
-        : undefined;
+        : Number.isFinite(video.duration)
+          ? video.duration
+          : undefined;
     const previousTrim = previousTrimRef.current;
     const assetChanged = previousTrim?.assetUrl !== assetUrl;
-    if (assetChanged || previousTrim?.start !== start) {
+    video.volume = Math.min(1, Math.max(0, element.volume ?? 1));
+    if (assetChanged && element.posterFrameSeconds !== undefined) {
+      video.currentTime = Math.max(0, element.posterFrameSeconds);
+    } else if (assetChanged || previousTrim?.start !== start) {
       video.currentTime = start;
     } else if (previousTrim?.end !== end && end !== undefined) {
       video.currentTime = end;
     }
     previousTrimRef.current = { assetUrl, end, start };
-  }, [assetUrl, element.trimEndSeconds, element.trimStartSeconds]);
+  }, [
+    assetUrl,
+    element.posterFrameSeconds,
+    element.trimEndSeconds,
+    element.trimStartSeconds,
+    element.volume,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (reverseIntervalRef.current === undefined) return;
+      window.clearInterval(reverseIntervalRef.current);
+      reverseIntervalRef.current = undefined;
+    };
+  }, []);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || element.playbackPositionSeconds === undefined) return;
+    stopReversePlayback();
+    video.currentTime = Math.max(0, element.playbackPositionSeconds);
+  }, [element.playbackPositionSeconds]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || element.playing === undefined) return;
+    stopReversePlayback();
+    if (!element.playing) {
+      video.pause();
+      return;
+    }
+    void video.play().catch(() => {
+      video.pause();
+    });
+  }, [element.playing]);
+
+  function playReverse(video: HTMLVideoElement) {
+    stopReversePlayback();
+    video.pause();
+    reverseIntervalRef.current = window.setInterval(() => {
+      const trimStart = getTrimStart();
+      const nextTime = Math.max(trimStart, video.currentTime - 1 / 30);
+      video.currentTime = nextTime;
+      if (nextTime > trimStart) return;
+      stopReversePlayback();
+      void video.play();
+    }, 1000 / 30);
+  }
 
   function enforceTrimWindow(video: HTMLVideoElement) {
-    const trimEnd = element.trimEndSeconds;
+    const trimEnd = getTrimEnd(video);
     if (trimEnd === undefined || trimEnd <= 0) return;
     if (video.currentTime < trimEnd) return;
-    if (element.loop) {
-      video.currentTime = Math.max(0, element.trimStartSeconds);
+    if (repeatMode === 'loop') {
+      video.currentTime = getTrimStart();
+      void video.play();
+      return;
+    }
+    if (repeatMode === 'loop-back-and-forth') {
+      playReverse(video);
       return;
     }
     video.pause();
@@ -1707,7 +1783,7 @@ function CanvasVideoElement({
       controls={interactive && element.controls}
       data-trim-end={element.trimEndSeconds ?? ''}
       data-trim-start={element.trimStartSeconds}
-      loop={element.loop}
+      loop={repeatMode === 'loop' && element.trimEndSeconds === undefined}
       muted={element.muted}
       playsInline
       preload="auto"
@@ -1715,7 +1791,8 @@ function CanvasVideoElement({
       src={assetUrl}
       style={getMediaStyle(element, scale, interactive, opacity)}
       onLoadedMetadata={(event) => {
-        event.currentTarget.currentTime = Math.max(0, element.trimStartSeconds);
+        event.currentTarget.volume = Math.min(1, Math.max(0, element.volume ?? 1));
+        event.currentTarget.currentTime = element.posterFrameSeconds ?? getTrimStart();
       }}
       onTimeUpdate={(event) => {
         enforceTrimWindow(event.currentTarget);

--- a/apps/editor/src/ui/editor/media/presentationMovieControls.ts
+++ b/apps/editor/src/ui/editor/media/presentationMovieControls.ts
@@ -1,0 +1,129 @@
+type MovieHoldAction = 'fast-forward' | 'rewind';
+
+interface MovieHoldVideoState {
+  playbackRate: number;
+  video: HTMLVideoElement;
+  wasPaused: boolean;
+}
+
+interface MovieHoldState {
+  action: MovieHoldAction;
+  accelerationTimeoutId: number;
+  intervalId?: number;
+  videos: MovieHoldVideoState[];
+}
+
+const movieHoldInitialRate = 2;
+const movieHoldAcceleratedRate = 4;
+const movieHoldAccelerationDelayMs = 4000;
+const movieRewindIntervalMs = 100;
+const movieClickPulseMs = 800;
+
+function getVideoTrimStart(video: HTMLVideoElement) {
+  const trimStart = Number(video.dataset.trimStart);
+  return Number.isFinite(trimStart) ? Math.max(0, trimStart) : 0;
+}
+
+function getVideoTrimEnd(video: HTMLVideoElement) {
+  const trimEnd = Number(video.dataset.trimEnd);
+  if (Number.isFinite(trimEnd) && trimEnd > 0) return trimEnd;
+  return Number.isFinite(video.duration) ? video.duration : video.currentTime;
+}
+
+function collectVideoState(videos: HTMLVideoElement[]) {
+  return videos.map((video) => ({
+    playbackRate: video.playbackRate,
+    video,
+    wasPaused: video.paused,
+  }));
+}
+
+function restoreVideoState(state: MovieHoldState) {
+  for (const item of state.videos) {
+    item.video.playbackRate = item.playbackRate;
+    if (item.wasPaused) item.video.pause();
+    else void item.video.play();
+  }
+}
+
+function startFastForward(videos: HTMLVideoElement[]) {
+  const videoStates = collectVideoState(videos);
+  for (const { video } of videoStates) {
+    video.playbackRate = movieHoldInitialRate;
+    void video.play();
+  }
+  const accelerationTimeoutId = window.setTimeout(() => {
+    for (const { video } of videoStates) {
+      video.playbackRate = movieHoldAcceleratedRate;
+    }
+  }, movieHoldAccelerationDelayMs);
+  return { action: 'fast-forward', accelerationTimeoutId, videos: videoStates } satisfies MovieHoldState;
+}
+
+function startRewind(videos: HTMLVideoElement[]) {
+  let rewindRate = movieHoldInitialRate;
+  const videoStates = collectVideoState(videos);
+  for (const { video } of videoStates) {
+    video.pause();
+  }
+  const intervalId = window.setInterval(() => {
+    const secondsPerTick = rewindRate * (movieRewindIntervalMs / 1000);
+    for (const { video } of videoStates) {
+      video.currentTime = Math.max(getVideoTrimStart(video), video.currentTime - secondsPerTick);
+    }
+  }, movieRewindIntervalMs);
+  const accelerationTimeoutId = window.setTimeout(() => {
+    rewindRate = movieHoldAcceleratedRate;
+  }, movieHoldAccelerationDelayMs);
+  return { action: 'rewind', accelerationTimeoutId, intervalId, videos: videoStates } satisfies MovieHoldState;
+}
+
+function stopHold(state: MovieHoldState | undefined) {
+  if (!state) return undefined;
+  window.clearTimeout(state.accelerationTimeoutId);
+  if (state.intervalId !== undefined) window.clearInterval(state.intervalId);
+  restoreVideoState(state);
+  return undefined;
+}
+
+function startHold(
+  videos: HTMLVideoElement[],
+  action: MovieHoldAction,
+  currentState: MovieHoldState | undefined,
+) {
+  const previousState = stopHold(currentState);
+  if (videos.length === 0) return previousState;
+  return action === 'fast-forward' ? startFastForward(videos) : startRewind(videos);
+}
+
+function pulse(videos: HTMLVideoElement[], action: MovieHoldAction, currentState: MovieHoldState | undefined) {
+  const nextState = startHold(videos, action, currentState);
+  if (!nextState) return undefined;
+  window.setTimeout(() => {
+    stopHold(nextState);
+  }, movieClickPulseMs);
+  return nextState;
+}
+
+function control(videos: HTMLVideoElement[], action: 'end' | 'play-toggle' | 'start') {
+  if (videos.length === 0) return false;
+  for (const video of videos) {
+    if (action === 'play-toggle') {
+      if (video.paused) void video.play();
+      else video.pause();
+      continue;
+    }
+    if (action === 'start') video.currentTime = getVideoTrimStart(video);
+    if (action === 'end') video.currentTime = getVideoTrimEnd(video);
+  }
+  return true;
+}
+
+export const presentationMovieControls = {
+  control,
+  pulse,
+  startHold,
+  stopHold,
+};
+
+export type { MovieHoldAction, MovieHoldState };

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -5,13 +5,20 @@ import {
   Bold,
   CaseSensitive,
   Download,
+  FileVideo,
   Film,
+  FolderOpen,
   Image,
   Plus,
+  Play,
   Search,
+  SkipBack,
+  SkipForward,
   Square,
   Type,
   Video,
+  Volume2,
+  VolumeX,
 } from 'lucide-react';
 import type { FormEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -23,10 +30,14 @@ import type {
   ShapeElement,
   ShapeLineEndpoint,
   VideoElement,
+  VideoRepeatMode,
 } from '../../../domain/documents/model';
 import type {
+  AlignMode,
+  ElementFramePatch,
   ElementStylePatch,
   MediaPlaybackPatch,
+  ZOrderMode,
 } from '../../../domain/commands/elements/basicCommands';
 import type { FontCatalogItem } from '../../../services/contracts/interfaces';
 import { PanelSection } from '../../components/PanelSection';
@@ -35,6 +46,11 @@ import { textStyleOptions } from '../text/textStyleOptions';
 const palette = ['#37FD76', '#050D10', '#FFFFFF', '#91999D', '#00779A'];
 const regularTextWeight = 400;
 const boldTextWeight = 800;
+const videoRepeatOptions: Array<{ value: VideoRepeatMode; label: string }> = [
+  { value: 'none', label: 'None' },
+  { value: 'loop', label: 'Loop' },
+  { value: 'loop-back-and-forth', label: 'Loop back and forth' },
+];
 const shapeLineEndpointOptions: Array<{ value: ShapeLineEndpoint; label: string }> = [
   { value: 'none', label: 'None' },
   { value: 'arrow', label: 'Arrow' },
@@ -55,8 +71,12 @@ interface DesignPanelProps {
   focusFontControlKey?: number | undefined;
   onDownloadFont?: (family: string) => Promise<void>;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
+  onUpdateElementFrame?: (elementId: string, patch: ElementFramePatch) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
+  onAlignSelectedElement?: (mode: AlignMode) => void;
+  onSetElementLock?: (elementId: string, locked: boolean) => void;
+  onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
 }
 
 function getSelectedElement(
@@ -88,8 +108,12 @@ export function DesignPanel({
   activePageId,
   selection,
   onUpdateElementStyle,
+  onUpdateElementFrame,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
+  onAlignSelectedElement,
+  onSetElementLock,
+  onSetSelectedElementZOrder,
   availableFonts = [],
   focusFontControlKey,
   onDownloadFont,
@@ -384,37 +408,47 @@ export function DesignPanel({
         </PanelSection>
       ) : null}
 
-      <PanelSection title="Selection">
-        <div className="compact-action design-selection-summary">
-          {selectedElement?.type === 'text' ? <Type size={16} /> : null}
-          {selectedElement?.type === 'image' ? <Image size={16} /> : null}
-          {selectedElement?.type === 'gif' ? <Film size={16} /> : null}
-          {selectedElement?.type === 'video' ? <Video size={16} /> : null}
-          {selectedElement?.type === 'shape' ? <Square size={16} /> : null}
-          {!selectedElement ? <CaseSensitive size={16} /> : null}
-          <span>
-            {selectedElement ? `Selected ${selectedElement.type}` : 'No selected element'}
-          </span>
-        </div>
-        {selectedElement ? (
-          <label className="design-control">
-            <span>Opacity</span>
-            <input
-              aria-label="Selected element opacity"
-              max="100"
-              min="0"
-              type="range"
-              value={Math.round(selectedElement.opacity * 100)}
-              onChange={(event) => {
-                updateSelectedStyle({ opacity: Number(event.target.value) / 100 });
-              }}
-            />
-          </label>
-        ) : null}
-      </PanelSection>
+      {selectedElement?.type !== 'video' ? (
+        <PanelSection title="Selection">
+          <div className="compact-action design-selection-summary">
+            {selectedElement?.type === 'text' ? <Type size={16} /> : null}
+            {selectedElement?.type === 'image' ? <Image size={16} /> : null}
+            {selectedElement?.type === 'gif' ? <Film size={16} /> : null}
+            {selectedElement?.type === 'shape' ? <Square size={16} /> : null}
+            {!selectedElement ? <CaseSensitive size={16} /> : null}
+            <span>
+              {selectedElement ? `Selected ${selectedElement.type}` : 'No selected element'}
+            </span>
+          </div>
+          {selectedElement ? (
+            <label className="design-control">
+              <span>Opacity</span>
+              <input
+                aria-label="Selected element opacity"
+                max="100"
+                min="0"
+                type="range"
+                value={Math.round(selectedElement.opacity * 100)}
+                onChange={(event) => {
+                  updateSelectedStyle({ opacity: Number(event.target.value) / 100 });
+                }}
+              />
+            </label>
+          ) : null}
+        </PanelSection>
+      ) : null}
 
       {selectedElement?.type === 'video' ? (
-        <VideoPlaybackPanel element={selectedElement} onUpdate={updateSelectedMediaPlayback} />
+        <VideoPlaybackPanel
+          assetName={project.assets[selectedElement.assetId]?.name ?? 'Imported movie'}
+          element={selectedElement}
+          onAlign={onAlignSelectedElement}
+          onFrameUpdate={(patch) => onUpdateElementFrame?.(selectedElement.id, patch)}
+          onLockChange={(locked) => onSetElementLock?.(selectedElement.id, locked)}
+          onUpdate={updateSelectedMediaPlayback}
+          onUpdateStyle={updateSelectedStyle}
+          onZOrderChange={onSetSelectedElementZOrder}
+        />
       ) : null}
 
       {selectedElement?.type === 'shape' ? (
@@ -549,8 +583,14 @@ export function DesignPanel({
 }
 
 interface VideoPlaybackPanelProps {
+  assetName: string;
   element: VideoElement;
+  onAlign?: ((mode: AlignMode) => void) | undefined;
+  onFrameUpdate?: ((patch: ElementFramePatch) => void) | undefined;
+  onLockChange?: ((locked: boolean) => void) | undefined;
   onUpdate: (patch: MediaPlaybackPatch) => void;
+  onUpdateStyle: (patch: ElementStylePatch) => void;
+  onZOrderChange?: ((mode: ZOrderMode) => void) | undefined;
 }
 
 function toTrimSeconds(value: string) {
@@ -559,86 +599,466 @@ function toTrimSeconds(value: string) {
 }
 
 function getTrimSliderMax(element: VideoElement) {
-  return Math.max(60, Math.ceil(element.trimStartSeconds), Math.ceil(element.trimEndSeconds ?? 0));
+  return Math.max(
+    1,
+    Math.ceil(element.durationSeconds ?? 0),
+    Math.ceil(element.trimStartSeconds),
+    Math.ceil(element.trimEndSeconds ?? 0),
+    Math.ceil(element.posterFrameSeconds ?? 0),
+  );
 }
 
-function VideoPlaybackPanel({ element, onUpdate }: VideoPlaybackPanelProps) {
+function formatMovieTime(seconds: number) {
+  const safeSeconds = Math.max(0, seconds);
+  const totalMilliseconds = Math.round(safeSeconds * 1000);
+  const milliseconds = (totalMilliseconds % 1000).toString().padStart(3, '0');
+  const totalSeconds = Math.floor(totalMilliseconds / 1000);
+  const displaySeconds = (totalSeconds % 60).toString().padStart(2, '0');
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const displayMinutes = (totalMinutes % 60).toString().padStart(2, '0');
+  const hours = Math.floor(totalMinutes / 60).toString().padStart(2, '0');
+  return `${hours}:${displayMinutes}:${displaySeconds},${milliseconds}`;
+}
+
+function getVideoRepeatMode(element: VideoElement): VideoRepeatMode {
+  return element.repeatMode ?? (element.loop ? 'loop' : 'none');
+}
+
+function getTrimEndSeconds(element: VideoElement) {
+  return element.trimEndSeconds ?? element.durationSeconds ?? getTrimSliderMax(element);
+}
+
+type MovieInspectorTab = 'arrange' | 'movie' | 'style';
+
+function getBoundedNumber(value: string, fallback: number, minimum = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(minimum, parsed) : fallback;
+}
+
+function VideoPlaybackPanel({
+  assetName,
+  element,
+  onAlign,
+  onFrameUpdate,
+  onLockChange,
+  onUpdate,
+  onUpdateStyle,
+  onZOrderChange,
+}: VideoPlaybackPanelProps) {
+  const [activeTab, setActiveTab] = useState<MovieInspectorTab>('movie');
   const trimSliderMax = getTrimSliderMax(element);
+  const trimEndSeconds = getTrimEndSeconds(element);
+  const volume = element.muted ? 0 : Math.round((element.volume ?? 1) * 100);
+  const repeatMode = getVideoRepeatMode(element);
+  const locked = element.locked;
 
   return (
-    <PanelSection title="Playback">
-      <label className="design-control">
-        <span>Loop</span>
-        <input
-          aria-label="Loop selected video"
-          type="checkbox"
-          checked={element.loop}
-          onChange={(event) => {
-            onUpdate({ loop: event.target.checked });
-          }}
-        />
-      </label>
-      <label className="design-control">
-        <span>Controls</span>
-        <input
-          aria-label="Show selected video controls"
-          type="checkbox"
-          checked={element.controls}
-          onChange={(event) => {
-            onUpdate({ controls: event.target.checked });
-          }}
-        />
-      </label>
-      <label className="design-control">
-        <span>Muted</span>
-        <input
-          aria-label="Mute selected video"
-          type="checkbox"
-          checked={element.muted}
-          onChange={(event) => {
-            onUpdate({ muted: event.target.checked });
-          }}
-        />
-      </label>
-      <label className="design-control">
-        <span>Preview autoplay</span>
-        <input
-          aria-label="Autoplay selected video in preview"
-          type="checkbox"
-          checked={element.autoplayInPreview}
-          onChange={(event) => {
-            onUpdate({ autoplayInPreview: event.target.checked });
-          }}
-        />
-      </label>
-      <label className="design-control">
-        <span>Trim start {element.trimStartSeconds.toFixed(1)}s</span>
-        <input
-          aria-label="Selected video trim start"
-          max={trimSliderMax}
-          min="0"
-          step="0.1"
-          type="range"
-          value={element.trimStartSeconds}
-          onChange={(event) => {
-            onUpdate({ trimStartSeconds: toTrimSeconds(event.target.value) });
-          }}
-        />
-      </label>
-      <label className="design-control">
-        <span>Trim end {(element.trimEndSeconds ?? 0).toFixed(1)}s</span>
-        <input
-          aria-label="Selected video trim end"
-          max={trimSliderMax}
-          min="0"
-          step="0.1"
-          type="range"
-          value={element.trimEndSeconds ?? 0}
-          onChange={(event) => {
-            onUpdate({ trimEndSeconds: toTrimSeconds(event.target.value) });
-          }}
-        />
-      </label>
+    <PanelSection title="Movie">
+      <div className="movie-inspector-tabs" role="tablist" aria-label="Movie inspector sections">
+        <button
+          aria-selected={activeTab === 'style'}
+          className={
+            activeTab === 'style'
+              ? 'movie-inspector-tab movie-inspector-tab-active'
+              : 'movie-inspector-tab'
+          }
+          role="tab"
+          type="button"
+          onClick={() => setActiveTab('style')}
+        >
+          Style
+        </button>
+        <button
+          aria-selected={activeTab === 'movie'}
+          className={
+            activeTab === 'movie'
+              ? 'movie-inspector-tab movie-inspector-tab-active'
+              : 'movie-inspector-tab'
+          }
+          role="tab"
+          type="button"
+          onClick={() => setActiveTab('movie')}
+        >
+          Movie
+        </button>
+        <button
+          aria-selected={activeTab === 'arrange'}
+          className={
+            activeTab === 'arrange'
+              ? 'movie-inspector-tab movie-inspector-tab-active'
+              : 'movie-inspector-tab'
+          }
+          role="tab"
+          type="button"
+          onClick={() => setActiveTab('arrange')}
+        >
+          Arrange
+        </button>
+      </div>
+
+      {activeTab === 'style' ? (
+        <>
+          <section className="movie-panel-section" aria-label="Selected movie style">
+            <h3>Selection</h3>
+            <div className="compact-action design-selection-summary">
+              <Video size={16} />
+              <span>Selected video</span>
+            </div>
+            <label className="design-control">
+              <span>Opacity</span>
+              <input
+                aria-label="Selected element opacity"
+                max="100"
+                min="0"
+                type="range"
+                value={Math.round(element.opacity * 100)}
+                onChange={(event) => {
+                  onUpdateStyle({ opacity: Number(event.target.value) / 100 });
+                }}
+              />
+            </label>
+            <label className="design-control">
+              <span>Controls</span>
+              <input
+                aria-label="Show selected video controls"
+                checked={element.controls}
+                type="checkbox"
+                onChange={(event) => onUpdate({ controls: event.target.checked })}
+              />
+            </label>
+          </section>
+        </>
+      ) : null}
+
+      {activeTab === 'movie' ? (
+        <>
+          <section className="movie-panel-section" aria-label="Movie file info">
+            <h3>File Info</h3>
+            <div className="movie-file-row">
+              <FileVideo size={18} aria-hidden="true" />
+              <span>{assetName}</span>
+              <button className="stitch-icon-button" type="button" aria-label="Browse movie file">
+                <FolderOpen size={18} aria-hidden="true" />
+              </button>
+            </div>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Movie controls">
+            <h3>Controls</h3>
+            <div className="movie-controls-row">
+              <button
+                type="button"
+                aria-label="Jump movie to beginning"
+                onClick={() =>
+                  onUpdate({
+                    playbackPositionSeconds: element.trimStartSeconds,
+                    playing: false,
+                  })
+                }
+              >
+                <SkipBack size={18} aria-hidden="true" />
+              </button>
+              <button
+                className="movie-play-button"
+                type="button"
+                aria-label={element.playing ? 'Pause movie' : 'Play movie'}
+                aria-pressed={Boolean(element.playing)}
+                onClick={() => onUpdate({ playing: !element.playing })}
+              >
+                <Play size={24} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label="Jump movie to end"
+                onClick={() =>
+                  onUpdate({
+                    playbackPositionSeconds: trimEndSeconds,
+                    playing: false,
+                  })
+                }
+              >
+                <SkipForward size={18} aria-hidden="true" />
+              </button>
+            </div>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Movie volume">
+            <h3>Volume</h3>
+            <div className="movie-volume-row">
+              <VolumeX size={18} aria-hidden="true" />
+              <input
+                aria-label="Selected video volume"
+                max="100"
+                min="0"
+                step="1"
+                type="range"
+                value={volume}
+                onChange={(event) => {
+                  const nextVolume = Number(event.target.value);
+                  onUpdate({ muted: nextVolume === 0, volume: nextVolume / 100 });
+                }}
+              />
+              <Volume2 size={20} aria-hidden="true" />
+            </div>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Edit movie">
+            <h3>Edit Movie</h3>
+            <div className="movie-trim-control">
+              <span>Trim</span>
+              <div className="movie-trim-track">
+                <input
+                  aria-label="Selected video trim start"
+                  max={trimSliderMax}
+                  min="0"
+                  step="0.1"
+                  type="range"
+                  value={element.trimStartSeconds}
+                  onChange={(event) => {
+                    const nextStart = Math.min(toTrimSeconds(event.target.value), trimEndSeconds);
+                    onUpdate({ trimStartSeconds: nextStart });
+                  }}
+                />
+                <input
+                  aria-label="Selected video trim end"
+                  max={trimSliderMax}
+                  min="0"
+                  step="0.1"
+                  type="range"
+                  value={trimEndSeconds}
+                  onChange={(event) => {
+                    const nextEnd = Math.max(
+                      toTrimSeconds(event.target.value),
+                      element.trimStartSeconds,
+                    );
+                    onUpdate({ trimEndSeconds: nextEnd });
+                  }}
+                />
+              </div>
+              <div className="movie-time-row">
+                <span>{formatMovieTime(element.trimStartSeconds)}</span>
+                <span>{formatMovieTime(trimEndSeconds)}</span>
+              </div>
+            </div>
+
+            <label className="movie-poster-control">
+              <span>Poster Frame</span>
+              <input
+                aria-label="Selected video poster frame"
+                max={trimSliderMax}
+                min="0"
+                step="0.1"
+                type="range"
+                value={element.posterFrameSeconds ?? element.trimStartSeconds}
+                onChange={(event) => {
+                  onUpdate({ posterFrameSeconds: toTrimSeconds(event.target.value) });
+                }}
+              />
+              <strong>{formatMovieTime(element.posterFrameSeconds ?? element.trimStartSeconds)}</strong>
+            </label>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Movie repeat">
+            <label className="movie-select-control">
+              <span>Repeat</span>
+              <select
+                aria-label="Selected video repeat mode"
+                value={repeatMode}
+                onChange={(event) => {
+                  const nextRepeatMode = event.target.value as VideoRepeatMode;
+                  onUpdate({ loop: nextRepeatMode === 'loop', repeatMode: nextRepeatMode });
+                }}
+              >
+                {videoRepeatOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="movie-checkbox-row movie-checkbox-row-disabled">
+              <input type="checkbox" disabled checked={Boolean(element.startOnClick)} readOnly />
+              <span>Start movie on click</span>
+            </label>
+            <label className="movie-checkbox-row">
+              <input
+                aria-label="Play movie across slides"
+                type="checkbox"
+                checked={Boolean(element.playAcrossSlides)}
+                onChange={(event) => onUpdate({ playAcrossSlides: event.target.checked })}
+              />
+              <span>Play movie across slides</span>
+            </label>
+          </section>
+        </>
+      ) : null}
+
+      {activeTab === 'arrange' ? (
+        <>
+          <section className="movie-panel-section" aria-label="Arrange movie order">
+            <div className="movie-arrange-grid">
+              <button type="button" onClick={() => onZOrderChange?.('back')}>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  flip_to_back
+                </span>
+                Back
+              </button>
+              <button type="button" onClick={() => onZOrderChange?.('front')}>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  flip_to_front
+                </span>
+                Front
+              </button>
+              <button type="button" onClick={() => onZOrderChange?.('backward')}>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  keyboard_arrow_down
+                </span>
+                Backward
+              </button>
+              <button type="button" onClick={() => onZOrderChange?.('forward')}>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  keyboard_arrow_up
+                </span>
+                Forward
+              </button>
+            </div>
+            <div className="movie-arrange-select-row">
+              <select
+                aria-label="Align selected video"
+                defaultValue=""
+                onChange={(event) => {
+                  if (!event.target.value) return;
+                  onAlign?.(event.target.value as AlignMode);
+                  event.target.value = '';
+                }}
+              >
+                <option value="" disabled>
+                  Align
+                </option>
+                <option value="horizontal-center">Horizontal center</option>
+                <option value="vertical-center">Vertical center</option>
+                <option value="page-center">Page center</option>
+              </select>
+              <button type="button" disabled>
+                Distribute
+              </button>
+            </div>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Movie size">
+            <h3>Size</h3>
+            <div className="movie-number-grid">
+              <label>
+                <input
+                  aria-label="Selected video width"
+                  min="1"
+                  type="number"
+                  value={Math.round(element.width)}
+                  onChange={(event) =>
+                    onFrameUpdate?.({
+                      width: getBoundedNumber(event.target.value, element.width, 1),
+                    })
+                  }
+                />
+                <span>Width</span>
+              </label>
+              <label>
+                <input
+                  aria-label="Selected video height"
+                  min="1"
+                  type="number"
+                  value={Math.round(element.height)}
+                  onChange={(event) =>
+                    onFrameUpdate?.({
+                      height: getBoundedNumber(event.target.value, element.height, 1),
+                    })
+                  }
+                />
+                <span>Height</span>
+              </label>
+            </div>
+            <label className="movie-checkbox-row">
+              <input type="checkbox" checked readOnly />
+              <span>Constrain proportions</span>
+            </label>
+            <button className="movie-full-button" type="button" disabled>
+              Original Size
+            </button>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Movie position">
+            <h3>Position</h3>
+            <div className="movie-number-grid">
+              <label>
+                <input
+                  aria-label="Selected video x position"
+                  type="number"
+                  value={Math.round(element.x)}
+                  onChange={(event) =>
+                    onFrameUpdate?.({
+                      x: getBoundedNumber(event.target.value, element.x),
+                    })
+                  }
+                />
+                <span>X</span>
+              </label>
+              <label>
+                <input
+                  aria-label="Selected video y position"
+                  type="number"
+                  value={Math.round(element.y)}
+                  onChange={(event) =>
+                    onFrameUpdate?.({
+                      y: getBoundedNumber(event.target.value, element.y),
+                    })
+                  }
+                />
+                <span>Y</span>
+              </label>
+            </div>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Movie rotation">
+            <h3>Rotate</h3>
+            <div className="movie-number-grid">
+              <label>
+                <input
+                  aria-label="Selected video rotation"
+                  type="number"
+                  value={Math.round(element.rotation)}
+                  onChange={(event) =>
+                    onFrameUpdate?.({
+                      rotation: getBoundedNumber(event.target.value, element.rotation, -360),
+                    })
+                  }
+                />
+                <span>Angle</span>
+              </label>
+              <button className="movie-full-button" type="button" disabled>
+                Flip
+              </button>
+            </div>
+          </section>
+
+          <section className="movie-panel-section" aria-label="Movie lock and grouping">
+            <div className="movie-lock-grid">
+              <button type="button" disabled={locked} onClick={() => onLockChange?.(true)}>
+                Lock
+              </button>
+              <button type="button" disabled={!locked} onClick={() => onLockChange?.(false)}>
+                Unlock
+              </button>
+              <button type="button" disabled>
+                Group
+              </button>
+              <button type="button" disabled>
+                Ungroup
+              </button>
+            </div>
+          </section>
+        </>
+      ) : null}
     </PanelSection>
   );
 }

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -10,6 +10,7 @@ import {
   FolderOpen,
   Image,
   Plus,
+  Pause,
   Play,
   Search,
   SkipBack,
@@ -77,6 +78,7 @@ interface DesignPanelProps {
   onAlignSelectedElement?: (mode: AlignMode) => void;
   onSetElementLock?: (elementId: string, locked: boolean) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
+  onReplaceVideoAsset?: (elementId: string, file: File) => void;
 }
 
 function getSelectedElement(
@@ -117,6 +119,7 @@ export function DesignPanel({
   availableFonts = [],
   focusFontControlKey,
   onDownloadFont,
+  onReplaceVideoAsset,
 }: DesignPanelProps) {
   const fontSelectRef = useRef<HTMLSelectElement>(null);
   const [fontDownloadOpen, setFontDownloadOpen] = useState(false);
@@ -408,187 +411,45 @@ export function DesignPanel({
         </PanelSection>
       ) : null}
 
-      {selectedElement?.type !== 'video' ? (
-        <PanelSection title="Selection">
-          <div className="compact-action design-selection-summary">
-            {selectedElement?.type === 'text' ? <Type size={16} /> : null}
-            {selectedElement?.type === 'image' ? <Image size={16} /> : null}
-            {selectedElement?.type === 'gif' ? <Film size={16} /> : null}
-            {selectedElement?.type === 'shape' ? <Square size={16} /> : null}
-            {!selectedElement ? <CaseSensitive size={16} /> : null}
-            <span>
-              {selectedElement ? `Selected ${selectedElement.type}` : 'No selected element'}
-            </span>
-          </div>
-          {selectedElement ? (
-            <label className="design-control">
-              <span>Opacity</span>
-              <input
-                aria-label="Selected element opacity"
-                max="100"
-                min="0"
-                type="range"
-                value={Math.round(selectedElement.opacity * 100)}
-                onChange={(event) => {
-                  updateSelectedStyle({ opacity: Number(event.target.value) / 100 });
-                }}
-              />
-            </label>
-          ) : null}
-        </PanelSection>
-      ) : null}
-
-      {selectedElement?.type === 'video' ? (
-        <VideoPlaybackPanel
-          assetName={project.assets[selectedElement.assetId]?.name ?? 'Imported movie'}
+      {selectedElement ? (
+        <ElementDesignInspector
+          key={selectedElement.id}
+          assetName={
+            selectedElement.type === 'image' ||
+            selectedElement.type === 'gif' ||
+            selectedElement.type === 'video'
+              ? project.assets[selectedElement.assetId]?.name
+              : undefined
+          }
           element={selectedElement}
           onAlign={onAlignSelectedElement}
           onFrameUpdate={(patch) => onUpdateElementFrame?.(selectedElement.id, patch)}
           onLockChange={(locked) => onSetElementLock?.(selectedElement.id, locked)}
-          onUpdate={updateSelectedMediaPlayback}
+          onReplaceVideoAsset={(file) => onReplaceVideoAsset?.(selectedElement.id, file)}
+          onUpdateMedia={updateSelectedMediaPlayback}
           onUpdateStyle={updateSelectedStyle}
           onZOrderChange={onSetSelectedElementZOrder}
         />
-      ) : null}
-
-      {selectedElement?.type === 'shape' ? (
-        <PanelSection title="Shape">
-          <label className="design-control">
-            <span>Fill</span>
-            <select
-              aria-label="Selected shape fill mode"
-              value={selectedElement.fill ? 'color' : 'none'}
-              onChange={(event) => {
-                updateSelectedStyle({
-                  fill: event.target.value === 'color' ? (selectedElement.fill ?? '#37FD76') : null,
-                });
-              }}
-            >
-              <option value="none">No fill</option>
-              <option value="color">Color fill</option>
-            </select>
-          </label>
-          {selectedElement.fill ? (
-            <label className="design-control">
-              <span>Fill color</span>
-              <input
-                aria-label="Selected shape fill color"
-                type="color"
-                value={selectedElement.fill}
-                onChange={(event) => {
-                  updateSelectedStyle({ fill: event.target.value });
-                }}
-              />
-            </label>
-          ) : null}
-          <label className="design-control">
-            <span>Border</span>
-            <select
-              aria-label="Selected shape border mode"
-              value={
-                selectedElement.stroke && (selectedElement.strokeWidth ?? 0) > 0 ? 'color' : 'none'
-              }
-              onChange={(event) => {
-                updateSelectedStyle(
-                  event.target.value === 'color'
-                    ? {
-                        stroke: selectedElement.stroke ?? '#37FD76',
-                        strokeWidth:
-                          selectedElement.strokeWidth && selectedElement.strokeWidth > 0
-                            ? selectedElement.strokeWidth
-                            : 2,
-                      }
-                    : { stroke: null, strokeWidth: 0 },
-                );
-              }}
-            >
-              <option value="none">No border</option>
-              <option value="color">Color border</option>
-            </select>
-          </label>
-          {selectedElement.stroke && (selectedElement.strokeWidth ?? 0) > 0 ? (
-            <>
-              <label className="design-control">
-                <span>Border color</span>
-                <input
-                  aria-label="Selected shape border color"
-                  type="color"
-                  value={selectedElement.stroke}
-                  onChange={(event) => {
-                    updateSelectedStyle({ stroke: event.target.value });
-                  }}
-                />
-              </label>
-              <label className="design-control">
-                <span>Border width</span>
-                <input
-                  aria-label="Selected shape border width"
-                  min="1"
-                  type="number"
-                  value={selectedElement.strokeWidth ?? 2}
-                  onChange={(event) => {
-                    updateSelectedStyle({ strokeWidth: Number(event.target.value) });
-                  }}
-                />
-              </label>
-              {supportsLineEndpoints(selectedElement) ? (
-                <>
-                  <label className="design-control">
-                    <span>Start endpoint</span>
-                    <select
-                      aria-label="Selected shape start endpoint"
-                      value={selectedElement.startEndpoint ?? 'none'}
-                      onChange={(event) => {
-                        updateSelectedStyle({
-                          startEndpoint: event.target.value as ShapeLineEndpoint,
-                        });
-                      }}
-                    >
-                      {shapeLineEndpointOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="design-control">
-                    <span>End endpoint</span>
-                    <select
-                      aria-label="Selected shape end endpoint"
-                      value={
-                        selectedElement.endEndpoint ??
-                        (selectedElement.shape === 'arrow' ? 'arrow' : 'none')
-                      }
-                      onChange={(event) => {
-                        updateSelectedStyle({
-                          endEndpoint: event.target.value as ShapeLineEndpoint,
-                        });
-                      }}
-                    >
-                      {shapeLineEndpointOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                </>
-              ) : null}
-            </>
-          ) : null}
+      ) : (
+        <PanelSection title="Selection">
+          <div className="compact-action design-selection-summary">
+            <CaseSensitive size={16} />
+            <span>No selected element</span>
+          </div>
         </PanelSection>
-      ) : null}
+      )}
     </div>
   );
 }
 
-interface VideoPlaybackPanelProps {
-  assetName: string;
-  element: VideoElement;
+interface ElementDesignInspectorProps {
+  assetName?: string | undefined;
+  element: DesignElement;
   onAlign?: ((mode: AlignMode) => void) | undefined;
   onFrameUpdate?: ((patch: ElementFramePatch) => void) | undefined;
   onLockChange?: ((locked: boolean) => void) | undefined;
-  onUpdate: (patch: MediaPlaybackPatch) => void;
+  onReplaceVideoAsset?: ((file: File) => void) | undefined;
+  onUpdateMedia: (patch: MediaPlaybackPatch) => void;
   onUpdateStyle: (patch: ElementStylePatch) => void;
   onZOrderChange?: ((mode: ZOrderMode) => void) | undefined;
 }
@@ -628,32 +489,52 @@ function getTrimEndSeconds(element: VideoElement) {
   return element.trimEndSeconds ?? element.durationSeconds ?? getTrimSliderMax(element);
 }
 
-type MovieInspectorTab = 'arrange' | 'movie' | 'style';
+type ElementInspectorTab = 'arrange' | 'content' | 'style';
 
 function getBoundedNumber(value: string, fallback: number, minimum = 0) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? Math.max(minimum, parsed) : fallback;
 }
 
-function VideoPlaybackPanel({
+function getElementContentTabLabel(element: DesignElement) {
+  if (element.type === 'text') return 'Text';
+  if (element.type === 'gif' || element.type === 'video') return 'Movie';
+  if (element.type === 'shape') return 'Shape';
+  return 'Image';
+}
+
+function getElementIcon(element: DesignElement) {
+  if (element.type === 'text') return <Type size={16} />;
+  if (element.type === 'image') return <Image size={16} />;
+  if (element.type === 'gif') return <Film size={16} />;
+  if (element.type === 'video') return <Video size={16} />;
+  return <Square size={16} />;
+}
+
+function ElementDesignInspector({
   assetName,
   element,
   onAlign,
   onFrameUpdate,
   onLockChange,
-  onUpdate,
+  onReplaceVideoAsset,
+  onUpdateMedia,
   onUpdateStyle,
   onZOrderChange,
-}: VideoPlaybackPanelProps) {
-  const [activeTab, setActiveTab] = useState<MovieInspectorTab>('movie');
-  const trimSliderMax = getTrimSliderMax(element);
-  const trimEndSeconds = getTrimEndSeconds(element);
-  const volume = element.muted ? 0 : Math.round((element.volume ?? 1) * 100);
-  const repeatMode = getVideoRepeatMode(element);
+}: ElementDesignInspectorProps) {
+  const defaultTab = element.type === 'text' ? 'style' : 'content';
+  const [activeTab, setActiveTab] = useState<ElementInspectorTab>(defaultTab);
+  const replaceVideoInputRef = useRef<HTMLInputElement>(null);
+  const contentLabel = getElementContentTabLabel(element);
   const locked = element.locked;
+  const videoElement = element.type === 'video' ? element : undefined;
+  const trimSliderMax = videoElement ? getTrimSliderMax(videoElement) : 1;
+  const trimEndSeconds = videoElement ? getTrimEndSeconds(videoElement) : 0;
+  const volume = videoElement?.muted ? 0 : Math.round((videoElement?.volume ?? 1) * 100);
+  const repeatMode = videoElement ? getVideoRepeatMode(videoElement) : 'none';
 
   return (
-    <PanelSection title="Movie">
+    <PanelSection title={contentLabel}>
       <div className="movie-inspector-tabs" role="tablist" aria-label="Movie inspector sections">
         <button
           aria-selected={activeTab === 'style'}
@@ -669,17 +550,17 @@ function VideoPlaybackPanel({
           Style
         </button>
         <button
-          aria-selected={activeTab === 'movie'}
+          aria-selected={activeTab === 'content'}
           className={
-            activeTab === 'movie'
+            activeTab === 'content'
               ? 'movie-inspector-tab movie-inspector-tab-active'
               : 'movie-inspector-tab'
           }
           role="tab"
           type="button"
-          onClick={() => setActiveTab('movie')}
+          onClick={() => setActiveTab('content')}
         >
-          Movie
+          {contentLabel}
         </button>
         <button
           aria-selected={activeTab === 'arrange'}
@@ -698,11 +579,11 @@ function VideoPlaybackPanel({
 
       {activeTab === 'style' ? (
         <>
-          <section className="movie-panel-section" aria-label="Selected movie style">
+          <section className="movie-panel-section" aria-label="Selected element style">
             <h3>Selection</h3>
             <div className="compact-action design-selection-summary">
-              <Video size={16} />
-              <span>Selected video</span>
+              {getElementIcon(element)}
+              <span>Selected {element.type}</span>
             </div>
             <label className="design-control">
               <span>Opacity</span>
@@ -717,29 +598,50 @@ function VideoPlaybackPanel({
                 }}
               />
             </label>
-            <label className="design-control">
-              <span>Controls</span>
-              <input
-                aria-label="Show selected video controls"
-                checked={element.controls}
-                type="checkbox"
-                onChange={(event) => onUpdate({ controls: event.target.checked })}
-              />
-            </label>
+            {element.type === 'video' ? (
+              <label className="design-control">
+                <span>Controls</span>
+                <input
+                  aria-label="Show selected video controls"
+                  checked={element.controls}
+                  type="checkbox"
+                  onChange={(event) => onUpdateMedia({ controls: event.target.checked })}
+                />
+              </label>
+            ) : null}
           </section>
         </>
       ) : null}
 
-      {activeTab === 'movie' ? (
+      {activeTab === 'content' ? (
         <>
+          {videoElement ? (
+            <>
           <section className="movie-panel-section" aria-label="Movie file info">
             <h3>File Info</h3>
             <div className="movie-file-row">
               <FileVideo size={18} aria-hidden="true" />
               <span>{assetName}</span>
-              <button className="stitch-icon-button" type="button" aria-label="Browse movie file">
+              <button
+                className="stitch-icon-button"
+                type="button"
+                aria-label="Replace movie file"
+                onClick={() => replaceVideoInputRef.current?.click()}
+              >
                 <FolderOpen size={18} aria-hidden="true" />
               </button>
+              <input
+                ref={replaceVideoInputRef}
+                aria-label="Replace video file"
+                accept="video/*"
+                className="visually-hidden-input"
+                type="file"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) onReplaceVideoAsset?.(file);
+                  event.target.value = '';
+                }}
+              />
             </div>
           </section>
 
@@ -750,8 +652,8 @@ function VideoPlaybackPanel({
                 type="button"
                 aria-label="Jump movie to beginning"
                 onClick={() =>
-                  onUpdate({
-                    playbackPositionSeconds: element.trimStartSeconds,
+                  onUpdateMedia({
+                    playbackPositionSeconds: videoElement.trimStartSeconds,
                     playing: false,
                   })
                 }
@@ -761,17 +663,21 @@ function VideoPlaybackPanel({
               <button
                 className="movie-play-button"
                 type="button"
-                aria-label={element.playing ? 'Pause movie' : 'Play movie'}
-                aria-pressed={Boolean(element.playing)}
-                onClick={() => onUpdate({ playing: !element.playing })}
+                aria-label={videoElement.playing ? 'Pause movie' : 'Play movie'}
+                aria-pressed={Boolean(videoElement.playing)}
+                onClick={() => onUpdateMedia({ playing: !videoElement.playing })}
               >
-                <Play size={24} aria-hidden="true" />
+                {videoElement.playing ? (
+                  <Pause size={24} aria-hidden="true" />
+                ) : (
+                  <Play size={24} aria-hidden="true" />
+                )}
               </button>
               <button
                 type="button"
                 aria-label="Jump movie to end"
                 onClick={() =>
-                  onUpdate({
+                  onUpdateMedia({
                     playbackPositionSeconds: trimEndSeconds,
                     playing: false,
                   })
@@ -795,7 +701,7 @@ function VideoPlaybackPanel({
                 value={volume}
                 onChange={(event) => {
                   const nextVolume = Number(event.target.value);
-                  onUpdate({ muted: nextVolume === 0, volume: nextVolume / 100 });
+                  onUpdateMedia({ muted: nextVolume === 0, volume: nextVolume / 100 });
                 }}
               />
               <Volume2 size={20} aria-hidden="true" />
@@ -813,10 +719,10 @@ function VideoPlaybackPanel({
                   min="0"
                   step="0.1"
                   type="range"
-                  value={element.trimStartSeconds}
+                value={videoElement.trimStartSeconds}
                   onChange={(event) => {
                     const nextStart = Math.min(toTrimSeconds(event.target.value), trimEndSeconds);
-                    onUpdate({ trimStartSeconds: nextStart });
+                    onUpdateMedia({ trimStartSeconds: nextStart });
                   }}
                 />
                 <input
@@ -829,14 +735,14 @@ function VideoPlaybackPanel({
                   onChange={(event) => {
                     const nextEnd = Math.max(
                       toTrimSeconds(event.target.value),
-                      element.trimStartSeconds,
+                      videoElement.trimStartSeconds,
                     );
-                    onUpdate({ trimEndSeconds: nextEnd });
+                    onUpdateMedia({ trimEndSeconds: nextEnd });
                   }}
                 />
               </div>
               <div className="movie-time-row">
-                <span>{formatMovieTime(element.trimStartSeconds)}</span>
+                <span>{formatMovieTime(videoElement.trimStartSeconds)}</span>
                 <span>{formatMovieTime(trimEndSeconds)}</span>
               </div>
             </div>
@@ -849,12 +755,14 @@ function VideoPlaybackPanel({
                 min="0"
                 step="0.1"
                 type="range"
-                value={element.posterFrameSeconds ?? element.trimStartSeconds}
+                value={videoElement.posterFrameSeconds ?? videoElement.trimStartSeconds}
                 onChange={(event) => {
-                  onUpdate({ posterFrameSeconds: toTrimSeconds(event.target.value) });
+                  onUpdateMedia({ posterFrameSeconds: toTrimSeconds(event.target.value) });
                 }}
               />
-              <strong>{formatMovieTime(element.posterFrameSeconds ?? element.trimStartSeconds)}</strong>
+              <strong>
+                {formatMovieTime(videoElement.posterFrameSeconds ?? videoElement.trimStartSeconds)}
+              </strong>
             </label>
           </section>
 
@@ -866,7 +774,7 @@ function VideoPlaybackPanel({
                 value={repeatMode}
                 onChange={(event) => {
                   const nextRepeatMode = event.target.value as VideoRepeatMode;
-                  onUpdate({ loop: nextRepeatMode === 'loop', repeatMode: nextRepeatMode });
+                  onUpdateMedia({ loop: nextRepeatMode === 'loop', repeatMode: nextRepeatMode });
                 }}
               >
                 {videoRepeatOptions.map((option) => (
@@ -878,25 +786,258 @@ function VideoPlaybackPanel({
             </label>
 
             <label className="movie-checkbox-row movie-checkbox-row-disabled">
-              <input type="checkbox" disabled checked={Boolean(element.startOnClick)} readOnly />
+              <input type="checkbox" disabled checked={Boolean(videoElement.startOnClick)} readOnly />
               <span>Start movie on click</span>
             </label>
             <label className="movie-checkbox-row">
               <input
                 aria-label="Play movie across slides"
                 type="checkbox"
-                checked={Boolean(element.playAcrossSlides)}
-                onChange={(event) => onUpdate({ playAcrossSlides: event.target.checked })}
+                checked={Boolean(videoElement.playAcrossSlides)}
+                onChange={(event) => onUpdateMedia({ playAcrossSlides: event.target.checked })}
               />
               <span>Play movie across slides</span>
             </label>
           </section>
+            </>
+          ) : null}
+          {element.type === 'text' ? (
+            <section className="movie-panel-section" aria-label="Selected text controls">
+              <h3>Typography</h3>
+              <label className="design-control">
+                <span>Font</span>
+                <select
+                  aria-label="Selected text font"
+                  value={element.fontFamily}
+                  onChange={(event) => {
+                    onUpdateStyle({ fontFamily: event.target.value });
+                  }}
+                >
+                  {textStyleOptions.TEXT_FONT_FAMILIES.map((fontFamily) => (
+                    <option key={fontFamily} value={fontFamily}>
+                      {fontFamily}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="design-control">
+                <span>Size</span>
+                <input
+                  aria-label="Selected text font size"
+                  min="1"
+                  type="number"
+                  value={element.fontSize}
+                  onChange={(event) => {
+                    onUpdateStyle({ fontSize: Number(event.target.value) });
+                  }}
+                />
+              </label>
+              <label className="design-control">
+                <span>Weight</span>
+                <select
+                  aria-label="Selected text font weight"
+                  value={element.fontWeight}
+                  onChange={(event) => {
+                    onUpdateStyle({ fontWeight: Number(event.target.value) });
+                  }}
+                >
+                  {textStyleOptions.TEXT_FONT_WEIGHTS.map((fontWeight) => (
+                    <option key={fontWeight} value={fontWeight}>
+                      {fontWeight}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="design-control">
+                <span>Color</span>
+                <input
+                  aria-label="Selected text color"
+                  type="color"
+                  value={element.fill}
+                  onChange={(event) => {
+                    onUpdateStyle({ fill: event.target.value });
+                  }}
+                />
+              </label>
+              <label className="design-control">
+                <span>Align</span>
+                <select
+                  aria-label="Selected text alignment"
+                  value={element.align}
+                  onChange={(event) => {
+                    onUpdateStyle({ align: event.target.value as 'left' | 'center' | 'right' });
+                  }}
+                >
+                  <option value="left">Left</option>
+                  <option value="center">Center</option>
+                  <option value="right">Right</option>
+                </select>
+              </label>
+              <div className="compact-action">
+                <AlignCenter size={16} />
+                <span>Text frame stays editable on canvas</span>
+              </div>
+            </section>
+          ) : null}
+
+          {element.type === 'gif' ? (
+            <section className="movie-panel-section" aria-label="GIF movie controls">
+              <h3>Movie</h3>
+              <div className="movie-file-row">
+                <Film size={18} aria-hidden="true" />
+                <span>{assetName ?? 'Animated GIF'}</span>
+              </div>
+              <label className="movie-checkbox-row">
+                <input
+                  aria-label="Play selected GIF"
+                  type="checkbox"
+                  checked={element.playing}
+                  onChange={(event) => onUpdateMedia({ playing: event.target.checked })}
+                />
+                <span>Play GIF</span>
+              </label>
+            </section>
+          ) : null}
+
+          {element.type === 'image' ? (
+            <section className="movie-panel-section" aria-label="Selected image controls">
+              <h3>Image</h3>
+              <div className="movie-file-row">
+                <Image size={18} aria-hidden="true" />
+                <span>{assetName ?? 'Imported image'}</span>
+              </div>
+            </section>
+          ) : null}
+
+          {element.type === 'shape' ? (
+            <section className="movie-panel-section" aria-label="Selected shape controls">
+              <h3>Shape</h3>
+              <label className="design-control">
+                <span>Fill</span>
+                <select
+                  aria-label="Selected shape fill mode"
+                  value={element.fill ? 'color' : 'none'}
+                  onChange={(event) => {
+                    onUpdateStyle({
+                      fill: event.target.value === 'color' ? (element.fill ?? '#37FD76') : null,
+                    });
+                  }}
+                >
+                  <option value="none">No fill</option>
+                  <option value="color">Color fill</option>
+                </select>
+              </label>
+              {element.fill ? (
+                <label className="design-control">
+                  <span>Fill color</span>
+                  <input
+                    aria-label="Selected shape fill color"
+                    type="color"
+                    value={element.fill}
+                    onChange={(event) => {
+                      onUpdateStyle({ fill: event.target.value });
+                    }}
+                  />
+                </label>
+              ) : null}
+              <label className="design-control">
+                <span>Border</span>
+                <select
+                  aria-label="Selected shape border mode"
+                  value={element.stroke && (element.strokeWidth ?? 0) > 0 ? 'color' : 'none'}
+                  onChange={(event) => {
+                    onUpdateStyle(
+                      event.target.value === 'color'
+                        ? {
+                            stroke: element.stroke ?? '#37FD76',
+                            strokeWidth:
+                              element.strokeWidth && element.strokeWidth > 0
+                                ? element.strokeWidth
+                                : 2,
+                          }
+                        : { stroke: null, strokeWidth: 0 },
+                    );
+                  }}
+                >
+                  <option value="none">No border</option>
+                  <option value="color">Color border</option>
+                </select>
+              </label>
+              {element.stroke && (element.strokeWidth ?? 0) > 0 ? (
+                <>
+                  <label className="design-control">
+                    <span>Border color</span>
+                    <input
+                      aria-label="Selected shape border color"
+                      type="color"
+                      value={element.stroke}
+                      onChange={(event) => {
+                        onUpdateStyle({ stroke: event.target.value });
+                      }}
+                    />
+                  </label>
+                  <label className="design-control">
+                    <span>Border width</span>
+                    <input
+                      aria-label="Selected shape border width"
+                      min="1"
+                      type="number"
+                      value={element.strokeWidth ?? 2}
+                      onChange={(event) => {
+                        onUpdateStyle({ strokeWidth: Number(event.target.value) });
+                      }}
+                    />
+                  </label>
+                  {supportsLineEndpoints(element) ? (
+                    <>
+                      <label className="design-control">
+                        <span>Start endpoint</span>
+                        <select
+                          aria-label="Selected shape start endpoint"
+                          value={element.startEndpoint ?? 'none'}
+                          onChange={(event) => {
+                            onUpdateStyle({
+                              startEndpoint: event.target.value as ShapeLineEndpoint,
+                            });
+                          }}
+                        >
+                          {shapeLineEndpointOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="design-control">
+                        <span>End endpoint</span>
+                        <select
+                          aria-label="Selected shape end endpoint"
+                          value={element.endEndpoint ?? (element.shape === 'arrow' ? 'arrow' : 'none')}
+                          onChange={(event) => {
+                            onUpdateStyle({
+                              endEndpoint: event.target.value as ShapeLineEndpoint,
+                            });
+                          }}
+                        >
+                          {shapeLineEndpointOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </>
+                  ) : null}
+                </>
+              ) : null}
+            </section>
+          ) : null}
         </>
       ) : null}
 
       {activeTab === 'arrange' ? (
         <>
-          <section className="movie-panel-section" aria-label="Arrange movie order">
+          <section className="movie-panel-section" aria-label="Arrange selected element order">
             <div className="movie-arrange-grid">
               <button type="button" onClick={() => onZOrderChange?.('back')}>
                 <span className="material-symbols-outlined" aria-hidden="true">
@@ -925,7 +1066,7 @@ function VideoPlaybackPanel({
             </div>
             <div className="movie-arrange-select-row">
               <select
-                aria-label="Align selected video"
+                aria-label="Align selected element"
                 defaultValue=""
                 onChange={(event) => {
                   if (!event.target.value) return;
@@ -946,12 +1087,12 @@ function VideoPlaybackPanel({
             </div>
           </section>
 
-          <section className="movie-panel-section" aria-label="Movie size">
+          <section className="movie-panel-section" aria-label="Selected element size">
             <h3>Size</h3>
             <div className="movie-number-grid">
               <label>
                 <input
-                  aria-label="Selected video width"
+                  aria-label="Selected element width"
                   min="1"
                   type="number"
                   value={Math.round(element.width)}
@@ -965,7 +1106,7 @@ function VideoPlaybackPanel({
               </label>
               <label>
                 <input
-                  aria-label="Selected video height"
+                  aria-label="Selected element height"
                   min="1"
                   type="number"
                   value={Math.round(element.height)}
@@ -987,12 +1128,12 @@ function VideoPlaybackPanel({
             </button>
           </section>
 
-          <section className="movie-panel-section" aria-label="Movie position">
+          <section className="movie-panel-section" aria-label="Selected element position">
             <h3>Position</h3>
             <div className="movie-number-grid">
               <label>
                 <input
-                  aria-label="Selected video x position"
+                  aria-label="Selected element x position"
                   type="number"
                   value={Math.round(element.x)}
                   onChange={(event) =>
@@ -1005,7 +1146,7 @@ function VideoPlaybackPanel({
               </label>
               <label>
                 <input
-                  aria-label="Selected video y position"
+                  aria-label="Selected element y position"
                   type="number"
                   value={Math.round(element.y)}
                   onChange={(event) =>
@@ -1019,12 +1160,12 @@ function VideoPlaybackPanel({
             </div>
           </section>
 
-          <section className="movie-panel-section" aria-label="Movie rotation">
+          <section className="movie-panel-section" aria-label="Selected element rotation">
             <h3>Rotate</h3>
             <div className="movie-number-grid">
               <label>
                 <input
-                  aria-label="Selected video rotation"
+                  aria-label="Selected element rotation"
                   type="number"
                   value={Math.round(element.rotation)}
                   onChange={(event) =>
@@ -1041,7 +1182,7 @@ function VideoPlaybackPanel({
             </div>
           </section>
 
-          <section className="movie-panel-section" aria-label="Movie lock and grouping">
+          <section className="movie-panel-section" aria-label="Selected element lock and grouping">
             <div className="movie-lock-grid">
               <button type="button" disabled={locked} onClick={() => onLockChange?.(true)}>
                 Lock

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -10,7 +10,13 @@ import type {
   ShapeKind,
   SlideTransition,
 } from '../../../domain/documents/model';
-import type { ElementStylePatch, MediaPlaybackPatch } from '../../../domain/commands/elements/basicCommands';
+import type {
+  AlignMode,
+  ElementFramePatch,
+  ElementStylePatch,
+  MediaPlaybackPatch,
+  ZOrderMode,
+} from '../../../domain/commands/elements/basicCommands';
 import type {
   AiProviderState,
   FontCatalogItem,
@@ -95,6 +101,9 @@ interface LeftToolPanelProps {
   onSetElementLock?: ((elementId: string, locked: boolean) => void) | undefined;
   onDeleteElement?: ((elementId: string) => void) | undefined;
   onReorderElement?: ((elementId: string, targetElementId: string, position?: 'before' | 'after') => void) | undefined;
+  onAlignSelectedElement?: ((mode: AlignMode) => void) | undefined;
+  onSetSelectedElementZOrder?: ((mode: ZOrderMode) => void) | undefined;
+  onUpdateElementFrame?: ((elementId: string, patch: ElementFramePatch) => void) | undefined;
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
   onUpdateMediaPlayback?: ((elementId: string, patch: MediaPlaybackPatch) => void) | undefined;
   onUpdatePageBackground?: ((background: PageBackground) => void) | undefined;
@@ -174,6 +183,9 @@ export function LeftToolPanel({
   onSetElementLock,
   onDeleteElement,
   onReorderElement,
+  onAlignSelectedElement,
+  onSetSelectedElementZOrder,
+  onUpdateElementFrame,
   onUpdateElementStyle,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
@@ -249,6 +261,10 @@ export function LeftToolPanel({
             {...(availableFonts ? { availableFonts } : {})}
             {...(focusFontControlKey ? { focusFontControlKey } : {})}
             {...(onDownloadFont ? { onDownloadFont } : {})}
+            {...(onAlignSelectedElement ? { onAlignSelectedElement } : {})}
+            {...(onSetElementLock ? { onSetElementLock } : {})}
+            {...(onSetSelectedElementZOrder ? { onSetSelectedElementZOrder } : {})}
+            {...(onUpdateElementFrame ? { onUpdateElementFrame } : {})}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -1,5 +1,5 @@
 import { Brush, Clapperboard, ImagePlus, Layers3, Shapes, Sparkles, Type } from 'lucide-react';
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { collectReferencedAssetIds } from '../../../domain/assets/assetUsage';
 import type {
   Asset,
@@ -107,6 +107,7 @@ interface LeftToolPanelProps {
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
   onUpdateMediaPlayback?: ((elementId: string, patch: MediaPlaybackPatch) => void) | undefined;
   onUpdatePageBackground?: ((background: PageBackground) => void) | undefined;
+  onReplaceVideoAsset?: ((elementId: string, file: File) => void) | undefined;
   onClearPageTransition?: (() => void) | undefined;
   onSetPageTransition?: ((transition: SlideTransition) => void) | undefined;
   onSetElementAnimationBuilds?: ((elementIds: string[], patch: Omit<ElementAnimationBuild, 'elementId' | 'id'>) => void) | undefined;
@@ -189,6 +190,7 @@ export function LeftToolPanel({
   onUpdateElementStyle,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
+  onReplaceVideoAsset,
   onClearPageTransition,
   onSetPageTransition,
   onSetElementAnimationBuilds,
@@ -197,6 +199,9 @@ export function LeftToolPanel({
   onPlayAnimationPreview,
 }: LeftToolPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const resizeStartRef = useRef<{ pointerX: number; width: number } | undefined>(undefined);
+  const [contentWidth, setContentWidth] = useState(266);
+  const [resizing, setResizing] = useState(false);
   const isAttentionOpen = Boolean(attentionModelId || promptApiAttention || translationTargetAttention);
   const panelOpen = open || isAttentionOpen;
   const assetRows = useMemo(() => {
@@ -210,8 +215,40 @@ export function LeftToolPanel({
       .sort((a, b) => a.asset.name.localeCompare(b.asset.name, undefined, { sensitivity: 'base' }));
   }, [activeTab, panelOpen, project]);
 
+  useEffect(() => {
+    if (!resizing) return undefined;
+
+    function handlePointerMove(event: PointerEvent) {
+      const resizeStart = resizeStartRef.current;
+      if (!resizeStart) return;
+      setContentWidth(Math.min(520, Math.max(240, resizeStart.width + event.clientX - resizeStart.pointerX)));
+    }
+
+    function handlePointerUp() {
+      resizeStartRef.current = undefined;
+      setResizing(false);
+    }
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [resizing]);
+
   return (
-    <aside className={panelOpen ? 'left-tool-panel left-tool-panel-open' : 'left-tool-panel'} aria-label="Editor tools">
+    <aside
+      className={
+        panelOpen
+          ? resizing
+            ? 'left-tool-panel left-tool-panel-open left-tool-panel-resizing'
+            : 'left-tool-panel left-tool-panel-open'
+          : 'left-tool-panel'
+      }
+      aria-label="Editor tools"
+      style={{ '--left-tool-content-width': `${contentWidth}px` } as CSSProperties}
+    >
       <nav className="left-tool-rail" aria-label="Tool menu">
         {menuItems.map((item) => {
           const Icon = item.icon;
@@ -268,6 +305,7 @@ export function LeftToolPanel({
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
+            {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}
           />
         ) : null}
         {panelOpen && activeTab === 'text' ? (
@@ -384,6 +422,21 @@ export function LeftToolPanel({
           </section>
         ) : null}
       </div>
+      {panelOpen ? (
+        <button
+          aria-label="Resize design panel"
+          className="left-tool-resize-handle"
+          type="button"
+          onPointerDown={(event) => {
+            resizeStartRef.current = {
+              pointerX: event.clientX,
+              width: contentWidth,
+            };
+            setResizing(true);
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }}
+        />
+      ) : null}
     </aside>
   );
 }

--- a/apps/editor/src/ui/editor/panels/RightPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/RightPanel.tsx
@@ -1,6 +1,12 @@
 import { Brush, Layers3, Sparkles } from 'lucide-react';
 import type { PageBackground, ProjectDocument, SelectionState } from '../../../domain/documents/model';
-import type { ElementStylePatch, MediaPlaybackPatch } from '../../../domain/commands/elements/basicCommands';
+import type {
+  AlignMode,
+  ElementFramePatch,
+  ElementStylePatch,
+  MediaPlaybackPatch,
+  ZOrderMode,
+} from '../../../domain/commands/elements/basicCommands';
 import type { AiProviderState, ModelState } from '../../../services/contracts/interfaces';
 import { SegmentedTabs, type SegmentedTab } from '../../components/SegmentedTabs';
 import { AiToolsPanel } from './AiToolsPanel';
@@ -42,9 +48,12 @@ interface RightPanelProps {
   onSetElementLock?: (elementId: string, locked: boolean) => void;
   onDeleteElement?: (elementId: string) => void;
   onReorderElement?: (elementId: string, targetElementId: string, position?: 'before' | 'after') => void;
+  onAlignSelectedElement?: (mode: AlignMode) => void;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
+  onUpdateElementFrame?: (elementId: string, patch: ElementFramePatch) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
+  onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
 }
 
 const tabs: Array<SegmentedTab<LegacyRightPanelTab>> = [
@@ -84,9 +93,12 @@ export function RightPanel({
   onSetElementLock,
   onDeleteElement,
   onReorderElement,
+  onAlignSelectedElement,
   onUpdateElementStyle,
+  onUpdateElementFrame,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
+  onSetSelectedElementZOrder,
 }: RightPanelProps) {
   return (
     <aside className="right-panel" aria-label="Editor tools">
@@ -133,6 +145,10 @@ export function RightPanel({
             project={project}
             activePageId={activePageId}
             selection={selection}
+            {...(onAlignSelectedElement ? { onAlignSelectedElement } : {})}
+            {...(onSetElementLock ? { onSetElementLock } : {})}
+            {...(onSetSelectedElementZOrder ? { onSetSelectedElementZOrder } : {})}
+            {...(onUpdateElementFrame ? { onUpdateElementFrame } : {})}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}

--- a/apps/editor/src/ui/editor/panels/RightPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/RightPanel.tsx
@@ -54,6 +54,7 @@ interface RightPanelProps {
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
+  onReplaceVideoAsset?: (elementId: string, file: File) => void;
 }
 
 const tabs: Array<SegmentedTab<LegacyRightPanelTab>> = [
@@ -99,6 +100,7 @@ export function RightPanel({
   onUpdateMediaPlayback,
   onUpdatePageBackground,
   onSetSelectedElementZOrder,
+  onReplaceVideoAsset,
 }: RightPanelProps) {
   return (
     <aside className="right-panel" aria-label="Editor tools">
@@ -152,6 +154,7 @@ export function RightPanel({
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
+            {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}
           />
         ) : null}
       </div>

--- a/apps/editor/src/ui/editor/shell/EditorFooter.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorFooter.tsx
@@ -1,8 +1,10 @@
 interface EditorFooterProps {
   activePageIndex: number;
+  notesOpen?: boolean;
   pageCount: number;
   pagesPanelOpen?: boolean;
   zoomPercent: number;
+  onToggleNotes?: () => void;
   onOpenSettings?: () => void;
   onResetZoom?: () => void;
   onTogglePagesPanel?: () => void;
@@ -12,9 +14,11 @@ interface EditorFooterProps {
 
 export function EditorFooter({
   activePageIndex,
+  notesOpen = false,
   pageCount,
   pagesPanelOpen = true,
   zoomPercent,
+  onToggleNotes,
   onOpenSettings,
   onResetZoom,
   onTogglePagesPanel,
@@ -34,6 +38,18 @@ export function EditorFooter({
           <span className="material-symbols-outlined" aria-hidden="true">
             settings
           </span>
+        </button>
+        <button
+          className={notesOpen ? 'footer-toggle footer-toggle-active' : 'footer-toggle'}
+          type="button"
+          aria-label="Toggle notes panel"
+          aria-pressed={notesOpen}
+          onClick={onToggleNotes}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            edit_note
+          </span>
+          Notes
         </button>
       </div>
       <div className="editor-footer-right">

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -875,6 +875,9 @@ export function EditorShell({ services }: EditorShellProps) {
           onSetElementLock={isHistoryReadOnly ? undefined : vm.setElementLock}
           onDeleteElement={isHistoryReadOnly ? undefined : vm.deleteElement}
           onReorderElement={isHistoryReadOnly ? undefined : vm.reorderElement}
+          onAlignSelectedElement={isHistoryReadOnly ? undefined : vm.alignSelectedElement}
+          onSetSelectedElementZOrder={isHistoryReadOnly ? undefined : vm.setSelectedElementZOrder}
+          onUpdateElementFrame={isHistoryReadOnly ? undefined : vm.updateElementFrame}
           onUpdateElementStyle={isHistoryReadOnly ? undefined : vm.updateElementStyle}
           onUpdateMediaPlayback={isHistoryReadOnly ? undefined : vm.updateMediaPlayback}
           onUpdatePageBackground={isHistoryReadOnly ? undefined : vm.updatePageBackground}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -28,6 +28,7 @@ import { VersionHistoryPanel } from '../panels/VersionHistoryPanel';
 import { useEditorViewModel } from '../state/useEditorViewModel';
 import { SharePanel } from '../../share/SharePanel';
 import { editorShellBrowserUtils } from '../browser/editorShellBrowserUtils';
+import { BrowserPresenterSessionService } from '../../../services/presenter/presenterSessionService';
 
 interface EditorShellProps {
   services: AppServices;
@@ -38,11 +39,17 @@ export function EditorShell({ services }: EditorShellProps) {
   const automationDelegateRef = useRef(vm.automation);
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);
   const [designFontFocusKey, setDesignFontFocusKey] = useState(0);
+  const [speakerNotesOpen, setSpeakerNotesOpen] = useState(false);
+  const [audienceFullscreenPromptOpen, setAudienceFullscreenPromptOpen] = useState(false);
+  const [presenterSessionId, setPresenterSessionId] = useState<string | undefined>();
+  const [presenterViewError, setPresenterViewError] = useState<string | undefined>();
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
   const [shareMetadata, setShareMetadata] = useState<ShareMetadata | undefined>();
   const stageRef = useRef<Konva.Stage>(null);
   const workspaceRef = useRef<HTMLElement>(null);
   const slideFrameRef = useRef<HTMLDivElement>(null);
+  const presenterSessionServiceRef = useRef<BrowserPresenterSessionService | undefined>(undefined);
+  const presenterFullscreenEnteredRef = useRef(false);
   const toolbarImageInputRef = useRef<HTMLInputElement>(null);
   const hasSelection = vm.selection.elementIds.length > 0;
   const isHistoryReadOnly = vm.versionHistoryOpen;
@@ -50,6 +57,7 @@ export function EditorShell({ services }: EditorShellProps) {
     0,
     vm.project.pages.findIndex((page) => page.id === vm.activePageId),
   );
+  const activePage = vm.project.pages[activePageIndex];
   const deckTranslationStatus = vm.deckTranslationProgress
     ? `Translating ${vm.deckTranslationProgress.currentPageName} · ${vm.deckTranslationProgress.completedPages}/${vm.deckTranslationProgress.totalPages}`
     : undefined;
@@ -92,6 +100,46 @@ export function EditorShell({ services }: EditorShellProps) {
     const pageId = options?.fromBeginning ? vm.project.pages[0]?.id : vm.activePageId;
     if (!pageId) return;
     vm.playPresentationPreview(pageId);
+    void vm.toggleFullscreen(workspaceRef.current);
+  }
+
+  function getPresenterSessionService() {
+    presenterSessionServiceRef.current ??= new BrowserPresenterSessionService();
+    return presenterSessionServiceRef.current;
+  }
+
+  function closePresenterViewSession() {
+    presenterSessionServiceRef.current?.closePresenterWindow();
+    presenterFullscreenEnteredRef.current = false;
+    setAudienceFullscreenPromptOpen(false);
+    setPresenterSessionId(undefined);
+  }
+
+  function openPresenterView() {
+    const pageId = vm.activePageId;
+    if (!pageId) return;
+    const service = getPresenterSessionService();
+    const result = service.openPresenterWindow();
+    if (result.status === 'blocked') {
+      setPresenterViewError('Allow popups to open presenter view.');
+      return;
+    }
+    setPresenterViewError(undefined);
+    setPresenterSessionId(result.sessionId);
+    presenterFullscreenEnteredRef.current = false;
+    setAudienceFullscreenPromptOpen(true);
+    vm.playPresentationPreview(pageId);
+    window.setTimeout(() => {
+      service.publishState({
+        activePageId: pageId,
+        animationPreview: vm.animationPreview,
+        project: vm.project,
+      });
+    }, 0);
+  }
+
+  function enterAudienceFullscreen() {
+    setAudienceFullscreenPromptOpen(false);
     void vm.toggleFullscreen(workspaceRef.current);
   }
 
@@ -214,6 +262,56 @@ export function EditorShell({ services }: EditorShellProps) {
   useEffect(() => {
     automationDelegateRef.current = vm.automation;
   }, [vm.automation]);
+
+  useEffect(() => {
+    if (!presenterSessionId) return undefined;
+    return getPresenterSessionService().subscribeToCommands((message) => {
+      if (message.command === 'next') {
+        vm.advancePresentationPreview();
+        return;
+      }
+      if (message.command === 'previous') {
+        vm.rewindPresentationPreview();
+        return;
+      }
+      if (message.command === 'update-notes') {
+        vm.updatePageSpeakerNotes(message.pageId, message.notes);
+        return;
+      }
+      if (message.command === 'request-state') {
+        getPresenterSessionService().publishState({
+          activePageId: vm.activePageId,
+          animationPreview: vm.animationPreview,
+          project: vm.project,
+        });
+        return;
+      }
+      if (message.command === 'close') {
+        closePresenterViewSession();
+      }
+    });
+  }, [presenterSessionId, vm]);
+
+  useEffect(() => {
+    if (!presenterSessionId) {
+      presenterFullscreenEnteredRef.current = false;
+      return;
+    }
+    if (vm.isFullscreen) {
+      presenterFullscreenEnteredRef.current = true;
+      return;
+    }
+    if (presenterFullscreenEnteredRef.current) closePresenterViewSession();
+  }, [presenterSessionId, vm.isFullscreen]);
+
+  useEffect(() => {
+    if (!presenterSessionId) return;
+    getPresenterSessionService().publishState({
+      activePageId: vm.activePageId,
+      animationPreview: vm.animationPreview,
+      project: vm.project,
+    });
+  }, [presenterSessionId, vm.activePageId, vm.animationPreview, vm.project]);
 
   useEffect(() => {
     function handleCopy(event: ClipboardEvent) {
@@ -395,6 +493,7 @@ export function EditorShell({ services }: EditorShellProps) {
         onShare={() => {
           setSharePanelOpen(true);
         }}
+        onOpenPresenterView={openPresenterView}
         onStartPresenterMode={startPresenterMode}
         onSaveLocal={() => {
           void vm.saveLocalNow();
@@ -646,6 +745,82 @@ export function EditorShell({ services }: EditorShellProps) {
             onReorderPage={isHistoryReadOnly ? undefined : vm.reorderPage}
             onSetPageVisibility={isHistoryReadOnly ? undefined : vm.setPageVisibility}
           />
+          {activePage ? (
+            <section className="speaker-notes-editor" aria-label="Speaker notes editor">
+              {speakerNotesOpen ? (
+                <div className="speaker-notes-card">
+                  <header className="speaker-notes-header">
+                    <h2>
+                      Page {activePageIndex + 1} - {activePage.name}
+                    </h2>
+                    <div className="speaker-notes-actions">
+                      <button type="button" aria-label="Change notes text size">
+                        aA
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="Close notes panel"
+                        onClick={() => setSpeakerNotesOpen(false)}
+                      >
+                        <span className="material-symbols-outlined" aria-hidden="true">
+                          close
+                        </span>
+                      </button>
+                    </div>
+                  </header>
+                  <textarea
+                    id="speaker-notes-textarea"
+                    aria-label="Speaker notes"
+                    maxLength={5000}
+                    placeholder="Add notes to your design"
+                    value={activePage.speakerNotes ?? ''}
+                    onChange={(event) =>
+                      vm.updatePageSpeakerNotes(activePage.id, event.target.value)
+                    }
+                  />
+                  <span className="speaker-notes-count">{activePage.speakerNotes?.length ?? 0}/5000</span>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+          {presenterViewError ? (
+            <p className="presenter-view-error" role="alert">
+              {presenterViewError}
+            </p>
+          ) : null}
+          {audienceFullscreenPromptOpen ? (
+            <div className="audience-fullscreen-backdrop" role="presentation">
+              <section
+                className="audience-fullscreen-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="audience-fullscreen-title"
+              >
+                <button
+                  className="audience-fullscreen-close"
+                  type="button"
+                  aria-label="Close audience fullscreen prompt"
+                  onClick={closePresenterViewSession}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    close
+                  </span>
+                </button>
+                <h2 id="audience-fullscreen-title">Audience Window</h2>
+                <p>
+                  This window is what your audience sees. Drag it to the screen your
+                  audience will be looking at and enter full screen mode.
+                </p>
+                <button
+                  className="audience-fullscreen-primary"
+                  type="button"
+                  onClick={enterAudienceFullscreen}
+                >
+                  Enter full screen mode
+                </button>
+              </section>
+            </div>
+          ) : null}
           <input
             ref={toolbarImageInputRef}
             aria-label="Insert media file"
@@ -789,11 +964,13 @@ export function EditorShell({ services }: EditorShellProps) {
       <ProjectVideoPreloader project={vm.project} />
       <EditorFooter
         activePageIndex={activePageIndex}
+        notesOpen={speakerNotesOpen}
         pageCount={vm.project.pages.length}
         pagesPanelOpen={vm.pagesPanelOpen}
         zoomPercent={vm.zoomPercent}
         onResetZoom={vm.resetZoom}
         onOpenSettings={vm.openSettings}
+        onToggleNotes={() => setSpeakerNotesOpen((current) => !current)}
         onTogglePagesPanel={togglePagesPanel}
         onZoomIn={vm.zoomIn}
         onZoomOut={vm.zoomOut}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -881,6 +881,13 @@ export function EditorShell({ services }: EditorShellProps) {
           onUpdateElementStyle={isHistoryReadOnly ? undefined : vm.updateElementStyle}
           onUpdateMediaPlayback={isHistoryReadOnly ? undefined : vm.updateMediaPlayback}
           onUpdatePageBackground={isHistoryReadOnly ? undefined : vm.updatePageBackground}
+          onReplaceVideoAsset={
+            isHistoryReadOnly
+              ? undefined
+              : (elementId, file) => {
+                  void vm.replaceVideoAsset(elementId, file);
+                }
+          }
           onClearPageTransition={isHistoryReadOnly ? undefined : vm.clearPageTransition}
           onSetPageTransition={isHistoryReadOnly ? undefined : vm.setPageTransition}
           onSetElementAnimationBuilds={isHistoryReadOnly ? undefined : vm.setElementAnimationBuilds}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -25,6 +25,10 @@ import { ScrollingCanvasWorkspace } from '../canvas/ScrollingCanvasWorkspace';
 import { SettingsPanel } from '../panels/SettingsPanel';
 import { TopToolbar } from '../toolbars/TopToolbar';
 import { VersionHistoryPanel } from '../panels/VersionHistoryPanel';
+import {
+  presentationMovieControls,
+  type MovieHoldState,
+} from '../media/presentationMovieControls';
 import { useEditorViewModel } from '../state/useEditorViewModel';
 import { SharePanel } from '../../share/SharePanel';
 import {
@@ -67,6 +71,7 @@ const editorShortcutActions = [
 export function EditorShell({ services }: EditorShellProps) {
   const vm = useEditorViewModel(services);
   const automationDelegateRef = useRef(vm.automation);
+  const movieHoldStateRef = useRef<MovieHoldState | undefined>(undefined);
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);
   const [designFontFocusKey, setDesignFontFocusKey] = useState(0);
   const [speakerNotesOpen, setSpeakerNotesOpen] = useState(false);
@@ -196,35 +201,29 @@ export function EditorShell({ services }: EditorShellProps) {
     return Array.from(slideFrameRef.current?.querySelectorAll('video') ?? []);
   }
 
-  function getVideoTrimStart(video: HTMLVideoElement) {
-    const trimStart = Number(video.dataset.trimStart);
-    return Number.isFinite(trimStart) ? Math.max(0, trimStart) : 0;
-  }
-
-  function getVideoTrimEnd(video: HTMLVideoElement) {
-    const trimEnd = Number(video.dataset.trimEnd);
-    if (Number.isFinite(trimEnd) && trimEnd > 0) return trimEnd;
-    return Number.isFinite(video.duration) ? video.duration : video.currentTime;
-  }
-
-  const controlPresentationMovies = useCallback((action: 'end' | 'forward' | 'play-toggle' | 'rewind' | 'start') => {
+  const controlPresentationMovies = useCallback((action: 'end' | 'play-toggle' | 'start') => {
     const videos = getPresentationVideos();
-    if (videos.length === 0) return false;
-    const frameStepSeconds = 1 / 30;
-    for (const video of videos) {
-      if (action === 'play-toggle') {
-        if (video.paused) void video.play();
-        else video.pause();
-        continue;
-      }
-      const trimStart = getVideoTrimStart(video);
-      const trimEnd = getVideoTrimEnd(video);
-      if (action === 'start') video.currentTime = trimStart;
-      if (action === 'end') video.currentTime = trimEnd;
-      if (action === 'rewind') video.currentTime = Math.max(trimStart, video.currentTime - frameStepSeconds);
-      if (action === 'forward') video.currentTime = Math.min(trimEnd, video.currentTime + frameStepSeconds);
-    }
-    return true;
+    return presentationMovieControls.control(videos, action);
+  }, []);
+
+  const pulsePresentationMovieHold = useCallback((action: 'fast-forward' | 'rewind') => {
+    movieHoldStateRef.current = presentationMovieControls.pulse(
+      getPresentationVideos(),
+      action,
+      movieHoldStateRef.current,
+    );
+  }, []);
+
+  const startPresentationMovieHold = useCallback((action: 'fast-forward' | 'rewind') => {
+    movieHoldStateRef.current = presentationMovieControls.startHold(
+      getPresentationVideos(),
+      action,
+      movieHoldStateRef.current,
+    );
+  }, []);
+
+  const stopPresentationMovieHold = useCallback(() => {
+    movieHoldStateRef.current = presentationMovieControls.stopHold(movieHoldStateRef.current);
   }, []);
 
   function showSlideNumber() {
@@ -316,8 +315,8 @@ export function EditorShell({ services }: EditorShellProps) {
       return;
     }
     if (action === 'play-pause-movie') controlPresentationMovies('play-toggle');
-    if (action === 'rewind-movie') controlPresentationMovies('rewind');
-    if (action === 'fast-forward-movie') controlPresentationMovies('forward');
+    if (action === 'rewind-movie') pulsePresentationMovieHold('rewind');
+    if (action === 'fast-forward-movie') pulsePresentationMovieHold('fast-forward');
     if (action === 'jump-movie-start') controlPresentationMovies('start');
     if (action === 'jump-movie-end') controlPresentationMovies('end');
   }
@@ -495,12 +494,12 @@ export function EditorShell({ services }: EditorShellProps) {
         }
         if (lowerKey === 'j') {
           event.preventDefault();
-          controlPresentationMovies('rewind');
+          if (!event.repeat) startPresentationMovieHold('rewind');
           return;
         }
         if (lowerKey === 'l') {
           event.preventDefault();
-          controlPresentationMovies('forward');
+          if (!event.repeat) startPresentationMovieHold('fast-forward');
           return;
         }
         if (lowerKey === 'i') {
@@ -553,9 +552,16 @@ export function EditorShell({ services }: EditorShellProps) {
       vm.deleteSelectedElement();
     }
 
+    function handleKeyUp(event: KeyboardEvent) {
+      if (event.key.toLowerCase() !== 'j' && event.key.toLowerCase() !== 'l') return;
+      stopPresentationMovieHold();
+    }
+
     window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
     };
   }, [
     activePageIndex,
@@ -567,10 +573,18 @@ export function EditorShell({ services }: EditorShellProps) {
     playRelativePresentationSlide,
     presentationBlankScreen,
     presentationPaused,
+    startPresentationMovieHold,
     slideNavigatorIndex,
     slideNavigatorOpen,
+    stopPresentationMovieHold,
     vm,
   ]);
+
+  useEffect(() => {
+    return () => {
+      movieHoldStateRef.current = presentationMovieControls.stopHold(movieHoldStateRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     automationDelegateRef.current = vm.automation;

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type Konva from 'konva';
 import type { AppServices } from '../../../app/composition';
 import type { ShareMetadata } from '../../../services/contracts/interfaces';
@@ -27,12 +27,42 @@ import { TopToolbar } from '../toolbars/TopToolbar';
 import { VersionHistoryPanel } from '../panels/VersionHistoryPanel';
 import { useEditorViewModel } from '../state/useEditorViewModel';
 import { SharePanel } from '../../share/SharePanel';
+import {
+  KeyboardShortcutsDialog,
+  type KeyboardShortcutAction,
+} from '../../components/KeyboardShortcutsDialog';
 import { editorShellBrowserUtils } from '../browser/editorShellBrowserUtils';
 import { BrowserPresenterSessionService } from '../../../services/presenter/presenterSessionService';
 
 interface EditorShellProps {
   services: AppServices;
 }
+
+const editorShortcutActions = [
+  'next-build',
+  'previous-build',
+  'next-slide',
+  'previous-slide',
+  'first-slide',
+  'last-slide',
+  'quit-presentation',
+  'shortcut-toggle',
+  'pause-presentation',
+  'black-screen',
+  'white-screen',
+  'cursor-toggle',
+  'show-slide-number',
+  'open-slide-navigator',
+  'next-navigator-slide',
+  'previous-navigator-slide',
+  'select-navigator-slide',
+  'close-slide-navigator',
+  'play-pause-movie',
+  'rewind-movie',
+  'fast-forward-movie',
+  'jump-movie-start',
+  'jump-movie-end',
+] satisfies KeyboardShortcutAction[];
 
 export function EditorShell({ services }: EditorShellProps) {
   const vm = useEditorViewModel(services);
@@ -41,6 +71,13 @@ export function EditorShell({ services }: EditorShellProps) {
   const [designFontFocusKey, setDesignFontFocusKey] = useState(0);
   const [speakerNotesOpen, setSpeakerNotesOpen] = useState(false);
   const [audienceFullscreenPromptOpen, setAudienceFullscreenPromptOpen] = useState(false);
+  const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
+  const [slideNavigatorOpen, setSlideNavigatorOpen] = useState(false);
+  const [slideNavigatorIndex, setSlideNavigatorIndex] = useState(0);
+  const [presentationPaused, setPresentationPaused] = useState(false);
+  const [presentationBlankScreen, setPresentationBlankScreen] = useState<'black' | 'white' | undefined>();
+  const [presentationCursorHidden, setPresentationCursorHidden] = useState(false);
+  const [slideNumberVisible, setSlideNumberVisible] = useState(false);
   const [presenterSessionId, setPresenterSessionId] = useState<string | undefined>();
   const [presenterViewError, setPresenterViewError] = useState<string | undefined>();
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
@@ -143,6 +180,148 @@ export function EditorShell({ services }: EditorShellProps) {
     void vm.toggleFullscreen(workspaceRef.current);
   }
 
+  const playPresentationPageAt = useCallback((index: number) => {
+    const pageId = vm.project.pages[index]?.id;
+    if (!pageId) return false;
+    setSlideNavigatorIndex(index);
+    vm.playPresentationPreview(pageId);
+    return true;
+  }, [vm]);
+
+  const playRelativePresentationSlide = useCallback((offset: -1 | 1) => {
+    return playPresentationPageAt(activePageIndex + offset);
+  }, [activePageIndex, playPresentationPageAt]);
+
+  function getPresentationVideos() {
+    return Array.from(slideFrameRef.current?.querySelectorAll('video') ?? []);
+  }
+
+  function getVideoTrimStart(video: HTMLVideoElement) {
+    const trimStart = Number(video.dataset.trimStart);
+    return Number.isFinite(trimStart) ? Math.max(0, trimStart) : 0;
+  }
+
+  function getVideoTrimEnd(video: HTMLVideoElement) {
+    const trimEnd = Number(video.dataset.trimEnd);
+    if (Number.isFinite(trimEnd) && trimEnd > 0) return trimEnd;
+    return Number.isFinite(video.duration) ? video.duration : video.currentTime;
+  }
+
+  const controlPresentationMovies = useCallback((action: 'end' | 'forward' | 'play-toggle' | 'rewind' | 'start') => {
+    const videos = getPresentationVideos();
+    if (videos.length === 0) return false;
+    const frameStepSeconds = 1 / 30;
+    for (const video of videos) {
+      if (action === 'play-toggle') {
+        if (video.paused) void video.play();
+        else video.pause();
+        continue;
+      }
+      const trimStart = getVideoTrimStart(video);
+      const trimEnd = getVideoTrimEnd(video);
+      if (action === 'start') video.currentTime = trimStart;
+      if (action === 'end') video.currentTime = trimEnd;
+      if (action === 'rewind') video.currentTime = Math.max(trimStart, video.currentTime - frameStepSeconds);
+      if (action === 'forward') video.currentTime = Math.min(trimEnd, video.currentTime + frameStepSeconds);
+    }
+    return true;
+  }, []);
+
+  function showSlideNumber() {
+    setSlideNumberVisible(true);
+    window.setTimeout(() => setSlideNumberVisible(false), 1600);
+  }
+
+  function togglePresentationPause(blankScreen?: 'black' | 'white') {
+    setPresentationPaused(true);
+    setPresentationBlankScreen(blankScreen);
+  }
+
+  function resumePresentation() {
+    setPresentationPaused(false);
+    setPresentationBlankScreen(undefined);
+  }
+
+  function executePresentationShortcut(action: KeyboardShortcutAction) {
+    if (action === 'shortcut-toggle') {
+      setKeyboardShortcutsOpen((current) => !current);
+      return;
+    }
+    if (action === 'quit-presentation') {
+      setKeyboardShortcutsOpen(false);
+      if (vm.isFullscreen) void vm.toggleFullscreen(workspaceRef.current);
+      return;
+    }
+    if (action === 'open-slide-navigator') {
+      setSlideNavigatorIndex(activePageIndex);
+      setSlideNavigatorOpen(true);
+      return;
+    }
+    if (action === 'close-slide-navigator') {
+      setSlideNavigatorOpen(false);
+      return;
+    }
+    if (action === 'next-navigator-slide') {
+      setSlideNavigatorIndex((current) => Math.min(vm.project.pages.length - 1, current + 1));
+      return;
+    }
+    if (action === 'previous-navigator-slide') {
+      setSlideNavigatorIndex((current) => Math.max(0, current - 1));
+      return;
+    }
+    if (action === 'select-navigator-slide') {
+      playPresentationPageAt(slideNavigatorIndex);
+      setSlideNavigatorOpen(false);
+      return;
+    }
+    if (action === 'first-slide') {
+      playPresentationPageAt(0);
+      return;
+    }
+    if (action === 'last-slide') {
+      playPresentationPageAt(vm.project.pages.length - 1);
+      return;
+    }
+    if (action === 'next-slide') {
+      playRelativePresentationSlide(1);
+      return;
+    }
+    if (action === 'previous-slide') {
+      playRelativePresentationSlide(-1);
+      return;
+    }
+    if (action === 'next-build') {
+      vm.advancePresentationPreview();
+      return;
+    }
+    if (action === 'previous-build') {
+      vm.rewindPresentationPreview();
+      return;
+    }
+    if (action === 'pause-presentation') {
+      if (presentationPaused && !presentationBlankScreen) resumePresentation();
+      else togglePresentationPause();
+      return;
+    }
+    if (action === 'black-screen' || action === 'white-screen') {
+      togglePresentationPause(action === 'black-screen' ? 'black' : 'white');
+      return;
+    }
+    if (action === 'cursor-toggle') {
+      setPresentationCursorHidden((current) => !current);
+      return;
+    }
+    if (action === 'show-slide-number') {
+      showSlideNumber();
+      return;
+    }
+    if (action === 'play-pause-movie') controlPresentationMovies('play-toggle');
+    if (action === 'rewind-movie') controlPresentationMovies('rewind');
+    if (action === 'fast-forward-movie') controlPresentationMovies('forward');
+    if (action === 'jump-movie-start') controlPresentationMovies('start');
+    if (action === 'jump-movie-end') controlPresentationMovies('end');
+  }
+
   function isAnimatedMediaFile(file: File) {
     return file.type === 'image/gif' || file.type.startsWith('video/');
   }
@@ -194,12 +373,14 @@ export function EditorShell({ services }: EditorShellProps) {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (isHistoryReadOnly) return;
+      const isEditableTarget = editorShellBrowserUtils.isEditableInteractionTarget(event.target);
       const isUndoShortcut =
         (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'z' && !event.shiftKey;
       const isRedoShortcut =
         ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'z' && event.shiftKey) ||
         ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'y');
       if (isUndoShortcut || isRedoShortcut) {
+        if (isEditableTarget) return;
         event.preventDefault();
         if (isUndoShortcut) vm.undo();
         if (isRedoShortcut) vm.redo();
@@ -222,22 +403,141 @@ export function EditorShell({ services }: EditorShellProps) {
       const isPresenterPlayback = vm.animationPreview?.mode === 'presenter';
       const isPreviewNavigationActive =
         vm.isFullscreen || Boolean(isPresenterPlayback && vm.animationPreview?.playing);
+      if (keyboardShortcutsOpen && event.key === 'Escape') {
+        event.preventDefault();
+        setKeyboardShortcutsOpen(false);
+        return;
+      }
+      if (slideNavigatorOpen && !isEditableTarget) {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          setSlideNavigatorOpen(false);
+          return;
+        }
+        if (event.key === '+' || event.key === '=') {
+          event.preventDefault();
+          setSlideNavigatorIndex((current) => Math.min(vm.project.pages.length - 1, current + 1));
+          return;
+        }
+        if (event.key === '-') {
+          event.preventDefault();
+          setSlideNavigatorIndex((current) => Math.max(0, current - 1));
+          return;
+        }
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          playPresentationPageAt(slideNavigatorIndex);
+          setSlideNavigatorOpen(false);
+          return;
+        }
+      }
       if (
         isPreviewNavigationActive &&
-        !editorShellBrowserUtils.isEditableInteractionTarget(event.target)
+        !isEditableTarget
       ) {
+        const lowerKey = event.key.toLowerCase();
+        if (event.key === '?' || (event.key === '/' && event.shiftKey)) {
+          event.preventDefault();
+          setKeyboardShortcutsOpen((current) => !current);
+          return;
+        }
+        if (presentationPaused && !['b', 'f', 'w'].includes(lowerKey)) {
+          event.preventDefault();
+          resumePresentation();
+          return;
+        }
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          if (vm.isFullscreen) void vm.toggleFullscreen(workspaceRef.current);
+          return;
+        }
+        if (event.key === '#') {
+          event.preventDefault();
+          setSlideNavigatorIndex(activePageIndex);
+          setSlideNavigatorOpen(true);
+          return;
+        }
+        if (event.key === 'Home') {
+          event.preventDefault();
+          playPresentationPageAt(0);
+          return;
+        }
+        if (event.key === 'End') {
+          event.preventDefault();
+          playPresentationPageAt(vm.project.pages.length - 1);
+          return;
+        }
+        if (lowerKey === 'f') {
+          event.preventDefault();
+          if (presentationPaused && !presentationBlankScreen) resumePresentation();
+          else togglePresentationPause();
+          return;
+        }
+        if (lowerKey === 'b' || lowerKey === 'w') {
+          event.preventDefault();
+          togglePresentationPause(lowerKey === 'b' ? 'black' : 'white');
+          return;
+        }
+        if (lowerKey === 'c') {
+          event.preventDefault();
+          setPresentationCursorHidden((current) => !current);
+          return;
+        }
+        if (lowerKey === 's') {
+          event.preventDefault();
+          showSlideNumber();
+          return;
+        }
+        if (lowerKey === 'k') {
+          event.preventDefault();
+          controlPresentationMovies('play-toggle');
+          return;
+        }
+        if (lowerKey === 'j') {
+          event.preventDefault();
+          controlPresentationMovies('rewind');
+          return;
+        }
+        if (lowerKey === 'l') {
+          event.preventDefault();
+          controlPresentationMovies('forward');
+          return;
+        }
+        if (lowerKey === 'i') {
+          event.preventDefault();
+          controlPresentationMovies('start');
+          return;
+        }
+        if (lowerKey === 'o') {
+          event.preventDefault();
+          controlPresentationMovies('end');
+          return;
+        }
+        if (event.key === 'ArrowDown' && event.shiftKey) {
+          event.preventDefault();
+          playRelativePresentationSlide(1);
+          return;
+        }
         const isNextPreviewKey =
           event.key === 'ArrowRight' ||
           event.key === 'ArrowDown' ||
           event.key === 'PageDown' ||
+          event.key === ']' ||
           event.key === ' ' ||
           event.key === 'Enter';
         const isPreviousPreviewKey =
-          event.key === 'ArrowLeft' || event.key === 'ArrowUp' || event.key === 'PageUp';
+          event.key === 'ArrowLeft' ||
+          event.key === 'ArrowUp' ||
+          event.key === 'PageUp';
+        if (event.key === '[') {
+          event.preventDefault();
+          vm.rewindPresentationPreview();
+          return;
+        }
         if (isNextPreviewKey || isPreviousPreviewKey) {
           event.preventDefault();
           if (isNextPreviewKey) vm.advancePresentationPreview();
-          if (isPreviousPreviewKey) vm.rewindPresentationPreview();
+          if (isPreviousPreviewKey) playRelativePresentationSlide(-1);
           return;
         }
       }
@@ -257,7 +557,20 @@ export function EditorShell({ services }: EditorShellProps) {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [hasSelection, isHistoryReadOnly, vm]);
+  }, [
+    activePageIndex,
+    controlPresentationMovies,
+    hasSelection,
+    isHistoryReadOnly,
+    keyboardShortcutsOpen,
+    playPresentationPageAt,
+    playRelativePresentationSlide,
+    presentationBlankScreen,
+    presentationPaused,
+    slideNavigatorIndex,
+    slideNavigatorOpen,
+    vm,
+  ]);
 
   useEffect(() => {
     automationDelegateRef.current = vm.automation;
@@ -272,6 +585,10 @@ export function EditorShell({ services }: EditorShellProps) {
       }
       if (message.command === 'previous') {
         vm.rewindPresentationPreview();
+        return;
+      }
+      if (message.command === 'go-to-page') {
+        vm.playPresentationPreview(message.pageId);
         return;
       }
       if (message.command === 'update-notes') {
@@ -477,6 +794,7 @@ export function EditorShell({ services }: EditorShellProps) {
         onMirrorToggle={vm.setMirrorEnabled}
         onNewProject={openBlankProjectInNewTab}
         onOpenMirrorSettings={vm.openMirrorSettings}
+        onOpenKeyboardShortcuts={() => setKeyboardShortcutsOpen(true)}
         onOpenVersionHistory={() => {
           void vm.openVersionHistory();
         }}
@@ -623,12 +941,75 @@ export function EditorShell({ services }: EditorShellProps) {
             'workspace-column',
             leftPanelOpen ? 'workspace-column-left-panel-open' : '',
             vm.zoomPercent < 100 ? 'workspace-column-zoomed-out' : '',
+            presentationCursorHidden ? 'workspace-column-cursor-hidden' : '',
           ]
             .filter(Boolean)
             .join(' ')}
           aria-label="Canvas workspace"
           ref={workspaceRef}
         >
+          {keyboardShortcutsOpen ? (
+            <KeyboardShortcutsDialog
+              onClose={() => setKeyboardShortcutsOpen(false)}
+              onShortcutAction={executePresentationShortcut}
+              supportedActions={editorShortcutActions}
+            />
+          ) : null}
+          {slideNavigatorOpen ? (
+            <div className="presentation-slide-navigator" role="dialog" aria-modal="true" aria-label="Slide navigator">
+              <div className="presentation-slide-navigator-header">
+                <h2>Slide Navigator</h2>
+                <button
+                  className="stitch-icon-button"
+                  type="button"
+                  aria-label="Close slide navigator"
+                  onClick={() => setSlideNavigatorOpen(false)}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    close
+                  </span>
+                </button>
+              </div>
+              <div className="presentation-slide-navigator-list" role="listbox" aria-label="Slides">
+                {vm.project.pages.map((page, index) => (
+                  <button
+                    aria-selected={index === slideNavigatorIndex}
+                    className={
+                      index === slideNavigatorIndex
+                        ? 'presentation-slide-navigator-item presentation-slide-navigator-item-active'
+                        : 'presentation-slide-navigator-item'
+                    }
+                    key={page.id}
+                    type="button"
+                    role="option"
+                    onClick={() => setSlideNavigatorIndex(index)}
+                    onDoubleClick={() => {
+                      playPresentationPageAt(index);
+                      setSlideNavigatorOpen(false);
+                    }}
+                  >
+                    <span>Slide {index + 1}</span>
+                    <strong>{page.name}</strong>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          {presentationBlankScreen ? (
+            <div
+              className={
+                presentationBlankScreen === 'black'
+                  ? 'presentation-blank-screen presentation-blank-screen-black'
+                  : 'presentation-blank-screen presentation-blank-screen-white'
+              }
+              aria-label={presentationBlankScreen === 'black' ? 'Black screen' : 'White screen'}
+            />
+          ) : null}
+          {slideNumberVisible ? (
+            <div className="presentation-slide-number" aria-live="polite">
+              Slide {activePageIndex + 1} of {vm.project.pages.length}
+            </div>
+          ) : null}
           <ScrollingCanvasWorkspace
             project={vm.project}
             activePageId={vm.activePageId}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -3768,6 +3768,31 @@ export function useEditorViewModel(services: AppServices) {
     }
   }
 
+  async function replaceVideoAsset(elementId: string, file: File) {
+    if (getMediaAssetType(file) !== 'video') return;
+    const dataUrl = await readImageFileAsDataUrl(file);
+    const mediaSize = await readVideoSize(dataUrl);
+    const videoDurationSeconds = mediaSize.durationSeconds;
+    const assetId = createPrefixedId('asset');
+    const mediaName = file.name.trim() || 'Replacement video';
+
+    commitProject(
+      (currentProject) =>
+        new basicCommands.ReplaceVideoAssetCommand(
+          elementId,
+          {
+            id: assetId,
+            type: 'video',
+            name: mediaName,
+            mimeType: file.type || 'video/mp4',
+            objectUrl: dataUrl,
+          },
+          videoDurationSeconds !== undefined ? { durationSeconds: videoDurationSeconds } : {},
+        ).execute(currentProject),
+      { selectedElementIds: [elementId] },
+    );
+  }
+
   function addRecentStockMedia(item: StockMediaItem) {
     setStockMediaRecentItems((currentItems) => [
       item,
@@ -4115,5 +4140,6 @@ export function useEditorViewModel(services: AppServices) {
     importImageFile,
     importMediaFile: importImageFile,
     clearMediaImportProgress,
+    replaceVideoAsset,
   };
 }

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -714,6 +714,9 @@ export function useEditorViewModel(services: AppServices) {
     if (stockMediaProviderState.gifs.configured && stockGifResults.length === 0) {
       void searchStockGifs('');
     }
+  // The stock search functions are declared later in this hook and intentionally not dependencies:
+  // adding them would rerun this bootstrap effect on every render.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     stockGifResults.length,
     stockImageResults.length,
@@ -3262,6 +3265,16 @@ export function useEditorViewModel(services: AppServices) {
     );
   }
 
+  function updatePageSpeakerNotes(pageId: string, speakerNotes: string) {
+    commitProject((currentProject) => ({
+      ...currentProject,
+      updatedAt: new Date().toISOString(),
+      pages: currentProject.pages.map((page) =>
+        page.id === pageId ? { ...page, speakerNotes } : page,
+      ),
+    }));
+  }
+
   function activateScrolledPage(pageId: string) {
     if (pageId === activePageId) return;
     const page = project.pages.find((item) => item.id === pageId);
@@ -4036,6 +4049,7 @@ export function useEditorViewModel(services: AppServices) {
     reorderPage,
     renamePage,
     setPageVisibility,
+    updatePageSpeakerNotes,
     togglePagesPanel,
     toggleFullscreen,
     undo,

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -291,8 +291,11 @@ function readImageFileAsDataUrl(file: File) {
   });
 }
 
+type MediaSize = { height: number; width: number };
+type VideoSize = MediaSize & { durationSeconds?: number };
+
 function readImageSize(src: string) {
-  return new Promise<{ width: number; height: number }>((resolve, reject) => {
+  return new Promise<MediaSize>((resolve, reject) => {
     const image = new Image();
     image.addEventListener('load', () => {
       resolve({ width: image.naturalWidth, height: image.naturalHeight });
@@ -305,11 +308,17 @@ function readImageSize(src: string) {
 }
 
 function readVideoSize(src: string) {
-  return new Promise<{ width: number; height: number }>((resolve, reject) => {
+  return new Promise<VideoSize>((resolve, reject) => {
     const video = document.createElement('video');
     video.preload = 'metadata';
     video.addEventListener('loadedmetadata', () => {
-      resolve({ width: video.videoWidth || 16, height: video.videoHeight || 9 });
+      resolve({
+        ...(Number.isFinite(video.duration) && video.duration > 0
+          ? { durationSeconds: video.duration }
+          : {}),
+        width: video.videoWidth || 16,
+        height: video.videoHeight || 9,
+      });
     });
     video.addEventListener('error', () => {
       reject(new Error('Video dimensions could not be read.'));
@@ -3616,6 +3625,8 @@ export function useEditorViewModel(services: AppServices) {
       const mediaUrl = objectUrl ?? (await readImageFileAsDataUrl(file));
       const mediaSize =
         assetType === 'video' ? await readVideoSize(mediaUrl) : await readImageSize(mediaUrl);
+      const videoDurationSeconds =
+        assetType === 'video' ? (mediaSize as VideoSize).durationSeconds : undefined;
       const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
       if (!page) {
         setMediaImportProgress(undefined);
@@ -3698,6 +3709,12 @@ export function useEditorViewModel(services: AppServices) {
                 muted: true,
                 autoplayInPreview: true,
                 trimStartSeconds: 0,
+                ...(videoDurationSeconds !== undefined
+                  ? {
+                      durationSeconds: videoDurationSeconds,
+                      trimEndSeconds: videoDurationSeconds,
+                    }
+                  : {}),
               },
             }).execute(currentProject),
           { selectedElementIds: [elementId] },

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -35,6 +35,7 @@ interface TopToolbarProps {
   onMirrorNow?: (() => void) | undefined;
   onMirrorToggle?: ((enabled: boolean) => void) | undefined;
   onOpenMirrorSettings?: (() => void) | undefined;
+  onOpenKeyboardShortcuts?: (() => void) | undefined;
   onOpenVersionHistory?: (() => void) | undefined;
   onNewProject?: (() => void) | undefined;
   onPersistenceToggle?: ((enabled: boolean) => void) | undefined;
@@ -146,6 +147,7 @@ export function TopToolbar({
   onMirrorNow,
   onMirrorToggle,
   onOpenMirrorSettings,
+  onOpenKeyboardShortcuts,
   onOpenVersionHistory,
   onNewProject,
   onPersistenceToggle,
@@ -267,7 +269,7 @@ export function TopToolbar({
         : { label: 'Toggle Layers Panel', disabled: true },
     ],
     Help: [
-      { label: 'Keyboard Shortcuts', disabled: true },
+      { label: 'Keyboard Shortcuts', disabled: !onOpenKeyboardShortcuts, onSelect: onOpenKeyboardShortcuts },
       { label: 'Local AI Setup', disabled: true },
     ],
   };

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -41,6 +41,7 @@ interface TopToolbarProps {
   onSaveLocal?: (() => void) | undefined;
   onSaveLocalAs?: (() => void) | undefined;
   onProjectNameChange?: ((name: string) => void) | undefined;
+  onOpenPresenterView?: (() => void) | undefined;
   onRedo?: (() => void) | undefined;
   onResetZoom?: (() => void) | undefined;
   onSelectLayers?: (() => void) | undefined;
@@ -149,6 +150,7 @@ export function TopToolbar({
   onNewProject,
   onPersistenceToggle,
   onProjectNameChange,
+  onOpenPresenterView,
   onRedo,
   onResetZoom,
   onSelectLayers,
@@ -208,6 +210,16 @@ export function TopToolbar({
   function startPresenterMode(options?: { fromBeginning?: boolean }) {
     if (options) {
       onStartPresenterMode?.(options);
+    } else {
+      onStartPresenterMode?.();
+    }
+    setPlayMenuOpen(false);
+    setTranslationMenuOpen(false);
+  }
+
+  function startDefaultPresentation() {
+    if (onOpenPresenterView) {
+      onOpenPresenterView();
     } else {
       onStartPresenterMode?.();
     }
@@ -428,8 +440,8 @@ export function TopToolbar({
               className="project-play-button project-play-main"
               type="button"
               aria-label="Play presentation"
-              title="Play presentation"
-              onClick={() => startPresenterMode()}
+              title="Open presenter view"
+              onClick={startDefaultPresentation}
             >
               <span className="material-symbols-outlined" aria-hidden="true">
                 play_arrow
@@ -458,6 +470,31 @@ export function TopToolbar({
                 role="menu"
                 aria-label="Presentation play menu"
               >
+                <button
+                  className="toolbar-dropdown-item project-play-dropdown-item"
+                  role="menuitem"
+                  type="button"
+                  onClick={() => startPresenterMode()}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    fullscreen
+                  </span>
+                  <span>Present in fullscreen</span>
+                </button>
+                <button
+                  className="toolbar-dropdown-item project-play-dropdown-item"
+                  role="menuitem"
+                  type="button"
+                  onClick={() => {
+                    setPlayMenuOpen(false);
+                    onOpenPresenterView?.();
+                  }}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    co_present
+                  </span>
+                  <span>Presenter view</span>
+                </button>
                 <button
                   className="toolbar-dropdown-item project-play-dropdown-item"
                   role="menuitem"

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -1,0 +1,393 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { DesignElement, Page, ProjectDocument, SelectionState } from '../../domain/documents/model';
+import type {
+  PresenterCommandMessage,
+  PresenterStateMessage,
+  PresenterStatePayload,
+  PresenterWindowCommand,
+} from '../../services/presenter/presenterSessionTypes';
+import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
+
+interface PresenterViewProps {
+  sessionId?: string;
+}
+
+const introStorageKey = 'localstudio.presenterWindowIntroDismissed';
+const notesZoomStepPx = 2;
+
+function isPresenterStateMessage(value: unknown): value is PresenterStateMessage {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record.source === 'localstudio-presenter-main' &&
+    record.type === 'state' &&
+    typeof record.sessionId === 'string' &&
+    Boolean(record.payload)
+  );
+}
+
+function getRouteSessionId() {
+  return new URL(window.location.href).searchParams.get('presenterSession') ?? undefined;
+}
+
+function getInitialIntroDismissed() {
+  return window.localStorage.getItem(introStorageKey) === '1';
+}
+
+function getPresenterOpener() {
+  const candidate = window.opener as unknown;
+  if (!candidate || typeof candidate !== 'object') return null;
+  if (!('postMessage' in candidate)) return null;
+  return candidate as Window;
+}
+
+function formatElapsed(ms: number) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+function getActivePage(project: ProjectDocument, activePageId: string) {
+  return project.pages.find((page) => page.id === activePageId) ?? project.pages[0];
+}
+
+function getPageIndex(project: ProjectDocument, activePageId: string) {
+  return Math.max(
+    0,
+    project.pages.findIndex((page) => page.id === activePageId),
+  );
+}
+
+function getBuildsRemaining(payload: PresenterStatePayload, page: Page) {
+  const validBuilds = (page.animationBuilds ?? []).filter((build) =>
+    page.elementIds.includes(build.elementId),
+  );
+  if (validBuilds.length === 0) return 0;
+  if (payload.animationPreview?.pageId !== page.id) return validBuilds.length;
+  if (payload.animationPreview.phase === 'complete') return 0;
+  const hiddenElementIds = new Set(payload.animationPreview.hiddenElementIds);
+  return validBuilds.filter((build) => hiddenElementIds.has(build.elementId)).length;
+}
+
+function getElementStyle(element: DesignElement, page: Page): CSSProperties {
+  return {
+    height: `${(element.height / page.height) * 100}%`,
+    left: `${(element.x / page.width) * 100}%`,
+    opacity: element.opacity,
+    top: `${(element.y / page.height) * 100}%`,
+    transform: `rotate(${element.rotation}deg)`,
+    width: `${(element.width / page.width) * 100}%`,
+  };
+}
+
+export function PresenterView({ sessionId = getRouteSessionId() }: PresenterViewProps) {
+  const [snapshot, setSnapshot] = useState<PresenterStatePayload | undefined>();
+  const [currentTime, setCurrentTime] = useState(() => new Date());
+  const [timerNow, setTimerNow] = useState(() => Date.now());
+  const [timerStartedAt, setTimerStartedAt] = useState(() => Date.now());
+  const [timerBaseMs, setTimerBaseMs] = useState(0);
+  const [timerPaused, setTimerPaused] = useState(false);
+  const [notesFontSize, setNotesFontSize] = useState(34);
+  const [introDismissed, setIntroDismissed] = useState(getInitialIntroDismissed);
+  const [dismissIntroForever, setDismissIntroForever] = useState(false);
+  const emptySelection = useMemo<SelectionState>(() => ({ elementIds: [], pageId: '' }), []);
+  const openerRef = useRef<Window | null>(getPresenterOpener());
+  const resolvedSessionId = sessionId ?? 'presenter';
+
+  const postCommand = useCallback((command: PresenterWindowCommand) => {
+    const message: PresenterCommandMessage = {
+      ...command,
+      sessionId: resolvedSessionId,
+      source: 'localstudio-presenter-window',
+      type: 'command',
+    };
+    openerRef.current?.postMessage(message, window.location.origin);
+  }, [resolvedSessionId]);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setCurrentTime(new Date());
+      setTimerNow(Date.now());
+    }, 1000);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return;
+      if (!isPresenterStateMessage(event.data)) return;
+      if (event.data.sessionId !== resolvedSessionId) return;
+      setSnapshot(event.data.payload);
+    }
+
+    window.addEventListener('message', handleMessage);
+    postCommand({ command: 'request-state' });
+    postCommand({ command: 'resume-timer' });
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [postCommand, resolvedSessionId]);
+
+  useEffect(() => {
+    function handlePageHide() {
+      postCommand({ command: 'close' });
+    }
+
+    window.addEventListener('pagehide', handlePageHide);
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide);
+    };
+  }, [postCommand]);
+
+  const elapsedMs = timerPaused ? timerBaseMs : timerBaseMs + (timerNow - timerStartedAt);
+  const activePage = snapshot ? getActivePage(snapshot.project, snapshot.activePageId) : undefined;
+  const activePageIndex = snapshot ? getPageIndex(snapshot.project, snapshot.activePageId) : 0;
+  const buildsRemaining = snapshot && activePage ? getBuildsRemaining(snapshot, activePage) : 0;
+  const speakerNotes = activePage?.speakerNotes ?? '';
+  const currentTimeLabel = currentTime.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  function toggleTimer() {
+    if (timerPaused) {
+      const now = Date.now();
+      setTimerNow(now);
+      setTimerStartedAt(now);
+      setTimerPaused(false);
+      postCommand({ command: 'resume-timer' });
+      return;
+    }
+    setTimerBaseMs(elapsedMs);
+    setTimerPaused(true);
+    postCommand({ command: 'pause-timer' });
+  }
+
+  function resetTimer() {
+    const now = Date.now();
+    setTimerBaseMs(0);
+    setTimerNow(now);
+    setTimerStartedAt(now);
+    setTimerPaused(false);
+    postCommand({ command: 'reset-timer' });
+  }
+
+  function dismissIntro() {
+    if (dismissIntroForever) window.localStorage.setItem(introStorageKey, '1');
+    setIntroDismissed(true);
+  }
+
+  const introOverlay = !introDismissed ? (
+    <div className="presenter-intro-backdrop" role="presentation">
+      <section className="presenter-intro-dialog" role="dialog" aria-modal="true" aria-labelledby="presenter-intro-title">
+        <h1 id="presenter-intro-title">Presenter Window</h1>
+        <p>
+          This window is just for you. Place it on the screen only you can see, such as your laptop or a fallback
+          monitor.
+        </p>
+        <label>
+          <input
+            type="checkbox"
+            checked={dismissIntroForever}
+            onChange={(event) => setDismissIntroForever(event.target.checked)}
+          />
+          <span>Don&apos;t show this message again</span>
+        </label>
+        <button type="button" onClick={dismissIntro}>
+          Got it
+        </button>
+      </section>
+    </div>
+  ) : null;
+
+  if (!snapshot || !activePage) {
+    return (
+      <main className="presenter-view presenter-view-disconnected" aria-label="Presenter view">
+        <p>Waiting for presentation...</p>
+        {introOverlay}
+      </main>
+    );
+  }
+
+  return (
+    <main className="presenter-view" aria-label="Presenter view">
+      <section className="presenter-main">
+        <header className="presenter-topbar">
+          <div className="presenter-clock-group">
+            <span className="presenter-clock">{currentTimeLabel}</span>
+            <span className="presenter-divider" aria-hidden="true" />
+            <span className="presenter-timer">{formatElapsed(elapsedMs)}</span>
+          </div>
+          <div className="presenter-controls" aria-label="Presenter controls">
+            <button
+              className="stitch-icon-button presenter-control-button"
+              type="button"
+              aria-label="Previous slide"
+              onClick={() => postCommand({ command: 'previous' })}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                chevron_left
+              </span>
+            </button>
+            <button
+              className="stitch-icon-button presenter-control-button"
+              type="button"
+              aria-label={timerPaused ? 'Resume timer' : 'Pause timer'}
+              onClick={toggleTimer}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                {timerPaused ? 'play_arrow' : 'pause'}
+              </span>
+            </button>
+            <button
+              className="stitch-icon-button presenter-control-button"
+              type="button"
+              aria-label="Reset timer"
+              onClick={resetTimer}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                history
+              </span>
+            </button>
+            <button
+              className="stitch-icon-button presenter-control-button"
+              type="button"
+              aria-label="Next slide"
+              onClick={() => postCommand({ command: 'next' })}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                chevron_right
+              </span>
+            </button>
+          </div>
+        </header>
+        <div className="presenter-status-row" aria-label="Presenter status">
+          <span className="presenter-status-item">
+            Current: Slide {activePageIndex + 1} of {snapshot.project.pages.length}
+          </span>
+          <span className="presenter-status-item">Builds remaining: {buildsRemaining}</span>
+        </div>
+        <section className="presenter-stage" aria-label="Current slide">
+          <CanvasWorkspace
+            project={snapshot.project}
+            activePageId={activePage.id}
+            selection={{ ...emptySelection, pageId: activePage.id }}
+            presentationMode
+            readOnly
+            zoomPercent={100}
+            animationPreview={snapshot.animationPreview}
+          />
+        </section>
+        <nav className="presenter-slide-strip" aria-label="Slide previews">
+          {snapshot.project.pages.map((page, index) => (
+            <button
+              aria-current={index === activePageIndex ? 'page' : undefined}
+              aria-label={page.name}
+              className={index === activePageIndex ? 'presenter-thumb presenter-thumb-active' : 'presenter-thumb'}
+              key={page.id}
+              type="button"
+              onClick={() => {
+                if (index < activePageIndex) postCommand({ command: 'previous' });
+                if (index > activePageIndex) postCommand({ command: 'next' });
+              }}
+            >
+              <PresenterThumbnail page={page} project={snapshot.project} />
+            </button>
+          ))}
+        </nav>
+      </section>
+      <aside className="presenter-notes-panel" aria-label="Presenter notes">
+        <div className="presenter-notes-tabs">
+          <span className="presenter-notes-tab-active">Notes</span>
+        </div>
+        <textarea
+          aria-label="Speaker notes"
+          className={speakerNotes ? 'presenter-notes-textarea' : 'presenter-notes-textarea presenter-notes-empty'}
+          placeholder="Add notes to your design"
+          style={{ fontSize: `${notesFontSize}px` }}
+          value={speakerNotes}
+          onChange={(event) =>
+            postCommand({ command: 'update-notes', notes: event.target.value, pageId: activePage.id })
+          }
+        />
+        <div className="presenter-notes-zoom" aria-label="Notes zoom controls">
+          <button
+            className="stitch-icon-button presenter-notes-zoom-button"
+            type="button"
+            aria-label="Decrease notes size"
+            onClick={() => setNotesFontSize((current) => Math.max(18, current - notesZoomStepPx))}
+          >
+            -
+          </button>
+          <span aria-hidden="true">aA</span>
+          <button
+            className="stitch-icon-button presenter-notes-zoom-button"
+            type="button"
+            aria-label="Increase notes size"
+            onClick={() => setNotesFontSize((current) => Math.min(56, current + notesZoomStepPx))}
+          >
+            +
+          </button>
+        </div>
+      </aside>
+      {introOverlay}
+    </main>
+  );
+}
+
+function PresenterThumbnail({ page, project }: { page: Page; project: ProjectDocument }) {
+  const background =
+    page.background.type === 'color'
+      ? page.background.color
+      : (project.assets[page.background.assetId]?.objectUrl ?? page.background.colorFallback);
+
+  return (
+    <span
+      className="presenter-thumb-canvas"
+      style={{
+        aspectRatio: `${page.width} / ${page.height}`,
+        backgroundColor: page.background.type === 'color' ? background : page.background.colorFallback,
+      }}
+    >
+      {page.background.type === 'asset' && project.assets[page.background.assetId]?.objectUrl ? (
+        <img alt="" className="presenter-thumb-bg" src={project.assets[page.background.assetId]?.objectUrl} />
+      ) : null}
+      {page.elementIds.map((elementId) => {
+        const element = project.elements[elementId];
+        if (!element || element.visible === false) return null;
+        const style = getElementStyle(element, page);
+        if (element.type === 'image') {
+          const asset = project.assets[element.assetId];
+          return asset?.objectUrl ? (
+            <img alt="" className="presenter-thumb-element" key={element.id} src={asset.objectUrl} style={style} />
+          ) : null;
+        }
+        if (element.type === 'text') {
+          return (
+            <span
+              className="presenter-thumb-element presenter-thumb-text"
+              key={element.id}
+              style={{
+                ...style,
+                color: element.fill,
+                fontFamily: element.fontFamily,
+                fontSize: `${Math.max(4, (element.fontSize / page.width) * 100)}cqw`,
+                fontWeight: element.fontWeight,
+                textAlign: element.align,
+              }}
+            >
+              {element.text}
+            </span>
+          );
+        }
+        return <span className="presenter-thumb-element" key={element.id} style={style} />;
+      })}
+    </span>
+  );
+}

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -7,6 +7,10 @@ import type {
   PresenterStatePayload,
   PresenterWindowCommand,
 } from '../../services/presenter/presenterSessionTypes';
+import {
+  KeyboardShortcutsDialog,
+  type KeyboardShortcutAction,
+} from '../components/KeyboardShortcutsDialog';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
 
 interface PresenterViewProps {
@@ -15,6 +19,30 @@ interface PresenterViewProps {
 
 const introStorageKey = 'localstudio.presenterWindowIntroDismissed';
 const notesZoomStepPx = 2;
+const presenterShortcutActions = [
+  'next-build',
+  'previous-build',
+  'next-slide',
+  'previous-slide',
+  'first-slide',
+  'last-slide',
+  'shortcut-toggle',
+  'open-slide-navigator',
+  'next-navigator-slide',
+  'previous-navigator-slide',
+  'select-navigator-slide',
+  'close-slide-navigator',
+  'reset-timer',
+  'scroll-notes-up',
+  'scroll-notes-down',
+  'increase-notes',
+  'decrease-notes',
+  'play-pause-movie',
+  'rewind-movie',
+  'fast-forward-movie',
+  'jump-movie-start',
+  'jump-movie-end',
+] satisfies KeyboardShortcutAction[];
 
 function isPresenterStateMessage(value: unknown): value is PresenterStateMessage {
   if (!value || typeof value !== 'object') return false;
@@ -40,6 +68,15 @@ function getPresenterOpener() {
   if (!candidate || typeof candidate !== 'object') return null;
   if (!('postMessage' in candidate)) return null;
   return candidate as Window;
+}
+
+function isEditablePresenterTarget(target: EventTarget | null) {
+  const isEditableElement = (value: Element | EventTarget | null) =>
+    value instanceof HTMLInputElement ||
+    value instanceof HTMLTextAreaElement ||
+    value instanceof HTMLSelectElement ||
+    (value instanceof HTMLElement && value.isContentEditable);
+  return isEditableElement(target) || isEditableElement(document.activeElement);
 }
 
 function formatElapsed(ms: number) {
@@ -92,10 +129,15 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
   const [timerBaseMs, setTimerBaseMs] = useState(0);
   const [timerPaused, setTimerPaused] = useState(false);
   const [notesFontSize, setNotesFontSize] = useState(34);
+  const [keyboardShortcutsMode, setKeyboardShortcutsMode] = useState<'dialog' | 'popover' | undefined>();
+  const [slideNavigatorOpen, setSlideNavigatorOpen] = useState(false);
+  const [slideNavigatorIndex, setSlideNavigatorIndex] = useState(0);
   const [introDismissed, setIntroDismissed] = useState(getInitialIntroDismissed);
   const [dismissIntroForever, setDismissIntroForever] = useState(false);
   const emptySelection = useMemo<SelectionState>(() => ({ elementIds: [], pageId: '' }), []);
   const openerRef = useRef<Window | null>(getPresenterOpener());
+  const presenterStageRef = useRef<HTMLElement>(null);
+  const notesRef = useRef<HTMLTextAreaElement>(null);
   const resolvedSessionId = sessionId ?? 'presenter';
 
   const postCommand = useCallback((command: PresenterWindowCommand) => {
@@ -169,19 +211,285 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     postCommand({ command: 'pause-timer' });
   }
 
-  function resetTimer() {
+  const resetTimer = useCallback(() => {
     const now = Date.now();
     setTimerBaseMs(0);
     setTimerNow(now);
     setTimerStartedAt(now);
     setTimerPaused(false);
     postCommand({ command: 'reset-timer' });
+  }, [postCommand]);
+
+  function getPresenterVideos() {
+    return Array.from(presenterStageRef.current?.querySelectorAll('video') ?? []);
   }
+
+  function getVideoTrimStart(video: HTMLVideoElement) {
+    const trimStart = Number(video.dataset.trimStart);
+    return Number.isFinite(trimStart) ? Math.max(0, trimStart) : 0;
+  }
+
+  function getVideoTrimEnd(video: HTMLVideoElement) {
+    const trimEnd = Number(video.dataset.trimEnd);
+    if (Number.isFinite(trimEnd) && trimEnd > 0) return trimEnd;
+    return Number.isFinite(video.duration) ? video.duration : video.currentTime;
+  }
+
+  const controlPresenterMovies = useCallback((action: 'end' | 'forward' | 'play-toggle' | 'rewind' | 'start') => {
+    const videos = getPresenterVideos();
+    if (videos.length === 0) return false;
+    const frameStepSeconds = 1 / 30;
+    for (const video of videos) {
+      if (action === 'play-toggle') {
+        if (video.paused) void video.play();
+        else video.pause();
+        continue;
+      }
+      const trimStart = getVideoTrimStart(video);
+      const trimEnd = getVideoTrimEnd(video);
+      if (action === 'start') video.currentTime = trimStart;
+      if (action === 'end') video.currentTime = trimEnd;
+      if (action === 'rewind') video.currentTime = Math.max(trimStart, video.currentTime - frameStepSeconds);
+      if (action === 'forward') video.currentTime = Math.min(trimEnd, video.currentTime + frameStepSeconds);
+    }
+    return true;
+  }, []);
+
+  const goToPage = useCallback((index: number) => {
+    const page = snapshot?.project.pages[index];
+    if (!page) return false;
+    setSlideNavigatorIndex(index);
+    postCommand({ command: 'go-to-page', pageId: page.id });
+    return true;
+  }, [postCommand, snapshot]);
+
+  const executePresenterShortcut = useCallback((action: KeyboardShortcutAction) => {
+    if (action === 'shortcut-toggle') {
+      setKeyboardShortcutsMode((current) => (current === 'dialog' ? undefined : 'dialog'));
+      return;
+    }
+    if (action === 'open-slide-navigator') {
+      setSlideNavigatorIndex(activePageIndex);
+      setSlideNavigatorOpen(true);
+      return;
+    }
+    if (action === 'close-slide-navigator') {
+      setSlideNavigatorOpen(false);
+      return;
+    }
+    if (action === 'next-navigator-slide') {
+      setSlideNavigatorIndex((current) =>
+        Math.min((snapshot?.project.pages.length ?? 1) - 1, current + 1),
+      );
+      return;
+    }
+    if (action === 'previous-navigator-slide') {
+      setSlideNavigatorIndex((current) => Math.max(0, current - 1));
+      return;
+    }
+    if (action === 'select-navigator-slide') {
+      goToPage(slideNavigatorIndex);
+      setSlideNavigatorOpen(false);
+      return;
+    }
+    if (action === 'first-slide') {
+      goToPage(0);
+      return;
+    }
+    if (action === 'last-slide') {
+      goToPage((snapshot?.project.pages.length ?? 1) - 1);
+      return;
+    }
+    if (action === 'next-slide') {
+      goToPage(activePageIndex + 1);
+      return;
+    }
+    if (action === 'previous-slide') {
+      goToPage(activePageIndex - 1);
+      return;
+    }
+    if (action === 'previous-build') {
+      postCommand({ command: 'previous' });
+      return;
+    }
+    if (action === 'next-build') {
+      postCommand({ command: 'next' });
+      return;
+    }
+    if (action === 'reset-timer') {
+      resetTimer();
+      return;
+    }
+    if (action === 'scroll-notes-up' || action === 'scroll-notes-down') {
+      notesRef.current?.scrollBy({ top: action === 'scroll-notes-up' ? -96 : 96, behavior: 'smooth' });
+      return;
+    }
+    if (action === 'increase-notes') {
+      setNotesFontSize((current) => Math.min(56, current + notesZoomStepPx));
+      return;
+    }
+    if (action === 'decrease-notes') {
+      setNotesFontSize((current) => Math.max(18, current - notesZoomStepPx));
+      return;
+    }
+    if (action === 'play-pause-movie') controlPresenterMovies('play-toggle');
+    if (action === 'rewind-movie') controlPresenterMovies('rewind');
+    if (action === 'fast-forward-movie') controlPresenterMovies('forward');
+    if (action === 'jump-movie-start') controlPresenterMovies('start');
+    if (action === 'jump-movie-end') controlPresenterMovies('end');
+    if (action === 'quit-presentation') window.close();
+  }, [
+    activePageIndex,
+    controlPresenterMovies,
+    goToPage,
+    postCommand,
+    resetTimer,
+    slideNavigatorIndex,
+    snapshot,
+  ]);
 
   function dismissIntro() {
     if (dismissIntroForever) window.localStorage.setItem(introStorageKey, '1');
     setIntroDismissed(true);
   }
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (isEditablePresenterTarget(event.target)) return;
+
+      if (keyboardShortcutsMode && event.key === 'Escape') {
+        event.preventDefault();
+        setKeyboardShortcutsMode(undefined);
+        return;
+      }
+      if (slideNavigatorOpen) {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          setSlideNavigatorOpen(false);
+          return;
+        }
+        if (event.key === '+' || event.key === '=') {
+          event.preventDefault();
+          setSlideNavigatorIndex((current) =>
+            Math.min((snapshot?.project.pages.length ?? 1) - 1, current + 1),
+          );
+          return;
+        }
+        if (event.key === '-') {
+          event.preventDefault();
+          setSlideNavigatorIndex((current) => Math.max(0, current - 1));
+          return;
+        }
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          goToPage(slideNavigatorIndex);
+          setSlideNavigatorOpen(false);
+          return;
+        }
+      }
+
+      const lowerKey = event.key.toLowerCase();
+      if (event.key === '?' || (event.key === '/' && event.shiftKey)) {
+        event.preventDefault();
+        executePresenterShortcut('shortcut-toggle');
+        return;
+      }
+      if (!snapshot) return;
+      if (event.key === '#') {
+        event.preventDefault();
+        executePresenterShortcut('open-slide-navigator');
+        return;
+      }
+      if (event.key === 'Home') {
+        event.preventDefault();
+        executePresenterShortcut('first-slide');
+        return;
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        executePresenterShortcut('last-slide');
+        return;
+      }
+      if (event.key === 'ArrowDown' && event.shiftKey) {
+        event.preventDefault();
+        executePresenterShortcut('next-slide');
+        return;
+      }
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown' || event.key === 'PageDown' || event.key === ' ' || event.key === 'Enter' || event.key === ']') {
+        event.preventDefault();
+        executePresenterShortcut('next-build');
+        return;
+      }
+      if (event.key === '[') {
+        event.preventDefault();
+        executePresenterShortcut('previous-build');
+        return;
+      }
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowUp' || event.key === 'PageUp') {
+        event.preventDefault();
+        executePresenterShortcut('previous-slide');
+        return;
+      }
+      if (lowerKey === 'r') {
+        event.preventDefault();
+        executePresenterShortcut('reset-timer');
+        return;
+      }
+      if (lowerKey === 'u' || lowerKey === 'd') {
+        event.preventDefault();
+        executePresenterShortcut(lowerKey === 'u' ? 'scroll-notes-up' : 'scroll-notes-down');
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && (event.key === '+' || event.key === '=')) {
+        event.preventDefault();
+        executePresenterShortcut('increase-notes');
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key === '-') {
+        event.preventDefault();
+        executePresenterShortcut('decrease-notes');
+        return;
+      }
+      if (lowerKey === 'k') {
+        event.preventDefault();
+        executePresenterShortcut('play-pause-movie');
+        return;
+      }
+      if (lowerKey === 'j') {
+        event.preventDefault();
+        executePresenterShortcut('rewind-movie');
+        return;
+      }
+      if (lowerKey === 'l') {
+        event.preventDefault();
+        executePresenterShortcut('fast-forward-movie');
+        return;
+      }
+      if (lowerKey === 'i') {
+        event.preventDefault();
+        executePresenterShortcut('jump-movie-start');
+        return;
+      }
+      if (lowerKey === 'o') {
+        event.preventDefault();
+        executePresenterShortcut('jump-movie-end');
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    activePageIndex,
+    controlPresenterMovies,
+    executePresenterShortcut,
+    goToPage,
+    keyboardShortcutsMode,
+    postCommand,
+    resetTimer,
+    slideNavigatorIndex,
+    slideNavigatorOpen,
+    snapshot,
+  ]);
 
   const introOverlay = !introDismissed ? (
     <div className="presenter-intro-backdrop" role="presentation">
@@ -258,6 +566,19 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
             <button
               className="stitch-icon-button presenter-control-button"
               type="button"
+              aria-label="Show keyboard shortcuts"
+              aria-expanded={keyboardShortcutsMode === 'popover'}
+              onClick={() =>
+                setKeyboardShortcutsMode((current) => (current === 'popover' ? undefined : 'popover'))
+              }
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                keyboard
+              </span>
+            </button>
+            <button
+              className="stitch-icon-button presenter-control-button"
+              type="button"
               aria-label="Next slide"
               onClick={() => postCommand({ command: 'next' })}
             >
@@ -273,7 +594,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
           </span>
           <span className="presenter-status-item">Builds remaining: {buildsRemaining}</span>
         </div>
-        <section className="presenter-stage" aria-label="Current slide">
+        <section className="presenter-stage" aria-label="Current slide" ref={presenterStageRef}>
           <CanvasWorkspace
             project={snapshot.project}
             activePageId={activePage.id}
@@ -307,6 +628,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
           <span className="presenter-notes-tab-active">Notes</span>
         </div>
         <textarea
+          ref={notesRef}
           aria-label="Speaker notes"
           className={speakerNotes ? 'presenter-notes-textarea' : 'presenter-notes-textarea presenter-notes-empty'}
           placeholder="Add notes to your design"
@@ -336,6 +658,55 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
           </button>
         </div>
       </aside>
+      {keyboardShortcutsMode ? (
+        <KeyboardShortcutsDialog
+          title={keyboardShortcutsMode === 'popover' ? 'Magic Shortcuts' : 'Keyboard Shortcuts'}
+          variant={keyboardShortcutsMode}
+          onClose={() => setKeyboardShortcutsMode(undefined)}
+          onShortcutAction={executePresenterShortcut}
+          supportedActions={presenterShortcutActions}
+        />
+      ) : null}
+      {slideNavigatorOpen && snapshot ? (
+        <div className="presentation-slide-navigator" role="dialog" aria-modal="true" aria-label="Slide navigator">
+          <div className="presentation-slide-navigator-header">
+            <h2>Slide Navigator</h2>
+            <button
+              className="stitch-icon-button"
+              type="button"
+              aria-label="Close slide navigator"
+              onClick={() => setSlideNavigatorOpen(false)}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                close
+              </span>
+            </button>
+          </div>
+          <div className="presentation-slide-navigator-list" role="listbox" aria-label="Slides">
+            {snapshot.project.pages.map((page, index) => (
+              <button
+                aria-selected={index === slideNavigatorIndex}
+                className={
+                  index === slideNavigatorIndex
+                    ? 'presentation-slide-navigator-item presentation-slide-navigator-item-active'
+                    : 'presentation-slide-navigator-item'
+                }
+                key={page.id}
+                type="button"
+                role="option"
+                onClick={() => setSlideNavigatorIndex(index)}
+                onDoubleClick={() => {
+                  goToPage(index);
+                  setSlideNavigatorOpen(false);
+                }}
+              >
+                <span>Slide {index + 1}</span>
+                <strong>{page.name}</strong>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
       {introOverlay}
     </main>
   );

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -12,6 +12,10 @@ import {
   type KeyboardShortcutAction,
 } from '../components/KeyboardShortcutsDialog';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
+import {
+  presentationMovieControls,
+  type MovieHoldState,
+} from '../editor/media/presentationMovieControls';
 
 interface PresenterViewProps {
   sessionId?: string;
@@ -136,6 +140,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
   const [dismissIntroForever, setDismissIntroForever] = useState(false);
   const emptySelection = useMemo<SelectionState>(() => ({ elementIds: [], pageId: '' }), []);
   const openerRef = useRef<Window | null>(getPresenterOpener());
+  const movieHoldStateRef = useRef<MovieHoldState | undefined>(undefined);
   const presenterStageRef = useRef<HTMLElement>(null);
   const notesRef = useRef<HTMLTextAreaElement>(null);
   const resolvedSessionId = sessionId ?? 'presenter';
@@ -224,35 +229,29 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     return Array.from(presenterStageRef.current?.querySelectorAll('video') ?? []);
   }
 
-  function getVideoTrimStart(video: HTMLVideoElement) {
-    const trimStart = Number(video.dataset.trimStart);
-    return Number.isFinite(trimStart) ? Math.max(0, trimStart) : 0;
-  }
-
-  function getVideoTrimEnd(video: HTMLVideoElement) {
-    const trimEnd = Number(video.dataset.trimEnd);
-    if (Number.isFinite(trimEnd) && trimEnd > 0) return trimEnd;
-    return Number.isFinite(video.duration) ? video.duration : video.currentTime;
-  }
-
-  const controlPresenterMovies = useCallback((action: 'end' | 'forward' | 'play-toggle' | 'rewind' | 'start') => {
+  const controlPresenterMovies = useCallback((action: 'end' | 'play-toggle' | 'start') => {
     const videos = getPresenterVideos();
-    if (videos.length === 0) return false;
-    const frameStepSeconds = 1 / 30;
-    for (const video of videos) {
-      if (action === 'play-toggle') {
-        if (video.paused) void video.play();
-        else video.pause();
-        continue;
-      }
-      const trimStart = getVideoTrimStart(video);
-      const trimEnd = getVideoTrimEnd(video);
-      if (action === 'start') video.currentTime = trimStart;
-      if (action === 'end') video.currentTime = trimEnd;
-      if (action === 'rewind') video.currentTime = Math.max(trimStart, video.currentTime - frameStepSeconds);
-      if (action === 'forward') video.currentTime = Math.min(trimEnd, video.currentTime + frameStepSeconds);
-    }
-    return true;
+    return presentationMovieControls.control(videos, action);
+  }, []);
+
+  const pulsePresenterMovieHold = useCallback((action: 'fast-forward' | 'rewind') => {
+    movieHoldStateRef.current = presentationMovieControls.pulse(
+      getPresenterVideos(),
+      action,
+      movieHoldStateRef.current,
+    );
+  }, []);
+
+  const startPresenterMovieHold = useCallback((action: 'fast-forward' | 'rewind') => {
+    movieHoldStateRef.current = presentationMovieControls.startHold(
+      getPresenterVideos(),
+      action,
+      movieHoldStateRef.current,
+    );
+  }, []);
+
+  const stopPresenterMovieHold = useCallback(() => {
+    movieHoldStateRef.current = presentationMovieControls.stopHold(movieHoldStateRef.current);
   }, []);
 
   const goToPage = useCallback((index: number) => {
@@ -333,8 +332,8 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       return;
     }
     if (action === 'play-pause-movie') controlPresenterMovies('play-toggle');
-    if (action === 'rewind-movie') controlPresenterMovies('rewind');
-    if (action === 'fast-forward-movie') controlPresenterMovies('forward');
+    if (action === 'rewind-movie') pulsePresenterMovieHold('rewind');
+    if (action === 'fast-forward-movie') pulsePresenterMovieHold('fast-forward');
     if (action === 'jump-movie-start') controlPresenterMovies('start');
     if (action === 'jump-movie-end') controlPresenterMovies('end');
     if (action === 'quit-presentation') window.close();
@@ -342,6 +341,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     activePageIndex,
     controlPresenterMovies,
     goToPage,
+    pulsePresenterMovieHold,
     postCommand,
     resetTimer,
     slideNavigatorIndex,
@@ -457,12 +457,12 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       }
       if (lowerKey === 'j') {
         event.preventDefault();
-        executePresenterShortcut('rewind-movie');
+        if (!event.repeat) startPresenterMovieHold('rewind');
         return;
       }
       if (lowerKey === 'l') {
         event.preventDefault();
-        executePresenterShortcut('fast-forward-movie');
+        if (!event.repeat) startPresenterMovieHold('fast-forward');
         return;
       }
       if (lowerKey === 'i') {
@@ -476,8 +476,17 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       }
     }
 
+    function handleKeyUp(event: KeyboardEvent) {
+      if (event.key.toLowerCase() !== 'j' && event.key.toLowerCase() !== 'l') return;
+      stopPresenterMovieHold();
+    }
+
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
   }, [
     activePageIndex,
     controlPresenterMovies,
@@ -489,7 +498,15 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     slideNavigatorIndex,
     slideNavigatorOpen,
     snapshot,
+    startPresenterMovieHold,
+    stopPresenterMovieHold,
   ]);
+
+  useEffect(() => {
+    return () => {
+      movieHoldStateRef.current = presentationMovieControls.stopHold(movieHoldStateRef.current);
+    };
+  }, []);
 
   const introOverlay = !introDismissed ? (
     <div className="presenter-intro-backdrop" role="presentation">

--- a/apps/editor/tests/unit/app/App.test.tsx
+++ b/apps/editor/tests/unit/app/App.test.tsx
@@ -112,6 +112,15 @@ describe('App', () => {
     expect(await screen.findByRole('heading', { name: 'WebMCP showcase' })).toBeInTheDocument();
   });
 
+  it('renders the presenter view route', async () => {
+    window.history.replaceState({}, '', '/editor/?presenter=1&presenterSession=session-1');
+
+    render(<App />);
+
+    expect(await screen.findByLabelText('Presenter view')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Presenter Window' })).toBeInTheDocument();
+  });
+
   it('renders a public shared deck page', async () => {
     const shareId = '00000000-0000-4000-8000-000000000101';
     const sourceUrl = `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`;

--- a/apps/editor/tests/unit/services/presenterSessionService.test.ts
+++ b/apps/editor/tests/unit/services/presenterSessionService.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sampleProject } from '../../../src/domain/projects/sampleProject';
+import { BrowserPresenterSessionService } from '../../../src/services/presenter/presenterSessionService';
+
+describe('BrowserPresenterSessionService', () => {
+  it('opens a same-origin presenter route with a generated session id', () => {
+    const popup = { location: { href: '' }, postMessage: vi.fn(), closed: false } as unknown as Window;
+    const openWindow = vi.fn(() => popup);
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/?project=Demo',
+      openWindow,
+      randomId: () => 'session-1',
+    });
+
+    const session = service.openPresenterWindow();
+
+    expect(session).toEqual({ status: 'opened', sessionId: 'session-1' });
+    expect(openWindow).toHaveBeenCalledWith(
+      '',
+      'localstudio-presenter-session-1',
+      'popup,width=1280,height=760',
+    );
+    expect(popup.location.href).toBe(
+      'https://localstudio.test/editor/?project=Demo&presenter=1&presenterSession=session-1',
+    );
+  });
+
+  it('returns a blocked result when the popup cannot open', () => {
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/',
+      openWindow: vi.fn(() => null),
+      randomId: () => 'session-2',
+    });
+
+    expect(service.openPresenterWindow()).toEqual({ status: 'blocked', sessionId: 'session-2' });
+  });
+
+  it('treats same-window popup fallback as blocked', () => {
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/',
+      openWindow: vi.fn(() => window),
+      randomId: () => 'session-2b',
+      targetWindow: window,
+    });
+
+    expect(service.openPresenterWindow()).toEqual({ status: 'blocked', sessionId: 'session-2b' });
+  });
+
+  it('publishes presenter state only to the matching popup', () => {
+    const popupPostMessage = vi.fn();
+    const popup = { location: { href: '' }, postMessage: popupPostMessage, closed: false } as unknown as Window;
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/',
+      openWindow: vi.fn(() => popup),
+      randomId: () => 'session-3',
+    });
+    service.openPresenterWindow();
+
+    service.publishState({
+      activePageId: 'page-1',
+      animationPreview: undefined,
+      project: sampleProject.createSampleProject(),
+    });
+
+    expect(popupPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-3',
+        source: 'localstudio-presenter-main',
+        type: 'state',
+      }),
+      'https://localstudio.test',
+    );
+  });
+
+  it('closes the active presenter popup and clears the session', () => {
+    const popupClose = vi.fn();
+    const popupPostMessage = vi.fn();
+    const popup = {
+      close: popupClose,
+      closed: false,
+      location: { href: '' },
+      postMessage: popupPostMessage,
+    } as unknown as Window;
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/',
+      openWindow: vi.fn(() => popup),
+      randomId: () => 'session-3b',
+    });
+    service.openPresenterWindow();
+
+    service.closePresenterWindow();
+    service.publishState({
+      activePageId: 'page-1',
+      animationPreview: undefined,
+      project: sampleProject.createSampleProject(),
+    });
+
+    expect(popupClose).toHaveBeenCalledTimes(1);
+    expect(popupPostMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not close an already closed presenter popup', () => {
+    const popupClose = vi.fn();
+    const popup = {
+      close: popupClose,
+      closed: true,
+      location: { href: '' },
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/',
+      openWindow: vi.fn(() => popup),
+      randomId: () => 'session-3c',
+    });
+    service.openPresenterWindow();
+
+    service.closePresenterWindow();
+
+    expect(popupClose).not.toHaveBeenCalled();
+  });
+
+  it('accepts commands only from the same origin and active session', () => {
+    const popup = { location: { href: '' }, postMessage: vi.fn(), closed: false } as unknown as Window;
+    const commandHandler = vi.fn();
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/',
+      openWindow: vi.fn(() => popup),
+      randomId: () => 'session-4',
+      targetWindow: window,
+    });
+    service.openPresenterWindow();
+    const unsubscribe = service.subscribeToCommands(commandHandler);
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://localstudio.test',
+        data: {
+          command: 'next',
+          sessionId: 'wrong-session',
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://evil.test',
+        data: {
+          command: 'next',
+          sessionId: 'session-4',
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://localstudio.test',
+        data: {
+          command: 'next',
+          sessionId: 'session-4',
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+      }),
+    );
+
+    expect(commandHandler).toHaveBeenCalledTimes(1);
+    expect(commandHandler).toHaveBeenCalledWith({ command: 'next' });
+    unsubscribe();
+  });
+
+  it('accepts request-state commands from the active presenter session', () => {
+    const popup = { location: { href: '' }, postMessage: vi.fn(), closed: false } as unknown as Window;
+    const commandHandler = vi.fn();
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/',
+      openWindow: vi.fn(() => popup),
+      randomId: () => 'session-5',
+      targetWindow: window,
+    });
+    service.openPresenterWindow();
+    const unsubscribe = service.subscribeToCommands(commandHandler);
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://localstudio.test',
+        data: {
+          command: 'request-state',
+          sessionId: 'session-5',
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+      }),
+    );
+
+    expect(commandHandler).toHaveBeenCalledWith({ command: 'request-state' });
+    unsubscribe();
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
@@ -52,11 +52,14 @@ describe('CanvasWorkspace', () => {
       visible: true,
       opacity: 1,
       loop: true,
+      repeatMode: 'loop',
       controls: true,
       muted: true,
       autoplayInPreview: true,
       trimStartSeconds: 2,
       trimEndSeconds: 6,
+      durationSeconds: 12,
+      volume: 0.75,
     };
     project.elements['gif-demo'] = {
       id: 'gif-demo',
@@ -485,9 +488,10 @@ describe('CanvasWorkspace', () => {
     ) as HTMLVideoElement;
     expect(editorVideo).toBeInTheDocument();
     expect(editorVideo.autoplay).toBe(false);
-    expect(editorVideo.loop).toBe(true);
+    expect(editorVideo.loop).toBe(false);
     expect(editorVideo.controls).toBe(true);
     expect(editorVideo.muted).toBe(true);
+    expect(editorVideo.volume).toBe(0.75);
     expect(editorVideo.preload).toBe('auto');
 
     rerender(
@@ -572,6 +576,41 @@ describe('CanvasWorkspace', () => {
       />,
     );
     expect(video.currentTime).toBe(5);
+  });
+
+  it('plays, pauses, and seeks the selected video from inspector playback state', async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockResolvedValue(undefined);
+    const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    const project = updateVideoElement(createMediaProject(), {
+      playbackPositionSeconds: 3,
+      playing: true,
+    });
+
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+
+    const video = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    await waitFor(() => expect(playSpy).toHaveBeenCalled());
+    expect(video.currentTime).toBe(3);
+
+    rerender(
+      <CanvasWorkspace
+        project={updateVideoElement(project, { playing: false })}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+      />,
+    );
+
+    await waitFor(() => expect(pauseSpy).toHaveBeenCalled());
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
   });
 
   it('renders GIF media as an animated non-image element', () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -595,6 +595,7 @@ function mockVideoMetadataLoad() {
       if (tagName.toLowerCase() === 'video') {
         Object.defineProperty(element, 'videoWidth', { configurable: true, value: 1280 });
         Object.defineProperty(element, 'videoHeight', { configurable: true, value: 720 });
+        Object.defineProperty(element, 'duration', { configurable: true, value: 8.5 });
         queueMicrotask(() => {
           element.dispatchEvent(new Event('loadedmetadata'));
         });
@@ -2379,7 +2380,8 @@ describe('EditorShell', () => {
     });
     expect(createObjectUrl).toHaveBeenCalledWith(video);
     expect(screen.getByRole('tab', { name: 'Design' })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByLabelText('Show selected video controls')).toBeChecked();
+    expect(screen.getByRole('tab', { name: 'Movie' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByLabelText('Selected video trim end')).toHaveValue('8.5');
   });
 
   it('shows loading feedback while local video metadata is imported', async () => {
@@ -2453,8 +2455,8 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Demo clip' }));
 
     expect(screen.getByRole('tab', { name: 'Design' })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByText('Playback')).toBeInTheDocument();
-    expect(screen.getByLabelText('Show selected video controls')).toBeChecked();
+    expect(screen.getByRole('tab', { name: 'Movie' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByLabelText('Selected video repeat mode')).toBeInTheDocument();
   });
 
   it('deletes the selected layer with Delete and Backspace keystrokes', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -1933,6 +1933,62 @@ describe('EditorShell', () => {
     });
   });
 
+  it('opens presenter view with an audience fullscreen prompt and closes the popup on fullscreen exit', async () => {
+    const user = userEvent.setup();
+    let fullscreenElement: Element | null = null;
+    const popupClose = vi.fn();
+    const popupPostMessage = vi.fn();
+    const popup = {
+      close: popupClose,
+      closed: false,
+      location: { href: '' },
+      postMessage: popupPostMessage,
+    } as unknown as Window;
+    const openWindow = vi.fn(() => popup);
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      value: openWindow,
+    });
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => fullscreenElement,
+    });
+    const requestFullscreen = vi.fn(() => {
+      fullscreenElement = document.querySelector('[aria-label="Canvas workspace"]');
+      document.dispatchEvent(new Event('fullscreenchange'));
+      return Promise.resolve();
+    });
+    Object.defineProperty(HTMLElement.prototype, 'requestFullscreen', {
+      configurable: true,
+      value: requestFullscreen,
+    });
+
+    render(<EditorShell services={createAppServices()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Presentation play options' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Presenter view' }));
+
+    expect(openWindow).toHaveBeenCalledTimes(1);
+    expect(popup.location.href).toContain('presenter=1');
+    expect(screen.getByRole('dialog', { name: 'Audience Window' })).toBeInTheDocument();
+    expect(requestFullscreen).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Enter full screen mode' }));
+
+    await waitFor(() => {
+      expect(requestFullscreen).toHaveBeenCalledTimes(1);
+      expect(document.fullscreenElement).toBe(screen.getByLabelText('Canvas workspace'));
+      expect(screen.queryByRole('dialog', { name: 'Audience Window' })).not.toBeInTheDocument();
+    });
+
+    fullscreenElement = null;
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    await waitFor(() => {
+      expect(popupClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('hides page insert controls in fullscreen presenter mode and restores a clean editor state on exit', async () => {
     const user = userEvent.setup();
     let fullscreenElement: Element | null = null;
@@ -2867,6 +2923,31 @@ describe('EditorShell', () => {
 
     expect(requestFullscreen).toHaveBeenCalled();
     expect(requestFullscreen.mock.instances[0]).toBe(screen.getByLabelText('Canvas workspace'));
+  });
+
+  it('shows speaker notes as a Canva-style side panel with controls', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    const notesToggle = screen.getByRole('button', { name: 'Toggle notes panel' });
+    expect(notesToggle).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByRole('heading', { name: 'Page 1 - Slide 1' })).not.toBeInTheDocument();
+
+    await user.click(notesToggle);
+
+    expect(notesToggle).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('heading', { name: 'Page 1 - Slide 1' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Timer' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Change notes text size' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close notes panel' })).toBeInTheDocument();
+    expect(screen.getByText('0/5000')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Speaker notes'), 'Opening note');
+
+    expect(screen.getByText('12/5000')).toBeInTheDocument();
+
+    await user.click(notesToggle);
+    expect(screen.queryByRole('heading', { name: 'Page 1 - Slide 1' })).not.toBeInTheDocument();
   });
 
   it('does not show the page size overlay on the canvas', () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -47,6 +47,11 @@ async function waitForShareButtonReady() {
   });
 }
 
+async function startFullscreenPresentation(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Presentation play options' }));
+  await user.click(screen.getByRole('menuitem', { name: 'Present in fullscreen' }));
+}
+
 function enableSyncedSharing(services: ReturnType<typeof createAppServices>) {
   services.mirrorService = new RecordingMirrorService();
   services.shareService = new RecordingShareService();
@@ -1645,7 +1650,7 @@ describe('EditorShell', () => {
 
     render(<EditorShell services={createAppServices({ initialProject: project })} />);
 
-    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+    await startFullscreenPresentation(user);
 
     await waitFor(() => {
       expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
@@ -1658,6 +1663,25 @@ describe('EditorShell', () => {
       );
     });
     expect(screen.queryByLabelText('Animation build 1 for Image')).not.toBeInTheDocument();
+  });
+
+  it('opens keyboard shortcuts with question mark while presenting fullscreen', async () => {
+    const user = userEvent.setup();
+    const project = sampleProject.createSampleProject();
+
+    render(<EditorShell services={createAppServices({ initialProject: project })} />);
+
+    await startFullscreenPresentation(user);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'presenter',
+      );
+    });
+
+    fireEvent.keyDown(window, { key: '?' });
+
+    expect(screen.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toBeInTheDocument();
   });
 
   it('starts animation preview from the Animate panel play button', async () => {
@@ -1713,7 +1737,7 @@ describe('EditorShell', () => {
 
     render(<EditorShell services={createAppServices({ initialProject: project })} />);
 
-    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+    await startFullscreenPresentation(user);
 
     await waitFor(() => {
       expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
@@ -1766,7 +1790,7 @@ describe('EditorShell', () => {
     render(<EditorShell services={createAppServices({ initialProject: project })} />);
 
     expect(screen.getByText('1 / 2')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+    await startFullscreenPresentation(user);
 
     await waitFor(() => {
       expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
@@ -1847,7 +1871,7 @@ describe('EditorShell', () => {
       <EditorShell services={createAppServices({ initialProject: project })} />,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+    await startFullscreenPresentation(user);
 
     await waitFor(() => {
       expect(document.fullscreenElement).toBe(screen.getByLabelText('Canvas workspace'));
@@ -1911,7 +1935,7 @@ describe('EditorShell', () => {
     await user.click(screen.getByRole('button', { name: 'Activate Slide 3' }));
     expect(screen.getByText('3 / 3')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+    await startFullscreenPresentation(user);
 
     await waitFor(() => {
       expect(screen.getByText('3 / 3')).toBeInTheDocument();
@@ -2038,7 +2062,7 @@ describe('EditorShell', () => {
     );
     expect(screen.getByRole('button', { name: 'Add page after Slide 1' })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+    await startFullscreenPresentation(user);
 
     await waitFor(() => {
       expect(document.fullscreenElement).toBe(screen.getByLabelText('Canvas workspace'));
@@ -2095,7 +2119,7 @@ describe('EditorShell', () => {
 
     render(<EditorShell services={createAppServices({ initialProject: project })} />);
 
-    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+    await startFullscreenPresentation(user);
 
     await waitFor(() => {
       expect(document.fullscreenElement).toBe(screen.getByLabelText('Canvas workspace'));

--- a/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
@@ -311,6 +311,7 @@ describe('RightPanel', () => {
     const onUpdateElementFrame = vi.fn();
     const onUpdateElementStyle = vi.fn();
     const onUpdateMediaPlayback = vi.fn();
+    const onReplaceVideoAsset = vi.fn();
 
     render(
       <RightPanel
@@ -326,6 +327,7 @@ describe('RightPanel', () => {
         onUpdateElementFrame={onUpdateElementFrame}
         onUpdateElementStyle={onUpdateElementStyle}
         onUpdateMediaPlayback={onUpdateMediaPlayback}
+        onReplaceVideoAsset={onReplaceVideoAsset}
       />,
     );
 
@@ -334,6 +336,9 @@ describe('RightPanel', () => {
     expect(screen.getByText('Demo clip')).toBeInTheDocument();
     expect(screen.getByLabelText('Selected video repeat mode')).toHaveValue('none');
     expect(screen.getByLabelText('Selected video volume')).toHaveValue('100');
+    const replacement = new File(['video'], 'replacement.mp4', { type: 'video/mp4' });
+    await user.upload(screen.getByLabelText('Replace video file'), replacement);
+    expect(onReplaceVideoAsset).toHaveBeenCalledWith('video-demo', replacement);
 
     await user.click(screen.getByRole('button', { name: 'Play movie' }));
     expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { playing: true });
@@ -377,15 +382,16 @@ describe('RightPanel', () => {
     await user.click(screen.getByRole('tab', { name: 'Arrange' }));
     await user.click(screen.getByRole('button', { name: /Front/ }));
     expect(onSetSelectedElementZOrder).toHaveBeenCalledWith('front');
-    await user.selectOptions(screen.getByLabelText('Align selected video'), 'page-center');
+    await user.selectOptions(screen.getByLabelText('Align selected element'), 'page-center');
     expect(onAlignSelectedElement).toHaveBeenCalledWith('page-center');
-    fireEvent.change(screen.getByLabelText('Selected video width'), { target: { value: '800' } });
+    fireEvent.change(screen.getByLabelText('Selected element width'), { target: { value: '800' } });
     expect(onUpdateElementFrame).toHaveBeenCalledWith('video-demo', { width: 800 });
     await user.click(screen.getByRole('button', { name: 'Lock' }));
     expect(onSetElementLock).toHaveBeenCalledWith('video-demo', true);
   });
 
-  it('does not show playback controls for selected GIF objects', () => {
+  it('shows movie controls for selected GIF objects', async () => {
+    const user = userEvent.setup();
     const onUpdateMediaPlayback = vi.fn();
 
     render(
@@ -400,9 +406,10 @@ describe('RightPanel', () => {
       />,
     );
 
-    expect(screen.queryByText('GIF Playback')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Play selected GIF')).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Movie' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByLabelText('Play selected GIF')).toBeChecked();
+    await user.click(screen.getByLabelText('Play selected GIF'));
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('gif-demo', { playing: false });
     expect(screen.queryByLabelText('Selected video trim start')).not.toBeInTheDocument();
-    expect(onUpdateMediaPlayback).not.toHaveBeenCalled();
   });
 });

--- a/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
@@ -53,7 +53,8 @@ describe('RightPanel', () => {
       muted: false,
       autoplayInPreview: false,
       trimStartSeconds: 0,
-      trimEndSeconds: 0,
+      trimEndSeconds: 12,
+      durationSeconds: 12,
     };
     mediaProject.elements['gif-demo'] = {
       id: 'gif-demo',
@@ -304,6 +305,11 @@ describe('RightPanel', () => {
 
   it('shows video playback settings for selected videos', async () => {
     const user = userEvent.setup();
+    const onAlignSelectedElement = vi.fn();
+    const onSetElementLock = vi.fn();
+    const onSetSelectedElementZOrder = vi.fn();
+    const onUpdateElementFrame = vi.fn();
+    const onUpdateElementStyle = vi.fn();
     const onUpdateMediaPlayback = vi.fn();
 
     render(
@@ -314,18 +320,35 @@ describe('RightPanel', () => {
         activePageId="page-1"
         selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
         modelStates={modelStates}
+        onAlignSelectedElement={onAlignSelectedElement}
+        onSetElementLock={onSetElementLock}
+        onSetSelectedElementZOrder={onSetSelectedElementZOrder}
+        onUpdateElementFrame={onUpdateElementFrame}
+        onUpdateElementStyle={onUpdateElementStyle}
         onUpdateMediaPlayback={onUpdateMediaPlayback}
       />,
     );
 
-    expect(screen.getByText('Playback')).toBeInTheDocument();
-    expect(screen.getByLabelText('Loop selected video')).not.toBeChecked();
-    expect(screen.getByLabelText('Show selected video controls')).not.toBeChecked();
-    expect(screen.getByLabelText('Mute selected video')).not.toBeChecked();
-    expect(screen.getByLabelText('Autoplay selected video in preview')).not.toBeChecked();
+    expect(screen.getByRole('tab', { name: 'Movie' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('File Info')).toBeInTheDocument();
+    expect(screen.getByText('Demo clip')).toBeInTheDocument();
+    expect(screen.getByLabelText('Selected video repeat mode')).toHaveValue('none');
+    expect(screen.getByLabelText('Selected video volume')).toHaveValue('100');
 
-    await user.click(screen.getByLabelText('Loop selected video'));
-    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { loop: true });
+    await user.click(screen.getByRole('button', { name: 'Play movie' }));
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { playing: true });
+
+    await user.click(screen.getByRole('button', { name: 'Jump movie to end' }));
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', {
+      playbackPositionSeconds: 12,
+      playing: false,
+    });
+
+    await user.selectOptions(screen.getByLabelText('Selected video repeat mode'), 'loop');
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', {
+      loop: true,
+      repeatMode: 'loop',
+    });
 
     expect(screen.getByLabelText('Selected video trim start')).toHaveAttribute('type', 'range');
     expect(screen.getByLabelText('Selected video trim end')).toHaveAttribute('type', 'range');
@@ -339,6 +362,27 @@ describe('RightPanel', () => {
       target: { value: '9.5' },
     });
     expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { trimEndSeconds: 9.5 });
+
+    fireEvent.change(screen.getByLabelText('Selected video poster frame'), {
+      target: { value: '3.5' },
+    });
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', { posterFrameSeconds: 3.5 });
+
+    await user.click(screen.getByRole('tab', { name: 'Style' }));
+    fireEvent.change(screen.getByLabelText('Selected element opacity'), {
+      target: { value: '48' },
+    });
+    expect(onUpdateElementStyle).toHaveBeenCalledWith('video-demo', { opacity: 0.48 });
+
+    await user.click(screen.getByRole('tab', { name: 'Arrange' }));
+    await user.click(screen.getByRole('button', { name: /Front/ }));
+    expect(onSetSelectedElementZOrder).toHaveBeenCalledWith('front');
+    await user.selectOptions(screen.getByLabelText('Align selected video'), 'page-center');
+    expect(onAlignSelectedElement).toHaveBeenCalledWith('page-center');
+    fireEvent.change(screen.getByLabelText('Selected video width'), { target: { value: '800' } });
+    expect(onUpdateElementFrame).toHaveBeenCalledWith('video-demo', { width: 800 });
+    await user.click(screen.getByRole('button', { name: 'Lock' }));
+    expect(onSetElementLock).toHaveBeenCalledWith('video-demo', true);
   });
 
   it('does not show playback controls for selected GIF objects', () => {

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -93,6 +93,24 @@ describe('TopToolbar', () => {
     expect(onPersistenceToggle).toHaveBeenCalledWith(true);
   });
 
+  it('opens keyboard shortcuts from the Help menu', async () => {
+    const user = userEvent.setup();
+    const onOpenKeyboardShortcuts = vi.fn();
+
+    render(
+      <TopToolbar
+        project={sampleProject.createSampleProject()}
+        language="PT-BR"
+        onOpenKeyboardShortcuts={onOpenKeyboardShortcuts}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Help' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Keyboard Shortcuts' }));
+
+    expect(onOpenKeyboardShortcuts).toHaveBeenCalledTimes(1);
+  });
+
   it('translates the deck from the toolbar icon beside persistence', async () => {
     const user = userEvent.setup();
     const onTranslateDeck = vi.fn();

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -465,7 +465,27 @@ describe('TopToolbar', () => {
     expect(onProjectNameChange).toHaveBeenCalledWith('Demo Deck');
   });
 
-  it('starts presenter mode from the play button near the project name', async () => {
+  it('opens presenter view from the play button near the project name by default', async () => {
+    const user = userEvent.setup();
+    const onOpenPresenterView = vi.fn();
+    const onStartPresenterMode = vi.fn();
+
+    render(
+      <TopToolbar
+        project={sampleProject.createSampleProject()}
+        language="PT-BR"
+        onOpenPresenterView={onOpenPresenterView}
+        onStartPresenterMode={onStartPresenterMode}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Play presentation' }));
+
+    expect(onOpenPresenterView).toHaveBeenCalledTimes(1);
+    expect(onStartPresenterMode).not.toHaveBeenCalled();
+  });
+
+  it('starts presenter mode from the play button when presenter view is unavailable', async () => {
     const user = userEvent.setup();
     const onStartPresenterMode = vi.fn();
 
@@ -499,6 +519,26 @@ describe('TopToolbar', () => {
     await user.click(screen.getByRole('menuitem', { name: 'Play from beginning' }));
 
     expect(onStartPresenterMode).toHaveBeenCalledWith({ fromBeginning: true });
+  });
+
+  it('opens presenter view from the play menu', async () => {
+    const user = userEvent.setup();
+    const onOpenPresenterView = vi.fn();
+
+    render(
+      <TopToolbar
+        project={sampleProject.createSampleProject()}
+        language="PT-BR"
+        onOpenPresenterView={onOpenPresenterView}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Presentation play options' }));
+
+    expect(screen.getByRole('menuitem', { name: 'Present in fullscreen' })).toBeInTheDocument();
+    await user.click(screen.getByRole('menuitem', { name: 'Presenter view' }));
+
+    expect(onOpenPresenterView).toHaveBeenCalledTimes(1);
   });
 
   it('selects the full project name when entering rename mode', async () => {

--- a/apps/editor/tests/unit/ui/editor/presentationMovieControls.test.ts
+++ b/apps/editor/tests/unit/ui/editor/presentationMovieControls.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { presentationMovieControls } from '../../../../src/ui/editor/media/presentationMovieControls';
+
+function createTestVideo(options: { currentTime?: number; duration?: number; paused?: boolean } = {}) {
+  const video = document.createElement('video');
+  let paused = options.paused ?? true;
+  const pauseMock = vi.fn(() => {
+    paused = true;
+  });
+  const playMock = vi.fn(() => {
+    paused = false;
+    return Promise.resolve();
+  });
+  Object.defineProperty(video, 'duration', { configurable: true, value: options.duration ?? 20 });
+  Object.defineProperty(video, 'paused', { configurable: true, get: () => paused });
+  video.currentTime = options.currentTime ?? 0;
+  video.playbackRate = 1;
+  video.play = playMock;
+  video.pause = pauseMock;
+  return { pauseMock, playMock, video };
+}
+
+describe('presentationMovieControls', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fast forwards at 2x, accelerates to 4x after four seconds, and restores on release', () => {
+    const { pauseMock, playMock, video } = createTestVideo({ paused: true });
+
+    const state = presentationMovieControls.startHold([video], 'fast-forward', undefined);
+
+    expect(video.playbackRate).toBe(2);
+    expect(playMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(4000);
+
+    expect(video.playbackRate).toBe(4);
+
+    presentationMovieControls.stopHold(state);
+
+    expect(video.playbackRate).toBe(1);
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rewinds by time while held, accelerates after four seconds, and resumes if the movie was playing', () => {
+    const { pauseMock, playMock, video } = createTestVideo({ currentTime: 20, duration: 30, paused: false });
+    video.dataset.trimStart = '2';
+
+    const state = presentationMovieControls.startHold([video], 'rewind', undefined);
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(100);
+    expect(video.currentTime).toBeCloseTo(19.8);
+
+    vi.advanceTimersByTime(4000);
+    const timeAfterAcceleration = video.currentTime;
+    vi.advanceTimersByTime(100);
+
+    expect(video.currentTime).toBeCloseTo(timeAfterAcceleration - 0.4);
+
+    presentationMovieControls.stopHold(state);
+
+    expect(video.currentTime).toBeGreaterThanOrEqual(2);
+    expect(playMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
@@ -167,4 +167,51 @@ describe('useAnimationPreviewController', () => {
     expect(onPresenterPageChange).toHaveBeenLastCalledWith('page-2');
     expect(activePageIdRef.current).toBe('page-2');
   });
+
+  it('rewinds through the current slide build pipeline before moving to the previous slide', () => {
+    const projectRef = { current: createProject() };
+    const activePageIdRef = { current: 'page-1' };
+    const setActivePageId = vi.fn();
+    const setSelectedElementIds = vi.fn();
+    const { result } = renderHook(() =>
+      useAnimationPreviewController({
+        activePageIdRef,
+        projectRef,
+        setActivePageId,
+        setSelectedElementIds,
+      }),
+    );
+
+    act(() => {
+      result.current.playPresentationPreview('page-1');
+    });
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    act(() => {
+      result.current.advancePresentationPreview();
+    });
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(result.current.animationPreview).toMatchObject({
+      hiddenElementIds: [],
+      pageId: 'page-1',
+      phase: 'complete',
+    });
+
+    act(() => {
+      result.current.rewindPresentationPreview();
+    });
+
+    expect(activePageIdRef.current).toBe('page-1');
+    expect(result.current.animationPreview).toMatchObject({
+      activeBuildElementId: 'title',
+      hiddenElementIds: ['title'],
+      pageId: 'page-1',
+      phase: 'waiting',
+      waitingForClick: true,
+    });
+  });
 });

--- a/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
+++ b/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
@@ -149,6 +149,121 @@ describe('PresenterView', () => {
     );
   });
 
+  it('opens shortcuts from the presenter toolbar and sends keyboard page jumps', () => {
+    const opener = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: opener,
+    });
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+    render(<PresenterView sessionId="session-1" />);
+    const project = sampleProject.createSampleProject();
+    project.pages.push({
+      background: { type: 'color', color: '#111111' },
+      elementIds: [],
+      height: 1080,
+      id: 'page-2',
+      name: 'Slide 2',
+      width: 1920,
+    });
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            payload: {
+              activePageId: 'page-1',
+              animationPreview: undefined,
+              project,
+            },
+            sessionId: 'session-1',
+            source: 'localstudio-presenter-main',
+            type: 'state',
+          },
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show keyboard shortcuts' }));
+    expect(screen.getByRole('dialog', { name: 'Magic Shortcuts' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Switch the slideshow/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Hide presentation/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /black screen/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Go to first slide/ }));
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'go-to-page',
+        pageId: 'page-1',
+        sessionId: 'session-1',
+        source: 'localstudio-presenter-window',
+        type: 'command',
+      }),
+      window.location.origin,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close keyboard shortcuts' }));
+
+    fireEvent.keyDown(window, { key: 'End' });
+
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'go-to-page',
+        pageId: 'page-2',
+        sessionId: 'session-1',
+        source: 'localstudio-presenter-window',
+        type: 'command',
+      }),
+      window.location.origin,
+    );
+  });
+
+  it('does not run presenter shortcuts while typing in speaker notes', () => {
+    const opener = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: opener,
+    });
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+    render(<PresenterView sessionId="session-1" />);
+    const project = sampleProject.createSampleProject();
+    project.pages.push({
+      background: { type: 'color', color: '#111111' },
+      elementIds: [],
+      height: 1080,
+      id: 'page-2',
+      name: 'Slide 2',
+      speakerNotes: '',
+      width: 1920,
+    });
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            payload: {
+              activePageId: 'page-1',
+              animationPreview: undefined,
+              project,
+            },
+            sessionId: 'session-1',
+            source: 'localstudio-presenter-main',
+            type: 'state',
+          },
+        }),
+      );
+    });
+
+    const notes = screen.getByLabelText('Speaker notes');
+    notes.focus();
+    fireEvent.keyDown(notes, { key: '?' });
+    fireEvent.keyDown(notes, { key: 'End' });
+
+    expect(screen.queryByRole('dialog', { name: 'Keyboard Shortcuts' })).not.toBeInTheDocument();
+    expect(opener.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'go-to-page', pageId: 'page-2' }),
+      window.location.origin,
+    );
+  });
+
   it('does not post close during StrictMode effect remounts', () => {
     const opener = { postMessage: vi.fn() };
     Object.defineProperty(window, 'opener', {

--- a/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
+++ b/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
@@ -1,0 +1,197 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sampleProject } from '../../../../src/domain/projects/sampleProject';
+import { PresenterView } from '../../../../src/ui/presenter/PresenterView';
+
+describe('PresenterView', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/editor/?presenter=1&presenterSession=session-1');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-03T22:47:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows and persists the first-run presenter window message', () => {
+    render(<PresenterView sessionId="session-1" />);
+
+    expect(screen.getByRole('heading', { name: 'Presenter Window' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox', { name: "Don't show this message again" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Got it' }));
+
+    expect(window.localStorage.getItem('localstudio.presenterWindowIntroDismissed')).toBe('1');
+    expect(screen.queryByRole('heading', { name: 'Presenter Window' })).not.toBeInTheDocument();
+  });
+
+  it('renders presenter state with timer, slide previews, and notes zoom controls', () => {
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+    render(<PresenterView sessionId="session-1" />);
+
+    const project = sampleProject.createSampleProject();
+    project.pages[0] = {
+      ...project.pages[0]!,
+      animationBuilds: [
+        {
+          delayMs: 0,
+          durationMs: 300,
+          effect: 'fade',
+          elementId: 'text-title',
+          id: 'build-1',
+          trigger: 'on-click',
+        },
+      ],
+      speakerNotes: 'Open with the Web AI timing story.',
+    };
+    project.pages.push({
+      id: 'page-2',
+      name: 'Slide 2',
+      width: 1920,
+      height: 1080,
+      background: { type: 'color', color: '#111111' },
+      elementIds: [],
+      speakerNotes: 'Second slide notes',
+    });
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            payload: {
+              activePageId: 'page-1',
+              animationPreview: {
+                activeBuild: undefined,
+                activeBuildElementId: 'text-title',
+                animationProgress: 0,
+                hiddenElementIds: ['text-title'],
+                mode: 'presenter',
+                pageId: 'page-1',
+                phase: 'waiting',
+                playing: true,
+                waitingForClick: true,
+              },
+              project,
+            },
+            sessionId: 'session-1',
+            source: 'localstudio-presenter-main',
+            type: 'state',
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByLabelText('Presenter view')).toBeInTheDocument();
+    expect(screen.getByText(/00:00/)).toBeInTheDocument();
+    expect(screen.getByText('Current: Slide 1 of 2')).toBeInTheDocument();
+    expect(screen.getByText('Builds remaining: 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Speaker notes')).toHaveValue(
+      'Open with the Web AI timing story.',
+    );
+    expect(screen.getByRole('button', { name: 'Slide 2' })).toBeInTheDocument();
+
+    const notes = screen.getByLabelText('Speaker notes');
+    const initialSize = notes.style.fontSize;
+    fireEvent.click(screen.getByRole('button', { name: 'Increase notes size' }));
+    expect(notes.style.fontSize).not.toBe(initialSize);
+  });
+
+  it('posts presenter commands and note updates to the opener', () => {
+    const opener = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: opener,
+    });
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+    render(<PresenterView sessionId="session-1" />);
+    const project = sampleProject.createSampleProject();
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            payload: {
+              activePageId: 'page-1',
+              animationPreview: undefined,
+              project,
+            },
+            sessionId: 'session-1',
+            source: 'localstudio-presenter-main',
+            type: 'state',
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByRole('button', { name: 'Next slide' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Next slide' }));
+    fireEvent.change(screen.getByLabelText('Speaker notes'), { target: { value: 'New note' } });
+
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'next',
+        sessionId: 'session-1',
+        source: 'localstudio-presenter-window',
+        type: 'command',
+      }),
+      window.location.origin,
+    );
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'update-notes',
+        notes: 'New note',
+        pageId: 'page-1',
+      }),
+      window.location.origin,
+    );
+  });
+
+  it('does not post close during StrictMode effect remounts', () => {
+    const opener = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: opener,
+    });
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+
+    render(
+      <StrictMode>
+        <PresenterView sessionId="session-1" />
+      </StrictMode>,
+    );
+
+    expect(opener.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'close',
+      }),
+      window.location.origin,
+    );
+  });
+
+  it('posts close when the presenter page is hidden or closed', () => {
+    const opener = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: opener,
+    });
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+    render(<PresenterView sessionId="session-1" />);
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'close',
+        sessionId: 'session-1',
+        source: 'localstudio-presenter-window',
+        type: 'command',
+      }),
+      window.location.origin,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a presenter-oriented view with its own shell and session state.
- Wire the editor to switch between editing and presenter modes from the top toolbar and footer.
- Update document model and styles to support the new mode without disrupting the existing editor flow.
- Cover the new behavior with unit tests for app wiring, presenter session service, editor shell, top toolbar, and presenter view.

## Testing
- Unit tests added/updated for presenter session behavior and UI mode switching.
- Not run (not requested).