### PR TITLE
Handle local video imports with explicit format support

### DIFF
--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -1136,6 +1136,19 @@ button {
   line-height: 1.4;
 }
 
+.media-import-info-icon {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 18px;
+  border: 1px solid rgba(125, 211, 252, 0.42);
+  border-radius: 50%;
+  background: rgba(125, 211, 252, 0.1);
+  color: #7dd3fc;
+  font-size: 28px;
+}
+
 .presentation-import-dismiss {
   margin-top: 22px;
   border: 1px solid rgba(255, 255, 255, 0.18);

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -1136,6 +1136,23 @@ button {
   line-height: 1.4;
 }
 
+.presentation-import-dismiss {
+  margin-top: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--ew-text);
+  font-weight: 700;
+  padding: 9px 14px;
+}
+
+.presentation-import-dismiss:hover,
+.presentation-import-dismiss:focus-visible {
+  border-color: rgba(125, 211, 252, 0.7);
+  background: rgba(125, 211, 252, 0.14);
+  outline: 0;
+}
+
 @keyframes presentationImportOrbit {
   from {
     transform: rotate(0deg) translateX(35px);

--- a/apps/editor/src/ui/editor/canvas/PageRail.tsx
+++ b/apps/editor/src/ui/editor/canvas/PageRail.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import type { ProjectDocument } from '../../../domain/documents/model';
+import { localMediaImportConfig } from '../media/localMediaImportConfig';
 
 interface PageRailProps {
   project: ProjectDocument;
@@ -69,7 +70,7 @@ export function PageRail({ project, activePageId, onAddPage, onImportImage, onIm
           aria-label="Import media file"
           className="visually-hidden-input"
           type="file"
-          accept="image/*,video/*"
+          accept={localMediaImportConfig.accept}
           onChange={(event) => {
             const file = event.target.files?.[0];
             if (!file) return;

--- a/apps/editor/src/ui/editor/media/localMediaImportConfig.ts
+++ b/apps/editor/src/ui/editor/media/localMediaImportConfig.ts
@@ -1,5 +1,5 @@
 export const localMediaImportConfig = {
-  accept: 'image/*,.mp4,video/mp4,.webm,video/webm',
+  accept: 'image/*,video/*',
   localVideoExtensions: new Set(['mp4', 'webm', 'mov']),
   supportedVideoExtensions: new Set(['mp4', 'webm']),
   supportedVideoMimeTypes: new Set(['video/mp4', 'video/webm']),

--- a/apps/editor/src/ui/editor/media/localMediaImportConfig.ts
+++ b/apps/editor/src/ui/editor/media/localMediaImportConfig.ts
@@ -1,0 +1,6 @@
+export const localMediaImportConfig = {
+  accept: 'image/*,.mp4,video/mp4,.webm,video/webm',
+  localVideoExtensions: new Set(['mp4', 'webm', 'mov']),
+  supportedVideoExtensions: new Set(['mp4', 'webm']),
+  supportedVideoMimeTypes: new Set(['video/mp4', 'video/webm']),
+};

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -22,6 +22,7 @@ import { AnimationPanel } from './AnimationPanel';
 import { DesignPanel } from './DesignPanel';
 import { ElementsPanel } from './ElementsPanel';
 import type { CreateImagePromptOptions } from '../media/imagePromptOptions';
+import { localMediaImportConfig } from '../media/localMediaImportConfig';
 import { LayersPanel } from './LayersPanel';
 import { TextPanel } from './TextPanel';
 import type { RightPanelTab, StockMediaErrorState, TextPreset } from '../state/useEditorViewModel';
@@ -328,7 +329,7 @@ export function LeftToolPanel({
               aria-label="Import media file"
               className="visually-hidden-input"
               type="file"
-              accept="image/*,video/*"
+              accept={localMediaImportConfig.accept}
               onChange={(event) => {
                 const file = event.target.files?.[0];
                 if (!file) return;

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -10,6 +10,7 @@ import {
   type WebMcpDemoWindow,
 } from '../../../services/webmcp/webMcpToolAdapter';
 import { EditorFooter } from './EditorFooter';
+import { MediaImportProgressOverlay } from './MediaImportProgressOverlay';
 import { PresentationImportProgressOverlay } from './PresentationImportProgressOverlay';
 import { LeftToolPanel } from '../panels/LeftToolPanel';
 import { LocalProjectSetupPanel } from '../panels/LocalProjectSetupPanel';
@@ -17,6 +18,7 @@ import { MediaIntegrationSettingsPanel } from '../panels/MediaIntegrationSetting
 import { MirrorSettingsPanel } from '../panels/MirrorSettingsPanel';
 import { PagesPanel } from '../panels/PagesPanel';
 import { ProjectVideoPreloader } from '../media/ProjectVideoPreloader';
+import { localMediaImportConfig } from '../media/localMediaImportConfig';
 import { PromptBar } from '../prompting/PromptBar';
 import { RemoteImportPanel } from '../panels/RemoteImportPanel';
 import { ScrollingCanvasWorkspace } from '../canvas/ScrollingCanvasWorkspace';
@@ -638,7 +640,7 @@ export function EditorShell({ services }: EditorShellProps) {
             aria-label="Insert media file"
             className="visually-hidden-input"
             type="file"
-            accept="image/*,video/*"
+            accept={localMediaImportConfig.accept}
             onChange={(event) => {
               const file = event.target.files?.[0];
               if (!file || isHistoryReadOnly) return;
@@ -766,6 +768,12 @@ export function EditorShell({ services }: EditorShellProps) {
       ) : null}
       {vm.presentationImportProgress ? (
         <PresentationImportProgressOverlay progress={vm.presentationImportProgress} />
+      ) : null}
+      {vm.mediaImportProgress ? (
+        <MediaImportProgressOverlay
+          progress={vm.mediaImportProgress}
+          onDismiss={vm.clearMediaImportProgress}
+        />
       ) : null}
       <ProjectVideoPreloader project={vm.project} />
       <EditorFooter

--- a/apps/editor/src/ui/editor/shell/MediaImportProgressOverlay.tsx
+++ b/apps/editor/src/ui/editor/shell/MediaImportProgressOverlay.tsx
@@ -10,23 +10,30 @@ export function MediaImportProgressOverlay({
   progress,
 }: MediaImportProgressOverlayProps) {
   const progressValue = progress.tone === 'loading' ? 62 : 100;
+  const isLoading = progress.tone === 'loading';
 
   return (
     <div className="presentation-import-backdrop" role="status" aria-live="polite">
       <div className="presentation-import-panel">
-        <div className="presentation-import-orbit" aria-hidden="true">
-          <span />
-          <span />
-          <span />
-        </div>
+        {isLoading ? (
+          <div className="presentation-import-orbit" aria-hidden="true">
+            <span />
+            <span />
+            <span />
+          </div>
+        ) : (
+          <span className="media-import-info-icon material-symbols-outlined" aria-hidden="true">
+            info
+          </span>
+        )}
         <div className="presentation-import-copy">
           <span className="presentation-import-stage">
-            {progress.tone === 'loading' ? 'Importing media' : 'Import blocked'}
+            {isLoading ? 'Importing media' : 'Supported formats'}
           </span>
           <h2>{progress.title}</h2>
           <p>{progress.detail}</p>
         </div>
-        {progress.tone === 'loading' ? (
+        {isLoading ? (
           <>
             <div
               className="presentation-import-progress"

--- a/apps/editor/src/ui/editor/shell/MediaImportProgressOverlay.tsx
+++ b/apps/editor/src/ui/editor/shell/MediaImportProgressOverlay.tsx
@@ -1,0 +1,54 @@
+import type { MediaImportProgressState } from '../state/useEditorViewModel';
+
+interface MediaImportProgressOverlayProps {
+  onDismiss?: () => void;
+  progress: MediaImportProgressState;
+}
+
+export function MediaImportProgressOverlay({
+  onDismiss,
+  progress,
+}: MediaImportProgressOverlayProps) {
+  const progressValue = progress.tone === 'loading' ? 62 : 100;
+
+  return (
+    <div className="presentation-import-backdrop" role="status" aria-live="polite">
+      <div className="presentation-import-panel">
+        <div className="presentation-import-orbit" aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </div>
+        <div className="presentation-import-copy">
+          <span className="presentation-import-stage">
+            {progress.tone === 'loading' ? 'Importing media' : 'Import blocked'}
+          </span>
+          <h2>{progress.title}</h2>
+          <p>{progress.detail}</p>
+        </div>
+        {progress.tone === 'loading' ? (
+          <>
+            <div
+              className="presentation-import-progress"
+              role="progressbar"
+              aria-label="Media import progress"
+              aria-valuemax={100}
+              aria-valuemin={0}
+              aria-valuenow={progressValue}
+            >
+              <span style={{ width: `${progressValue}%` }} />
+            </div>
+            <div className="presentation-import-progress-meta">
+              <span>Loading</span>
+              <span>Keeping large video files off the main memory path</span>
+            </div>
+          </>
+        ) : (
+          <button className="presentation-import-dismiss" type="button" onClick={onDismiss}>
+            OK
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -3473,7 +3473,7 @@ export function useEditorViewModel(services: AppServices) {
     if (assetType === 'video' && !isSupportedLocalVideoFile(file)) {
       setMediaImportProgress({
         detail:
-          'MOV and other non-MP4/WebM videos are not reliably supported in browser playback. Convert the clip to MP4 or WebM and import it again.',
+          'Video import supports MP4 and WebM files. Convert this clip to MP4 or WebM and import it again.',
         title: 'Unsupported video format',
         tone: 'error',
       });

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -48,6 +48,7 @@ import { createPrefixedId } from '../../../services/ids/idUtils';
 import { slideTaskPrompt } from '../../../services/prompting/slideTaskPrompt';
 import { imagePromptOptions } from '../media/imagePromptOptions';
 import type { CreateImagePromptOptions } from '../media/imagePromptOptions';
+import { localMediaImportConfig } from '../media/localMediaImportConfig';
 import { TRANSLATION_LANGUAGE_OPTIONS } from '../translation/translationLanguages';
 import { translationLanguageUtils } from '../translation/translationLanguageUtils';
 import { editorPreferences } from '../persistence/editorPreferences';
@@ -104,6 +105,12 @@ export interface PresentationImportProgressState {
   progress: number;
   stage: 'reading' | 'inspecting' | 'extracting-objects' | 'extracting-media' | 'mapping-animations' | 'opening';
   title: string;
+}
+
+export interface MediaImportProgressState {
+  detail: string;
+  title: string;
+  tone: 'loading' | 'error';
 }
 
 interface ElementClipboardState {
@@ -298,9 +305,32 @@ function readVideoSize(src: string) {
   });
 }
 
+function getFileExtension(fileName: string) {
+  const extension = fileName.trim().toLowerCase().split('.').pop();
+  return extension && extension !== fileName.toLowerCase() ? extension : '';
+}
+
+function isSupportedLocalVideoFile(file: File) {
+  const extension = getFileExtension(file.name);
+  return (
+    localMediaImportConfig.supportedVideoMimeTypes.has(file.type) ||
+    localMediaImportConfig.supportedVideoExtensions.has(extension)
+  );
+}
+
+function createMediaObjectUrl(file: File) {
+  if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    throw new Error('This browser cannot import video files from disk.');
+  }
+  return URL.createObjectURL(file);
+}
+
 function getMediaAssetType(file: File): 'image' | 'gif' | 'video' {
+  const extension = getFileExtension(file.name);
   if (file.type === 'image/gif') return 'gif';
-  if (file.type.startsWith('video/')) return 'video';
+  if (file.type.startsWith('video/') || localMediaImportConfig.localVideoExtensions.has(extension)) {
+    return 'video';
+  }
   return 'image';
 }
 
@@ -517,6 +547,9 @@ export function useEditorViewModel(services: AppServices) {
   const [persistenceEnabled, setPersistenceEnabled] = useState(shouldRestoreStoredProject);
   const [presentationImportProgress, setPresentationImportProgress] = useState<
     PresentationImportProgressState | undefined
+  >();
+  const [mediaImportProgress, setMediaImportProgress] = useState<
+    MediaImportProgressState | undefined
   >();
   const [hasPersistedLocalProject, setHasPersistedLocalProject] = useState(
     shouldRestoreStoredProject,
@@ -3436,43 +3469,140 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   async function importImageFile(file: File) {
-    const dataUrl = await readImageFileAsDataUrl(file);
     const assetType = getMediaAssetType(file);
-    const mediaSize =
-      assetType === 'video' ? await readVideoSize(dataUrl) : await readImageSize(dataUrl);
-    const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
-    if (!page) return;
+    if (assetType === 'video' && !isSupportedLocalVideoFile(file)) {
+      setMediaImportProgress({
+        detail:
+          'MOV and other non-MP4/WebM videos are not reliably supported in browser playback. Convert the clip to MP4 or WebM and import it again.',
+        title: 'Unsupported video format',
+        tone: 'error',
+      });
+      return;
+    }
 
-    const assetId = createPrefixedId('asset');
-    const elementId = createPrefixedId(assetType);
-    const mediaName =
-      file.name.trim() ||
-      (assetType === 'video'
-        ? 'Pasted video'
-        : assetType === 'gif'
-          ? 'Pasted GIF'
-          : 'Pasted image');
-    const fittedMedia = fitImageWithinPage({
-      imageWidth: mediaSize.width,
-      imageHeight: mediaSize.height,
-      pageWidth: page.width,
-      pageHeight: page.height,
+    setMediaImportProgress({
+      detail:
+        assetType === 'video'
+          ? 'Loading video metadata without copying the full file into memory.'
+          : assetType === 'gif'
+            ? 'Loading animated media from disk.'
+            : 'Loading image from disk.',
+      title: 'Loading media',
+      tone: 'loading',
     });
+    await waitForNextPaint();
 
-    if (assetType === 'gif') {
+    let imported = false;
+    let objectUrl: string | undefined;
+    try {
+      objectUrl =
+        assetType === 'video' || assetType === 'gif' ? createMediaObjectUrl(file) : undefined;
+      const mediaUrl = objectUrl ?? (await readImageFileAsDataUrl(file));
+      const mediaSize =
+        assetType === 'video' ? await readVideoSize(mediaUrl) : await readImageSize(mediaUrl);
+      const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
+      if (!page) {
+        setMediaImportProgress(undefined);
+        return;
+      }
+
+      const assetId = createPrefixedId('asset');
+      const elementId = createPrefixedId(assetType);
+      const mediaName =
+        file.name.trim() ||
+        (assetType === 'video'
+          ? 'Pasted video'
+          : assetType === 'gif'
+            ? 'Pasted GIF'
+            : 'Pasted image');
+      const fittedMedia = fitImageWithinPage({
+        imageWidth: mediaSize.width,
+        imageHeight: mediaSize.height,
+        pageWidth: page.width,
+        pageHeight: page.height,
+      });
+
+      if (assetType === 'gif') {
+        commitProject(
+          (currentProject) =>
+            new basicCommands.AddMediaElementCommand(activePageId, {
+              asset: {
+                id: assetId,
+                type: 'gif',
+                name: mediaName,
+                mimeType: file.type || 'image/gif',
+                objectUrl: mediaUrl,
+              },
+              element: {
+                id: elementId,
+                type: 'gif',
+                assetId,
+                x: fittedMedia.x,
+                y: fittedMedia.y,
+                width: fittedMedia.width,
+                height: fittedMedia.height,
+                rotation: 0,
+                locked: false,
+                visible: true,
+                opacity: 1,
+                playing: true,
+              },
+            }).execute(currentProject),
+          { selectedElementIds: [elementId] },
+        );
+        imported = true;
+        return;
+      }
+
+      if (assetType === 'video') {
+        commitProject(
+          (currentProject) =>
+            new basicCommands.AddMediaElementCommand(activePageId, {
+              asset: {
+                id: assetId,
+                type: 'video',
+                name: mediaName,
+                mimeType: file.type || 'video/mp4',
+                objectUrl: mediaUrl,
+              },
+              element: {
+                id: elementId,
+                type: 'video',
+                assetId,
+                x: fittedMedia.x,
+                y: fittedMedia.y,
+                width: fittedMedia.width,
+                height: fittedMedia.height,
+                rotation: 0,
+                locked: false,
+                visible: true,
+                opacity: 1,
+                loop: false,
+                controls: true,
+                muted: true,
+                autoplayInPreview: true,
+                trimStartSeconds: 0,
+              },
+            }).execute(currentProject),
+          { selectedElementIds: [elementId] },
+        );
+        imported = true;
+        return;
+      }
+
       commitProject(
         (currentProject) =>
-          new basicCommands.AddMediaElementCommand(activePageId, {
+          new basicCommands.AddImageElementCommand(activePageId, {
             asset: {
               id: assetId,
-              type: 'gif',
+              type: 'image',
               name: mediaName,
-              mimeType: file.type || 'image/gif',
-              objectUrl: dataUrl,
+              mimeType: file.type || 'image/*',
+              objectUrl: mediaUrl,
             },
             element: {
               id: elementId,
-              type: 'gif',
+              type: 'image',
               assetId,
               x: fittedMedia.x,
               y: fittedMedia.y,
@@ -3482,75 +3612,27 @@ export function useEditorViewModel(services: AppServices) {
               locked: false,
               visible: true,
               opacity: 1,
-              playing: true,
             },
-          }).execute(currentProject),
-        { selectedElementIds: [elementId] },
-      );
-      return;
-    }
-
-    if (assetType === 'video') {
-      commitProject(
-        (currentProject) =>
-          new basicCommands.AddMediaElementCommand(activePageId, {
-            asset: {
-              id: assetId,
-              type: 'video',
-              name: mediaName,
-              mimeType: file.type || 'video/mp4',
-              objectUrl: dataUrl,
-            },
-            element: {
-              id: elementId,
-              type: 'video',
-              assetId,
-              x: fittedMedia.x,
-              y: fittedMedia.y,
-              width: fittedMedia.width,
-              height: fittedMedia.height,
-              rotation: 0,
-              locked: false,
-              visible: true,
-              opacity: 1,
-              loop: false,
-              controls: true,
-              muted: true,
-              autoplayInPreview: true,
-              trimStartSeconds: 0,
-            },
-          }).execute(currentProject),
-        { selectedElementIds: [elementId] },
-      );
-      return;
-    }
-
-    commitProject(
-      (currentProject) =>
-        new basicCommands.AddImageElementCommand(activePageId, {
-          asset: {
-            id: assetId,
-            type: 'image',
-            name: mediaName,
-            mimeType: file.type || 'image/*',
-            objectUrl: dataUrl,
-          },
-          element: {
-            id: elementId,
-            type: 'image',
-            assetId,
-            x: fittedMedia.x,
-            y: fittedMedia.y,
-            width: fittedMedia.width,
-            height: fittedMedia.height,
-            rotation: 0,
-            locked: false,
-            visible: true,
-            opacity: 1,
-          },
         }).execute(currentProject),
-      { selectedElementIds: [elementId] },
-    );
+        { selectedElementIds: [elementId] },
+      );
+      imported = true;
+    } catch (error) {
+      setMediaImportProgress({
+        detail:
+          error instanceof Error
+            ? error.message
+            : 'The selected media file could not be loaded.',
+        title: 'Media import failed',
+        tone: 'error',
+      });
+      return;
+    } finally {
+      if (!imported && objectUrl && typeof URL.revokeObjectURL === 'function') {
+        URL.revokeObjectURL(objectUrl);
+      }
+      if (imported) setMediaImportProgress(undefined);
+    }
   }
 
   function addRecentStockMedia(item: StockMediaItem) {
@@ -3702,6 +3784,10 @@ export function useEditorViewModel(services: AppServices) {
     );
   }
 
+  function clearMediaImportProgress() {
+    setMediaImportProgress(undefined);
+  }
+
   return {
     project: previewProject ?? project,
     automation,
@@ -3711,6 +3797,7 @@ export function useEditorViewModel(services: AppServices) {
     isFullscreen,
     persistenceEnabled,
     presentationImportProgress,
+    mediaImportProgress,
     persistenceAttention,
     persistenceNotice,
     mirrorState,
@@ -3891,5 +3978,6 @@ export function useEditorViewModel(services: AppServices) {
     removeAsset,
     importImageFile,
     importMediaFile: importImageFile,
+    clearMediaImportProgress,
   };
 }

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -564,6 +564,32 @@ function mockVideoMetadataLoad() {
     });
 }
 
+function mockControllableVideoMetadataLoad() {
+  const createElement = document.createElement.bind(document);
+  let videoElement: HTMLElement | undefined;
+  const createElementSpy = vi
+    .spyOn(document, 'createElement')
+    .mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+      const element = createElement(tagName, options);
+      if (tagName.toLowerCase() === 'video') {
+        Object.defineProperty(element, 'videoWidth', { configurable: true, value: 1280 });
+        Object.defineProperty(element, 'videoHeight', { configurable: true, value: 720 });
+        videoElement = element;
+      }
+      return element;
+    });
+
+  return {
+    createElementSpy,
+    hasMetadataTarget() {
+      return Boolean(videoElement);
+    },
+    loadMetadata() {
+      videoElement?.dispatchEvent(new Event('loadedmetadata'));
+    },
+  };
+}
+
 describe('EditorShell', () => {
   afterEach(() => {
     window.history.pushState({}, '', '/editor/');
@@ -2142,6 +2168,7 @@ describe('EditorShell', () => {
     );
 
     mockVideoMetadataLoad();
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:toolbar-video');
     const video = new File(['video-bytes'], 'toolbar-video.mp4', { type: 'video/mp4' });
     await user.click(screen.getByRole('button', { name: 'Insert Media' }));
     await user.upload(screen.getByLabelText('Insert media file'), video);
@@ -2153,9 +2180,69 @@ describe('EditorShell', () => {
       );
       expect(importedVideo).toMatchObject({ type: 'video' });
       expect(savedProject?.assets[importedVideo?.assetId ?? '']?.name).toBe('toolbar-video.mp4');
+      expect(savedProject?.assets[importedVideo?.assetId ?? '']?.objectUrl).toBe(
+        'blob:toolbar-video',
+      );
     });
+    expect(createObjectUrl).toHaveBeenCalledWith(video);
     expect(screen.getByRole('tab', { name: 'Design' })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByLabelText('Show selected video controls')).toBeChecked();
+  });
+
+  it('shows loading feedback while local video metadata is imported', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    services.projectRepository = new SavingProjectRepository();
+    const metadata = mockControllableVideoMetadataLoad();
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:pending-video');
+    render(<EditorShell services={services} />);
+
+    const video = new File(['video-bytes'], 'pending-video.mp4', { type: 'video/mp4' });
+    await user.click(screen.getByRole('button', { name: 'Insert Media' }));
+    await user.upload(screen.getByLabelText('Insert media file'), video);
+
+    expect(await screen.findByText('Loading media')).toBeInTheDocument();
+    expect(
+      screen.getByText('Loading video metadata without copying the full file into memory.'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(metadata.hasMetadataTarget()).toBe(true);
+    });
+
+    act(() => {
+      metadata.loadMetadata();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading media')).not.toBeInTheDocument();
+    });
+    metadata.createElementSpy.mockRestore();
+  });
+
+  it('blocks MOV uploads with a clear unsupported-format message', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new SavingProjectRepository();
+    services.projectRepository = repository;
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL');
+    render(<EditorShell services={services} />);
+
+    const video = new File(['video-bytes'], 'phone-video.mov', { type: 'video/quicktime' });
+    await user.click(screen.getByRole('button', { name: 'Insert Media' }));
+    fireEvent.change(screen.getByLabelText('Insert media file'), { target: { files: [video] } });
+
+    expect(await screen.findByText('Unsupported video format')).toBeInTheDocument();
+    expect(screen.getByText(/Convert the clip to MP4 or WebM/)).toBeInTheDocument();
+    expect(createObjectUrl).not.toHaveBeenCalled();
+    expect(
+      Object.values(repository.savedProjects.at(-1)?.assets ?? {}).some(
+        (asset) => asset.name === 'phone-video.mov',
+      ),
+    ).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+    expect(screen.queryByText('Unsupported video format')).not.toBeInTheDocument();
   });
 
   it('opens the media settings panel when a video layer is selected', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -2230,10 +2230,15 @@ describe('EditorShell', () => {
 
     const video = new File(['video-bytes'], 'phone-video.mov', { type: 'video/quicktime' });
     await user.click(screen.getByRole('button', { name: 'Insert Media' }));
-    fireEvent.change(screen.getByLabelText('Insert media file'), { target: { files: [video] } });
+    const input = screen.getByLabelText('Insert media file');
+    expect(input).toHaveAttribute('accept', 'image/*,video/*');
+    await user.upload(input, video);
 
     expect(await screen.findByText('Unsupported video format')).toBeInTheDocument();
-    expect(screen.getByText(/Convert the clip to MP4 or WebM/)).toBeInTheDocument();
+    expect(screen.getByText('Supported formats')).toBeInTheDocument();
+    expect(screen.getByText('info')).toHaveClass('media-import-info-icon');
+    expect(screen.getByText(/Video import supports MP4 and WebM files/)).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar', { name: 'Media import progress' })).not.toBeInTheDocument();
     expect(createObjectUrl).not.toHaveBeenCalled();
     expect(
       Object.values(repository.savedProjects.at(-1)?.assets ?? {}).some(

--- a/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
@@ -122,8 +122,7 @@ describe('LeftToolPanel', () => {
 
     await user.click(screen.getByRole('tab', { name: 'Assets' }));
     const input = screen.getByLabelText('Import media file');
-    expect(input).toHaveAttribute('accept', 'image/*,.mp4,video/mp4,.webm,video/webm');
-    expect(input.getAttribute('accept')).not.toContain('video/*');
+    expect(input).toHaveAttribute('accept', 'image/*,video/*');
     await user.upload(input, file);
 
     expect(onImportMedia).toHaveBeenCalledWith(file);

--- a/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
@@ -121,7 +121,10 @@ describe('LeftToolPanel', () => {
     );
 
     await user.click(screen.getByRole('tab', { name: 'Assets' }));
-    await user.upload(screen.getByLabelText('Import media file'), file);
+    const input = screen.getByLabelText('Import media file');
+    expect(input).toHaveAttribute('accept', 'image/*,.mp4,video/mp4,.webm,video/webm');
+    expect(input.getAttribute('accept')).not.toContain('video/*');
+    await user.upload(input, file);
 
     expect(onImportMedia).toHaveBeenCalledWith(file);
   });

--- a/apps/editor/tests/unit/ui/editor/PageRail.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/PageRail.test.tsx
@@ -39,7 +39,10 @@ describe('PageRail', () => {
       />,
     );
 
-    await user.upload(screen.getByLabelText('Import media file'), file);
+    const input = screen.getByLabelText('Import media file');
+    expect(input).toHaveAttribute('accept', 'image/*,.mp4,video/mp4,.webm,video/webm');
+    expect(input.getAttribute('accept')).not.toContain('video/*');
+    await user.upload(input, file);
 
     expect(onImportImage).toHaveBeenCalledWith(file);
   });

--- a/apps/editor/tests/unit/ui/editor/PageRail.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/PageRail.test.tsx
@@ -40,8 +40,7 @@ describe('PageRail', () => {
     );
 
     const input = screen.getByLabelText('Import media file');
-    expect(input).toHaveAttribute('accept', 'image/*,.mp4,video/mp4,.webm,video/webm');
-    expect(input.getAttribute('accept')).not.toContain('video/*');
+    expect(input).toHaveAttribute('accept', 'image/*,video/*');
     await user.upload(input, file);
 
     expect(onImportImage).toHaveBeenCalledWith(file);


### PR DESCRIPTION
## Summary
- Centralize local media import accept rules for editor upload entry points
- Import local videos via `objectUrl` and show progress or error overlays during media loading
- Block unsupported MOV uploads with a clear dismissal flow
- Add coverage for accept attributes, loading state, and unsupported-format behavior

## Testing
- Added/updated unit tests for toolbar import, page rail import, loading feedback, and MOV rejection
- Not run (not requested)