### PR TITLE
Add font download planning for PPTX imports and editor workflows

### DIFF
--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -28,6 +28,7 @@ export function App() {
       <Suspense fallback={null}>
         <PublicDeckViewer
           shareId={shareRoute.shareId}
+          fontImportService={services.fontImportService}
           shareService={services.shareService}
           embed={shareRoute.embed}
         />

--- a/apps/editor/src/app/composition.ts
+++ b/apps/editor/src/app/composition.ts
@@ -3,6 +3,7 @@ import type { ProjectDocument } from '../domain/documents/model';
 import type {
   BackgroundRemovalService,
   ExportService,
+  FontImportService,
   ImageGenerationService,
   LocalSetupService,
   MagicEraserService,
@@ -32,6 +33,7 @@ import { modelSetupService } from '../services/model-setup/modelSetupService';
 import { BrowserShareService } from '../services/sharing/shareService';
 import { BrowserPptxImportService } from '../services/importing/pptx/pptxImportService';
 import { BrowserStockMediaService } from '../services/stock-media/stockMediaService';
+import { BrowserGoogleFontsImportService } from '../services/fonts/googleFontsImportService';
 import { webGpuLanguageDetectionRuntime } from '../services/translation/webGpuLanguageDetectionRuntime';
 import { webGpuTextGenerationRuntime } from '../services/prompting/webGpuTextGenerationRuntime';
 import { minioMirrorService } from '../services/mirror/minioMirrorService';
@@ -45,6 +47,7 @@ export interface AppServices {
   persistenceMode: PersistenceStorageMode;
   projectRepository: ProjectRepository;
   exportService: ExportService;
+  fontImportService: FontImportService;
   presentationImportService: PresentationImportService;
   shareService: ShareService;
   stockMediaService: StockMediaService;
@@ -88,6 +91,7 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
     persistenceMode,
     projectRepository: createProjectRepository(persistenceMode),
     exportService: new BrowserExportService(),
+    fontImportService: new BrowserGoogleFontsImportService(),
     presentationImportService: new BrowserPptxImportService(),
     shareService: new BrowserShareService({ mirrorService }),
     stockMediaService: new BrowserStockMediaService(),

--- a/apps/editor/src/app/styles.css
+++ b/apps/editor/src/app/styles.css
@@ -2571,6 +2571,11 @@ button {
   font:
     600 13px 'Open Sans',
     sans-serif;
+  cursor: pointer;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .text-toolbar-size {
@@ -5569,6 +5574,232 @@ button {
 .design-control select:focus {
   border-color: var(--ew-green);
   box-shadow: 0 0 0 2px rgba(55, 253, 118, 0.14);
+}
+
+.text-inspector-stack {
+  display: grid;
+  gap: 10px;
+}
+
+.text-inspector-field {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.text-inspector-label {
+  color: var(--ew-text);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.text-inspector-field input,
+.text-inspector-field select {
+  width: 100%;
+  min-width: 0;
+  height: 40px;
+  border: 0;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--ew-text);
+  font: inherit;
+  font-size: 14px;
+  outline: 0;
+  padding: 0 12px;
+}
+
+.text-inspector-field input:focus,
+.text-inspector-field select:focus {
+  box-shadow: 0 0 0 2px rgba(55, 253, 118, 0.42);
+}
+
+.text-inspector-pair {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(86px, 0.6fr);
+  gap: 8px;
+  align-items: end;
+}
+
+.text-style-row,
+.text-align-grid {
+  display: grid;
+  overflow: hidden;
+  min-height: 40px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.text-style-row {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.text-align-grid {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.text-style-toggle,
+.text-align-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  border: 0;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  background: transparent;
+  color: var(--ew-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.text-style-toggle:last-child,
+.text-align-button:last-child {
+  border-right: 0;
+}
+
+.text-style-toggle.active,
+.text-align-button.active {
+  color: #000;
+  background: var(--ew-green);
+}
+
+.text-style-toggle:focus-visible,
+.text-align-button:focus-visible {
+  outline: 2px solid rgba(55, 253, 118, 0.55);
+  outline-offset: -2px;
+}
+
+.text-style-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.text-color-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 132px;
+  align-items: center;
+  min-height: 54px;
+  gap: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--ew-text);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.text-color-row input {
+  width: 100%;
+  height: 34px;
+  border: 0;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.16);
+  padding: 3px;
+}
+
+.font-control-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  gap: 8px;
+  align-items: end;
+}
+
+.font-control-select {
+  min-width: 0;
+}
+
+.font-add-button,
+.font-search-submit,
+.font-download-result {
+  border: 1px solid rgba(55, 253, 118, 0.24);
+  border-radius: 6px;
+  background: #050d10;
+  color: var(--ew-text);
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+}
+
+.font-add-button,
+.font-search-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 38px;
+  width: 38px;
+  height: 40px;
+  min-height: 0;
+  padding: 0;
+}
+
+.font-add-button:hover,
+.font-add-button:focus-visible,
+.font-search-submit:hover,
+.font-search-submit:focus-visible,
+.font-download-result:hover,
+.font-download-result:focus-visible {
+  border-color: var(--ew-green);
+  box-shadow: 0 0 16px rgba(55, 253, 118, 0.1);
+  outline: 0;
+}
+
+.font-add-button[aria-expanded='true'] {
+  color: #000;
+  background: var(--ew-green);
+}
+
+.font-download-panel {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid rgba(55, 253, 118, 0.18);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.34);
+}
+
+.font-download-search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  gap: 8px;
+}
+
+.font-download-search-box {
+  margin: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  background: #000;
+}
+
+.font-download-results {
+  display: grid;
+  gap: 6px;
+}
+
+.font-download-result {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18px;
+  align-items: center;
+  min-height: 36px;
+  gap: 8px;
+  padding: 0 10px;
+  color: var(--ew-text);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+}
+
+.font-download-result span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.font-download-result:disabled {
+  cursor: progress;
+  opacity: 0.65;
 }
 
 .design-selection-summary {

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -26,6 +26,7 @@ export interface ProjectDocument {
   name: string;
   pages: Page[];
   assets: Record<string, Asset>;
+  fonts?: Record<string, ProjectFont>;
   elements: Record<string, DesignElement>;
   createdAt: string;
   updatedAt: string;
@@ -95,6 +96,20 @@ export interface Asset {
   objectUrl?: string;
   fileName?: string;
   storage?: 'inline' | 'file' | 'remote';
+}
+
+export interface ProjectFont {
+  id: string;
+  family: string;
+  source: 'google-fonts';
+  requestedFamily: string;
+  fontStyle: 'normal' | 'italic';
+  fontWeight: number;
+  mimeType: 'font/woff2';
+  fileName: string;
+  storage: 'inline' | 'file' | 'remote';
+  objectUrl?: string;
+  sourceUrl?: string;
 }
 
 export type DesignElement = TextElement | ImageElement | GifElement | VideoElement | ShapeElement;

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -1,4 +1,4 @@
-import type { Asset, ProjectDocument } from '../../domain/documents/model';
+import type { Asset, ImportWarning, ProjectDocument, ProjectFont } from '../../domain/documents/model';
 import type { PptxImportInput } from '../importing/pptx/pptxImportService';
 import type {
   GeneratedSlideElement,
@@ -132,6 +132,29 @@ export interface ExportService {
 
 export interface PresentationImportService {
   importPowerPoint(input: PptxImportInput): Promise<ProjectDocument>;
+}
+
+export interface FontImportRequest {
+  family: string;
+  fontStyle: 'normal' | 'italic';
+  fontWeight: number;
+}
+
+export interface FontImportResult {
+  fonts: Record<string, ProjectFont>;
+  warnings: ImportWarning[];
+}
+
+export interface FontCatalogItem {
+  aliases?: string[];
+  family: string;
+  source: 'google-fonts';
+}
+
+export interface FontImportService {
+  listDownloadableFonts(): FontCatalogItem[];
+  resolveAndDownloadFonts(requests: FontImportRequest[]): Promise<FontImportResult>;
+  loadProjectFonts(project: ProjectDocument): Promise<void>;
 }
 
 export type ShareStatus = 'published' | 'copied' | 'syncing' | 'sync-failed';

--- a/apps/editor/src/services/fonts/googleFontsCatalog.ts
+++ b/apps/editor/src/services/fonts/googleFontsCatalog.ts
@@ -1,0 +1,54 @@
+export interface GoogleFontCatalogItem {
+  aliases?: string[];
+  family: string;
+  source: 'google-fonts';
+}
+
+const families: GoogleFontCatalogItem[] = [
+  { family: 'Abril Fatface', source: 'google-fonts' },
+  { family: 'Anton', source: 'google-fonts' },
+  { family: 'Archivo', source: 'google-fonts' },
+  { family: 'Arimo', aliases: ['Arial', 'Helvetica'], source: 'google-fonts' },
+  { family: 'Bebas Neue', source: 'google-fonts' },
+  { family: 'Bitter', source: 'google-fonts' },
+  { family: 'Cabin', source: 'google-fonts' },
+  { family: 'Caladea', aliases: ['Cambria'], source: 'google-fonts' },
+  { family: 'Carlito', aliases: ['Calibri'], source: 'google-fonts' },
+  { family: 'Cormorant Garamond', source: 'google-fonts' },
+  { family: 'Cousine', aliases: ['Courier', 'Courier New'], source: 'google-fonts' },
+  { family: 'DM Sans', source: 'google-fonts' },
+  { family: 'Fira Sans', source: 'google-fonts' },
+  { family: 'IBM Plex Sans', source: 'google-fonts' },
+  { family: 'Inconsolata', source: 'google-fonts' },
+  { family: 'Inter', source: 'google-fonts' },
+  { family: 'Lato', source: 'google-fonts' },
+  { family: 'Libre Baskerville', source: 'google-fonts' },
+  { family: 'Lora', source: 'google-fonts' },
+  { family: 'Manrope', source: 'google-fonts' },
+  { family: 'Merriweather', source: 'google-fonts' },
+  { family: 'Montserrat', source: 'google-fonts' },
+  { family: 'Mulish', source: 'google-fonts' },
+  { family: 'Noto Sans', source: 'google-fonts' },
+  { family: 'Noto Sans JP', source: 'google-fonts' },
+  { family: 'Noto Sans KR', source: 'google-fonts' },
+  { family: 'Noto Sans SC', source: 'google-fonts' },
+  { family: 'Noto Serif', source: 'google-fonts' },
+  { family: 'Nunito', source: 'google-fonts' },
+  { family: 'Open Sans', source: 'google-fonts' },
+  { family: 'Oswald', source: 'google-fonts' },
+  { family: 'Playfair Display', source: 'google-fonts' },
+  { family: 'Poppins', source: 'google-fonts' },
+  { family: 'Raleway', source: 'google-fonts' },
+  { family: 'Roboto', source: 'google-fonts' },
+  { family: 'Roboto Condensed', source: 'google-fonts' },
+  { family: 'Roboto Mono', source: 'google-fonts' },
+  { family: 'Rubik', source: 'google-fonts' },
+  { family: 'Source Sans 3', source: 'google-fonts' },
+  { family: 'Source Serif 4', source: 'google-fonts' },
+  { family: 'Space Grotesk', source: 'google-fonts' },
+  { family: 'Tinos', aliases: ['Times', 'Times New Roman'], source: 'google-fonts' },
+  { family: 'Ubuntu', source: 'google-fonts' },
+  { family: 'Work Sans', source: 'google-fonts' },
+];
+
+export const googleFontsCatalog = families satisfies GoogleFontCatalogItem[];

--- a/apps/editor/src/services/fonts/googleFontsImportService.ts
+++ b/apps/editor/src/services/fonts/googleFontsImportService.ts
@@ -1,0 +1,163 @@
+import type { ImportWarning, ProjectDocument, ProjectFont } from '../../domain/documents/model';
+import type { FontImportRequest, FontImportResult, FontImportService } from '../contracts/interfaces';
+import { googleFontsCatalog } from './googleFontsCatalog';
+
+interface BrowserGoogleFontsImportServiceOptions {
+  fetch?: typeof fetch;
+  fontFaceConstructor?: typeof FontFace;
+  fontSet?: FontFaceSet;
+}
+
+const GOOGLE_FONTS_CSS_ORIGIN = 'https://fonts.googleapis.com';
+const GOOGLE_FONTS_FILE_ORIGIN = 'https://fonts.gstatic.com';
+
+function getDefaultFetch() {
+  if (typeof window !== 'undefined') return window.fetch.bind(window);
+  return globalThis.fetch.bind(globalThis);
+}
+
+function createFontId(request: FontImportRequest) {
+  const slug = request.family
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 64);
+  return `google-fonts-${slug || 'font'}-${request.fontStyle}-${request.fontWeight}`;
+}
+
+function encodeGoogleFontFamily(request: FontImportRequest) {
+  const family = encodeURIComponent(request.family).replaceAll('%20', '+');
+  if (request.fontStyle === 'italic') return `${family}:ital,wght@1,${request.fontWeight}`;
+  return `${family}:wght@${request.fontWeight}`;
+}
+
+function createCssUrl(request: FontImportRequest) {
+  return `${GOOGLE_FONTS_CSS_ORIGIN}/css2?family=${encodeGoogleFontFamily(request)}&display=swap`;
+}
+
+function extractWoff2Url(css: string) {
+  const match = css.match(/url\((https:\/\/fonts\.gstatic\.com\/[^)]+?\.woff2)\)/);
+  return match?.[1];
+}
+
+function isAllowedFontUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.origin === GOOGLE_FONTS_FILE_ORIGIN && url.pathname.endsWith('.woff2');
+  } catch {
+    return false;
+  }
+}
+
+function createWarning(request: FontImportRequest, reason: string, code = 'font-download-failed'): ImportWarning {
+  return {
+    code,
+    message: `Could not download ${request.family} ${request.fontWeight}: ${reason}`,
+    severity: 'warning',
+  };
+}
+
+function getFontFaceConstructor(options: BrowserGoogleFontsImportServiceOptions) {
+  return options.fontFaceConstructor ?? (typeof FontFace !== 'undefined' ? FontFace : undefined);
+}
+
+function getFontSet(options: BrowserGoogleFontsImportServiceOptions) {
+  return options.fontSet ?? (typeof document !== 'undefined' ? document.fonts : undefined);
+}
+
+export class BrowserGoogleFontsImportService implements FontImportService {
+  private readonly requestFetch: typeof fetch;
+  private readonly downloadableFamilies = new Map(
+    googleFontsCatalog.map((font) => [font.family.toLowerCase(), font.family]),
+  );
+
+  constructor(private readonly options: BrowserGoogleFontsImportServiceOptions = {}) {
+    this.requestFetch = options.fetch ?? getDefaultFetch();
+  }
+
+  async resolveAndDownloadFonts(requests: FontImportRequest[]): Promise<FontImportResult> {
+    const fonts: Record<string, ProjectFont> = {};
+    const warnings: ImportWarning[] = [];
+    for (const request of requests) {
+      const result = await this.downloadFont(request);
+      if ('font' in result) {
+        fonts[result.font.id] = result.font;
+      } else {
+        warnings.push(result.warning);
+      }
+    }
+    await this.loadProjectFonts({ fonts } as ProjectDocument);
+    return { fonts, warnings };
+  }
+
+  listDownloadableFonts() {
+    return googleFontsCatalog;
+  }
+
+  async loadProjectFonts(project: ProjectDocument): Promise<void> {
+    const FontFaceConstructor = getFontFaceConstructor(this.options);
+    const fontSet = getFontSet(this.options);
+    if (!FontFaceConstructor || !fontSet) return;
+    const fonts = Object.values(project.fonts ?? {}).filter((font) => font.objectUrl);
+    await Promise.all(
+      fonts.map(async (font) => {
+        const face = new FontFaceConstructor(font.family, `url(${font.objectUrl})`, {
+          style: font.fontStyle,
+          weight: String(font.fontWeight),
+        });
+        await face.load();
+        fontSet.add(face);
+      }),
+    );
+  }
+
+  private async downloadFont(
+    request: FontImportRequest,
+  ): Promise<{ font: ProjectFont } | { warning: ImportWarning }> {
+    const catalogFamily = this.downloadableFamilies.get(request.family.toLowerCase());
+    if (!catalogFamily) {
+      return {
+        warning: createWarning(
+          request,
+          'font family is not in the local Google Fonts catalog',
+          'font-download-unavailable',
+        ),
+      };
+    }
+    const normalizedRequest = { ...request, family: catalogFamily };
+    const cssResponse = await this.requestFetch(createCssUrl(normalizedRequest), {
+      headers: { Accept: 'text/css' },
+    });
+    if (!cssResponse.ok) {
+      return { warning: createWarning(normalizedRequest, `Google Fonts returned ${cssResponse.status}`) };
+    }
+
+    const fontUrl = extractWoff2Url(await cssResponse.text());
+    if (!fontUrl || !isAllowedFontUrl(fontUrl)) {
+      return { warning: createWarning(normalizedRequest, 'no downloadable woff2 file was found') };
+    }
+
+    const fontResponse = await this.requestFetch(fontUrl, { headers: { Accept: 'font/woff2' } });
+    if (!fontResponse.ok) {
+      return { warning: createWarning(normalizedRequest, `font file returned ${fontResponse.status}`) };
+    }
+
+    const blob = await fontResponse.blob();
+    const id = createFontId(normalizedRequest);
+    return {
+      font: {
+        id,
+        family: normalizedRequest.family,
+        requestedFamily: request.family,
+        source: 'google-fonts',
+        fontStyle: normalizedRequest.fontStyle,
+        fontWeight: normalizedRequest.fontWeight,
+        mimeType: 'font/woff2',
+        fileName: `${id}.woff2`,
+        storage: 'inline',
+        objectUrl: URL.createObjectURL(blob),
+        sourceUrl: fontUrl,
+      },
+    };
+  }
+}

--- a/apps/editor/src/services/importing/pptx/pptxFontRequests.ts
+++ b/apps/editor/src/services/importing/pptx/pptxFontRequests.ts
@@ -1,0 +1,59 @@
+import type { ProjectDocument } from '../../../domain/documents/model';
+import type { FontImportRequest } from '../../contracts/interfaces';
+
+const SYSTEM_FONT_FAMILIES = new Set([
+  'arial',
+  'avenir',
+  'calibri',
+  'cambria',
+  'candara',
+  'consolas',
+  'courier',
+  'courier new',
+  'georgia',
+  'helvetica',
+  'sans-serif',
+  'serif',
+  'system-ui',
+  'tahoma',
+  'times',
+  'times new roman',
+  'trebuchet ms',
+  'verdana',
+]);
+
+function normalizeFontFamily(fontFamily: string) {
+  return fontFamily
+    .split(',')
+    .at(0)
+    ?.replace(/^["']|["']$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function shouldDownloadFont(fontFamily: string | undefined) {
+  if (!fontFamily) return false;
+  if (fontFamily.startsWith('+')) return false;
+  return !SYSTEM_FONT_FAMILIES.has(fontFamily.toLowerCase());
+}
+
+function collect(project: ProjectDocument): FontImportRequest[] {
+  const requests = new Map<string, FontImportRequest>();
+  for (const element of Object.values(project.elements)) {
+    if (element.type !== 'text') continue;
+    const family = normalizeFontFamily(element.fontFamily);
+    if (!family) continue;
+    if (!shouldDownloadFont(family)) continue;
+    const request: FontImportRequest = {
+      family,
+      fontStyle: 'normal',
+      fontWeight: element.fontWeight >= 700 ? 700 : 400,
+    };
+    requests.set(`${request.family.toLowerCase()}:${request.fontStyle}:${request.fontWeight}`, request);
+  }
+  return Array.from(requests.values());
+}
+
+export const pptxFontRequests = {
+  collect,
+};

--- a/apps/editor/src/services/mirror/minioMirrorFiles.ts
+++ b/apps/editor/src/services/mirror/minioMirrorFiles.ts
@@ -39,11 +39,22 @@ function cloneProjectWithoutObjectUrls(project: ProjectDocument): ProjectDocumen
         return [assetId, nextAsset];
       }),
     ),
+    ...(project.fonts
+      ? {
+          fonts: Object.fromEntries(
+            Object.entries(project.fonts).map(([fontId, font]) => {
+              const nextFont = { ...font };
+              delete nextFont.objectUrl;
+              return [fontId, nextFont];
+            }),
+          ),
+        }
+      : {}),
   };
 }
 
-async function assetToBlob(asset: Asset, requestFetch: typeof fetch) {
-  return assetFileUtils.objectUrlToBlobIfReadable(asset.objectUrl, requestFetch);
+async function objectUrlToBlob(value: { objectUrl?: string }, requestFetch: typeof fetch) {
+  return assetFileUtils.objectUrlToBlobIfReadable(value.objectUrl, requestFetch);
 }
 
 async function createFileEntry(path: string, blob: Blob): Promise<MirrorFile & MirrorManifestFile> {
@@ -67,13 +78,14 @@ async function createMirrorFiles(
   const projectForMirror: ProjectDocument = {
     ...project,
     assets: {},
+    ...(project.fonts ? { fonts: {} } : {}),
   };
   const files: Array<MirrorFile & MirrorManifestFile> = [];
 
   for (const [assetId, asset] of Object.entries(project.assets)) {
     if (!referencedAssetIds.has(assetId)) continue;
     const fileName = asset.fileName ?? `${asset.id}.${assetFileUtils.getAssetFileExtension(asset.mimeType)}`;
-    const blob = await assetToBlob(asset, requestFetch);
+    const blob = await objectUrlToBlob(asset, requestFetch);
     if (blob) {
       const assetForMirror: Asset = {
         ...asset,
@@ -85,6 +97,21 @@ async function createMirrorFiles(
       files.push(await createFileEntry(`assets/${fileName}`, blob));
     } else {
       projectForMirror.assets[assetId] = { ...asset };
+    }
+  }
+
+  for (const [fontId, font] of Object.entries(project.fonts ?? {})) {
+    const blob = await objectUrlToBlob(font, requestFetch);
+    if (blob) {
+      const fontForMirror = {
+        ...font,
+        storage: 'file' as const,
+      };
+      delete fontForMirror.objectUrl;
+      projectForMirror.fonts![fontId] = fontForMirror;
+      files.push(await createFileEntry(`fonts/${font.fileName}`, blob));
+    } else {
+      projectForMirror.fonts![fontId] = { ...font };
     }
   }
 

--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -45,11 +45,14 @@ const VERSION_HISTORY_LIMIT = 100;
 async function createFileBackedProjectSnapshot(
   project: ProjectDocument,
   assetsDirectory: FileSystemDirectoryHandle,
+  fontsDirectory: FileSystemDirectoryHandle,
 ): Promise<ProjectDocument> {
   const projectAssets = project.assets;
+  const projectFonts = project.fonts ?? {};
   const projectForDisk: ProjectDocument = {
     ...project,
     assets: { ...projectAssets },
+    ...(project.fonts ? { fonts: { ...projectFonts } } : {}),
   };
 
   for (const [assetId, asset] of Object.entries(projectAssets)) {
@@ -72,6 +75,28 @@ async function createFileBackedProjectSnapshot(
     projectForDisk.assets[assetId] = {
       ...assetForDisk,
       fileName,
+      storage: 'file',
+    };
+  }
+
+  for (const [fontId, font] of Object.entries(projectFonts)) {
+    if (font.storage === 'file' && font.fileName) {
+      const fontForDisk = { ...font };
+      delete fontForDisk.objectUrl;
+      projectForDisk.fonts![fontId] = fontForDisk;
+      continue;
+    }
+
+    if (!assetFileUtils.isReadableObjectUrl(font.objectUrl)) continue;
+    await writeBlobFileToDirectory(
+      fontsDirectory,
+      font.fileName,
+      await assetFileUtils.objectUrlToBlob(font.objectUrl),
+    );
+    const fontForDisk = { ...font };
+    delete fontForDisk.objectUrl;
+    projectForDisk.fonts![fontId] = {
+      ...fontForDisk,
       storage: 'file',
     };
   }
@@ -168,7 +193,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     }
 
     const project = JSON.parse(await file.text()) as ProjectDocument;
-    return this.hydrateProjectAssets(project, options);
+    return this.hydrateProjectFiles(project, options);
   }
 
   async saveProject(
@@ -178,12 +203,13 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     const previousProjectDirectoryName = this.projectDirectoryName;
     const directoryHandle = await this.ensureProjectDirectory(project.name, options);
     const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
+    const fontsDirectory = await directoryHandle.getDirectoryHandle('fonts', { create: true });
     await Promise.all([
       directoryHandle.getDirectoryHandle('cache', { create: true }),
       directoryHandle.getDirectoryHandle('config', { create: true }),
     ]);
 
-    const projectForDisk = await createFileBackedProjectSnapshot(project, assetsDirectory);
+    const projectForDisk = await createFileBackedProjectSnapshot(project, assetsDirectory, fontsDirectory);
     const retainedAssetFileNames = new Set(
       Object.values(projectForDisk.assets)
         .map((asset) => asset.fileName)
@@ -191,6 +217,14 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     );
 
     await this.removeUnretainedAssetFiles(assetsDirectory, retainedAssetFileNames);
+    await this.removeUnretainedAssetFiles(
+      fontsDirectory,
+      new Set(
+        Object.values(projectForDisk.fonts ?? {})
+          .map((font) => font.fileName)
+          .filter((fileName): fileName is string => Boolean(fileName)),
+      ),
+    );
     await this.writeJsonFile(directoryHandle, PROJECT_FILE_NAME, projectForDisk);
     const configDirectory = await directoryHandle.getDirectoryHandle('config', { create: true });
     await this.writeJsonFile(configDirectory, PROJECT_CONFIG_FILE_NAME, {
@@ -232,6 +266,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
   ): Promise<VersionHistoryEntry> {
     const directoryHandle = await this.ensureProjectDirectory(project.name);
     const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
+    const fontsDirectory = await directoryHandle.getDirectoryHandle('fonts', { create: true });
     const historyDirectory = await directoryHandle.getDirectoryHandle('history', { create: true });
     const versionsDirectory = await historyDirectory.getDirectoryHandle('versions', {
       create: true,
@@ -257,7 +292,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
         : {}),
     };
 
-    const projectForHistory = await createFileBackedProjectSnapshot(project, assetsDirectory);
+    const projectForHistory = await createFileBackedProjectSnapshot(project, assetsDirectory, fontsDirectory);
     await this.writeJsonFile(
       versionsDirectory,
       fileName,
@@ -288,7 +323,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       const versionsDirectory = await historyDirectory.getDirectoryHandle('versions');
       const fileHandle = await versionsDirectory.getFileHandle(entry.fileName);
       const file = await fileHandle.getFile();
-      return this.hydrateProjectAssets(JSON.parse(await file.text()) as ProjectDocument, {
+      return this.hydrateProjectFiles(JSON.parse(await file.text()) as ProjectDocument, {
         allowMissingAssetFiles: true,
       });
     } catch (error) {
@@ -426,13 +461,15 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     }
   }
 
-  private async hydrateProjectAssets(
+  private async hydrateProjectFiles(
     project: ProjectDocument,
     options: HydrateProjectAssetsOptions = {},
   ): Promise<ProjectDocument> {
     if (!this.directoryHandle) return project;
     const assets: ProjectDocument['assets'] = {};
+    const fonts: ProjectDocument['fonts'] = {};
     let assetsDirectory: FileSystemDirectoryHandle | undefined;
+    let fontsDirectory: FileSystemDirectoryHandle | undefined;
 
     for (const [assetId, asset] of Object.entries(project.assets)) {
       if (asset.storage !== 'file' || !asset.fileName) {
@@ -453,7 +490,26 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       }
     }
 
-    return { ...project, assets };
+    for (const [fontId, font] of Object.entries(project.fonts ?? {})) {
+      if (font.storage !== 'file' || !font.fileName) {
+        fonts[fontId] = font;
+        continue;
+      }
+      try {
+        fontsDirectory ??= await this.directoryHandle.getDirectoryHandle('fonts');
+        const fileHandle = await fontsDirectory.getFileHandle(font.fileName);
+        const file = await fileHandle.getFile();
+        fonts[fontId] = {
+          ...font,
+          objectUrl: URL.createObjectURL(file),
+        };
+      } catch (error) {
+        if (!isNotFoundError(error) || !options.allowMissingAssetFiles) throw error;
+        fonts[fontId] = font;
+      }
+    }
+
+    return { ...project, assets, ...(project.fonts ? { fonts } : {}) };
   }
 }
 

--- a/apps/editor/src/services/storage/opfsProjectRepository.ts
+++ b/apps/editor/src/services/storage/opfsProjectRepository.ts
@@ -35,11 +35,14 @@ const LAST_PROJECT_NAME_KEY = 'localstudio.ai.opfs.last-project-name';
 async function createFileBackedProjectSnapshot(
   project: ProjectDocument,
   assetsDirectory: FileSystemDirectoryHandle,
+  fontsDirectory: FileSystemDirectoryHandle,
 ): Promise<ProjectDocument> {
   const projectAssets = project.assets;
+  const projectFonts = project.fonts ?? {};
   const projectForDisk: ProjectDocument = {
     ...project,
     assets: { ...projectAssets },
+    ...(project.fonts ? { fonts: { ...projectFonts } } : {}),
   };
 
   for (const [assetId, asset] of Object.entries(projectAssets)) {
@@ -62,6 +65,28 @@ async function createFileBackedProjectSnapshot(
     projectForDisk.assets[assetId] = {
       ...assetForDisk,
       fileName,
+      storage: 'file',
+    };
+  }
+
+  for (const [fontId, font] of Object.entries(projectFonts)) {
+    if (font.storage === 'file' && font.fileName) {
+      const fontForDisk = { ...font };
+      delete fontForDisk.objectUrl;
+      projectForDisk.fonts![fontId] = fontForDisk;
+      continue;
+    }
+
+    if (!assetFileUtils.isReadableObjectUrl(font.objectUrl)) continue;
+    await writeBlobFileToDirectory(
+      fontsDirectory,
+      font.fileName,
+      await assetFileUtils.objectUrlToBlob(font.objectUrl),
+    );
+    const fontForDisk = { ...font };
+    delete fontForDisk.objectUrl;
+    projectForDisk.fonts![fontId] = {
+      ...fontForDisk,
       storage: 'file',
     };
   }
@@ -151,12 +176,13 @@ export class OpfsProjectRepository implements ProjectRepository {
       options?.projectDirectoryName ?? project.name,
     );
     const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
+    const fontsDirectory = await directoryHandle.getDirectoryHandle('fonts', { create: true });
     await Promise.all([
       directoryHandle.getDirectoryHandle('cache', { create: true }),
       directoryHandle.getDirectoryHandle('config', { create: true }),
     ]);
 
-    const projectForDisk = await createFileBackedProjectSnapshot(project, assetsDirectory);
+    const projectForDisk = await createFileBackedProjectSnapshot(project, assetsDirectory, fontsDirectory);
     const retainedAssetFileNames = new Set(
       Object.values(projectForDisk.assets)
         .map((asset) => asset.fileName)
@@ -164,6 +190,14 @@ export class OpfsProjectRepository implements ProjectRepository {
     );
 
     await this.removeUnretainedAssetFiles(assetsDirectory, retainedAssetFileNames);
+    await this.removeUnretainedAssetFiles(
+      fontsDirectory,
+      new Set(
+        Object.values(projectForDisk.fonts ?? {})
+          .map((font) => font.fileName)
+          .filter((fileName): fileName is string => Boolean(fileName)),
+      ),
+    );
     await this.writeJsonFile(directoryHandle, PROJECT_FILE_NAME, projectForDisk);
     const configDirectory = await directoryHandle.getDirectoryHandle('config', { create: true });
     await this.writeJsonFile(configDirectory, PROJECT_CONFIG_FILE_NAME, {
@@ -206,6 +240,7 @@ export class OpfsProjectRepository implements ProjectRepository {
   ): Promise<VersionHistoryEntry> {
     const directoryHandle = await this.ensureProjectDirectory(project.name);
     const assetsDirectory = await directoryHandle.getDirectoryHandle('assets', { create: true });
+    const fontsDirectory = await directoryHandle.getDirectoryHandle('fonts', { create: true });
     const historyDirectory = await directoryHandle.getDirectoryHandle('history', { create: true });
     const versionsDirectory = await historyDirectory.getDirectoryHandle('versions', {
       create: true,
@@ -231,7 +266,7 @@ export class OpfsProjectRepository implements ProjectRepository {
         : {}),
     };
 
-    const projectForHistory = await createFileBackedProjectSnapshot(project, assetsDirectory);
+    const projectForHistory = await createFileBackedProjectSnapshot(project, assetsDirectory, fontsDirectory);
     await this.writeJsonFile(
       versionsDirectory,
       fileName,
@@ -263,7 +298,7 @@ export class OpfsProjectRepository implements ProjectRepository {
       const versionsDirectory = await historyDirectory.getDirectoryHandle('versions');
       const fileHandle = await versionsDirectory.getFileHandle(entry.fileName);
       const file = await fileHandle.getFile();
-      return this.hydrateProjectAssets(JSON.parse(await file.text()) as ProjectDocument, {
+      return this.hydrateProjectFiles(JSON.parse(await file.text()) as ProjectDocument, {
         allowMissingAssetFiles: true,
       });
     } catch (error) {
@@ -389,16 +424,18 @@ export class OpfsProjectRepository implements ProjectRepository {
     }
 
     const project = JSON.parse(await file.text()) as ProjectDocument;
-    return this.hydrateProjectAssets(project, options);
+    return this.hydrateProjectFiles(project, options);
   }
 
-  private async hydrateProjectAssets(
+  private async hydrateProjectFiles(
     project: ProjectDocument,
     options: HydrateProjectAssetsOptions = {},
   ): Promise<ProjectDocument> {
     if (!this.directoryHandle) return project;
     const assets: ProjectDocument['assets'] = {};
+    const fonts: ProjectDocument['fonts'] = {};
     let assetsDirectory: FileSystemDirectoryHandle | undefined;
+    let fontsDirectory: FileSystemDirectoryHandle | undefined;
 
     for (const [assetId, asset] of Object.entries(project.assets)) {
       if (asset.storage !== 'file' || !asset.fileName) {
@@ -419,7 +456,26 @@ export class OpfsProjectRepository implements ProjectRepository {
       }
     }
 
-    return { ...project, assets };
+    for (const [fontId, font] of Object.entries(project.fonts ?? {})) {
+      if (font.storage !== 'file' || !font.fileName) {
+        fonts[fontId] = font;
+        continue;
+      }
+      try {
+        fontsDirectory ??= await this.directoryHandle.getDirectoryHandle('fonts');
+        const fileHandle = await fontsDirectory.getFileHandle(font.fileName);
+        const file = await fileHandle.getFile();
+        fonts[fontId] = {
+          ...font,
+          objectUrl: URL.createObjectURL(file),
+        };
+      } catch (error) {
+        if (!isNotFoundError(error) || !options.allowMissingAssetFiles) throw error;
+        fonts[fontId] = font;
+      }
+    }
+
+    return { ...project, assets, ...(project.fonts ? { fonts } : {}) };
   }
 
   private rememberProject(projectName: string) {

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -519,6 +520,14 @@ export function CanvasWorkspace({
     (element): element is GifElement | VideoElement =>
       element.type === 'gif' || element.type === 'video',
   );
+  const projectFontSignature = useMemo(
+    () =>
+      Object.values(project.fonts ?? {})
+        .map((font) => `${font.family}:${font.fontStyle}:${font.fontWeight}:${font.objectUrl ?? ''}`)
+        .sort()
+        .join('|'),
+    [project.fonts],
+  );
   const hasSelection = selection.elementIds.length > 0;
   const isPresenterPlayback = presentationMode || animationPreview?.mode === 'presenter';
   const showEditorOverlays = !isPresenterPlayback && !readOnly;
@@ -619,9 +628,14 @@ export function CanvasWorkspace({
     if (!fontSet) return;
     let isMounted = true;
 
+    const projectFontLoads = Object.values(project.fonts ?? {}).map((font) =>
+      fontSet.load(`${font.fontWeight} 16px "${font.family}"`),
+    );
+
     void Promise.all([
       fontSet.load('800 96px Orbitron'),
       fontSet.load('600 40px "Open Sans"'),
+      ...projectFontLoads,
       fontSet.ready,
     ]).then(() => {
       if (!isMounted) return;
@@ -632,7 +646,7 @@ export function CanvasWorkspace({
     return () => {
       isMounted = false;
     };
-  }, [stageRef]);
+  }, [project.fonts, projectFontSignature, stageRef]);
 
   useEffect(() => {
     if (backgroundSelectionMode || hasProcessingElements) return;

--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -23,6 +23,7 @@ interface ScrollingCanvasWorkspaceProps extends CanvasWorkspaceProps {
   onRenamePage?: ((pageId: string, name: string) => void) | undefined;
   onReorderPage?: ((pageId: string, targetIndex: number) => void) | undefined;
   onSetPageVisibility?: ((pageId: string, visible: boolean) => void) | undefined;
+  onOpenFontPanel?: (() => void) | undefined;
   onTranslatePage?: ((pageId: string) => void) | undefined;
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
   translatingPageIds?: string[] | undefined;
@@ -41,6 +42,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
       onRenamePage,
       onReorderPage,
       onSetPageVisibility,
+      onOpenFontPanel,
       onTranslatePage,
       onUpdateElementStyle,
       project,
@@ -136,6 +138,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
               {...(canvasProps.onOpenAnimations
                 ? { onOpenAnimations: canvasProps.onOpenAnimations }
                 : {})}
+              {...(onOpenFontPanel ? { onOpenFontPanel } : {})}
               {...(canvasProps.onTranslateSelectedText
                 ? { onTranslateSelectedText: canvasProps.onTranslateSelectedText }
                 : {})}

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -1,4 +1,20 @@
-import { AlignCenter, CaseSensitive, Film, Image, Square, Type, Video } from 'lucide-react';
+import {
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  Bold,
+  CaseSensitive,
+  Download,
+  Film,
+  Image,
+  Plus,
+  Search,
+  Square,
+  Type,
+  Video,
+} from 'lucide-react';
+import type { FormEvent } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   DesignElement,
   PageBackground,
@@ -12,10 +28,13 @@ import type {
   ElementStylePatch,
   MediaPlaybackPatch,
 } from '../../../domain/commands/elements/basicCommands';
+import type { FontCatalogItem } from '../../../services/contracts/interfaces';
 import { PanelSection } from '../../components/PanelSection';
 import { textStyleOptions } from '../text/textStyleOptions';
 
 const palette = ['#37FD76', '#050D10', '#FFFFFF', '#91999D', '#00779A'];
+const regularTextWeight = 400;
+const boldTextWeight = 800;
 const shapeLineEndpointOptions: Array<{ value: ShapeLineEndpoint; label: string }> = [
   { value: 'none', label: 'None' },
   { value: 'arrow', label: 'Arrow' },
@@ -32,6 +51,9 @@ interface DesignPanelProps {
   project: ProjectDocument;
   activePageId: string;
   selection: SelectionState;
+  availableFonts?: FontCatalogItem[];
+  focusFontControlKey?: number | undefined;
+  onDownloadFont?: (family: string) => Promise<void>;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
@@ -52,6 +74,15 @@ function supportsLineEndpoints(element: ShapeElement) {
   return element.shape === 'arc' || element.shape === 'arrow' || element.shape === 'line';
 }
 
+function fontMatchesQuery(font: FontCatalogItem, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return false;
+  return (
+    font.family.toLowerCase().includes(normalizedQuery) ||
+    (font.aliases ?? []).some((alias) => alias.toLowerCase().includes(normalizedQuery))
+  );
+}
+
 export function DesignPanel({
   project,
   activePageId,
@@ -59,10 +90,43 @@ export function DesignPanel({
   onUpdateElementStyle,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
+  availableFonts = [],
+  focusFontControlKey,
+  onDownloadFont,
 }: DesignPanelProps) {
+  const fontSelectRef = useRef<HTMLSelectElement>(null);
+  const [fontDownloadOpen, setFontDownloadOpen] = useState(false);
+  const [fontSearchInput, setFontSearchInput] = useState('');
+  const [fontSearchQuery, setFontSearchQuery] = useState('');
+  const [downloadingFontFamily, setDownloadingFontFamily] = useState<string | undefined>();
+  const [fontDownloadStatus, setFontDownloadStatus] = useState<string | undefined>();
   const page = project.pages.find((item) => item.id === activePageId);
   const selectedElement = getSelectedElement(project, selection);
   const backgroundColor = page ? getBackgroundColor(page.background) : '#050D10';
+  const projectFontFamilies = useMemo(
+    () => Array.from(new Set(Object.values(project.fonts ?? {}).map((font) => font.family))).sort(),
+    [project.fonts],
+  );
+  const fontFamilyOptions = useMemo(
+    () =>
+      Array.from(
+        new Set([...textStyleOptions.TEXT_FONT_FAMILIES, ...projectFontFamilies]),
+      ).sort((left, right) => left.localeCompare(right)),
+    [projectFontFamilies],
+  );
+  const filteredDownloadableFonts = useMemo(() => {
+    const query = fontSearchQuery.trim();
+    return availableFonts
+      .filter((font) => fontMatchesQuery(font, query))
+      .slice(0, 12);
+  }, [availableFonts, fontSearchQuery]);
+  const selectedTextIsBold =
+    selectedElement?.type === 'text' && selectedElement.fontWeight >= boldTextWeight;
+
+  useEffect(() => {
+    if (!focusFontControlKey || selectedElement?.type !== 'text') return;
+    fontSelectRef.current?.focus();
+  }, [focusFontControlKey, selectedElement?.type]);
 
   function updateSelectedStyle(patch: Parameters<NonNullable<typeof onUpdateElementStyle>>[1]) {
     if (!selectedElement || selectedElement.locked) return;
@@ -81,6 +145,25 @@ export function DesignPanel({
       return;
     }
     onUpdatePageBackground?.({ type: 'color', color });
+  }
+
+  async function downloadFont(family: string) {
+    if (!family || !onDownloadFont) return;
+    setDownloadingFontFamily(family);
+    setFontDownloadStatus(`Downloading ${family}...`);
+    try {
+      await onDownloadFont(family);
+      setFontDownloadStatus(`${family} downloaded and applied`);
+    } catch (error) {
+      setFontDownloadStatus(error instanceof Error ? error.message : 'Font download failed.');
+    } finally {
+      setDownloadingFontFamily(undefined);
+    }
+  }
+
+  function submitFontSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFontSearchQuery(fontSearchInput.trim());
   }
 
   return (
@@ -120,6 +203,187 @@ export function DesignPanel({
         </div>
       </PanelSection>
 
+      {selectedElement?.type === 'text' ? (
+        <PanelSection title="Font">
+          <div className="text-inspector-stack">
+            <div className="font-control-row">
+              <label className="text-inspector-field text-inspector-field-full">
+                <span className="text-inspector-label">Font</span>
+                <select
+                  aria-label="Selected text font"
+                  ref={fontSelectRef}
+                  value={selectedElement.fontFamily}
+                  onChange={(event) => {
+                    updateSelectedStyle({ fontFamily: event.target.value });
+                  }}
+                >
+                  {fontFamilyOptions.map((fontFamily) => (
+                    <option key={fontFamily} value={fontFamily}>
+                      {fontFamily}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                aria-expanded={fontDownloadOpen}
+                aria-label="Download additional font"
+                className="font-add-button"
+                title="Download additional font"
+                type="button"
+                onClick={() => {
+                  setFontDownloadOpen((current) => !current);
+                }}
+              >
+                <Plus size={16} />
+              </button>
+            </div>
+            {fontDownloadOpen ? (
+              <div className="font-download-panel">
+                <form className="font-download-search" onSubmit={submitFontSearch}>
+                  <label className="layer-search font-download-search-box">
+                    <Search size={16} aria-hidden="true" />
+                    <input
+                      aria-label="Search downloadable fonts"
+                      placeholder="Search Google Fonts"
+                      type="search"
+                      value={fontSearchInput}
+                      onChange={(event) => {
+                        const nextSearch = event.target.value;
+                        setFontSearchInput(nextSearch);
+                        setFontSearchQuery(nextSearch.trim());
+                      }}
+                    />
+                  </label>
+                  <button className="font-search-submit" type="submit" aria-label="Search fonts">
+                    <Search size={16} />
+                  </button>
+                </form>
+                {fontSearchQuery ? (
+                  <div className="font-download-results" aria-label="Downloadable font results">
+                    {filteredDownloadableFonts.length > 0 ? (
+                      filteredDownloadableFonts.map((font) => (
+                        <button
+                          aria-label={`Download ${font.family}`}
+                          className="font-download-result"
+                          disabled={!onDownloadFont || downloadingFontFamily === font.family}
+                          key={font.family}
+                          type="button"
+                          onClick={() => {
+                            void downloadFont(font.family);
+                          }}
+                        >
+                          <span>{font.family}</span>
+                          <Download size={15} />
+                        </button>
+                      ))
+                    ) : (
+                      <p className="panel-muted">No Google Fonts match that search.</p>
+                    )}
+                  </div>
+                ) : null}
+                {fontDownloadStatus ? (
+                  <div className="panel-muted" role="status">
+                    {fontDownloadStatus}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+            <div className="text-inspector-pair">
+              <label className="text-inspector-field">
+                <span className="text-inspector-label">Weight</span>
+              <select
+                aria-label="Selected text font weight"
+                value={selectedElement.fontWeight}
+                onChange={(event) => {
+                  updateSelectedStyle({ fontWeight: Number(event.target.value) });
+                }}
+              >
+                {textStyleOptions.TEXT_FONT_WEIGHTS.map((fontWeight) => (
+                  <option key={fontWeight} value={fontWeight}>
+                    {fontWeight}
+                  </option>
+                ))}
+              </select>
+              </label>
+              <label className="text-inspector-field">
+                <span className="text-inspector-label">Size</span>
+                <input
+                  aria-label="Selected text font size"
+                  min="1"
+                  type="number"
+                  value={selectedElement.fontSize}
+                  onChange={(event) => {
+                    updateSelectedStyle({ fontSize: Number(event.target.value) });
+                  }}
+                />
+              </label>
+            </div>
+            <div className="text-style-row" aria-label="Text style controls">
+              <button
+                aria-label="Bold selected text"
+                aria-pressed={selectedTextIsBold}
+                className={selectedTextIsBold ? 'text-style-toggle active' : 'text-style-toggle'}
+                type="button"
+                onClick={() => {
+                  updateSelectedStyle({
+                    fontWeight: selectedTextIsBold ? regularTextWeight : boldTextWeight,
+                  });
+                }}
+              >
+                <Bold size={16} />
+              </button>
+              <button className="text-style-toggle" disabled type="button" aria-label="Italic unavailable">
+                <span>I</span>
+              </button>
+              <button className="text-style-toggle" disabled type="button" aria-label="Underline unavailable">
+                <span>U</span>
+              </button>
+              <button className="text-style-toggle" disabled type="button" aria-label="Strikethrough unavailable">
+                <span>S</span>
+              </button>
+            </div>
+            <label className="text-color-row">
+              <span>Text Color</span>
+              <input
+                aria-label="Selected text color"
+                type="color"
+                value={selectedElement.fill}
+                onChange={(event) => {
+                  updateSelectedStyle({ fill: event.target.value });
+                }}
+              />
+            </label>
+            <div className="text-align-grid" aria-label="Selected text alignment">
+              {([
+                { align: 'left' as const, icon: AlignLeft, label: 'Align selected text left' },
+                { align: 'center' as const, icon: AlignCenter, label: 'Align selected text center' },
+                { align: 'right' as const, icon: AlignRight, label: 'Align selected text right' },
+              ]).map((item) => {
+                const Icon = item.icon;
+                return (
+                  <button
+                    aria-label={item.label}
+                    aria-pressed={selectedElement.align === item.align}
+                    className={
+                      selectedElement.align === item.align
+                        ? 'text-align-button active'
+                        : 'text-align-button'
+                    }
+                    key={item.align}
+                    type="button"
+                    onClick={() => {
+                      updateSelectedStyle({ align: item.align });
+                    }}
+                  >
+                    <Icon size={18} />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </PanelSection>
+      ) : null}
+
       <PanelSection title="Selection">
         <div className="compact-action design-selection-summary">
           {selectedElement?.type === 'text' ? <Type size={16} /> : null}
@@ -148,84 +412,6 @@ export function DesignPanel({
           </label>
         ) : null}
       </PanelSection>
-
-      {selectedElement?.type === 'text' ? (
-        <PanelSection title="Typography">
-          <label className="design-control">
-            <span>Font</span>
-            <select
-              aria-label="Selected text font"
-              value={selectedElement.fontFamily}
-              onChange={(event) => {
-                updateSelectedStyle({ fontFamily: event.target.value });
-              }}
-            >
-              {textStyleOptions.TEXT_FONT_FAMILIES.map((fontFamily) => (
-                <option key={fontFamily} value={fontFamily}>
-                  {fontFamily}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="design-control">
-            <span>Size</span>
-            <input
-              aria-label="Selected text font size"
-              min="1"
-              type="number"
-              value={selectedElement.fontSize}
-              onChange={(event) => {
-                updateSelectedStyle({ fontSize: Number(event.target.value) });
-              }}
-            />
-          </label>
-          <label className="design-control">
-            <span>Weight</span>
-            <select
-              aria-label="Selected text font weight"
-              value={selectedElement.fontWeight}
-              onChange={(event) => {
-                updateSelectedStyle({ fontWeight: Number(event.target.value) });
-              }}
-            >
-              {textStyleOptions.TEXT_FONT_WEIGHTS.map((fontWeight) => (
-                <option key={fontWeight} value={fontWeight}>
-                  {fontWeight}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="design-control">
-            <span>Color</span>
-            <input
-              aria-label="Selected text color"
-              type="color"
-              value={selectedElement.fill}
-              onChange={(event) => {
-                updateSelectedStyle({ fill: event.target.value });
-              }}
-            />
-          </label>
-          <label className="design-control">
-            <span>Align</span>
-            <select
-              aria-label="Selected text alignment"
-              value={selectedElement.align}
-              onChange={(event) => {
-                updateSelectedStyle({ align: event.target.value as 'left' | 'center' | 'right' });
-              }}
-            >
-              <option value="left">Left</option>
-              <option value="center">Center</option>
-              <option value="right">Right</option>
-            </select>
-          </label>
-          <div className="compact-action">
-            <AlignCenter size={16} />
-            <span>Text frame stays editable on canvas</span>
-          </div>
-        </PanelSection>
-      ) : null}
 
       {selectedElement?.type === 'video' ? (
         <VideoPlaybackPanel element={selectedElement} onUpdate={updateSelectedMediaPlayback} />

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -13,6 +13,7 @@ import type {
 import type { ElementStylePatch, MediaPlaybackPatch } from '../../../domain/commands/elements/basicCommands';
 import type {
   AiProviderState,
+  FontCatalogItem,
   ModelState,
   StockMediaItem,
   StockMediaProviderState,
@@ -39,6 +40,7 @@ interface LeftToolPanelProps {
       }
     | undefined;
   activeSlideLanguage?: { code: string; displayCode: string; flag: string; label: string } | undefined;
+  focusFontControlKey?: number | undefined;
   onTabChange: (tab: RightPanelTab) => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -49,6 +51,7 @@ interface LeftToolPanelProps {
   translationProviderStates?: AiProviderState[];
   languageDetectionProviderStates?: AiProviderState[];
   translationLanguageOptions?: Array<{ code: string; flag: string; label: string }>;
+  availableFonts?: FontCatalogItem[];
   languageDetectionPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' };
   translationPreparation?: { progress: number; sourceLanguage?: string; status: 'idle' | 'downloading' | 'ready' | 'failed' };
   translationTargetAttention?: boolean;
@@ -57,6 +60,7 @@ interface LeftToolPanelProps {
   promptApiNotice?: string | undefined;
   promptPreparation?: { availability: string; progress: number; status: 'idle' | 'downloading' | 'ready' | 'failed' };
   onDownloadModel?: ((id: string) => Promise<void>) | undefined;
+  onDownloadFont?: ((family: string) => Promise<void>) | undefined;
   onRemoveModel?: ((id: string) => Promise<void>) | undefined;
   onCreateImageOptionsChange?: ((options: CreateImagePromptOptions) => void) | undefined;
   stockGifResults?: StockMediaItem[];
@@ -115,6 +119,7 @@ export function LeftToolPanel({
   activeTab,
   animationPreview,
   activeSlideLanguage,
+  focusFontControlKey,
   onTabChange,
   open = false,
   onOpenChange,
@@ -125,6 +130,7 @@ export function LeftToolPanel({
   translationProviderStates,
   languageDetectionProviderStates,
   translationLanguageOptions,
+  availableFonts,
   languageDetectionPreparation,
   translationPreparation,
   translationTargetAttention,
@@ -133,6 +139,7 @@ export function LeftToolPanel({
   promptApiNotice,
   promptPreparation,
   onDownloadModel,
+  onDownloadFont,
   onRemoveModel,
   onCreateImageOptionsChange,
   stockGifResults,
@@ -238,6 +245,9 @@ export function LeftToolPanel({
             project={project}
             activePageId={activePageId}
             selection={selection}
+            {...(availableFonts ? { availableFonts } : {})}
+            {...(focusFontControlKey ? { focusFontControlKey } : {})}
+            {...(onDownloadFont ? { onDownloadFont } : {})}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -35,6 +35,7 @@ export function EditorShell({ services }: EditorShellProps) {
   const vm = useEditorViewModel(services);
   const automationDelegateRef = useRef(vm.automation);
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);
+  const [designFontFocusKey, setDesignFontFocusKey] = useState(0);
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
   const [shareMetadata, setShareMetadata] = useState<ShareMetadata | undefined>();
   const stageRef = useRef<Konva.Stage>(null);
@@ -119,6 +120,12 @@ export function EditorShell({ services }: EditorShellProps) {
     if (selectedElement?.type !== 'gif' && selectedElement?.type !== 'video') return;
     vm.setActiveTab('design');
     openLeftPanel();
+  }
+
+  function openDesignFontList() {
+    vm.setActiveTab('design');
+    openLeftPanel();
+    setDesignFontFocusKey((current) => current + 1);
   }
 
   function selectElement(elementId: string, options?: { additive?: boolean }) {
@@ -421,12 +428,15 @@ export function EditorShell({ services }: EditorShellProps) {
           activeTab={vm.activeTab}
           animationPreview={vm.animationPreview}
           activeSlideLanguage={vm.activeSlideLanguage}
+          focusFontControlKey={designFontFocusKey}
           onTabChange={vm.setActiveTab}
           open={leftPanelOpen}
           onOpenChange={handleLeftPanelOpenChange}
           project={vm.project}
           activePageId={vm.activePageId}
           selection={vm.selection}
+          availableFonts={vm.availableFonts}
+          onDownloadFont={isHistoryReadOnly ? undefined : vm.downloadFontForSelection}
           onSelectElement={isHistoryReadOnly ? undefined : selectElement}
           onSetElementVisibility={isHistoryReadOnly ? undefined : vm.setElementVisibility}
           onSetElementLock={isHistoryReadOnly ? undefined : vm.setElementLock}
@@ -598,6 +608,7 @@ export function EditorShell({ services }: EditorShellProps) {
                     openLeftPanel();
                   }
             }
+            onOpenFontPanel={isHistoryReadOnly ? undefined : openDesignFontList}
             onSelectElement={isHistoryReadOnly ? undefined : selectElement}
             onSendSelectedElementBackward={
               isHistoryReadOnly

--- a/apps/editor/src/ui/editor/shell/PresentationImportProgressOverlay.tsx
+++ b/apps/editor/src/ui/editor/shell/PresentationImportProgressOverlay.tsx
@@ -8,6 +8,7 @@ const stageLabels: Record<PresentationImportProgressState['stage'], string> = {
   reading: 'Reading package',
   inspecting: 'Inspecting PPTX structure',
   'extracting-objects': 'Extracting text and images',
+  'downloading-fonts': 'Downloading fonts',
   'extracting-media': 'Extracting videos',
   'mapping-animations': 'Mapping animations',
   opening: 'Opening editor',

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -27,6 +27,7 @@ import { sampleProject } from '../../../domain/projects/sampleProject';
 import type { EditorAutomationDelegate } from '../../../services/automation/editorAutomationController';
 import type {
   AiProviderState,
+  FontImportService,
   MirrorProjectSummary,
   MirrorState,
   ModelDownloadProgressDetails,
@@ -38,6 +39,7 @@ import type {
   VersionHistoryEntry,
 } from '../../../services/contracts/interfaces';
 import type { PptxImportInput } from '../../../services/importing/pptx/pptxImportService';
+import { pptxFontRequests } from '../../../services/importing/pptx/pptxFontRequests';
 import { pptxImportLogger } from '../../../services/importing/pptx/pptxImportLogger';
 import { minioMirrorService } from '../../../services/mirror/minioMirrorService';
 import type { MinioMirrorConfig } from '../../../services/mirror/minioMirrorService';
@@ -102,7 +104,14 @@ interface PromptPreparationState extends ModelDownloadProgressDetails {
 export interface PresentationImportProgressState {
   detail: string;
   progress: number;
-  stage: 'reading' | 'inspecting' | 'extracting-objects' | 'extracting-media' | 'mapping-animations' | 'opening';
+  stage:
+    | 'reading'
+    | 'inspecting'
+    | 'extracting-objects'
+    | 'downloading-fonts'
+    | 'extracting-media'
+    | 'mapping-animations'
+    | 'opening';
   title: string;
 }
 
@@ -252,6 +261,10 @@ function normalizeProjectDocument(project: ProjectDocument): ProjectDocument {
       visible: page.visible ?? true,
     })),
   };
+}
+
+async function loadProjectFonts(project: ProjectDocument, fontImportService: FontImportService) {
+  await fontImportService.loadProjectFonts(project).catch(() => undefined);
 }
 
 function readImageFileAsDataUrl(file: File) {
@@ -657,6 +670,10 @@ export function useEditorViewModel(services: AppServices) {
     const element = project.elements[selectedElementIds[0] ?? ''];
     return element?.type === 'image' ? element : undefined;
   }, [project.elements, selectedElementIds]);
+  const availableFonts = useMemo(
+    () => services.fontImportService.listDownloadableFonts(),
+    [services.fontImportService],
+  );
   useEffect(() => {
     if (stockMediaProviderState.images.configured && stockImageResults.length === 0) {
       void searchStockImages('');
@@ -769,10 +786,12 @@ export function useEditorViewModel(services: AppServices) {
       .loadProject(
         services.storedProjectName ? { projectName: services.storedProjectName } : undefined,
       )
-      .then((savedProject) => {
+      .then(async (savedProject) => {
         if (!isMounted) return;
         if (savedProject) {
           const normalizedProject = normalizeProjectDocument(savedProject);
+          await loadProjectFonts(normalizedProject, services.fontImportService);
+          if (!isMounted) return;
           setProject(normalizedProject);
           setActivePageId(normalizedProject.pages[0]?.id ?? '');
           setPageLanguageCodes({});
@@ -805,6 +824,7 @@ export function useEditorViewModel(services: AppServices) {
     };
   }, [
     persistenceEnabled,
+    services.fontImportService,
     services.projectRepository,
     services.storedProjectName,
     storedMirrorConfig,
@@ -1723,6 +1743,7 @@ export function useEditorViewModel(services: AppServices) {
       const importedProject = await services.projectRepository.importProject();
       if (!importedProject) return;
       const normalizedProject = normalizeProjectDocument(importedProject);
+      await loadProjectFonts(normalizedProject, services.fontImportService);
       setProject(normalizedProject);
       setActivePageId(normalizedProject.pages[0]?.id ?? '');
       setPageLanguageCodes({});
@@ -1785,6 +1806,43 @@ export function useEditorViewModel(services: AppServices) {
       });
       await waitForNextPaint();
       setPresentationImportProgress({
+        detail: 'Matching imported text styles with downloadable Google Fonts.',
+        progress: 68,
+        stage: 'downloading-fonts',
+        title: 'Downloading fonts',
+      });
+      await waitForNextPaint();
+      const fontRequests = pptxFontRequests.collect(importedProject);
+      const fontImportResult =
+        fontRequests.length > 0
+          ? await services.fontImportService.resolveAndDownloadFonts(fontRequests).catch(() => ({
+              fonts: {},
+              warnings: [
+                {
+                  code: 'font-download-failed',
+                  message: 'Could not download one or more imported PowerPoint fonts.',
+                  severity: 'warning' as const,
+                },
+              ],
+            }))
+          : { fonts: {}, warnings: [] };
+      const importedProjectWithFonts: ProjectDocument = {
+        ...importedProject,
+        fonts: {
+          ...(importedProject.fonts ?? {}),
+          ...fontImportResult.fonts,
+        },
+        ...((importedProject.importWarnings?.length ?? 0) > 0 ||
+        fontImportResult.warnings.length > 0
+          ? {
+              importWarnings: [
+                ...(importedProject.importWarnings ?? []),
+                ...fontImportResult.warnings,
+              ],
+            }
+          : {}),
+      };
+      setPresentationImportProgress({
         detail: 'Linking original videos and GIFs from the PowerPoint package.',
         progress: 72,
         stage: 'extracting-media',
@@ -1798,7 +1856,8 @@ export function useEditorViewModel(services: AppServices) {
         title: 'Mapping animations',
       });
       await waitForNextPaint();
-      const normalizedProject = normalizeProjectDocument(importedProject);
+      const normalizedProject = normalizeProjectDocument(importedProjectWithFonts);
+      await loadProjectFonts(normalizedProject, services.fontImportService);
       setPresentationImportProgress({
         detail: 'Opening the imported project in the editor.',
         progress: 94,
@@ -2048,6 +2107,7 @@ export function useEditorViewModel(services: AppServices) {
       const files = await services.mirrorService.downloadProject(projectId, config);
       const importedProject = await services.projectRepository.importMirrorFiles(files);
       const normalizedProject = normalizeProjectDocument(importedProject);
+      await loadProjectFonts(normalizedProject, services.fontImportService);
       setProject(normalizedProject);
       setActivePageId(normalizedProject.pages[0]?.id ?? '');
       setPageLanguageCodes({});
@@ -2134,6 +2194,7 @@ export function useEditorViewModel(services: AppServices) {
     const versionProject = await services.projectRepository.loadVersion(versionId);
     if (!versionProject) return;
     const normalizedVersionProject = normalizeProjectDocument(versionProject);
+    await loadProjectFonts(normalizedVersionProject, services.fontImportService);
     setSelectedVersionId(versionId);
     setPreviewProject(normalizedVersionProject);
     const nextPageId = entry?.firstChangedPageId ?? normalizedVersionProject.pages[0]?.id ?? '';
@@ -2149,6 +2210,7 @@ export function useEditorViewModel(services: AppServices) {
       ...restoredProject,
       updatedAt: new Date().toISOString(),
     });
+    await loadProjectFonts(normalizedProject, services.fontImportService);
     await services.projectRepository.saveProject(normalizedProject);
     setSaveAnimationKey((current) => current + 1);
     if (services.projectRepository.saveVersion) {
@@ -2236,6 +2298,47 @@ export function useEditorViewModel(services: AppServices) {
       const minimumHeight = getMinimumTextHeight(element.text, element.fontSize);
       if (element.height >= minimumHeight) return nextProject;
       return new basicCommands.UpdateElementFrameCommand(elementId, {
+        height: minimumHeight,
+      }).execute(nextProject);
+    });
+  }
+
+  async function downloadFontForSelection(family: string) {
+    const selectedElementId = selectedElementIdsRef.current[0];
+    if (!selectedElementId) throw new Error('Select a text element before downloading a font.');
+    const selectedElement = projectRef.current.elements[selectedElementId];
+    if (!selectedElement || selectedElement.type !== 'text') {
+      throw new Error('Select a text element before downloading a font.');
+    }
+
+    const result = await services.fontImportService.resolveAndDownloadFonts([
+      {
+        family,
+        fontStyle: 'normal',
+        fontWeight: selectedElement.fontWeight >= 700 ? 700 : 400,
+      },
+    ]);
+    const font = Object.values(result.fonts)[0];
+    if (!font) {
+      throw new Error(result.warnings[0]?.message ?? 'Font download failed.');
+    }
+
+    commitProject((currentProject) => {
+      const projectWithFont: ProjectDocument = {
+        ...currentProject,
+        fonts: {
+          ...(currentProject.fonts ?? {}),
+          ...result.fonts,
+        },
+      };
+      const nextProject = new basicCommands.UpdateElementStyleCommand(selectedElementId, {
+        fontFamily: font.family,
+      }).execute(projectWithFont);
+      const nextElement = nextProject.elements[selectedElementId];
+      if (!nextElement || nextElement.type !== 'text') return nextProject;
+      const minimumHeight = getMinimumTextHeight(nextElement.text, nextElement.fontSize);
+      if (nextElement.height >= minimumHeight) return nextProject;
+      return new basicCommands.UpdateElementFrameCommand(selectedElementId, {
         height: minimumHeight,
       }).execute(nextProject);
     });
@@ -3748,6 +3851,7 @@ export function useEditorViewModel(services: AppServices) {
     canRedo: history.future.length > 0,
     selection,
     activeTab,
+    availableFonts,
     activeSlideLanguage,
     setActiveTab,
     modelStates,
@@ -3871,6 +3975,7 @@ export function useEditorViewModel(services: AppServices) {
     updateElementFrame,
     updateElementFrames,
     updateElementStyle,
+    downloadFontForSelection,
     updateMediaPlayback,
     updatePageBackground,
     clearPageTransition,

--- a/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
@@ -1,12 +1,12 @@
 import type { ElementStylePatch } from '../../../domain/commands/elements/basicCommands';
 import type { TextElement } from '../../../domain/documents/model';
-import { textStyleOptions } from '../text/textStyleOptions';
 
 interface TextSelectionToolbarProps {
   disabled?: boolean;
   canTranslateSelection?: boolean;
   element: TextElement;
   onOpenAnimations?: () => void;
+  onOpenFontPanel?: () => void;
   onTranslateSelectedText?: () => void;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
 }
@@ -20,6 +20,7 @@ export function TextSelectionToolbar({
   canTranslateSelection = false,
   element,
   onOpenAnimations,
+  onOpenFontPanel,
   onTranslateSelectedText,
   onUpdateElementStyle,
 }: TextSelectionToolbarProps) {
@@ -32,21 +33,19 @@ export function TextSelectionToolbar({
 
   return (
     <div className="text-selection-toolbar" role="toolbar" aria-label="Text editing controls">
-      <select
+      <button
         aria-label="Text font family"
         className="text-toolbar-font"
         disabled={disabled || element.locked}
-        value={element.fontFamily}
-        onChange={(event) => {
-          updateStyle({ fontFamily: event.target.value });
+        title="Open font list"
+        type="button"
+        onClick={() => {
+          if (disabled || element.locked) return;
+          onOpenFontPanel?.();
         }}
       >
-        {textStyleOptions.TEXT_FONT_FAMILIES.map((fontFamily) => (
-          <option key={fontFamily} value={fontFamily}>
-            {fontFamily}
-          </option>
-        ))}
-      </select>
+        {element.fontFamily}
+      </button>
 
       <div className="text-toolbar-size" aria-label="Text size">
         <button

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -4,11 +4,12 @@ import type {
   ProjectDocument,
   SelectionState,
 } from '../../domain/documents/model';
-import type { ShareService } from '../../services/contracts/interfaces';
+import type { FontImportService, ShareService } from '../../services/contracts/interfaces';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
 
 interface PublicDeckViewerProps {
   shareId: string;
+  fontImportService: FontImportService;
   shareService: ShareService;
   embed?: boolean;
 }
@@ -34,7 +35,12 @@ function getBuildPlaybackDurationMs(build: ElementAnimationBuild) {
   return Math.max(0, build.durationMs ?? build.delayMs);
 }
 
-export function PublicDeckViewer({ shareId, shareService, embed = false }: PublicDeckViewerProps) {
+export function PublicDeckViewer({
+  shareId,
+  fontImportService,
+  shareService,
+  embed = false,
+}: PublicDeckViewerProps) {
   const [viewerState, setViewerState] = useState<ViewerState>({ status: 'loading' });
   const [activePageIndex, setActivePageIndex] = useState(0);
   const [animationPreview, setAnimationPreview] = useState<AnimationPreviewState | undefined>();
@@ -250,7 +256,11 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
 
   useEffect(() => {
     let isActive = true;
-    void shareService.getShare(shareId).then((record) => {
+    void shareService.getShare(shareId).then(async (record) => {
+      if (!isActive) return;
+      if (record) {
+        await fontImportService.loadProjectFonts(record.project).catch(() => undefined);
+      }
       if (!isActive) return;
       setViewerState(record ? { status: 'ready', project: record.project } : { status: 'missing' });
       if (record) {
@@ -263,7 +273,7 @@ export function PublicDeckViewer({ shareId, shareService, embed = false }: Publi
     return () => {
       isActive = false;
     };
-  }, [playPresentationPage, shareId, shareService]);
+  }, [fontImportService, playPresentationPage, shareId, shareService]);
 
   useEffect(() => {
     return () => {

--- a/apps/editor/tests/unit/services/googleFontsImportService.test.ts
+++ b/apps/editor/tests/unit/services/googleFontsImportService.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BrowserGoogleFontsImportService } from '../../../src/services/fonts/googleFontsImportService';
+
+describe('BrowserGoogleFontsImportService', () => {
+  function getRequestUrl(input: RequestInfo | URL) {
+    if (input instanceof Request) return input.url;
+    if (input instanceof URL) return input.toString();
+    return input;
+  }
+
+  it('downloads matching Google Fonts woff2 files and registers them in the browser', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url.startsWith('https://fonts.googleapis.com/css2')) {
+        expect(url).toContain('family=Montserrat:wght@700');
+        return Promise.resolve(
+          new Response(
+            `@font-face {
+              font-family: 'Montserrat';
+              font-style: normal;
+              font-weight: 700;
+              src: url(https://fonts.gstatic.com/s/montserrat/v31/montserrat-700.woff2) format('woff2');
+            }`,
+            { status: 200, headers: { 'content-type': 'text/css' } },
+          ),
+        );
+      }
+      if (url === 'https://fonts.gstatic.com/s/montserrat/v31/montserrat-700.woff2') {
+        return Promise.resolve(
+          new Response(new TextEncoder().encode('font'), {
+            status: 200,
+            headers: { 'content-type': 'font/woff2' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:font');
+
+    const service = new BrowserGoogleFontsImportService({
+      fetch: fetchMock,
+      fontFaceConstructor: class {
+        constructor(
+          readonly family: string,
+          readonly source: string,
+          readonly descriptors: FontFaceDescriptors,
+        ) {}
+
+        load(): Promise<FontFace> {
+          return Promise.resolve(this as unknown as FontFace);
+        }
+      } as unknown as typeof FontFace,
+      fontSet: { add: vi.fn() } as unknown as FontFaceSet,
+    });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'Montserrat', fontStyle: 'normal', fontWeight: 700 },
+    ]);
+
+    expect(result.fonts).toMatchObject({
+      'google-fonts-montserrat-normal-700': {
+        family: 'Montserrat',
+        fileName: 'google-fonts-montserrat-normal-700.woff2',
+        fontWeight: 700,
+        mimeType: 'font/woff2',
+        objectUrl: 'blob:font',
+        source: 'google-fonts',
+        storage: 'inline',
+      },
+    });
+    expect(result.warnings).toEqual([]);
+    expect(createObjectUrl).toHaveBeenCalled();
+  });
+
+  it('returns a warning instead of failing when Google Fonts has no exact match', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 400 })));
+    const service = new BrowserGoogleFontsImportService({
+      fetch: fetchMock,
+    });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'Missing Font', fontStyle: 'normal', fontWeight: 400 },
+    ]);
+
+    expect(result.fonts).toEqual({});
+    expect(result.warnings[0]?.message).toContain('Missing Font');
+    expect(result.warnings).toMatchObject([
+      { code: 'font-download-unavailable', severity: 'warning' },
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not request Google CSS for unsupported PowerPoint font names', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 200 })));
+    const service = new BrowserGoogleFontsImportService({ fetch: fetchMock });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'Adobe 고딕 Std B', fontStyle: 'normal', fontWeight: 400 },
+    ]);
+
+    expect(result.fonts).toEqual({});
+    expect(result.warnings[0]?.message).toContain('Adobe 고딕 Std B');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a searchable list of downloadable fonts', () => {
+    const service = new BrowserGoogleFontsImportService();
+
+    expect(service.listDownloadableFonts()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ family: 'Montserrat', source: 'google-fonts' }),
+        expect.objectContaining({ family: 'Noto Sans KR', source: 'google-fonts' }),
+        expect.objectContaining({ aliases: ['Arial', 'Helvetica'], family: 'Arimo' }),
+      ]),
+    );
+  });
+});

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -101,6 +101,41 @@ describe('minioMirrorService.createMirrorFiles', () => {
       publicBaseUrl: config.publicBaseUrl,
     });
   });
+
+  it('includes project font files in mirror payloads', async () => {
+    const project: ProjectDocument = {
+      ...sampleProject.createSampleProject(),
+      fonts: {
+        montserrat: {
+          id: 'montserrat',
+          family: 'Montserrat',
+          requestedFamily: 'Montserrat',
+          source: 'google-fonts',
+          fontStyle: 'normal',
+          fontWeight: 700,
+          mimeType: 'font/woff2',
+          fileName: 'montserrat-700.woff2',
+          storage: 'inline',
+          objectUrl: 'data:font/woff2;base64,Zm9udA==',
+        },
+      },
+    };
+
+    const files = await minioMirrorService.createMirrorFiles(
+      project,
+      new VersionedRepository([], project),
+      config,
+    );
+
+    expect(files.map((file) => file.path)).toContain('fonts/montserrat-700.woff2');
+    const projectJson = JSON.parse(
+      await files.find((file) => file.path === 'project.json')!.blob.text(),
+    ) as ProjectDocument;
+    expect(projectJson.fonts?.montserrat).toMatchObject({
+      fileName: 'montserrat-700.woff2',
+      storage: 'file',
+    });
+  });
 });
 
 describe('minioMirrorService.MinioMirrorService', () => {

--- a/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
@@ -176,6 +176,55 @@ describe('OpfsProjectRepository', () => {
     expect(createObjectUrl).toHaveBeenCalled();
   });
 
+  it('persists project fonts under fonts and hydrates object URLs on load', async () => {
+    const root = new MockDirectoryHandle();
+    const storage = new MemoryStorage();
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:font');
+    const repository = new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage,
+    });
+    const project: ProjectDocument = {
+      ...sampleProject.createSampleProject(),
+      fonts: {
+        montserrat: {
+          id: 'montserrat',
+          family: 'Montserrat',
+          requestedFamily: 'Montserrat',
+          source: 'google-fonts',
+          fontStyle: 'normal',
+          fontWeight: 700,
+          mimeType: 'font/woff2',
+          fileName: 'montserrat-700.woff2',
+          storage: 'inline',
+          objectUrl: 'data:font/woff2;base64,Zm9udA==',
+        },
+      },
+    };
+
+    await repository.saveProject(project);
+
+    const projectDirectory = await getProjectDirectory(root, project.name);
+    const fontsDirectory = projectDirectory.directories.get('fonts');
+    const projectJson = JSON.parse(
+      await readMockText(projectDirectory.files.get('project.json')!),
+    ) as ProjectDocument;
+    expect(fontsDirectory?.files.has('montserrat-700.woff2')).toBe(true);
+    expect(projectJson.fonts?.montserrat).toMatchObject({
+      fileName: 'montserrat-700.woff2',
+      storage: 'file',
+    });
+    expect(projectJson.fonts?.montserrat?.objectUrl).toBeUndefined();
+
+    const loaded = await new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage,
+    }).loadProject();
+
+    expect(loaded?.fonts?.montserrat?.objectUrl).toBe('blob:font');
+    expect(createObjectUrl).toHaveBeenCalled();
+  });
+
   it('updates project JSON during autosave', async () => {
     const root = new MockDirectoryHandle();
     const repository = new OpfsProjectRepository({

--- a/apps/editor/tests/unit/services/pptxFontRequests.test.ts
+++ b/apps/editor/tests/unit/services/pptxFontRequests.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { ProjectDocument } from '../../../src/domain/documents/model';
+import { sampleProject } from '../../../src/domain/projects/sampleProject';
+import { pptxFontRequests } from '../../../src/services/importing/pptx/pptxFontRequests';
+
+describe('pptxFontRequests', () => {
+  it('collects unique downloadable text font requests from a PPTX project', () => {
+    const project: ProjectDocument = {
+      ...sampleProject.createBlankProject(),
+      elements: {
+        title: {
+          id: 'title',
+          type: 'text',
+          text: 'Title',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 30,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          align: 'left',
+          fill: '#111111',
+          fontFamily: 'Montserrat',
+          fontSize: 32,
+          fontWeight: 700,
+        },
+        subtitle: {
+          id: 'subtitle',
+          type: 'text',
+          text: 'Subtitle',
+          x: 0,
+          y: 40,
+          width: 100,
+          height: 30,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          align: 'left',
+          fill: '#111111',
+          fontFamily: 'Montserrat',
+          fontSize: 20,
+          fontWeight: 700,
+        },
+        body: {
+          id: 'body',
+          type: 'text',
+          text: 'Body',
+          x: 0,
+          y: 80,
+          width: 100,
+          height: 30,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          align: 'left',
+          fill: '#111111',
+          fontFamily: 'Merriweather',
+          fontSize: 20,
+          fontWeight: 400,
+        },
+        system: {
+          id: 'system',
+          type: 'text',
+          text: 'System',
+          x: 0,
+          y: 120,
+          width: 100,
+          height: 30,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          align: 'left',
+          fill: '#111111',
+          fontFamily: 'Arial',
+          fontSize: 20,
+          fontWeight: 400,
+        },
+      },
+    };
+
+    expect(pptxFontRequests.collect(project)).toEqual([
+      { family: 'Montserrat', fontStyle: 'normal', fontWeight: 700 },
+      { family: 'Merriweather', fontStyle: 'normal', fontWeight: 400 },
+    ]);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -1,7 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
-import type { ProjectDocument, ShapeElement } from '../../../../src/domain/documents/model';
+import type {
+  ProjectDocument,
+  ShapeElement,
+  TextElement,
+} from '../../../../src/domain/documents/model';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import { DesignPanel } from '../../../../src/ui/editor/panels/DesignPanel';
 
@@ -53,6 +57,38 @@ function createProjectWithSelectedLine(): ProjectDocument {
   };
 }
 
+function createProjectWithSelectedText(): ProjectDocument {
+  const project = sampleProject.createSampleProject();
+  const text: TextElement = {
+    id: 'text-test',
+    type: 'text',
+    text: 'Editable text',
+    x: 120,
+    y: 160,
+    width: 360,
+    height: 120,
+    rotation: 0,
+    locked: false,
+    visible: true,
+    opacity: 1,
+    align: 'left',
+    fill: '#ffffff',
+    fontFamily: 'Open Sans',
+    fontSize: 32,
+    fontWeight: 400,
+  };
+  return {
+    ...project,
+    elements: {
+      ...project.elements,
+      [text.id]: text,
+    },
+    pages: project.pages.map((page) =>
+      page.id === 'page-1' ? { ...page, elementIds: [...page.elementIds, text.id] } : page,
+    ),
+  };
+}
+
 describe('DesignPanel', () => {
   it('updates selected shape fill and border modes', async () => {
     const user = userEvent.setup();
@@ -100,6 +136,86 @@ describe('DesignPanel', () => {
     });
     expect(onUpdateElementStyle).toHaveBeenCalledWith('shape-test', {
       endEndpoint: 'open-arrow',
+    });
+  });
+
+  it('lets users expand search results and download a Google font for selected text', async () => {
+    const user = userEvent.setup();
+    const onDownloadFont = vi.fn(() => Promise.resolve());
+
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedText()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+        availableFonts={[
+          { family: 'Arimo', aliases: ['Arial'], source: 'google-fonts' },
+          { family: 'Montserrat', source: 'google-fonts' },
+          { family: 'Noto Sans KR', source: 'google-fonts' },
+        ]}
+        onDownloadFont={onDownloadFont}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Search downloadable fonts')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Download additional font' }));
+    await user.type(screen.getByLabelText('Search downloadable fonts'), 'mont');
+    await user.click(screen.getByRole('button', { name: 'Search fonts' }));
+    expect(screen.getByLabelText('Downloadable font results')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Download Montserrat' }));
+
+    expect(onDownloadFont).toHaveBeenCalledWith('Montserrat');
+  });
+
+  it('finds Google font alternatives by system font aliases', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedText()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+        availableFonts={[
+          { family: 'Arimo', aliases: ['Arial'], source: 'google-fonts' },
+          { family: 'Montserrat', source: 'google-fonts' },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Download additional font' }));
+    await user.type(screen.getByLabelText('Search downloadable fonts'), 'aria');
+
+    expect(screen.getByRole('button', { name: 'Download Arimo' })).toBeInTheDocument();
+    expect(screen.queryByText('No Google Fonts match that search.')).not.toBeInTheDocument();
+  });
+
+  it('shows font controls before selection controls for selected text', () => {
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedText()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+      />,
+    );
+
+    const headings = screen.getAllByRole('heading').map((heading) => heading.textContent);
+    expect(headings.indexOf('Font')).toBeLessThan(headings.indexOf('Selection'));
+  });
+
+  it('focuses the selected text font list when requested', async () => {
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedText()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+        focusFontControlKey={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Selected text font')).toHaveFocus();
     });
   });
 });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -6,6 +6,9 @@ import type { Asset, ProjectDocument } from '../../../../src/domain/documents/mo
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import type {
   BackgroundRemovalService,
+  FontImportResult,
+  FontImportService,
+  FontImportRequest,
   MirrorFile,
   MirrorProjectSummary,
   MirrorService,
@@ -403,6 +406,37 @@ class PendingPresentationImportService implements PresentationImportService {
     return new Promise((resolve) => {
       this.resolveImport = resolve;
     });
+  }
+}
+
+class FailingFontImportService implements FontImportService {
+  requests: FontImportRequest[] = [];
+  resolveFonts: (() => void) | undefined;
+
+  listDownloadableFonts() {
+    return [];
+  }
+
+  resolveAndDownloadFonts(requests: FontImportRequest[]): Promise<FontImportResult> {
+    this.requests = requests;
+    return new Promise((resolve) => {
+      this.resolveFonts = () => {
+        resolve({
+          fonts: {},
+          warnings: [
+            {
+              code: 'font-download-failed',
+              message: 'Could not download Montserrat.',
+              severity: 'warning',
+            },
+          ],
+        });
+      };
+    });
+  }
+
+  loadProjectFonts(): Promise<void> {
+    return Promise.resolve();
   }
 }
 
@@ -1224,6 +1258,85 @@ describe('EditorShell', () => {
     expect(
       await screen.findByRole('button', { name: 'Edit project name Imported PowerPoint Deck' }),
     ).toBeInTheDocument();
+  });
+
+  it('downloads PPTX fonts during import without blocking the deck when fonts fail', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const fontImportService = new FailingFontImportService();
+    services.fontImportService = fontImportService;
+    services.presentationImportService = {
+      importPowerPoint: () =>
+        Promise.resolve({
+          ...services.initialProject,
+          name: 'Imported Font Deck',
+          elements: {
+            title: {
+              id: 'title',
+              type: 'text',
+              text: 'Custom font',
+              x: 0,
+              y: 0,
+              width: 400,
+              height: 100,
+              rotation: 0,
+              locked: false,
+              visible: true,
+              opacity: 1,
+              align: 'left',
+              fill: '#111111',
+              fontFamily: 'Montserrat',
+              fontSize: 48,
+              fontWeight: 700,
+            },
+          },
+          pages: [
+            {
+              ...services.initialProject.pages[0]!,
+              elementIds: ['title'],
+            },
+          ],
+        }),
+    };
+    vi.stubGlobal(
+      'showOpenFilePicker',
+      vi.fn(() =>
+        Promise.resolve([
+          createPowerPointFileHandle(
+            new File(['pptx'], 'deck.pptx', {
+              type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            }),
+          ),
+        ] as FileSystemFileHandle[]),
+      ),
+    );
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Import PowerPoint...' }));
+
+    expect(await screen.findAllByText('Downloading fonts')).toHaveLength(2);
+    await waitFor(() => {
+      expect(fontImportService.resolveFonts).toBeDefined();
+    });
+    await act(async () => {
+      fontImportService.resolveFonts?.();
+      await new Promise<void>((resolve) => {
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => {
+            window.requestAnimationFrame(() => {
+              window.requestAnimationFrame(() => resolve());
+            });
+          });
+        });
+      });
+    });
+    expect(
+      await screen.findByRole('button', { name: 'Edit project name Imported Font Deck' }),
+    ).toBeInTheDocument();
+    expect(fontImportService.requests).toEqual([
+      { family: 'Montserrat', fontStyle: 'normal', fontWeight: 700 },
+    ]);
   });
 
   it('reports PowerPoint picker failures without starting import progress', async () => {

--- a/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
@@ -298,7 +298,7 @@ describe('RightPanel', () => {
     });
     expect(onUpdateElementStyle).toHaveBeenCalledWith('text-title', { fill: '#ffffff' });
 
-    await user.selectOptions(screen.getByLabelText('Selected text alignment'), 'left');
+    await user.click(screen.getByRole('button', { name: 'Align selected text left' }));
     expect(onUpdateElementStyle).toHaveBeenCalledWith('text-title', { align: 'left' });
   });
 

--- a/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
@@ -101,6 +101,7 @@ describe('ScrollingCanvasWorkspace', () => {
   it('keeps text editing controls in the sticky slide toolbar and wires translation', async () => {
     const user = userEvent.setup();
     const onOpenAnimations = vi.fn();
+    const onOpenFontPanel = vi.fn();
     const onTranslateSelectedText = vi.fn();
     const onUpdateElementStyle = vi.fn();
 
@@ -111,6 +112,7 @@ describe('ScrollingCanvasWorkspace', () => {
         selection={{ pageId: 'page-1', elementIds: ['text-subtitle'] }}
         canTranslateSelection
         onOpenAnimations={onOpenAnimations}
+        onOpenFontPanel={onOpenFontPanel}
         onTranslateSelectedText={onTranslateSelectedText}
         onUpdateElementStyle={onUpdateElementStyle}
       />,
@@ -119,6 +121,18 @@ describe('ScrollingCanvasWorkspace', () => {
     expect(screen.getByTestId('sticky-text-selection-toolbar')).toContainElement(
       screen.getByRole('toolbar', { name: 'Text editing controls' }),
     );
+
+    await user.click(
+      within(screen.getByTestId('sticky-text-selection-toolbar')).getByRole('button', {
+        name: 'Text font family',
+      }),
+    );
+    expect(onOpenFontPanel).toHaveBeenCalledTimes(1);
+    expect(
+      onUpdateElementStyle.mock.calls.some(
+        ([elementId, patch]) => elementId === 'text-subtitle' && 'fontFamily' in patch,
+      ),
+    ).toBe(false);
 
     await user.click(
       within(screen.getByTestId('sticky-text-selection-toolbar')).getByRole('button', {

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -2,11 +2,27 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
-import type { ShareRecord } from '../../../../src/services/contracts/interfaces';
+import type {
+  FontImportResult,
+  FontImportService,
+  ShareRecord,
+} from '../../../../src/services/contracts/interfaces';
 import { BrowserShareService } from '../../../../src/services/sharing/shareService';
 import { PublicDeckViewer } from '../../../../src/ui/share/PublicDeckViewer';
 
 describe('PublicDeckViewer', () => {
+  const fontImportService: FontImportService = {
+    listDownloadableFonts() {
+      return [];
+    },
+    resolveAndDownloadFonts(): Promise<FontImportResult> {
+      return Promise.resolve({ fonts: {}, warnings: [] });
+    },
+    loadProjectFonts(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+
   beforeEach(() => {
     window.history.replaceState({}, '', '/');
   });
@@ -43,7 +59,13 @@ describe('PublicDeckViewer', () => {
 
   it('renders a shared deck in read-only mode', async () => {
     const { share, shareService } = createRemoteShare('00000000-0000-4000-8000-000000000201');
-    render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
 
     expect(await screen.findByLabelText('Public presentation')).toHaveClass('public-deck-viewer-present');
     expect(screen.queryByRole('heading', { name: 'Untitled AI Deck' })).not.toBeInTheDocument();
@@ -55,7 +77,14 @@ describe('PublicDeckViewer', () => {
   it('keeps embeds in a compact shared deck layout', async () => {
     const { share, shareService } = createRemoteShare('00000000-0000-4000-8000-000000000202');
 
-    render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} embed />);
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+        embed
+      />,
+    );
 
     expect(await screen.findByLabelText('Embedded shared deck')).toHaveClass('public-deck-viewer-embed');
     expect(screen.getByLabelText('Embedded shared deck')).not.toHaveClass('public-deck-viewer-present');
@@ -77,7 +106,13 @@ describe('PublicDeckViewer', () => {
       project,
     );
 
-    render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
 
     expect(await screen.findByText('1 / 2')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Next slide' }));
@@ -103,7 +138,13 @@ describe('PublicDeckViewer', () => {
       project,
     );
 
-    render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
 
     expect(await screen.findByText('1 / 2')).toBeInTheDocument();
     await userEvent.keyboard('{ArrowRight}');
@@ -129,7 +170,13 @@ describe('PublicDeckViewer', () => {
       project,
     );
 
-    render(<PublicDeckViewer shareId={share.shareId} shareService={shareService} />);
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
 
     const slideCanvas = await screen.findByLabelText('Slide canvas');
     expect(slideCanvas).toHaveAttribute('data-animation-preview', 'playing');
@@ -150,7 +197,13 @@ describe('PublicDeckViewer', () => {
       fetch: vi.fn(() => Promise.resolve(new Response(null, { status: 404 }))),
     });
 
-    render(<PublicDeckViewer shareId="missing-share" shareService={shareService} />);
+    render(
+      <PublicDeckViewer
+        shareId="missing-share"
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
 
     expect(await screen.findByRole('heading', { name: 'Deck not found' })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Adds font-request planning and Google Fonts import support for PPTX ingestion.
- Wires the editor, import progress, and public deck viewer to handle font-related import state.
- Updates storage and mirror services to persist and synchronize the new font-download flow.
- Expands unit coverage across font import, PPTX font requests, storage, mirror, and editor UI components.

## Testing
- Unit tests added/updated for font import, PPTX font request planning, storage, mirror, and editor UI behavior.
- Not run (not requested).