### PR TITLE
Exclude Host from signed browser requests

### DIFF
--- a/apps/editor/src/services/mirror/minioObjectUtils.ts
+++ b/apps/editor/src/services/mirror/minioObjectUtils.ts
@@ -62,18 +62,18 @@ async function createSignedHeaders(
   const now = new Date();
   const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
   const dateStamp = amzDate.slice(0, 8);
-  const headers: Record<string, string> = {
+  const signingHeaders: Record<string, string> = {
     host: url.host,
     'x-amz-content-sha256': 'UNSIGNED-PAYLOAD',
     'x-amz-date': amzDate,
   };
-  if (contentType) headers['content-type'] = contentType;
+  if (contentType) signingHeaders['content-type'] = contentType;
 
-  const canonicalHeaders = Object.entries(headers)
+  const canonicalHeaders = Object.entries(signingHeaders)
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([name, value]) => `${name}:${value.trim()}\n`)
     .join('');
-  const signedHeaders = Object.keys(headers).sort().join(';');
+  const signedHeaders = Object.keys(signingHeaders).sort().join(';');
   const canonicalQuery = Array.from(url.searchParams.entries())
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([name, value]) => `${encodeURIComponent(name)}=${encodeURIComponent(value)}`)
@@ -96,8 +96,11 @@ async function createSignedHeaders(
   ].join('\n');
   const signature = await hmacHex(await getSigningKey(config, dateStamp), stringToSign);
 
+  const requestHeaders = Object.fromEntries(
+    Object.entries(signingHeaders).filter(([name]) => name !== 'host'),
+  );
   return {
-    ...headers,
+    ...requestHeaders,
     authorization: `AWS4-HMAC-SHA256 Credential=${config.accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
   };
 }

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -212,6 +212,31 @@ describe('minioMirrorService.MinioMirrorService', () => {
     expect(putUrls.some((url) => url.endsWith('/localstudio-mirror.json'))).toBe(true);
   });
 
+  it('does not set the forbidden Host header on signed browser requests', async () => {
+    const project = sampleProject.createSampleProject();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({
+      fetch: fetchMock,
+      now: () => new Date('2026-06-30T10:00:00.000Z'),
+    });
+
+    await service.syncProject(project, new VersionedRepository([], project), config);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.host).toBeUndefined();
+    expect(headers.authorization).toContain('SignedHeaders=host;x-amz-content-sha256;x-amz-date');
+  });
+
   it('deletes every object under a mirrored project prefix', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = getRequestUrl(input);


### PR DESCRIPTION
## Summary
- Stop sending the forbidden `Host` header on browser-signed MinIO requests while keeping it in the SigV4 canonical request.
- Add a unit test that verifies signed PUT requests omit `headers.host` and still include `host` in `SignedHeaders`.

## Testing
- Unit tests added/updated for MinIO mirror request signing behavior.