### PR TITLE
Clean up design tab panel styles

### DIFF
--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -21,7 +21,7 @@ import {
   Volume2,
   VolumeX,
 } from 'lucide-react';
-import type { FormEvent } from 'react';
+import type { FormEvent, RefObject } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   DesignElement,
@@ -30,6 +30,7 @@ import type {
   SelectionState,
   ShapeElement,
   ShapeLineEndpoint,
+  TextElement,
   VideoElement,
   VideoRepeatMode,
 } from '../../../domain/documents/model';
@@ -73,6 +74,7 @@ interface DesignPanelProps {
   onDownloadFont?: (family: string) => Promise<void>;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
   onUpdateElementFrame?: (elementId: string, patch: ElementFramePatch) => void;
+  onUpdateTextContent?: (elementId: string, text: string) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
   onAlignSelectedElement?: (mode: AlignMode) => void;
@@ -111,6 +113,7 @@ export function DesignPanel({
   selection,
   onUpdateElementStyle,
   onUpdateElementFrame,
+  onUpdateTextContent,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
   onAlignSelectedElement,
@@ -147,8 +150,6 @@ export function DesignPanel({
       .filter((font) => fontMatchesQuery(font, query))
       .slice(0, 12);
   }, [availableFonts, fontSearchQuery]);
-  const selectedTextIsBold =
-    selectedElement?.type === 'text' && selectedElement.fontWeight >= boldTextWeight;
 
   useEffect(() => {
     if (!focusFontControlKey || selectedElement?.type !== 'text') return;
@@ -230,187 +231,6 @@ export function DesignPanel({
         </div>
       </PanelSection>
 
-      {selectedElement?.type === 'text' ? (
-        <PanelSection title="Font">
-          <div className="text-inspector-stack">
-            <div className="font-control-row">
-              <label className="text-inspector-field ew-field-scope ew-grid-compact text-inspector-field-full">
-                <span className="text-inspector-label ew-strong-label">Font</span>
-                <select
-                  aria-label="Selected text font"
-                  ref={fontSelectRef}
-                  value={selectedElement.fontFamily}
-                  onChange={(event) => {
-                    updateSelectedStyle({ fontFamily: event.target.value });
-                  }}
-                >
-                  {fontFamilyOptions.map((fontFamily) => (
-                    <option key={fontFamily} value={fontFamily}>
-                      {fontFamily}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <button
-                aria-expanded={fontDownloadOpen}
-                aria-label="Download additional font"
-                className="font-add-button"
-                title="Download additional font"
-                type="button"
-                onClick={() => {
-                  setFontDownloadOpen((current) => !current);
-                }}
-              >
-                <Plus size={16} />
-              </button>
-            </div>
-            {fontDownloadOpen ? (
-              <div className="font-download-panel">
-                <form className="font-download-search" onSubmit={submitFontSearch}>
-                  <label className="layer-search font-download-search-box ew-surface ew-compact-row">
-                    <Search size={16} aria-hidden="true" />
-                    <input
-                      aria-label="Search downloadable fonts"
-                      placeholder="Search Google Fonts"
-                      type="search"
-                      value={fontSearchInput}
-                      onChange={(event) => {
-                        const nextSearch = event.target.value;
-                        setFontSearchInput(nextSearch);
-                        setFontSearchQuery(nextSearch.trim());
-                      }}
-                    />
-                  </label>
-                  <button className="font-search-submit" type="submit" aria-label="Search fonts">
-                    <Search size={16} />
-                  </button>
-                </form>
-                {fontSearchQuery ? (
-                  <div className="font-download-results" aria-label="Downloadable font results">
-                    {filteredDownloadableFonts.length > 0 ? (
-                      filteredDownloadableFonts.map((font) => (
-                        <button
-                          aria-label={`Download ${font.family}`}
-                          className="font-download-result"
-                          disabled={!onDownloadFont || downloadingFontFamily === font.family}
-                          key={font.family}
-                          type="button"
-                          onClick={() => {
-                            void downloadFont(font.family);
-                          }}
-                        >
-                          <span className="ew-ellipsis">{font.family}</span>
-                          <Download size={15} />
-                        </button>
-                      ))
-                    ) : (
-                      <p className="panel-muted">No Google Fonts match that search.</p>
-                    )}
-                  </div>
-                ) : null}
-                {fontDownloadStatus ? (
-                  <div className="panel-muted" role="status">
-                    {fontDownloadStatus}
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
-            <div className="text-inspector-pair">
-              <label className="text-inspector-field ew-field-scope ew-grid-compact">
-                <span className="text-inspector-label ew-strong-label">Weight</span>
-              <select
-                aria-label="Selected text font weight"
-                value={selectedElement.fontWeight}
-                onChange={(event) => {
-                  updateSelectedStyle({ fontWeight: Number(event.target.value) });
-                }}
-              >
-                {textStyleOptions.TEXT_FONT_WEIGHTS.map((fontWeight) => (
-                  <option key={fontWeight} value={fontWeight}>
-                    {fontWeight}
-                  </option>
-                ))}
-              </select>
-              </label>
-              <label className="text-inspector-field ew-field-scope ew-grid-compact">
-                <span className="text-inspector-label ew-strong-label">Size</span>
-                <input
-                  aria-label="Selected text font size"
-                  min="1"
-                  type="number"
-                  value={selectedElement.fontSize}
-                  onChange={(event) => {
-                    updateSelectedStyle({ fontSize: Number(event.target.value) });
-                  }}
-                />
-              </label>
-            </div>
-            <div className="text-style-row" aria-label="Text style controls">
-              <button
-                aria-label="Bold selected text"
-                aria-pressed={selectedTextIsBold}
-                className={selectedTextIsBold ? 'text-style-toggle active' : 'text-style-toggle'}
-                type="button"
-                onClick={() => {
-                  updateSelectedStyle({
-                    fontWeight: selectedTextIsBold ? regularTextWeight : boldTextWeight,
-                  });
-                }}
-              >
-                <Bold size={16} />
-              </button>
-              <button className="text-style-toggle" disabled type="button" aria-label="Italic unavailable">
-                <span>I</span>
-              </button>
-              <button className="text-style-toggle" disabled type="button" aria-label="Underline unavailable">
-                <span>U</span>
-              </button>
-              <button className="text-style-toggle" disabled type="button" aria-label="Strikethrough unavailable">
-                <span>S</span>
-              </button>
-            </div>
-            <label className="text-color-row">
-              <span>Text Color</span>
-              <input
-                aria-label="Selected text color"
-                type="color"
-                value={selectedElement.fill}
-                onChange={(event) => {
-                  updateSelectedStyle({ fill: event.target.value });
-                }}
-              />
-            </label>
-            <div className="text-align-grid" aria-label="Selected text alignment">
-              {([
-                { align: 'left' as const, icon: AlignLeft, label: 'Align selected text left' },
-                { align: 'center' as const, icon: AlignCenter, label: 'Align selected text center' },
-                { align: 'right' as const, icon: AlignRight, label: 'Align selected text right' },
-              ]).map((item) => {
-                const Icon = item.icon;
-                return (
-                  <button
-                    aria-label={item.label}
-                    aria-pressed={selectedElement.align === item.align}
-                    className={
-                      selectedElement.align === item.align
-                        ? 'text-align-button active'
-                        : 'text-align-button'
-                    }
-                    key={item.align}
-                    type="button"
-                    onClick={() => {
-                      updateSelectedStyle({ align: item.align });
-                    }}
-                  >
-                    <Icon size={18} />
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        </PanelSection>
-      ) : null}
-
       {selectedElement ? (
         <ElementDesignInspector
           key={selectedElement.id}
@@ -426,9 +246,34 @@ export function DesignPanel({
           onFrameUpdate={(patch) => onUpdateElementFrame?.(selectedElement.id, patch)}
           onLockChange={(locked) => onSetElementLock?.(selectedElement.id, locked)}
           onReplaceVideoAsset={(file) => onReplaceVideoAsset?.(selectedElement.id, file)}
+          onTextContentChange={(text) => onUpdateTextContent?.(selectedElement.id, text)}
           onUpdateMedia={updateSelectedMediaPlayback}
           onUpdateStyle={updateSelectedStyle}
           onZOrderChange={onSetSelectedElementZOrder}
+          textStyleControls={
+            selectedElement.type === 'text'
+              ? {
+                  downloadingFontFamily,
+                  filteredDownloadableFonts,
+                  fontDownloadOpen,
+                  fontDownloadStatus,
+                  fontFamilyOptions,
+                  fontSearchInput,
+                  fontSearchQuery,
+                  fontSelectRef,
+                  hasFontDownload: Boolean(onDownloadFont),
+                  onDownloadFontFamily: downloadFont,
+                  onFontSearchInputChange: (value) => {
+                    setFontSearchInput(value);
+                    setFontSearchQuery(value.trim());
+                  },
+                  onFontSearchSubmit: submitFontSearch,
+                  onToggleFontDownload: () => {
+                    setFontDownloadOpen((current) => !current);
+                  },
+                }
+              : undefined
+          }
         />
       ) : (
         <PanelSection title="Selection">
@@ -449,9 +294,27 @@ interface ElementDesignInspectorProps {
   onFrameUpdate?: ((patch: ElementFramePatch) => void) | undefined;
   onLockChange?: ((locked: boolean) => void) | undefined;
   onReplaceVideoAsset?: ((file: File) => void) | undefined;
+  onTextContentChange?: ((text: string) => void) | undefined;
   onUpdateMedia: (patch: MediaPlaybackPatch) => void;
   onUpdateStyle: (patch: ElementStylePatch) => void;
   onZOrderChange?: ((mode: ZOrderMode) => void) | undefined;
+  textStyleControls?: TextStyleControls | undefined;
+}
+
+interface TextStyleControls {
+  downloadingFontFamily?: string | undefined;
+  filteredDownloadableFonts: FontCatalogItem[];
+  fontDownloadOpen: boolean;
+  fontDownloadStatus?: string | undefined;
+  fontFamilyOptions: string[];
+  fontSearchInput: string;
+  fontSearchQuery: string;
+  fontSelectRef: RefObject<HTMLSelectElement | null>;
+  hasFontDownload: boolean;
+  onDownloadFontFamily: (family: string) => Promise<void>;
+  onFontSearchInputChange: (value: string) => void;
+  onFontSearchSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onToggleFontDownload: () => void;
 }
 
 function toTrimSeconds(value: string) {
@@ -511,6 +374,203 @@ function getElementIcon(element: DesignElement) {
   return <Square size={16} />;
 }
 
+function TextStyleInspector({
+  downloadingFontFamily,
+  element,
+  filteredDownloadableFonts,
+  fontDownloadOpen,
+  fontDownloadStatus,
+  fontFamilyOptions,
+  fontSearchInput,
+  fontSearchQuery,
+  fontSelectRef,
+  hasFontDownload,
+  onDownloadFontFamily,
+  onFontSearchInputChange,
+  onFontSearchSubmit,
+  onToggleFontDownload,
+  onUpdateStyle,
+}: TextStyleControls & {
+  element: TextElement;
+  onUpdateStyle: (patch: ElementStylePatch) => void;
+}) {
+  const selectedTextIsBold = element.fontWeight >= boldTextWeight;
+
+  return (
+    <section className="movie-panel-section" aria-label="Selected text controls">
+      <h3>Typography</h3>
+      <div className="text-inspector-stack">
+        <div className="font-control-row">
+          <label className="text-inspector-field ew-field-scope ew-grid-compact text-inspector-field-full">
+            <span className="text-inspector-label ew-strong-label">Font</span>
+            <select
+              aria-label="Selected text font"
+              ref={fontSelectRef}
+              value={element.fontFamily}
+              onChange={(event) => {
+                onUpdateStyle({ fontFamily: event.target.value });
+              }}
+            >
+              {fontFamilyOptions.map((fontFamily) => (
+                <option key={fontFamily} value={fontFamily}>
+                  {fontFamily}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            aria-expanded={fontDownloadOpen}
+            aria-label="Download additional font"
+            className="font-add-button"
+            title="Download additional font"
+            type="button"
+            onClick={onToggleFontDownload}
+          >
+            <Plus size={16} />
+          </button>
+        </div>
+        {fontDownloadOpen ? (
+          <div className="font-download-panel">
+            <form className="font-download-search" onSubmit={onFontSearchSubmit}>
+              <label className="layer-search font-download-search-box ew-surface ew-compact-row">
+                <Search size={16} aria-hidden="true" />
+                <input
+                  aria-label="Search downloadable fonts"
+                  placeholder="Search Google Fonts"
+                  type="search"
+                  value={fontSearchInput}
+                  onChange={(event) => {
+                    onFontSearchInputChange(event.target.value);
+                  }}
+                />
+              </label>
+              <button className="font-search-submit" type="submit" aria-label="Search fonts">
+                <Search size={16} />
+              </button>
+            </form>
+            {fontSearchQuery ? (
+              <div className="font-download-results" aria-label="Downloadable font results">
+                {filteredDownloadableFonts.length > 0 ? (
+                  filteredDownloadableFonts.map((font) => (
+                    <button
+                      aria-label={`Download ${font.family}`}
+                      className="font-download-result"
+                      disabled={!hasFontDownload || downloadingFontFamily === font.family}
+                      key={font.family}
+                      type="button"
+                      onClick={() => {
+                        void onDownloadFontFamily(font.family);
+                      }}
+                    >
+                      <span className="ew-ellipsis">{font.family}</span>
+                      <Download size={15} />
+                    </button>
+                  ))
+                ) : (
+                  <p className="panel-muted">No Google Fonts match that search.</p>
+                )}
+              </div>
+            ) : null}
+            {fontDownloadStatus ? (
+              <div className="panel-muted" role="status">
+                {fontDownloadStatus}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="text-inspector-pair">
+          <label className="text-inspector-field ew-field-scope ew-grid-compact">
+            <span className="text-inspector-label ew-strong-label">Weight</span>
+            <select
+              aria-label="Selected text font weight"
+              value={element.fontWeight}
+              onChange={(event) => {
+                onUpdateStyle({ fontWeight: Number(event.target.value) });
+              }}
+            >
+              {textStyleOptions.TEXT_FONT_WEIGHTS.map((fontWeight) => (
+                <option key={fontWeight} value={fontWeight}>
+                  {fontWeight}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-inspector-field ew-field-scope ew-grid-compact">
+            <span className="text-inspector-label ew-strong-label">Size</span>
+            <input
+              aria-label="Selected text font size"
+              min="1"
+              type="number"
+              value={element.fontSize}
+              onChange={(event) => {
+                onUpdateStyle({ fontSize: Number(event.target.value) });
+              }}
+            />
+          </label>
+        </div>
+        <div className="text-style-row" aria-label="Text style controls">
+          <button
+            aria-label="Bold selected text"
+            aria-pressed={selectedTextIsBold}
+            className={selectedTextIsBold ? 'text-style-toggle active' : 'text-style-toggle'}
+            type="button"
+            onClick={() => {
+              onUpdateStyle({
+                fontWeight: selectedTextIsBold ? regularTextWeight : boldTextWeight,
+              });
+            }}
+          >
+            <Bold size={16} />
+          </button>
+          <button className="text-style-toggle" disabled type="button" aria-label="Italic unavailable">
+            <span>I</span>
+          </button>
+          <button className="text-style-toggle" disabled type="button" aria-label="Underline unavailable">
+            <span>U</span>
+          </button>
+          <button className="text-style-toggle" disabled type="button" aria-label="Strikethrough unavailable">
+            <span>S</span>
+          </button>
+        </div>
+        <label className="text-color-row">
+          <span>Text Color</span>
+          <input
+            aria-label="Selected text color"
+            type="color"
+            value={element.fill}
+            onChange={(event) => {
+              onUpdateStyle({ fill: event.target.value });
+            }}
+          />
+        </label>
+        <div className="text-align-grid" aria-label="Selected text alignment">
+          {([
+            { align: 'left' as const, icon: AlignLeft, label: 'Align selected text left' },
+            { align: 'center' as const, icon: AlignCenter, label: 'Align selected text center' },
+            { align: 'right' as const, icon: AlignRight, label: 'Align selected text right' },
+          ]).map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                aria-label={item.label}
+                aria-pressed={element.align === item.align}
+                className={element.align === item.align ? 'text-align-button active' : 'text-align-button'}
+                key={item.align}
+                type="button"
+                onClick={() => {
+                  onUpdateStyle({ align: item.align });
+                }}
+              >
+                <Icon size={18} />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function ElementDesignInspector({
   assetName,
   element,
@@ -518,11 +578,13 @@ function ElementDesignInspector({
   onFrameUpdate,
   onLockChange,
   onReplaceVideoAsset,
+  onTextContentChange,
   onUpdateMedia,
   onUpdateStyle,
   onZOrderChange,
+  textStyleControls,
 }: ElementDesignInspectorProps) {
-  const defaultTab = element.type === 'text' ? 'style' : 'content';
+  const defaultTab = element.type === 'text' || element.type === 'shape' ? 'style' : 'content';
   const [activeTab, setActiveTab] = useState<ElementInspectorTab>(defaultTab);
   const replaceVideoInputRef = useRef<HTMLInputElement>(null);
   const contentLabel = getElementContentTabLabel(element);
@@ -579,6 +641,136 @@ function ElementDesignInspector({
 
       {activeTab === 'style' ? (
         <>
+          {element.type === 'text' && textStyleControls ? (
+            <TextStyleInspector
+              element={element}
+              onUpdateStyle={onUpdateStyle}
+              {...textStyleControls}
+            />
+          ) : null}
+          {element.type === 'shape' ? (
+            <section className="movie-panel-section" aria-label="Selected shape controls">
+              <h3>Shape</h3>
+              <label className="design-control ew-field-scope">
+                <span>Fill</span>
+                <select
+                  aria-label="Selected shape fill mode"
+                  value={element.fill ? 'color' : 'none'}
+                  onChange={(event) => {
+                    onUpdateStyle({
+                      fill: event.target.value === 'color' ? (element.fill ?? '#37FD76') : null,
+                    });
+                  }}
+                >
+                  <option value="none">No fill</option>
+                  <option value="color">Color fill</option>
+                </select>
+              </label>
+              {element.fill ? (
+                <label className="design-control ew-field-scope">
+                  <span>Fill color</span>
+                  <input
+                    aria-label="Selected shape fill color"
+                    type="color"
+                    value={element.fill}
+                    onChange={(event) => {
+                      onUpdateStyle({ fill: event.target.value });
+                    }}
+                  />
+                </label>
+              ) : null}
+              <label className="design-control ew-field-scope">
+                <span>Border</span>
+                <select
+                  aria-label="Selected shape border mode"
+                  value={element.stroke && (element.strokeWidth ?? 0) > 0 ? 'color' : 'none'}
+                  onChange={(event) => {
+                    onUpdateStyle(
+                      event.target.value === 'color'
+                        ? {
+                            stroke: element.stroke ?? '#37FD76',
+                            strokeWidth:
+                              element.strokeWidth && element.strokeWidth > 0
+                                ? element.strokeWidth
+                                : 2,
+                          }
+                        : { stroke: null, strokeWidth: 0 },
+                    );
+                  }}
+                >
+                  <option value="none">No border</option>
+                  <option value="color">Color border</option>
+                </select>
+              </label>
+              {element.stroke && (element.strokeWidth ?? 0) > 0 ? (
+                <>
+                  <label className="design-control ew-field-scope">
+                    <span>Border color</span>
+                    <input
+                      aria-label="Selected shape border color"
+                      type="color"
+                      value={element.stroke}
+                      onChange={(event) => {
+                        onUpdateStyle({ stroke: event.target.value });
+                      }}
+                    />
+                  </label>
+                  <label className="design-control ew-field-scope">
+                    <span>Border width</span>
+                    <input
+                      aria-label="Selected shape border width"
+                      min="1"
+                      type="number"
+                      value={element.strokeWidth ?? 2}
+                      onChange={(event) => {
+                        onUpdateStyle({ strokeWidth: Number(event.target.value) });
+                      }}
+                    />
+                  </label>
+                  {supportsLineEndpoints(element) ? (
+                    <>
+                      <label className="design-control ew-field-scope">
+                        <span>Start endpoint</span>
+                        <select
+                          aria-label="Selected shape start endpoint"
+                          value={element.startEndpoint ?? 'none'}
+                          onChange={(event) => {
+                            onUpdateStyle({
+                              startEndpoint: event.target.value as ShapeLineEndpoint,
+                            });
+                          }}
+                        >
+                          {shapeLineEndpointOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="design-control ew-field-scope">
+                        <span>End endpoint</span>
+                        <select
+                          aria-label="Selected shape end endpoint"
+                          value={element.endEndpoint ?? (element.shape === 'arrow' ? 'arrow' : 'none')}
+                          onChange={(event) => {
+                            onUpdateStyle({
+                              endEndpoint: event.target.value as ShapeLineEndpoint,
+                            });
+                          }}
+                        >
+                          {shapeLineEndpointOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </>
+                  ) : null}
+                </>
+              ) : null}
+            </section>
+          ) : null}
           <section className="movie-panel-section" aria-label="Selected element style">
             <h3>Selection</h3>
             <div className="compact-action design-selection-summary ew-surface ew-surface-hover ew-compact-row">
@@ -806,84 +998,20 @@ function ElementDesignInspector({
             </>
           ) : null}
           {element.type === 'text' ? (
-            <section className="movie-panel-section" aria-label="Selected text controls">
-              <h3>Typography</h3>
-              <label className="design-control ew-field-scope">
-                <span>Font</span>
-                <select
-                  aria-label="Selected text font"
-                  value={element.fontFamily}
+            <section className="movie-panel-section" aria-label="Selected text content controls">
+              <h3>Content</h3>
+              <label className="design-control design-control-stacked ew-field-scope">
+                <span>Text</span>
+                <textarea
+                  aria-label="Selected text content"
+                  value={element.text}
                   onChange={(event) => {
-                    onUpdateStyle({ fontFamily: event.target.value });
-                  }}
-                >
-                  {textStyleOptions.TEXT_FONT_FAMILIES.map((fontFamily) => (
-                    <option key={fontFamily} value={fontFamily}>
-                      {fontFamily}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="design-control ew-field-scope">
-                <span>Size</span>
-                <input
-                  aria-label="Selected text font size"
-                  min="1"
-                  type="number"
-                  value={element.fontSize}
-                  onChange={(event) => {
-                    onUpdateStyle({ fontSize: Number(event.target.value) });
+                    onTextContentChange?.(event.target.value);
                   }}
                 />
               </label>
-              <label className="design-control ew-field-scope">
-                <span>Weight</span>
-                <select
-                  aria-label="Selected text font weight"
-                  value={element.fontWeight}
-                  onChange={(event) => {
-                    onUpdateStyle({ fontWeight: Number(event.target.value) });
-                  }}
-                >
-                  {textStyleOptions.TEXT_FONT_WEIGHTS.map((fontWeight) => (
-                    <option key={fontWeight} value={fontWeight}>
-                      {fontWeight}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="design-control ew-field-scope">
-                <span>Color</span>
-                <input
-                  aria-label="Selected text color"
-                  type="color"
-                  value={element.fill}
-                  onChange={(event) => {
-                    onUpdateStyle({ fill: event.target.value });
-                  }}
-                />
-              </label>
-              <label className="design-control ew-field-scope">
-                <span>Align</span>
-                <select
-                  aria-label="Selected text alignment"
-                  value={element.align}
-                  onChange={(event) => {
-                    onUpdateStyle({ align: event.target.value as 'left' | 'center' | 'right' });
-                  }}
-                >
-                  <option value="left">Left</option>
-                  <option value="center">Center</option>
-                  <option value="right">Right</option>
-                </select>
-              </label>
-              <div className="compact-action ew-surface ew-surface-hover ew-compact-row">
-                <AlignCenter size={16} />
-                <span>Text frame stays editable on canvas</span>
-              </div>
             </section>
           ) : null}
-
           {element.type === 'gif' ? (
             <section className="movie-panel-section" aria-label="GIF movie controls">
               <h3>Movie</h3>
@@ -913,129 +1041,6 @@ function ElementDesignInspector({
             </section>
           ) : null}
 
-          {element.type === 'shape' ? (
-            <section className="movie-panel-section" aria-label="Selected shape controls">
-              <h3>Shape</h3>
-              <label className="design-control ew-field-scope">
-                <span>Fill</span>
-                <select
-                  aria-label="Selected shape fill mode"
-                  value={element.fill ? 'color' : 'none'}
-                  onChange={(event) => {
-                    onUpdateStyle({
-                      fill: event.target.value === 'color' ? (element.fill ?? '#37FD76') : null,
-                    });
-                  }}
-                >
-                  <option value="none">No fill</option>
-                  <option value="color">Color fill</option>
-                </select>
-              </label>
-              {element.fill ? (
-                <label className="design-control ew-field-scope">
-                  <span>Fill color</span>
-                  <input
-                    aria-label="Selected shape fill color"
-                    type="color"
-                    value={element.fill}
-                    onChange={(event) => {
-                      onUpdateStyle({ fill: event.target.value });
-                    }}
-                  />
-                </label>
-              ) : null}
-              <label className="design-control ew-field-scope">
-                <span>Border</span>
-                <select
-                  aria-label="Selected shape border mode"
-                  value={element.stroke && (element.strokeWidth ?? 0) > 0 ? 'color' : 'none'}
-                  onChange={(event) => {
-                    onUpdateStyle(
-                      event.target.value === 'color'
-                        ? {
-                            stroke: element.stroke ?? '#37FD76',
-                            strokeWidth:
-                              element.strokeWidth && element.strokeWidth > 0
-                                ? element.strokeWidth
-                                : 2,
-                          }
-                        : { stroke: null, strokeWidth: 0 },
-                    );
-                  }}
-                >
-                  <option value="none">No border</option>
-                  <option value="color">Color border</option>
-                </select>
-              </label>
-              {element.stroke && (element.strokeWidth ?? 0) > 0 ? (
-                <>
-                  <label className="design-control ew-field-scope">
-                    <span>Border color</span>
-                    <input
-                      aria-label="Selected shape border color"
-                      type="color"
-                      value={element.stroke}
-                      onChange={(event) => {
-                        onUpdateStyle({ stroke: event.target.value });
-                      }}
-                    />
-                  </label>
-                  <label className="design-control ew-field-scope">
-                    <span>Border width</span>
-                    <input
-                      aria-label="Selected shape border width"
-                      min="1"
-                      type="number"
-                      value={element.strokeWidth ?? 2}
-                      onChange={(event) => {
-                        onUpdateStyle({ strokeWidth: Number(event.target.value) });
-                      }}
-                    />
-                  </label>
-                  {supportsLineEndpoints(element) ? (
-                    <>
-                      <label className="design-control ew-field-scope">
-                        <span>Start endpoint</span>
-                        <select
-                          aria-label="Selected shape start endpoint"
-                          value={element.startEndpoint ?? 'none'}
-                          onChange={(event) => {
-                            onUpdateStyle({
-                              startEndpoint: event.target.value as ShapeLineEndpoint,
-                            });
-                          }}
-                        >
-                          {shapeLineEndpointOptions.map((option) => (
-                            <option key={option.value} value={option.value}>
-                              {option.label}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                      <label className="design-control ew-field-scope">
-                        <span>End endpoint</span>
-                        <select
-                          aria-label="Selected shape end endpoint"
-                          value={element.endEndpoint ?? (element.shape === 'arrow' ? 'arrow' : 'none')}
-                          onChange={(event) => {
-                            onUpdateStyle({
-                              endEndpoint: event.target.value as ShapeLineEndpoint,
-                            });
-                          }}
-                        >
-                          {shapeLineEndpointOptions.map((option) => (
-                            <option key={option.value} value={option.value}>
-                              {option.label}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                    </>
-                  ) : null}
-                </>
-              ) : null}
-            </section>
-          ) : null}
         </>
       ) : null}
 

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -105,6 +105,7 @@ interface LeftToolPanelProps {
   onSetSelectedElementZOrder?: ((mode: ZOrderMode) => void) | undefined;
   onUpdateElementFrame?: ((elementId: string, patch: ElementFramePatch) => void) | undefined;
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
+  onUpdateTextContent?: ((elementId: string, text: string) => void) | undefined;
   onUpdateMediaPlayback?: ((elementId: string, patch: MediaPlaybackPatch) => void) | undefined;
   onUpdatePageBackground?: ((background: PageBackground) => void) | undefined;
   onReplaceVideoAsset?: ((elementId: string, file: File) => void) | undefined;
@@ -188,6 +189,7 @@ export function LeftToolPanel({
   onSetSelectedElementZOrder,
   onUpdateElementFrame,
   onUpdateElementStyle,
+  onUpdateTextContent,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
   onReplaceVideoAsset,
@@ -303,6 +305,7 @@ export function LeftToolPanel({
             {...(onSetSelectedElementZOrder ? { onSetSelectedElementZOrder } : {})}
             {...(onUpdateElementFrame ? { onUpdateElementFrame } : {})}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
+            {...(onUpdateTextContent ? { onUpdateTextContent } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
             {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}

--- a/apps/editor/src/ui/editor/panels/RightPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/RightPanel.tsx
@@ -51,6 +51,7 @@ interface RightPanelProps {
   onAlignSelectedElement?: (mode: AlignMode) => void;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
   onUpdateElementFrame?: (elementId: string, patch: ElementFramePatch) => void;
+  onUpdateTextContent?: (elementId: string, text: string) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
@@ -97,6 +98,7 @@ export function RightPanel({
   onAlignSelectedElement,
   onUpdateElementStyle,
   onUpdateElementFrame,
+  onUpdateTextContent,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
   onSetSelectedElementZOrder,
@@ -152,6 +154,7 @@ export function RightPanel({
             {...(onSetSelectedElementZOrder ? { onSetSelectedElementZOrder } : {})}
             {...(onUpdateElementFrame ? { onUpdateElementFrame } : {})}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
+            {...(onUpdateTextContent ? { onUpdateTextContent } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
             {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -879,6 +879,7 @@ export function EditorShell({ services }: EditorShellProps) {
           onSetSelectedElementZOrder={isHistoryReadOnly ? undefined : vm.setSelectedElementZOrder}
           onUpdateElementFrame={isHistoryReadOnly ? undefined : vm.updateElementFrame}
           onUpdateElementStyle={isHistoryReadOnly ? undefined : vm.updateElementStyle}
+          onUpdateTextContent={isHistoryReadOnly ? undefined : vm.updateTextContent}
           onUpdateMediaPlayback={isHistoryReadOnly ? undefined : vm.updateMediaPlayback}
           onUpdatePageBackground={isHistoryReadOnly ? undefined : vm.updatePageBackground}
           onReplaceVideoAsset={

--- a/apps/editor/src/ui/styles/design-panel.css
+++ b/apps/editor/src/ui/styles/design-panel.css
@@ -35,9 +35,20 @@
 }
 
 .design-control input,
-.design-control select {
+.design-control select,
+.design-control textarea {
   width: 100%;
   padding: 7px 8px;
+}
+
+.design-control-stacked {
+  grid-template-columns: 1fr;
+  align-items: start;
+}
+
+.design-control textarea {
+  min-height: 96px;
+  resize: vertical;
 }
 
 .design-control input[type='color'] {

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import type {
@@ -191,7 +191,7 @@ describe('DesignPanel', () => {
     expect(screen.queryByText('No Google Fonts match that search.')).not.toBeInTheDocument();
   });
 
-  it('shows font controls before selection controls for selected text', () => {
+  it('shows typography controls before selection controls for selected text styles', () => {
     render(
       <DesignPanel
         project={createProjectWithSelectedText()}
@@ -201,7 +201,54 @@ describe('DesignPanel', () => {
     );
 
     const headings = screen.getAllByRole('heading').map((heading) => heading.textContent);
-    expect(headings.indexOf('Font')).toBeLessThan(headings.indexOf('Selection'));
+    expect(headings).toContain('Typography');
+    expect(headings).toContain('Selection');
+    expect(headings.indexOf('Typography')).toBeLessThan(headings.indexOf('Selection'));
+  });
+
+  it('keeps selected text style controls in the Style tab only', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedText()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+      />,
+    );
+
+    expect(screen.getAllByLabelText('Selected text font')).toHaveLength(1);
+
+    await user.click(screen.getByRole('tab', { name: 'Text' }));
+
+    expect(screen.queryByLabelText('Selected text font')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Selected text font size')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Selected text font weight')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Selected text color')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Selected text alignment')).not.toBeInTheDocument();
+  });
+
+  it('shows selected text content editing in the Text tab', async () => {
+    const user = userEvent.setup();
+    const onUpdateTextContent = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedText()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+        onUpdateTextContent={onUpdateTextContent}
+      />,
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Text' }));
+
+    const textContent = screen.getByLabelText('Selected text content');
+    expect(textContent).toHaveValue('Editable text');
+
+    fireEvent.change(textContent, { target: { value: 'Updated copy' } });
+
+    expect(onUpdateTextContent).toHaveBeenLastCalledWith('text-test', 'Updated copy');
   });
 
   it('focuses the selected text font list when requested', async () => {


### PR DESCRIPTION
## Summary
- Refine the editor design tab panel layout and styling across left, right, and shell panels
- Update shared design-panel CSS for cleaner spacing and presentation
- Add unit coverage for the DesignPanel behavior

## Testing
- Unit tests updated for `DesignPanel`
- UI behavior verified at a high level in the editor panel flow