### PR TITLE
Add PPTX video playback animation support

### DIFF
--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -959,6 +959,7 @@ class SetElementAnimationBuildsCommand implements EditorCommand {
             ...(this.patch.lineDrawDirection
               ? { lineDrawDirection: this.patch.lineDrawDirection }
               : {}),
+            ...(this.patch.mediaAction ? { mediaAction: this.patch.mediaAction } : {}),
           };
         });
         return { ...page, animationBuilds: [...retainedBuilds, ...nextBuilds] };

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -80,6 +80,7 @@ export interface ElementAnimationBuild {
   durationMs?: number;
   kind?: ElementAnimationKind;
   lineDrawDirection?: AnimationLineDrawDirection;
+  mediaAction?: 'play';
 }
 
 export interface ImportWarning {

--- a/apps/editor/src/services/importing/pptx/pptxParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxParser.ts
@@ -53,6 +53,7 @@ export type PptxSlideObject =
       frame: PptxRect;
       id: string;
       kind: 'image' | 'gif' | 'video';
+      startTrigger?: AnimationTrigger;
       sourceShapeId: string;
       zIndex: number;
     };
@@ -538,6 +539,28 @@ function isMediaControlTiming(timingNode: Element | undefined) {
   return timingNode?.getAttribute('presetClass') === 'mediacall';
 }
 
+function getVideoStartTriggers(document: Document, objects: PptxSlideObject[]) {
+  const videoObjectsByShapeId = new Map(
+    objects
+      .filter((object) => object.kind === 'video' && object.id.includes('-slide-'))
+      .map((object) => [object.sourceShapeId, object]),
+  );
+  const triggers = new Map<string, AnimationTrigger>();
+  let mediaBuildIndex = 0;
+  pptxXml.descendants(document, 'cBhvr').forEach((behavior) => {
+    const sourceShapeId = findBuildSourceShapeId(behavior);
+    if (!sourceShapeId || !videoObjectsByShapeId.has(sourceShapeId)) return;
+    const timingNode = findNearestAnimationTimingNode(behavior);
+    if (!isMediaControlTiming(timingNode)) return;
+    triggers.set(
+      sourceShapeId,
+      toBuildTrigger(timingNode?.getAttribute('nodeType') ?? null, mediaBuildIndex),
+    );
+    mediaBuildIndex += 1;
+  });
+  return triggers;
+}
+
 function parseAnimationBuilds(
   document: Document,
   slideId: string,
@@ -557,7 +580,7 @@ function parseAnimationBuilds(
     const object = slideObjectsByShapeId.get(sourceShapeId);
     if (!object) return;
     const timingNode = findNearestAnimationTimingNode(behavior);
-    if (isMediaControlTiming(timingNode)) return;
+    if (isMediaControlTiming(timingNode) && object.kind !== 'video') return;
     const buildIndex = builds.length;
     builds.push({
       id: `${slideId}-build-${buildIndex + 1}-${object.id}`,
@@ -565,8 +588,9 @@ function parseAnimationBuilds(
       effect: 'reveal',
       trigger: toBuildTrigger(timingNode?.getAttribute('nodeType') ?? null, buildIndex),
       delayMs: 0,
-      durationMs: getBuildDurationMs(timingNode),
+      durationMs: isMediaControlTiming(timingNode) ? 0 : getBuildDurationMs(timingNode),
       kind: toBuildKind(timingNode?.getAttribute('presetClass') ?? null),
+      ...(isMediaControlTiming(timingNode) ? { mediaAction: 'play' as const } : {}),
     });
     seenShapeIds.add(sourceShapeId);
   });
@@ -667,6 +691,11 @@ async function parseSlide(
         if (object) objects.push(object);
       }
     }
+  }
+  const videoStartTriggers = getVideoStartTriggers(document, objects);
+  for (const object of objects) {
+    const startTrigger = videoStartTriggers.get(object.sourceShapeId);
+    if (object.kind === 'video' && startTrigger) object.startTrigger = startTrigger;
   }
   return {
     backgroundColor: getBackgroundColor(document),

--- a/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
+++ b/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
@@ -211,7 +211,8 @@ function mapObject(
       loop: false,
       controls: true,
       muted: false,
-      autoplayInPreview: false,
+      autoplayInPreview: true,
+      startOnClick: object.startTrigger === 'on-click',
       trimStartSeconds: 0,
     };
   }

--- a/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
+++ b/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
@@ -199,7 +199,9 @@ export function useAnimationPreviewController({
       activeBuild: undefined,
       activeBuildElementId: undefined,
       animationProgress: 0,
-      hiddenElementIds: builds.map((build) => build.elementId),
+      hiddenElementIds: builds
+        .filter((build) => build.mediaAction !== 'play')
+        .map((build) => build.elementId),
       mode,
       pageId: page.id,
       phase: transitionDelay > 0 ? 'transition' : builds.length > 0 ? 'animation' : 'complete',
@@ -283,6 +285,7 @@ export function useAnimationPreviewController({
             animationProgress: 0,
             hiddenElementIds: builds
               .slice(targetBuildIndex)
+              .filter((build) => build.mediaAction !== 'play')
               .map((build) => build.elementId),
             phase: 'waiting',
             waitingForClick: true,

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -42,6 +42,7 @@ import { FloatingSelectionToolbar } from '../toolbars/FloatingSelectionToolbar';
 import { imageCrop } from './imageCrop';
 import type { ImageCropHandle } from './imageCrop';
 import { canvasWorkspaceUtils } from './canvasWorkspaceUtils';
+import { movieStartPlayback } from '../media/movieStartPlayback';
 
 const TEXT_FRAME_PADDING = 6;
 
@@ -146,9 +147,11 @@ function easeOutCubic(value: number) {
 }
 
 function getAnimationOpacity(baseOpacity: number, state: ElementAnimationRenderState) {
+  if (state.activeBuild?.mediaAction === 'play') return baseOpacity;
   if (state.activeBuild?.effect === 'dissolve') return baseOpacity * easeOutCubic(state.progress);
   if (state.activeBuild?.effect === 'keyboard-typing') return baseOpacity;
   if (state.activeBuild?.effect === 'line-draw') return baseOpacity;
+  if (state.hidden && state.activeBuild?.mediaAction === 'play') return baseOpacity;
   return state.hidden ? 0 : baseOpacity;
 }
 
@@ -955,6 +958,7 @@ export function CanvasWorkspace({
 
   function handleStagePointerDown(event: Konva.KonvaEventObject<MouseEvent | TouchEvent>) {
     if (canAdvanceAnimationPreviewByClick) {
+      movieStartPlayback.playPendingMovieStart(artboardRef.current, project, animationPreview);
       onAnimationPreviewAdvance?.();
       return;
     }
@@ -1340,19 +1344,16 @@ export function CanvasWorkspace({
               const animationState = getElementAnimationState(element);
               return (
                 <CanvasMediaElement
+                  animationState={animationState}
                   key={element.id}
                   assetName={
                     asset?.name ?? (element.type === 'video' ? 'Imported video' : 'Imported GIF')
                   }
                   assetUrl={asset?.objectUrl}
                   element={element}
-                  interactive={
-                    presentationMode ||
-                    readOnly ||
-                    (element.type === 'video' && selection.elementIds.includes(element.id))
-                  }
+                  interactive={presentationMode || readOnly}
                   opacity={getAnimationOpacity(element.opacity, animationState)}
-                  previewMode={presentationMode || readOnly}
+                  previewMode={presentationMode || readOnly || isAnimationPreviewRunning}
                   scale={{ x: scaleX, y: scaleY }}
                 />
               );
@@ -1586,6 +1587,7 @@ interface CanvasImageElementProps {
 }
 
 interface CanvasMediaElementProps {
+  animationState: ElementAnimationRenderState;
   assetName: string;
   assetUrl: string | undefined;
   element: GifElement | VideoElement;
@@ -1613,6 +1615,7 @@ function getMediaStyle(
 }
 
 function CanvasMediaElement({
+  animationState,
   assetName,
   assetUrl,
   element,
@@ -1637,6 +1640,7 @@ function CanvasMediaElement({
       assetName={assetName}
       assetUrl={assetUrl}
       element={element}
+      animationState={animationState}
       interactive={interactive}
       opacity={opacity}
       previewMode={previewMode}
@@ -1646,6 +1650,7 @@ function CanvasMediaElement({
 }
 
 interface CanvasVideoElementProps {
+  animationState: ElementAnimationRenderState;
   assetName: string;
   assetUrl: string | undefined;
   element: VideoElement;
@@ -1656,6 +1661,7 @@ interface CanvasVideoElementProps {
 }
 
 function CanvasVideoElement({
+  animationState,
   assetName,
   assetUrl,
   element,
@@ -1676,7 +1682,8 @@ function CanvasVideoElement({
     | undefined
   >(undefined);
   const repeatMode = element.repeatMode ?? (element.loop ? 'loop' : 'none');
-  const autoplay = previewMode && element.autoplayInPreview && !element.startOnClick;
+  const autoplay =
+    previewMode && element.autoplayInPreview && !element.startOnClick && !animationState.hidden;
 
   function stopReversePlayback() {
     if (reverseIntervalRef.current === undefined) return;
@@ -1693,6 +1700,15 @@ function CanvasVideoElement({
       return Math.max(0, element.trimEndSeconds);
     }
     return Number.isFinite(video.duration) ? video.duration : undefined;
+  }
+
+  function playVideo(video: HTMLVideoElement) {
+    const playResult = video.play() as Promise<void> | undefined;
+    if (playResult !== undefined) {
+      void playResult.catch(() => {
+        video.pause();
+      });
+    }
   }
 
   useEffect(() => {
@@ -1752,10 +1768,32 @@ function CanvasVideoElement({
       video.pause();
       return;
     }
-    void video.play().catch(() => {
-      video.pause();
-    });
+    playVideo(video);
   }, [element.playing]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !previewMode || !element.autoplayInPreview) return;
+    if (animationState.activeBuild?.mediaAction === 'play') {
+      stopReversePlayback();
+      video.currentTime = Math.max(0, element.trimStartSeconds);
+      if (movieStartPlayback.consumeStartedBuild(video, animationState.activeBuild.id)) return;
+      playVideo(video);
+      return;
+    }
+    if (animationState.hidden || element.startOnClick) {
+      stopReversePlayback();
+      video.pause();
+      video.currentTime = Math.max(0, element.trimStartSeconds);
+    }
+  }, [
+    animationState.activeBuild,
+    animationState.hidden,
+    element.autoplayInPreview,
+    element.startOnClick,
+    element.trimStartSeconds,
+    previewMode,
+  ]);
 
   function playReverse(video: HTMLVideoElement) {
     stopReversePlayback();
@@ -1766,7 +1804,7 @@ function CanvasVideoElement({
       video.currentTime = nextTime;
       if (nextTime > trimStart) return;
       stopReversePlayback();
-      void video.play();
+      playVideo(video);
     }, 1000 / 30);
   }
 
@@ -1776,7 +1814,7 @@ function CanvasVideoElement({
     if (video.currentTime < trimEnd) return;
     if (repeatMode === 'loop') {
       video.currentTime = getTrimStart();
-      void video.play();
+      playVideo(video);
       return;
     }
     if (repeatMode === 'loop-back-and-forth') {
@@ -1792,6 +1830,7 @@ function CanvasVideoElement({
       autoPlay={autoplay}
       className="canvas-media-element"
       controls={interactive && element.controls}
+      data-element-id={element.id}
       data-trim-end={element.trimEndSeconds ?? ''}
       data-trim-start={element.trimStartSeconds}
       loop={repeatMode === 'loop' && element.trimEndSeconds === undefined}

--- a/apps/editor/src/ui/editor/media/movieStartPlayback.ts
+++ b/apps/editor/src/ui/editor/media/movieStartPlayback.ts
@@ -1,0 +1,61 @@
+import type { ProjectDocument } from '../../../domain/documents/model';
+
+interface MovieStartAnimationPreview {
+  activeBuildElementId: string | undefined;
+  pageId: string;
+  waitingForClick: boolean;
+}
+
+function playVideo(video: HTMLVideoElement) {
+  const playResult = video.play() as Promise<void> | undefined;
+  if (playResult !== undefined) {
+    void playResult.catch(() => {
+      video.pause();
+    });
+  }
+}
+
+function getMovieStartVideo(
+  root: ParentNode,
+  elementId: string,
+): HTMLVideoElement | undefined {
+  return Array.from(root.querySelectorAll<HTMLVideoElement>('video[data-element-id]')).find(
+    (video): video is HTMLVideoElement => video.dataset.elementId === elementId,
+  );
+}
+
+function consumeStartedBuild(video: HTMLVideoElement, buildId: string) {
+  if (video.dataset.startedMovieBuildId !== buildId) return false;
+  delete video.dataset.startedMovieBuildId;
+  return true;
+}
+
+function playPendingMovieStart(
+  root: ParentNode | null | undefined,
+  project: ProjectDocument,
+  animationPreview: MovieStartAnimationPreview | undefined,
+) {
+  if (!root || !animationPreview?.waitingForClick || !animationPreview.activeBuildElementId) {
+    return false;
+  }
+  const page = project.pages.find((item) => item.id === animationPreview.pageId);
+  const build = page?.animationBuilds?.find(
+    (item) =>
+      item.elementId === animationPreview.activeBuildElementId && item.mediaAction === 'play',
+  );
+  if (!build) return false;
+  const element = project.elements[build.elementId];
+  if (element?.type !== 'video') return false;
+  const video = getMovieStartVideo(root, element.id);
+  if (!video) return false;
+
+  video.currentTime = Math.max(0, element.trimStartSeconds);
+  playVideo(video);
+  video.dataset.startedMovieBuildId = build.id;
+  return true;
+}
+
+export const movieStartPlayback = {
+  consumeStartedBuild,
+  playPendingMovieStart,
+};

--- a/apps/editor/src/ui/editor/panels/AnimationPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/AnimationPanel.tsx
@@ -9,6 +9,7 @@ import type {
   SelectionState,
   SlideTransition,
 } from '../../../domain/documents/model';
+import type { MediaPlaybackPatch } from '../../../domain/commands/elements/basicCommands';
 
 type ElementAnimationPatch = Omit<ElementAnimationPatchSource, 'elementId' | 'id'>;
 type DurationChangeHandler = (durationMs: number) => void;
@@ -35,6 +36,7 @@ interface AnimationPanelProps {
   onSetElementAnimationBuilds?:
     | ((elementIds: string[], patch: ElementAnimationPatch) => void)
     | undefined;
+  onUpdateMediaPlayback?: ((elementId: string, patch: MediaPlaybackPatch) => void) | undefined;
   onSetPageTransition?: ((transition: SlideTransition) => void) | undefined;
 }
 
@@ -71,6 +73,11 @@ function getElementLabel(project: ProjectDocument, elementId: string) {
   return element.shape === 'ellipse' ? 'Ellipse' : 'Rectangle';
 }
 
+function getBuildLabel(project: ProjectDocument, build: ElementAnimationBuild) {
+  if (build.mediaAction === 'play') return 'Movie start';
+  return getElementLabel(project, build.elementId);
+}
+
 function getBuildPatch(build: ElementAnimationBuild | undefined): ElementAnimationPatch {
   return build
     ? {
@@ -81,6 +88,7 @@ function getBuildPatch(build: ElementAnimationBuild | undefined): ElementAnimati
         ...(build.durationMs !== undefined ? { durationMs: build.durationMs } : {}),
         ...(build.kind ? { kind: build.kind } : {}),
         ...(build.lineDrawDirection ? { lineDrawDirection: build.lineDrawDirection } : {}),
+        ...(build.mediaAction ? { mediaAction: build.mediaAction } : {}),
       }
     : DEFAULT_ELEMENT_ANIMATION;
 }
@@ -201,6 +209,7 @@ export function AnimationPanel({
   onPlayAnimationPreview,
   onReorderElementAnimationBuild,
   onSetElementAnimationBuilds,
+  onUpdateMediaPlayback,
   onSetPageTransition,
 }: AnimationPanelProps) {
   const [dropIndicator, setDropIndicator] = useState<
@@ -337,9 +346,10 @@ export function AnimationPanel({
           {animationBuilds.map((build, index) => {
             const elementId = build.elementId;
             const element = project.elements[elementId];
-            const label = getElementLabel(project, elementId);
+            const label = getBuildLabel(project, build);
             const patch = getBuildPatch(build);
             const availableEffects = getAvailableEffects(element);
+            const isMovieStartBuild = build.mediaAction === 'play';
             const dropPosition =
               dropIndicator?.elementId === elementId ? dropIndicator.position : undefined;
             const isActivePreviewBuild = activePreviewBuildElementId === elementId;
@@ -353,6 +363,18 @@ export function AnimationPanel({
             ]
               .filter(Boolean)
               .join(' ');
+            function setBuildTrigger(trigger: ElementAnimationPatch['trigger']) {
+              onSetElementAnimationBuilds?.([elementId], {
+                ...patch,
+                trigger,
+              });
+              if (isMovieStartBuild) {
+                onUpdateMediaPlayback?.(elementId, {
+                  autoplayInPreview: true,
+                  startOnClick: trigger === 'on-click',
+                });
+              }
+            }
             return (
               <div
                 aria-label={`Build ${index + 1}: ${label}`}
@@ -427,40 +449,49 @@ export function AnimationPanel({
                     </button>
                   </div>
                 </div>
-                <label className="animation-field ew-field-scope ew-compact-row">
-                  <span>Effect</span>
-                  <select
-                    aria-label={`Effect for ${label}`}
-                    value={build ? patch.effect : 'none'}
-                    onChange={(event) => {
-                      if (event.target.value === 'none') {
-                        onClearElementAnimationBuild?.(elementId);
-                        return;
-                      }
-                      onSetElementAnimationBuilds?.(
-                        [elementId],
-                        getAnimationEffectPatch(
-                          toAnimationEffect(event.target.value, availableEffects),
-                          patch,
-                        ),
-                      );
-                    }}
-                  >
-                    <option value="none">None</option>
-                    {ANIMATION_EFFECT_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                    {availableEffects.canLineDraw ? (
-                      <option value="line-draw">Line draw</option>
-                    ) : null}
-                    {availableEffects.canKeyboardType ? (
-                      <option value="keyboard-typing">Keyboard typing</option>
-                    ) : null}
-                  </select>
-                </label>
-                {patch.effect === 'line-draw' ? (
+                {isMovieStartBuild ? (
+                  <label className="animation-field ew-field-scope ew-compact-row">
+                    <span>Animation</span>
+                    <select aria-label={`Animation for ${label}`} value="movie-start" disabled>
+                      <option value="movie-start">Movie start</option>
+                    </select>
+                  </label>
+                ) : (
+                  <label className="animation-field ew-field-scope ew-compact-row">
+                    <span>Effect</span>
+                    <select
+                      aria-label={`Effect for ${label}`}
+                      value={build ? patch.effect : 'none'}
+                      onChange={(event) => {
+                        if (event.target.value === 'none') {
+                          onClearElementAnimationBuild?.(elementId);
+                          return;
+                        }
+                        onSetElementAnimationBuilds?.(
+                          [elementId],
+                          getAnimationEffectPatch(
+                            toAnimationEffect(event.target.value, availableEffects),
+                            patch,
+                          ),
+                        );
+                      }}
+                    >
+                      <option value="none">None</option>
+                      {ANIMATION_EFFECT_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                      {availableEffects.canLineDraw ? (
+                        <option value="line-draw">Line draw</option>
+                      ) : null}
+                      {availableEffects.canKeyboardType ? (
+                        <option value="keyboard-typing">Keyboard typing</option>
+                      ) : null}
+                    </select>
+                  </label>
+                )}
+                {!isMovieStartBuild && patch.effect === 'line-draw' ? (
                   <label className="animation-field ew-field-scope ew-compact-row">
                     <span>Direction</span>
                     <select
@@ -491,10 +522,7 @@ export function AnimationPanel({
                           : event.target.value === 'after-previous'
                             ? 'after-previous'
                             : 'on-click';
-                      onSetElementAnimationBuilds?.([elementId], {
-                        ...patch,
-                        trigger,
-                      });
+                      setBuildTrigger(trigger);
                     }}
                   >
                     <option value="on-click">On click</option>
@@ -502,16 +530,18 @@ export function AnimationPanel({
                     <option value="after-previous">After previous build</option>
                   </select>
                 </label>
-                <DurationField
-                  ariaLabel={`Duration for ${label}`}
-                  valueMs={patch.delayMs}
-                  onChange={(durationMs) => {
-                    onSetElementAnimationBuilds?.([elementId], {
-                      ...patch,
-                      delayMs: durationMs,
-                    });
-                  }}
-                />
+                {!isMovieStartBuild ? (
+                  <DurationField
+                    ariaLabel={`Duration for ${label}`}
+                    valueMs={patch.delayMs}
+                    onChange={(durationMs) => {
+                      onSetElementAnimationBuilds?.([elementId], {
+                        ...patch,
+                        delayMs: durationMs,
+                      });
+                    }}
+                  />
+                ) : null}
               </div>
             );
           })}

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -25,6 +25,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   DesignElement,
+  ElementAnimationBuild,
   PageBackground,
   ProjectDocument,
   SelectionState,
@@ -43,6 +44,9 @@ import type {
 import type { FontCatalogItem } from '../../../services/contracts/interfaces';
 import { PanelSection } from '../../components/PanelSection';
 import { textStyleOptions } from '../text/textStyleOptions';
+
+type ElementAnimationPatch = Omit<ElementAnimationBuild, 'elementId' | 'id'>;
+type MovieStartTrigger = ElementAnimationBuild['trigger'];
 
 const palette = ['#37FD76', '#050D10', '#FFFFFF', '#91999D', '#00779A'];
 const regularTextWeight = 400;
@@ -79,6 +83,7 @@ interface DesignPanelProps {
   onSetElementLock?: (elementId: string, locked: boolean) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
   onReplaceVideoAsset?: (elementId: string, file: File) => void;
+  onSetElementAnimationBuilds?: (elementIds: string[], patch: ElementAnimationPatch) => void;
 }
 
 function getSelectedElement(
@@ -120,6 +125,7 @@ export function DesignPanel({
   focusFontControlKey,
   onDownloadFont,
   onReplaceVideoAsset,
+  onSetElementAnimationBuilds,
 }: DesignPanelProps) {
   const fontSelectRef = useRef<HTMLSelectElement>(null);
   const [fontDownloadOpen, setFontDownloadOpen] = useState(false);
@@ -426,8 +432,10 @@ export function DesignPanel({
           onFrameUpdate={(patch) => onUpdateElementFrame?.(selectedElement.id, patch)}
           onLockChange={(locked) => onSetElementLock?.(selectedElement.id, locked)}
           onReplaceVideoAsset={(file) => onReplaceVideoAsset?.(selectedElement.id, file)}
+          {...(onSetElementAnimationBuilds ? { onSetElementAnimationBuilds } : {})}
           onUpdateMedia={updateSelectedMediaPlayback}
           onUpdateStyle={updateSelectedStyle}
+          page={page}
           onZOrderChange={onSetSelectedElementZOrder}
         />
       ) : (
@@ -449,8 +457,10 @@ interface ElementDesignInspectorProps {
   onFrameUpdate?: ((patch: ElementFramePatch) => void) | undefined;
   onLockChange?: ((locked: boolean) => void) | undefined;
   onReplaceVideoAsset?: ((file: File) => void) | undefined;
+  onSetElementAnimationBuilds?: (elementIds: string[], patch: ElementAnimationPatch) => void;
   onUpdateMedia: (patch: MediaPlaybackPatch) => void;
   onUpdateStyle: (patch: ElementStylePatch) => void;
+  page?: ProjectDocument['pages'][number] | undefined;
   onZOrderChange?: ((mode: ZOrderMode) => void) | undefined;
 }
 
@@ -489,6 +499,21 @@ function getTrimEndSeconds(element: VideoElement) {
   return element.trimEndSeconds ?? element.durationSeconds ?? getTrimSliderMax(element);
 }
 
+function getMovieStartValue(
+  mediaStartBuild: ElementAnimationBuild | undefined,
+  videoElement: VideoElement | undefined,
+) {
+  if (mediaStartBuild) {
+    return mediaStartBuild.trigger;
+  }
+  return videoElement?.startOnClick ? 'on-click' : 'after-transition';
+}
+
+function toMovieStartTrigger(value: string): MovieStartTrigger {
+  if (value === 'after-transition' || value === 'after-previous') return value;
+  return 'on-click';
+}
+
 type ElementInspectorTab = 'arrange' | 'content' | 'style';
 
 function getBoundedNumber(value: string, fallback: number, minimum = 0) {
@@ -518,8 +543,10 @@ function ElementDesignInspector({
   onFrameUpdate,
   onLockChange,
   onReplaceVideoAsset,
+  onSetElementAnimationBuilds,
   onUpdateMedia,
   onUpdateStyle,
+  page,
   onZOrderChange,
 }: ElementDesignInspectorProps) {
   const defaultTab = element.type === 'text' ? 'style' : 'content';
@@ -532,6 +559,25 @@ function ElementDesignInspector({
   const trimEndSeconds = videoElement ? getTrimEndSeconds(videoElement) : 0;
   const volume = videoElement?.muted ? 0 : Math.round((videoElement?.volume ?? 1) * 100);
   const repeatMode = videoElement ? getVideoRepeatMode(videoElement) : 'none';
+  const mediaStartBuild =
+    videoElement && page
+      ? page.animationBuilds?.find(
+          (build) => build.elementId === videoElement.id && build.mediaAction === 'play',
+        )
+      : undefined;
+  const movieStart = getMovieStartValue(mediaStartBuild, videoElement);
+
+  function setMovieStart(trigger: MovieStartTrigger) {
+    if (!videoElement) return;
+    onSetElementAnimationBuilds?.([videoElement.id], {
+      effect: 'reveal',
+      trigger,
+      delayMs: 0,
+      durationMs: 0,
+      mediaAction: 'play',
+    });
+    onUpdateMedia({ autoplayInPreview: true, startOnClick: trigger === 'on-click' });
+  }
 
   return (
     <PanelSection title={contentLabel}>
@@ -789,9 +835,19 @@ function ElementDesignInspector({
               </select>
             </label>
 
-            <label className="movie-checkbox-row movie-checkbox-row-disabled">
-              <input type="checkbox" disabled checked={Boolean(videoElement.startOnClick)} readOnly />
-              <span>Start movie on click</span>
+            <label className="movie-select-control">
+              <span>Start</span>
+              <select
+                aria-label="Selected video start"
+                value={movieStart}
+                onChange={(event) => {
+                  setMovieStart(toMovieStartTrigger(event.target.value));
+                }}
+              >
+                <option value="on-click">On click</option>
+                <option value="after-transition">After transition</option>
+                <option value="after-previous">After previous build</option>
+              </select>
             </label>
             <label className="movie-checkbox-row">
               <input

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -306,6 +306,7 @@ export function LeftToolPanel({
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
             {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}
+            {...(onSetElementAnimationBuilds ? { onSetElementAnimationBuilds } : {})}
           />
         ) : null}
         {panelOpen && activeTab === 'text' ? (
@@ -336,6 +337,7 @@ export function LeftToolPanel({
             {...(onClearPageTransition ? { onClearPageTransition } : {})}
             {...(onSetPageTransition ? { onSetPageTransition } : {})}
             {...(onSetElementAnimationBuilds ? { onSetElementAnimationBuilds } : {})}
+            {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onClearElementAnimationBuild ? { onClearElementAnimationBuild } : {})}
             {...(onReorderElementAnimationBuild ? { onReorderElementAnimationBuild } : {})}
             {...(onPlayAnimationPreview ? { onPlayAnimationPreview } : {})}

--- a/apps/editor/src/ui/editor/panels/RightPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/RightPanel.tsx
@@ -1,5 +1,10 @@
 import { Brush, Layers3, Sparkles } from 'lucide-react';
-import type { PageBackground, ProjectDocument, SelectionState } from '../../../domain/documents/model';
+import type {
+  ElementAnimationBuild,
+  PageBackground,
+  ProjectDocument,
+  SelectionState,
+} from '../../../domain/documents/model';
 import type {
   AlignMode,
   ElementFramePatch,
@@ -16,6 +21,7 @@ import { LayersPanel } from './LayersPanel';
 import type { RightPanelTab } from '../state/useEditorViewModel';
 
 type LegacyRightPanelTab = Exclude<RightPanelTab, 'assets' | 'animations' | 'elements' | 'text'>;
+type ElementAnimationPatch = Omit<ElementAnimationBuild, 'elementId' | 'id'>;
 
 interface RightPanelProps {
   activeTab: LegacyRightPanelTab;
@@ -55,6 +61,7 @@ interface RightPanelProps {
   onUpdatePageBackground?: (background: PageBackground) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
   onReplaceVideoAsset?: (elementId: string, file: File) => void;
+  onSetElementAnimationBuilds?: (elementIds: string[], patch: ElementAnimationPatch) => void;
 }
 
 const tabs: Array<SegmentedTab<LegacyRightPanelTab>> = [
@@ -101,6 +108,7 @@ export function RightPanel({
   onUpdatePageBackground,
   onSetSelectedElementZOrder,
   onReplaceVideoAsset,
+  onSetElementAnimationBuilds,
 }: RightPanelProps) {
   return (
     <aside className="right-panel" aria-label="Editor tools">
@@ -155,6 +163,7 @@ export function RightPanel({
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
             {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}
+            {...(onSetElementAnimationBuilds ? { onSetElementAnimationBuilds } : {})}
           />
         ) : null}
       </div>

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -19,6 +19,7 @@ import { MirrorSettingsPanel } from '../panels/MirrorSettingsPanel';
 import { PagesPanel } from '../panels/PagesPanel';
 import { ProjectVideoPreloader } from '../media/ProjectVideoPreloader';
 import { localMediaImportConfig } from '../media/localMediaImportConfig';
+import { movieStartPlayback } from '../media/movieStartPlayback';
 import { PromptBar } from '../prompting/PromptBar';
 import { RemoteImportPanel } from '../panels/RemoteImportPanel';
 import { ScrollingCanvasWorkspace } from '../canvas/ScrollingCanvasWorkspace';
@@ -206,6 +207,15 @@ export function EditorShell({ services }: EditorShellProps) {
     return presentationMovieControls.control(videos, action);
   }, []);
 
+  const advancePresentationPreviewFromUserAction = useCallback(() => {
+    movieStartPlayback.playPendingMovieStart(
+      slideFrameRef.current,
+      vm.project,
+      vm.animationPreview,
+    );
+    vm.advancePresentationPreview();
+  }, [vm]);
+
   const pulsePresentationMovieHold = useCallback((action: 'fast-forward' | 'rewind') => {
     movieHoldStateRef.current = presentationMovieControls.pulse(
       getPresentationVideos(),
@@ -290,7 +300,7 @@ export function EditorShell({ services }: EditorShellProps) {
       return;
     }
     if (action === 'next-build') {
-      vm.advancePresentationPreview();
+      advancePresentationPreviewFromUserAction();
       return;
     }
     if (action === 'previous-build') {
@@ -535,7 +545,7 @@ export function EditorShell({ services }: EditorShellProps) {
         }
         if (isNextPreviewKey || isPreviousPreviewKey) {
           event.preventDefault();
-          if (isNextPreviewKey) vm.advancePresentationPreview();
+          if (isNextPreviewKey) advancePresentationPreviewFromUserAction();
           if (isPreviousPreviewKey) playRelativePresentationSlide(-1);
           return;
         }
@@ -565,6 +575,7 @@ export function EditorShell({ services }: EditorShellProps) {
     };
   }, [
     activePageIndex,
+    advancePresentationPreviewFromUserAction,
     controlPresentationMovies,
     hasSelection,
     isHistoryReadOnly,
@@ -594,7 +605,7 @@ export function EditorShell({ services }: EditorShellProps) {
     if (!presenterSessionId) return undefined;
     return getPresenterSessionService().subscribeToCommands((message) => {
       if (message.command === 'next') {
-        vm.advancePresentationPreview();
+        advancePresentationPreviewFromUserAction();
         return;
       }
       if (message.command === 'previous') {
@@ -621,7 +632,7 @@ export function EditorShell({ services }: EditorShellProps) {
         closePresenterViewSession();
       }
     });
-  }, [presenterSessionId, vm]);
+  }, [advancePresentationPreviewFromUserAction, presenterSessionId, vm]);
 
   useEffect(() => {
     if (!presenterSessionId) {

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -3708,6 +3708,7 @@ export function useEditorViewModel(services: AppServices) {
                 controls: true,
                 muted: true,
                 autoplayInPreview: true,
+                playing: true,
                 trimStartSeconds: 0,
                 ...(videoDurationSeconds !== undefined
                   ? {

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -216,7 +216,9 @@ export function PublicDeckViewer({
         activeBuild: undefined,
         activeBuildElementId: undefined,
         animationProgress: 0,
-        hiddenElementIds: builds.map((build) => build.elementId),
+        hiddenElementIds: builds
+          .filter((build) => build.mediaAction !== 'play')
+          .map((build) => build.elementId),
         mode: 'presenter',
         pageId: page.id,
         phase: transitionDelay > 0 ? 'transition' : builds.length > 0 ? 'animation' : 'complete',

--- a/apps/editor/tests/unit/services/pptxImportService.test.ts
+++ b/apps/editor/tests/unit/services/pptxImportService.test.ts
@@ -121,6 +121,11 @@ const slideXml = `<?xml version="1.0" encoding="UTF-8"?>
                 <p:childTnLst><p:anim><p:cBhvr><p:tgtEl><p:spTgt spid="3"/></p:tgtEl></p:cBhvr></p:anim></p:childTnLst>
               </p:cTn>
             </p:par>
+            <p:par>
+              <p:cTn id="4" nodeType="clickEffect" presetClass="mediacall">
+                <p:childTnLst><p:cmd type="call" cmd="play"><p:cBhvr><p:tgtEl><p:spTgt spid="4"/></p:tgtEl></p:cBhvr></p:cmd></p:childTnLst>
+              </p:cTn>
+            </p:par>
           </p:childTnLst>
         </p:cTn>
       </p:par>
@@ -154,11 +159,11 @@ const notesSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
   </p:cSld>
 </p:notes>`;
 
-function createPptxFixture() {
+function createPptxFixture(slideContents = slideXml) {
   return createStoredPptxFile([
     { path: 'ppt/presentation.xml', contents: presentationXml },
     { path: 'ppt/_rels/presentation.xml.rels', contents: presentationRels },
-    { path: 'ppt/slides/slide1.xml', contents: slideXml },
+    { path: 'ppt/slides/slide1.xml', contents: slideContents },
     { path: 'ppt/slides/_rels/slide1.xml.rels', contents: slideRels },
     { path: 'ppt/notesSlides/notesSlide1.xml', contents: notesSlideXml },
     { path: 'ppt/slideLayouts/slideLayout1.xml', contents: layoutXml },
@@ -197,6 +202,14 @@ describe('BrowserPptxImportService', () => {
         trigger: 'on-click',
         durationMs: 450,
         kind: 'build-out',
+      },
+      {
+        elementId: 'pptx-page-1-slide-video-4',
+        effect: 'reveal',
+        trigger: 'on-click',
+        durationMs: 0,
+        kind: 'build-in',
+        mediaAction: 'play',
       },
     ]);
 
@@ -262,12 +275,49 @@ describe('BrowserPptxImportService', () => {
     expect(project.pages[0]?.elementIds.some((elementId) => elementId.includes('placeholder'))).toBe(false);
     expect(imageElements).toHaveLength(2);
     expect(imageElement).toMatchObject({ locked: false, type: 'image' });
-    expect(videoElement).toMatchObject({ controls: true, locked: false, type: 'video' });
+    expect(videoElement).toMatchObject({
+      autoplayInPreview: true,
+      controls: true,
+      locked: false,
+      startOnClick: true,
+      type: 'video',
+    });
 
     const videoAsset = Object.values(project.assets).find((asset) => asset.fileName === 'media1.mp4');
     expect(imageAsset?.mimeType).toBe('image/png');
     expect(layoutImageAsset?.mimeType).toBe('image/png');
     expect(videoAsset?.mimeType).toBe('video/mp4');
+  });
+
+  it('imports PowerPoint video media calls that start after the slide transition', async () => {
+    const service = new BrowserPptxImportService();
+    const project = await service.importPowerPoint({
+      file: createPptxFixture(
+        slideXml
+          .replace(
+            '<p:cTn id="4" nodeType="clickEffect" presetClass="mediacall">',
+            '<p:cTn id="4" nodeType="afterEffect" presetClass="mediacall">',
+          )
+          .replace('<p:spTgt spid="2"/>', '<p:spTgt spid="200"/>')
+          .replace('<p:spTgt spid="3"/>', '<p:spTgt spid="300"/>')
+          .replace('<p:bldP spid="3"/>', '<p:bldP spid="300"/>')
+          .replace('<p:bldP spid="2"/>', '<p:bldP spid="200"/>'),
+      ),
+    });
+    const videoElement = Object.values(project.elements).find(
+      (element) => element.type === 'video',
+    );
+
+    expect(project.pages[0]?.animationBuilds?.at(-1)).toMatchObject({
+      elementId: 'pptx-page-1-slide-video-4',
+      mediaAction: 'play',
+      trigger: 'after-transition',
+    });
+    expect(videoElement).toMatchObject({
+      autoplayInPreview: true,
+      startOnClick: false,
+      type: 'video',
+    });
   });
 
   it('rejects files that are not valid PPTX packages', async () => {

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -290,6 +290,49 @@ describe('CanvasWorkspace', () => {
     expect(onAnimationPreviewAdvance).toHaveBeenCalledTimes(1);
   });
 
+  it('starts pending movie builds when the slide click advances the next build', () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockImplementation(() => Promise.resolve());
+    const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    const onAnimationPreviewAdvance = vi.fn();
+    const project = updateVideoElement(createMediaProject(), { startOnClick: true });
+    project.pages[0]!.animationBuilds = [
+      {
+        id: 'video-build',
+        elementId: 'video-demo',
+        effect: 'reveal',
+        trigger: 'on-click',
+        delayMs: 0,
+        durationMs: 0,
+        mediaAction: 'play',
+      },
+    ];
+    const { container } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: 'video-demo',
+          pageId: 'page-1',
+          phase: 'waiting',
+          hiddenElementIds: [],
+          playing: true,
+          waitingForClick: true,
+        }}
+        onAnimationPreviewAdvance={onAnimationPreviewAdvance}
+      />,
+    );
+
+    fireEvent.mouseDown(container.querySelector('canvas')!);
+
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(onAnimationPreviewAdvance).toHaveBeenCalledTimes(1);
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+  });
+
   it('advances completed animation previews by click in presentation mode', () => {
     const onAnimationPreviewAdvance = vi.fn();
     const { container } = render(
@@ -489,7 +532,7 @@ describe('CanvasWorkspace', () => {
     expect(editorVideo).toBeInTheDocument();
     expect(editorVideo.autoplay).toBe(false);
     expect(editorVideo.loop).toBe(false);
-    expect(editorVideo.controls).toBe(true);
+    expect(editorVideo.controls).toBe(false);
     expect(editorVideo.muted).toBe(true);
     expect(editorVideo.volume).toBe(0.75);
     expect(editorVideo.preload).toBe('auto');
@@ -514,7 +557,116 @@ describe('CanvasWorkspace', () => {
     expect(previewVideo.dataset.trimEnd).toBe('6');
   });
 
-  it('allows native controls on the selected video in editor mode', () => {
+  it('plays start-on-click videos when their animation build becomes active', async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockImplementation(() => Promise.resolve());
+    const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    const project = updateVideoElement(createMediaProject(), { startOnClick: true });
+    project.pages[0]!.animationBuilds = [
+      {
+        id: 'video-build',
+        elementId: 'video-demo',
+        effect: 'reveal',
+        trigger: 'on-click',
+        delayMs: 0,
+        durationMs: 0,
+        mediaAction: 'play',
+      },
+    ];
+
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: 'video-demo',
+          animationProgress: 0,
+          hiddenElementIds: [],
+          pageId: 'page-1',
+          phase: 'waiting',
+          playing: true,
+          waitingForClick: true,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    const video = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    expect(video.autoplay).toBe(false);
+    expect(video.style.opacity).toBe('1');
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuild: project.pages[0]?.animationBuilds?.[0],
+          activeBuildElementId: 'video-demo',
+          animationProgress: 1,
+          hiddenElementIds: ['video-demo'],
+          pageId: 'page-1',
+          phase: 'animation',
+          playing: true,
+          waitingForClick: false,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    await waitFor(() => expect(playSpy).toHaveBeenCalled());
+    expect(video.style.opacity).toBe('1');
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+  });
+
+  it('plays movie-start builds during editor animation preview', async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockImplementation(() => Promise.resolve());
+    const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    const project = updateVideoElement(createMediaProject(), { startOnClick: true });
+    project.pages[0]!.animationBuilds = [
+      {
+        id: 'video-build',
+        elementId: 'video-demo',
+        effect: 'reveal',
+        trigger: 'on-click',
+        delayMs: 0,
+        durationMs: 0,
+        mediaAction: 'play',
+      },
+    ];
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuild: project.pages[0]?.animationBuilds?.[0],
+          activeBuildElementId: 'video-demo',
+          animationProgress: 1,
+          hiddenElementIds: [],
+          mode: 'editor',
+          pageId: 'page-1',
+          phase: 'animation',
+          playing: true,
+          waitingForClick: false,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(playSpy).toHaveBeenCalled());
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+  });
+
+  it('keeps video overlays non-interactive in editor mode so the canvas handles selection', () => {
     const project = createMediaProject();
     const { container, rerender } = render(
       <CanvasWorkspace
@@ -540,7 +692,8 @@ describe('CanvasWorkspace', () => {
     const selectedVideo = container.querySelector(
       'video[aria-label="Demo clip"]',
     ) as HTMLVideoElement;
-    expect(selectedVideo.style.pointerEvents).toBe('auto');
+    expect(selectedVideo.style.pointerEvents).toBe('none');
+    expect(selectedVideo.controls).toBe(false);
   });
 
   it('seeks the selected video when trim sliders update the boundaries', () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -1760,6 +1760,49 @@ describe('EditorShell', () => {
     });
   });
 
+  it.each(['ArrowRight', ']'])(
+    'starts pending movie-start builds from the %s presentation shortcut',
+    async (key) => {
+      const user = userEvent.setup();
+      const playSpy = vi
+        .spyOn(HTMLMediaElement.prototype, 'play')
+        .mockImplementation(() => Promise.resolve());
+      const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+      const project = createProjectWithVideo();
+      project.pages[0] = {
+        ...project.pages[0]!,
+        transition: { effect: 'reveal', delayMs: 0 },
+        animationBuilds: [
+          {
+            id: 'build-video-demo',
+            elementId: 'video-demo',
+            effect: 'reveal',
+            trigger: 'on-click',
+            delayMs: 0,
+            durationMs: 0,
+            mediaAction: 'play',
+          },
+        ],
+      };
+
+      render(<EditorShell services={createAppServices({ initialProject: project })} />);
+
+      await startFullscreenPresentation(user);
+      await waitFor(() => {
+        expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+          'data-animation-preview-waiting',
+          'true',
+        );
+      });
+
+      fireEvent.keyDown(window, { key });
+
+      expect(playSpy).toHaveBeenCalledTimes(1);
+      playSpy.mockRestore();
+      pauseSpy.mockRestore();
+    },
+  );
+
   it('uses arrow keys to move between slides after the current preview step completes', async () => {
     const user = userEvent.setup();
     const project = sampleProject.createSampleProject();
@@ -2372,7 +2415,11 @@ describe('EditorShell', () => {
       const importedVideo = Object.values(savedProject?.elements ?? {}).find(
         (element) => element.type === 'video',
       );
-      expect(importedVideo).toMatchObject({ type: 'video' });
+      expect(importedVideo).toMatchObject({
+        autoplayInPreview: true,
+        playing: true,
+        type: 'video',
+      });
       expect(savedProject?.assets[importedVideo?.assetId ?? '']?.name).toBe('toolbar-video.mp4');
       expect(savedProject?.assets[importedVideo?.assetId ?? '']?.objectUrl).toBe(
         'blob:toolbar-video',

--- a/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/LeftToolPanel.test.tsx
@@ -200,10 +200,11 @@ describe('LeftToolPanel', () => {
     const onReorderElementAnimationBuild = vi.fn();
     const onPlayAnimationPreview = vi.fn();
     const onSetElementAnimationBuilds = vi.fn();
+    const onUpdateMediaPlayback = vi.fn();
     const project = sampleProject.createSampleProject();
     project.pages[0] = {
       ...project.pages[0]!,
-      elementIds: [...project.pages[0]!.elementIds, 'shape-line'],
+      elementIds: [...project.pages[0]!.elementIds, 'shape-line', 'video-demo'],
       transition: { effect: 'reveal', delayMs: 0 },
       animationBuilds: [
         {
@@ -228,7 +229,40 @@ describe('LeftToolPanel', () => {
           delayMs: 0,
           lineDrawDirection: 'start-to-end',
         },
+        {
+          id: 'build-video-demo',
+          elementId: 'video-demo',
+          effect: 'reveal',
+          trigger: 'on-click',
+          delayMs: 0,
+          durationMs: 0,
+          mediaAction: 'play',
+        },
       ],
+    };
+    project.assets['asset-video'] = {
+      id: 'asset-video',
+      type: 'video',
+      name: 'Demo clip',
+      mimeType: 'video/mp4',
+    };
+    project.elements['video-demo'] = {
+      id: 'video-demo',
+      type: 'video',
+      assetId: 'asset-video',
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+      loop: false,
+      controls: true,
+      muted: false,
+      autoplayInPreview: true,
+      trimStartSeconds: 0,
     };
     project.elements['shape-line'] = {
       id: 'shape-line',
@@ -266,6 +300,7 @@ describe('LeftToolPanel', () => {
         onClearElementAnimationBuild={onClearElementAnimationBuild}
         onSetPageTransition={onSetPageTransition}
         onSetElementAnimationBuilds={onSetElementAnimationBuilds}
+        onUpdateMediaPlayback={onUpdateMediaPlayback}
         onReorderElementAnimationBuild={onReorderElementAnimationBuild}
         onPlayAnimationPreview={onPlayAnimationPreview}
       />,
@@ -280,6 +315,11 @@ describe('LeftToolPanel', () => {
     expect(screen.getByLabelText('Build 1')).toBeInTheDocument();
     expect(screen.getByLabelText('Build 2')).toBeInTheDocument();
     expect(screen.getByLabelText('Build 3')).toBeInTheDocument();
+    expect(screen.getByLabelText('Build 4')).toBeInTheDocument();
+    expect(screen.getByRole('listitem', { name: 'Build 4: Movie start' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Animation for Movie start' })).toHaveValue(
+      'movie-start',
+    );
     expect(screen.getByRole('listitem', { name: 'Build 2: AI Design Revolution' })).toHaveAttribute(
       'aria-current',
       'step',
@@ -345,6 +385,10 @@ describe('LeftToolPanel', () => {
       screen.getByRole('combobox', { name: 'Start for AI Design Revolution' }),
       'after-previous',
     );
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Start for Movie start' }),
+      'after-transition',
+    );
     await user.click(
       screen.getByRole('button', { name: 'Move AI Design Revolution animation up' }),
     );
@@ -379,6 +423,17 @@ describe('LeftToolPanel', () => {
       effect: 'reveal',
       trigger: 'after-previous',
       delayMs: 0,
+    });
+    expect(onSetElementAnimationBuilds).toHaveBeenCalledWith(['video-demo'], {
+      effect: 'reveal',
+      trigger: 'after-transition',
+      delayMs: 0,
+      durationMs: 0,
+      mediaAction: 'play',
+    });
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', {
+      autoplayInPreview: true,
+      startOnClick: false,
     });
     expect(onReorderElementAnimationBuild).toHaveBeenCalledWith('text-title', 0);
     expect(onPlayAnimationPreview).toHaveBeenCalledTimes(1);

--- a/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RightPanel.test.tsx
@@ -312,6 +312,7 @@ describe('RightPanel', () => {
     const onUpdateElementStyle = vi.fn();
     const onUpdateMediaPlayback = vi.fn();
     const onReplaceVideoAsset = vi.fn();
+    const onSetElementAnimationBuilds = vi.fn();
 
     render(
       <RightPanel
@@ -328,6 +329,7 @@ describe('RightPanel', () => {
         onUpdateElementStyle={onUpdateElementStyle}
         onUpdateMediaPlayback={onUpdateMediaPlayback}
         onReplaceVideoAsset={onReplaceVideoAsset}
+        onSetElementAnimationBuilds={onSetElementAnimationBuilds}
       />,
     );
 
@@ -353,6 +355,19 @@ describe('RightPanel', () => {
     expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', {
       loop: true,
       repeatMode: 'loop',
+    });
+
+    await user.selectOptions(screen.getByLabelText('Selected video start'), 'after-previous');
+    expect(onSetElementAnimationBuilds).toHaveBeenCalledWith(['video-demo'], {
+      effect: 'reveal',
+      trigger: 'after-previous',
+      delayMs: 0,
+      durationMs: 0,
+      mediaAction: 'play',
+    });
+    expect(onUpdateMediaPlayback).toHaveBeenCalledWith('video-demo', {
+      autoplayInPreview: true,
+      startOnClick: false,
     });
 
     expect(screen.getByLabelText('Selected video trim start')).toHaveAttribute('type', 'range');
@@ -388,6 +403,40 @@ describe('RightPanel', () => {
     expect(onUpdateElementFrame).toHaveBeenCalledWith('video-demo', { width: 800 });
     await user.click(screen.getByRole('button', { name: 'Lock' }));
     expect(onSetElementLock).toHaveBeenCalledWith('video-demo', true);
+  });
+
+  it('reflects the movie start animation build in the video design settings', () => {
+    const mediaProject = createMediaProject();
+    const videoElement = mediaProject.elements['video-demo'];
+    if (videoElement?.type !== 'video') throw new Error('Expected video fixture.');
+    mediaProject.elements['video-demo'] = {
+      ...videoElement,
+      startOnClick: true,
+    };
+    mediaProject.pages[0]!.animationBuilds = [
+      {
+        id: 'video-start',
+        elementId: 'video-demo',
+        effect: 'reveal',
+        trigger: 'after-previous',
+        delayMs: 0,
+        durationMs: 0,
+        mediaAction: 'play',
+      },
+    ];
+
+    render(
+      <RightPanel
+        activeTab="design"
+        onTabChange={vi.fn()}
+        project={mediaProject}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['video-demo'] }}
+        modelStates={modelStates}
+      />,
+    );
+
+    expect(screen.getByLabelText('Selected video start')).toHaveValue('after-previous');
   });
 
   it('shows movie controls for selected GIF objects', async () => {

--- a/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
@@ -127,6 +127,68 @@ describe('useAnimationPreviewController', () => {
     });
   });
 
+  it('does not hide video media-play builds while waiting for their start trigger', () => {
+    const project = createProject();
+    project.assets.video = {
+      id: 'video',
+      type: 'video',
+      name: 'Clip',
+      mimeType: 'video/mp4',
+    };
+    project.elements.video = {
+      id: 'video',
+      type: 'video',
+      assetId: 'video',
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360,
+      rotation: 0,
+      opacity: 1,
+      visible: true,
+      locked: false,
+      loop: false,
+      controls: true,
+      muted: false,
+      autoplayInPreview: true,
+      trimStartSeconds: 0,
+    };
+    project.pages[0]!.elementIds = ['video'];
+    project.pages[0]!.animationBuilds = [
+      {
+        id: 'video-play',
+        elementId: 'video',
+        effect: 'reveal',
+        trigger: 'on-click',
+        delayMs: 0,
+        durationMs: 0,
+        mediaAction: 'play',
+      },
+    ];
+    const projectRef = { current: project };
+    const activePageIdRef = { current: 'page-1' };
+    const { result } = renderHook(() =>
+      useAnimationPreviewController({
+        activePageIdRef,
+        projectRef,
+        setActivePageId: vi.fn(),
+        setSelectedElementIds: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.playAnimationPreview('page-1', 'presenter');
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(result.current.animationPreview).toMatchObject({
+      activeBuildElementId: 'video',
+      hiddenElementIds: [],
+      phase: 'waiting',
+      waitingForClick: true,
+    });
+  });
+
   it('reports the current presenter page synchronously during presentation navigation', () => {
     const projectRef = { current: createProject() };
     const activePageIdRef = { current: 'page-1' };


### PR DESCRIPTION
## Summary
- Map PPTX video objects into the project model with playback animation metadata
- Add animation preview and playback control for video elements in the editor and public viewer
- Update editor panels and shell state so video animations are exposed consistently across the UI
- Expand PPTX import and UI unit coverage for the new playback flow

## Testing
- Added and updated unit tests for PPTX import, canvas rendering, editor shell, panels, and animation preview controller
- Not run (not requested)