### PR TITLE
Add GIPHY MP4 support for inserted GIFs

### DIFF
--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -212,6 +212,7 @@ export interface StockMediaItem {
   authorUrl?: string | undefined;
   thumbnailUrl: string;
   mediaUrl: string;
+  videoUrl?: string | undefined;
   width: number;
   height: number;
   downloadLocation?: string | undefined;

--- a/apps/editor/src/services/stock-media/stockMediaService.ts
+++ b/apps/editor/src/services/stock-media/stockMediaService.ts
@@ -44,14 +44,18 @@ interface GiphyResponse {
   username?: unknown;
   url?: unknown;
   images?: {
+    downsized_small?: GiphyImageResponse;
     downsized_medium?: GiphyImageResponse;
     original?: GiphyImageResponse;
     fixed_width?: GiphyImageResponse;
+    fixed_height?: GiphyImageResponse;
     preview_gif?: GiphyImageResponse;
+    preview?: GiphyImageResponse;
   };
 }
 
 interface GiphyImageResponse {
+  mp4?: unknown;
   url?: unknown;
   width?: unknown;
   height?: unknown;
@@ -123,6 +127,12 @@ function mapUnsplashPhoto(photo: UnsplashPhotoResponse): StockMediaItem | null {
 function mapGiphyGif(gif: GiphyResponse): StockMediaItem | null {
   const media = gif.images?.downsized_medium ?? gif.images?.original;
   const thumbnail = gif.images?.fixed_width ?? gif.images?.preview_gif ?? media;
+  const video =
+    gif.images?.original?.mp4 ??
+    gif.images?.fixed_width?.mp4 ??
+    gif.images?.fixed_height?.mp4 ??
+    gif.images?.downsized_small?.mp4 ??
+    gif.images?.preview?.mp4;
   if (!isNonEmptyString(gif.id) || !isSafeRemoteUrl(media?.url) || !isSafeRemoteUrl(thumbnail?.url))
     return null;
 
@@ -135,6 +145,7 @@ function mapGiphyGif(gif: GiphyResponse): StockMediaItem | null {
     authorUrl: isSafeRemoteUrl(gif.url) ? gif.url : undefined,
     thumbnailUrl: thumbnail.url,
     mediaUrl: media.url,
+    ...(isSafeRemoteUrl(video) ? { videoUrl: video } : {}),
     width: readPositiveNumber(media.width, 480),
     height: readPositiveNumber(media.height, 270),
   };

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -1791,7 +1791,7 @@ function CanvasVideoElement({
       aria-label={assetName}
       autoPlay={autoplay}
       className="canvas-media-element"
-      controls={interactive && element.controls}
+      controls={false}
       data-trim-end={element.trimEndSeconds ?? ''}
       data-trim-start={element.trimStartSeconds}
       loop={repeatMode === 'loop' && element.trimEndSeconds === undefined}

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -790,17 +790,6 @@ function ElementDesignInspector({
                 }}
               />
             </label>
-            {element.type === 'video' ? (
-              <label className="design-control ew-field-scope">
-                <span>Controls</span>
-                <input
-                  aria-label="Show selected video controls"
-                  checked={element.controls}
-                  type="checkbox"
-                  onChange={(event) => onUpdateMedia({ controls: event.target.checked })}
-                />
-              </label>
-            ) : null}
           </section>
         </>
       ) : null}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -3883,7 +3883,7 @@ export function useEditorViewModel(services: AppServices) {
     addRecentStockMedia(item);
   }
 
-  function insertRemoteGif(item: StockMediaItem) {
+  function commitRemoteGifElement(item: StockMediaItem) {
     if (item.kind !== 'gif') return;
     const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
     if (!page) return;
@@ -3928,9 +3928,75 @@ export function useEditorViewModel(services: AppServices) {
     addRecentStockMedia(item);
   }
 
+  async function insertRemoteGif(item: StockMediaItem) {
+    if (item.kind !== 'gif') return;
+    if (!item.videoUrl) {
+      commitRemoteGifElement(item);
+      return;
+    }
+    const videoUrl = item.videoUrl;
+    const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
+    if (!page) return;
+
+    try {
+      const mediaSize = await readVideoSize(videoUrl);
+      const assetId = createPrefixedId('asset');
+      const elementId = createPrefixedId('video');
+      const fittedMedia = fitImageWithinPage({
+        imageWidth: item.width || mediaSize.width,
+        imageHeight: item.height || mediaSize.height,
+        pageWidth: page.width,
+        pageHeight: page.height,
+      });
+
+      commitProject(
+        (currentProject) =>
+          new basicCommands.AddMediaElementCommand(activePageId, {
+            asset: {
+              id: assetId,
+              type: 'video',
+              name: item.title,
+              mimeType: 'video/mp4',
+              objectUrl: videoUrl,
+              storage: 'remote',
+            },
+            element: {
+              id: elementId,
+              type: 'video',
+              assetId,
+              x: fittedMedia.x,
+              y: fittedMedia.y,
+              width: fittedMedia.width,
+              height: fittedMedia.height,
+              rotation: 0,
+              locked: false,
+              visible: true,
+              opacity: 1,
+              loop: true,
+              controls: true,
+              muted: true,
+              autoplayInPreview: true,
+              trimStartSeconds: 0,
+              repeatMode: 'loop',
+              ...(mediaSize.durationSeconds !== undefined
+                ? {
+                    durationSeconds: mediaSize.durationSeconds,
+                    trimEndSeconds: mediaSize.durationSeconds,
+                  }
+                : {}),
+            },
+          }).execute(currentProject),
+        { selectedElementIds: [elementId] },
+      );
+      addRecentStockMedia(item);
+    } catch {
+      commitRemoteGifElement(item);
+    }
+  }
+
   function insertStockMedia(item: StockMediaItem) {
     if (item.kind === 'gif') {
-      insertRemoteGif(item);
+      void insertRemoteGif(item);
       return;
     }
     void insertRemoteImage(item);

--- a/apps/editor/tests/unit/services/stockMediaService.test.ts
+++ b/apps/editor/tests/unit/services/stockMediaService.test.ts
@@ -123,8 +123,15 @@ describe('BrowserStockMediaService', () => {
                   width: '480',
                   height: '270',
                 },
+                original: {
+                  url: 'https://media.giphy.com/media/gif-1/original.gif',
+                  mp4: 'https://media.giphy.com/media/gif-1/giphy.mp4',
+                  width: '480',
+                  height: '270',
+                },
                 fixed_width: {
                   url: 'https://media.giphy.com/media/gif-1/200w.gif',
+                  mp4: 'https://media.giphy.com/media/gif-1/200w.mp4',
                   width: '200',
                   height: '113',
                 },
@@ -148,6 +155,7 @@ describe('BrowserStockMediaService', () => {
         authorUrl: 'https://giphy.com/gifs/gif-1',
         thumbnailUrl: 'https://media.giphy.com/media/gif-1/200w.gif',
         mediaUrl: 'https://media.giphy.com/media/gif-1/giphy.gif',
+        videoUrl: 'https://media.giphy.com/media/gif-1/giphy.mp4',
         width: 480,
         height: 270,
       },

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -489,7 +489,7 @@ describe('CanvasWorkspace', () => {
     expect(editorVideo).toBeInTheDocument();
     expect(editorVideo.autoplay).toBe(false);
     expect(editorVideo.loop).toBe(false);
-    expect(editorVideo.controls).toBe(true);
+    expect(editorVideo.controls).toBe(false);
     expect(editorVideo.muted).toBe(true);
     expect(editorVideo.volume).toBe(0.75);
     expect(editorVideo.preload).toBe('auto');
@@ -508,13 +508,13 @@ describe('CanvasWorkspace', () => {
       'video[aria-label="Demo clip"]',
     ) as HTMLVideoElement;
     expect(previewVideo.autoplay).toBe(true);
-    expect(previewVideo.controls).toBe(true);
+    expect(previewVideo.controls).toBe(false);
     expect(previewVideo.preload).toBe('auto');
     expect(previewVideo.dataset.trimStart).toBe('2');
     expect(previewVideo.dataset.trimEnd).toBe('6');
   });
 
-  it('allows native controls on the selected video in editor mode', () => {
+  it('keeps native video controls hidden while selected in editor mode', () => {
     const project = createMediaProject();
     const { container, rerender } = render(
       <CanvasWorkspace
@@ -541,6 +541,7 @@ describe('CanvasWorkspace', () => {
       'video[aria-label="Demo clip"]',
     ) as HTMLVideoElement;
     expect(selectedVideo.style.pointerEvents).toBe('auto');
+    expect(selectedVideo.controls).toBe(false);
   });
 
   it('seeks the selected video when trim sliders update the boundaries', () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -140,6 +140,7 @@ const stockGif: StockMediaItem = {
   authorName: 'Motion Studio',
   thumbnailUrl: 'https://media.giphy.com/media/gif-1/200w.gif',
   mediaUrl: 'https://media.giphy.com/media/gif-1/giphy.gif',
+  videoUrl: 'https://media.giphy.com/media/gif-1/giphy.mp4',
   width: 480,
   height: 270,
 };
@@ -788,9 +789,10 @@ describe('EditorShell', () => {
     expect(stockMediaService.trackedItems).toEqual([stockImage]);
   });
 
-  it('inserts and selects a GIPHY GIF from the Elements panel', async () => {
+  it('inserts and selects a GIPHY GIF movie from the Elements panel', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
+    mockVideoMetadataLoad();
     services.stockMediaService = new ReadyStockMediaService();
 
     render(<EditorShell services={services} />);
@@ -801,9 +803,14 @@ describe('EditorShell', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
         'data-selected-elements',
-        expect.stringMatching(/^gif-/),
+        expect.stringMatching(/^video-/),
       );
     });
+    expect(screen.getByLabelText('Launch GIF').tagName.toLowerCase()).toBe('video');
+    expect(screen.getByLabelText('Launch GIF')).toHaveAttribute(
+      'src',
+      'https://media.giphy.com/media/gif-1/giphy.mp4',
+    );
   });
 
   it('shows a generic API key error when stock image search is rejected', async () => {


### PR DESCRIPTION
## Summary
- Map GIPHY MP4 variants into stock media items so GIF results can carry a playable video URL.
- Insert GIPHY GIFs as video elements when an MP4 source is available, with sizing based on remote video metadata.
- Hide native video controls in the editor and canvas, and update the related UI and unit tests.

## Testing
- Updated unit coverage for GIPHY media mapping, canvas video rendering, and editor insertion behavior.
- Local validation reflected in the updated test expectations for GIF movie insertion and hidden controls.