### PR TITLE
Improve font import resolution and preserve imported text fonts

### DIFF
--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -140,8 +140,25 @@ export interface FontImportRequest {
   fontWeight: number;
 }
 
+export type FontResolutionStatus =
+  | 'available-system'
+  | 'downloaded-exact'
+  | 'downloaded-compatible'
+  | 'missing-needs-user'
+  | 'failed';
+
+export interface FontResolution {
+  family?: string;
+  fontStyle: 'normal' | 'italic';
+  fontWeight: number;
+  message?: string;
+  requestedFamily: string;
+  status: FontResolutionStatus;
+}
+
 export interface FontImportResult {
   fonts: Record<string, ProjectFont>;
+  resolutions: FontResolution[];
   warnings: ImportWarning[];
 }
 

--- a/apps/editor/src/services/fonts/googleFontsImportService.ts
+++ b/apps/editor/src/services/fonts/googleFontsImportService.ts
@@ -1,5 +1,10 @@
 import type { ImportWarning, ProjectDocument, ProjectFont } from '../../domain/documents/model';
-import type { FontImportRequest, FontImportResult, FontImportService } from '../contracts/interfaces';
+import type {
+  FontImportRequest,
+  FontImportResult,
+  FontImportService,
+  FontResolution,
+} from '../contracts/interfaces';
 import { googleFontsCatalog } from './googleFontsCatalog';
 
 interface BrowserGoogleFontsImportServiceOptions {
@@ -35,8 +40,13 @@ function createCssUrl(request: FontImportRequest) {
   return `${GOOGLE_FONTS_CSS_ORIGIN}/css2?family=${encodeGoogleFontFamily(request)}&display=swap`;
 }
 
-function extractWoff2Url(css: string) {
-  const match = css.match(/url\((https:\/\/fonts\.gstatic\.com\/[^)]+?\.woff2)\)/);
+function getCssProperty(block: string, property: string) {
+  const match = block.match(new RegExp(`${property}\\s*:\\s*([^;]+)`, 'i'));
+  return match?.[1]?.trim().replace(/^["']|["']$/g, '');
+}
+
+function getCssFontUrl(block: string) {
+  const match = block.match(/url\((https:\/\/fonts\.gstatic\.com\/[^)]+?\.woff2)\)/);
   return match?.[1];
 }
 
@@ -49,11 +59,52 @@ function isAllowedFontUrl(value: string) {
   }
 }
 
+function fontWeightMatches(cssWeight: string | undefined, requestedWeight: number) {
+  if (!cssWeight) return true;
+  const weights = cssWeight
+    .split(/\s+/)
+    .map((weight) => Number(weight))
+    .filter(Number.isFinite);
+  if (weights.length === 0) return true;
+  if (weights.length === 1) return weights[0] === requestedWeight;
+  const minimum = weights[0] ?? requestedWeight;
+  const maximum = weights[1] ?? minimum;
+  return requestedWeight >= minimum && requestedWeight <= maximum;
+}
+
+function extractWoff2Url(css: string, request: FontImportRequest) {
+  const blocks = Array.from(css.matchAll(/@font-face\s*{([^}]+)}/gi)).map((match) => match[1] ?? '');
+  const matchingBlock = blocks.find((block) => {
+    const style = getCssProperty(block, 'font-style');
+    const weight = getCssProperty(block, 'font-weight');
+    return (!style || style === request.fontStyle) && fontWeightMatches(weight, request.fontWeight);
+  });
+  const matchedUrl = matchingBlock ? getCssFontUrl(matchingBlock) : undefined;
+  if (matchedUrl) return matchedUrl;
+  return blocks.map(getCssFontUrl).find((url): url is string => Boolean(url));
+}
+
 function createWarning(request: FontImportRequest, reason: string, code = 'font-download-failed'): ImportWarning {
   return {
     code,
     message: `Could not download ${request.family} ${request.fontWeight}: ${reason}`,
     severity: 'warning',
+  };
+}
+
+function createMissingWarning(request: FontImportRequest): ImportWarning {
+  return {
+    code: 'font-missing',
+    message: `${request.family} is not available locally and no downloadable match is configured. Replace it or upload the font to preserve the PowerPoint design.`,
+    severity: 'warning',
+  };
+}
+
+function createSubstitutionWarning(request: FontImportRequest, family: string): ImportWarning {
+  return {
+    code: 'font-substituted',
+    message: `Using ${family} as a compatible substitute for ${request.family}.`,
+    severity: 'info',
   };
 }
 
@@ -65,29 +116,40 @@ function getFontSet(options: BrowserGoogleFontsImportServiceOptions) {
   return options.fontSet ?? (typeof document !== 'undefined' ? document.fonts : undefined);
 }
 
+function escapeFontFamily(family: string) {
+  return family.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}
+
 export class BrowserGoogleFontsImportService implements FontImportService {
   private readonly requestFetch: typeof fetch;
-  private readonly downloadableFamilies = new Map(
-    googleFontsCatalog.map((font) => [font.family.toLowerCase(), font.family]),
-  );
+  private readonly downloadableFamilies = new Map<string, { family: string; exact: boolean }>();
 
   constructor(private readonly options: BrowserGoogleFontsImportServiceOptions = {}) {
     this.requestFetch = options.fetch ?? getDefaultFetch();
+    for (const font of googleFontsCatalog) {
+      this.downloadableFamilies.set(font.family.toLowerCase(), { exact: true, family: font.family });
+      for (const alias of font.aliases ?? []) {
+        this.downloadableFamilies.set(alias.toLowerCase(), { exact: false, family: font.family });
+      }
+    }
   }
 
   async resolveAndDownloadFonts(requests: FontImportRequest[]): Promise<FontImportResult> {
     const fonts: Record<string, ProjectFont> = {};
+    const resolutions: FontResolution[] = [];
     const warnings: ImportWarning[] = [];
     for (const request of requests) {
       const result = await this.downloadFont(request);
       if ('font' in result) {
         fonts[result.font.id] = result.font;
-      } else {
+      }
+      resolutions.push(result.resolution);
+      if ('warning' in result) {
         warnings.push(result.warning);
       }
     }
     await this.loadProjectFonts({ fonts } as ProjectDocument);
-    return { fonts, warnings };
+    return { fonts, resolutions, warnings };
   }
 
   listDownloadableFonts() {
@@ -113,37 +175,85 @@ export class BrowserGoogleFontsImportService implements FontImportService {
 
   private async downloadFont(
     request: FontImportRequest,
-  ): Promise<{ font: ProjectFont } | { warning: ImportWarning }> {
-    const catalogFamily = this.downloadableFamilies.get(request.family.toLowerCase());
-    if (!catalogFamily) {
+  ): Promise<
+    | { font: ProjectFont; resolution: FontResolution; warning?: ImportWarning }
+    | { resolution: FontResolution }
+    | { resolution: FontResolution; warning: ImportWarning }
+  > {
+    const localResolution = this.resolveLocalFont(request);
+    if (localResolution) return { resolution: localResolution };
+
+    const catalogMatch = this.downloadableFamilies.get(request.family.toLowerCase());
+    if (!catalogMatch) {
       return {
-        warning: createWarning(
-          request,
-          'font family is not in the local Google Fonts catalog',
-          'font-download-unavailable',
-        ),
+        resolution: {
+          fontStyle: request.fontStyle,
+          fontWeight: request.fontWeight,
+          message: `${request.family} is missing and needs a replacement or uploaded font file.`,
+          requestedFamily: request.family,
+          status: 'missing-needs-user',
+        },
+        warning: createMissingWarning(request),
       };
     }
-    const normalizedRequest = { ...request, family: catalogFamily };
+    const normalizedRequest = { ...request, family: catalogMatch.family };
     const cssResponse = await this.requestFetch(createCssUrl(normalizedRequest), {
       headers: { Accept: 'text/css' },
     });
     if (!cssResponse.ok) {
-      return { warning: createWarning(normalizedRequest, `Google Fonts returned ${cssResponse.status}`) };
+      return {
+        resolution: {
+          family: normalizedRequest.family,
+          fontStyle: normalizedRequest.fontStyle,
+          fontWeight: normalizedRequest.fontWeight,
+          message: `Google Fonts returned ${cssResponse.status}.`,
+          requestedFamily: request.family,
+          status: 'failed',
+        },
+        warning: createWarning(normalizedRequest, `Google Fonts returned ${cssResponse.status}`),
+      };
     }
 
-    const fontUrl = extractWoff2Url(await cssResponse.text());
+    const fontUrl = extractWoff2Url(await cssResponse.text(), normalizedRequest);
     if (!fontUrl || !isAllowedFontUrl(fontUrl)) {
-      return { warning: createWarning(normalizedRequest, 'no downloadable woff2 file was found') };
+      return {
+        resolution: {
+          family: normalizedRequest.family,
+          fontStyle: normalizedRequest.fontStyle,
+          fontWeight: normalizedRequest.fontWeight,
+          message: 'No downloadable WOFF2 file was found.',
+          requestedFamily: request.family,
+          status: 'failed',
+        },
+        warning: createWarning(normalizedRequest, 'no downloadable woff2 file was found'),
+      };
     }
 
     const fontResponse = await this.requestFetch(fontUrl, { headers: { Accept: 'font/woff2' } });
     if (!fontResponse.ok) {
-      return { warning: createWarning(normalizedRequest, `font file returned ${fontResponse.status}`) };
+      return {
+        resolution: {
+          family: normalizedRequest.family,
+          fontStyle: normalizedRequest.fontStyle,
+          fontWeight: normalizedRequest.fontWeight,
+          message: `Font file returned ${fontResponse.status}.`,
+          requestedFamily: request.family,
+          status: 'failed',
+        },
+        warning: createWarning(normalizedRequest, `font file returned ${fontResponse.status}`),
+      };
     }
 
     const blob = await fontResponse.blob();
     const id = createFontId(normalizedRequest);
+    const status = catalogMatch.exact ? 'downloaded-exact' : 'downloaded-compatible';
+    const resolution: FontResolution = {
+      family: normalizedRequest.family,
+      fontStyle: normalizedRequest.fontStyle,
+      fontWeight: normalizedRequest.fontWeight,
+      requestedFamily: request.family,
+      status,
+    };
     return {
       font: {
         id,
@@ -158,6 +268,26 @@ export class BrowserGoogleFontsImportService implements FontImportService {
         objectUrl: URL.createObjectURL(blob),
         sourceUrl: fontUrl,
       },
+      resolution,
+      ...(!catalogMatch.exact ? { warning: createSubstitutionWarning(request, normalizedRequest.family) } : {}),
     };
+  }
+
+  private resolveLocalFont(request: FontImportRequest): FontResolution | undefined {
+    const fontSet = getFontSet(this.options);
+    if (!fontSet || typeof fontSet.check !== 'function') return undefined;
+    try {
+      const descriptor = `${request.fontStyle} ${request.fontWeight} 16px "${escapeFontFamily(request.family)}"`;
+      if (!fontSet.check(descriptor)) return undefined;
+      return {
+        family: request.family,
+        fontStyle: request.fontStyle,
+        fontWeight: request.fontWeight,
+        requestedFamily: request.family,
+        status: 'available-system',
+      };
+    } catch {
+      return undefined;
+    }
   }
 }

--- a/apps/editor/src/services/importing/pptx/pptxFontRequests.ts
+++ b/apps/editor/src/services/importing/pptx/pptxFontRequests.ts
@@ -4,8 +4,6 @@ import type { FontImportRequest } from '../../contracts/interfaces';
 const SYSTEM_FONT_FAMILIES = new Set([
   'arial',
   'avenir',
-  'calibri',
-  'cambria',
   'candara',
   'consolas',
   'courier',
@@ -22,6 +20,17 @@ const SYSTEM_FONT_FAMILIES = new Set([
   'verdana',
 ]);
 
+const DOWNLOADABLE_COMPATIBLE_FONT_FAMILIES = new Set([
+  'arial',
+  'calibri',
+  'cambria',
+  'courier',
+  'courier new',
+  'helvetica',
+  'times',
+  'times new roman',
+]);
+
 function normalizeFontFamily(fontFamily: string) {
   return fontFamily
     .split(',')
@@ -34,6 +43,7 @@ function normalizeFontFamily(fontFamily: string) {
 function shouldDownloadFont(fontFamily: string | undefined) {
   if (!fontFamily) return false;
   if (fontFamily.startsWith('+')) return false;
+  if (DOWNLOADABLE_COMPATIBLE_FONT_FAMILIES.has(fontFamily.toLowerCase())) return true;
   return !SYSTEM_FONT_FAMILIES.has(fontFamily.toLowerCase());
 }
 

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -112,6 +112,12 @@ function fontMatchesQuery(font: FontCatalogItem, query: string) {
   );
 }
 
+function collectDocumentTextFontFamilies(project: ProjectDocument) {
+  return Object.values(project.elements)
+    .filter((element) => element.type === 'text')
+    .map((element) => element.fontFamily);
+}
+
 export function DesignPanel({
   project,
   activePageId,
@@ -140,8 +146,14 @@ export function DesignPanel({
   const selectedElement = getSelectedElement(project, selection);
   const backgroundColor = page ? getBackgroundColor(page.background) : '#050D10';
   const projectFontFamilies = useMemo(
-    () => Array.from(new Set(Object.values(project.fonts ?? {}).map((font) => font.family))).sort(),
-    [project.fonts],
+    () =>
+      Array.from(
+        new Set([
+          ...Object.values(project.fonts ?? {}).map((font) => font.family),
+          ...collectDocumentTextFontFamilies(project),
+        ]),
+      ).sort(),
+    [project],
   );
   const fontFamilyOptions = useMemo(
     () =>

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -1893,6 +1893,7 @@ export function useEditorViewModel(services: AppServices) {
         fontRequests.length > 0
           ? await services.fontImportService.resolveAndDownloadFonts(fontRequests).catch(() => ({
               fonts: {},
+              resolutions: [],
               warnings: [
                 {
                   code: 'font-download-failed',
@@ -1960,6 +1961,25 @@ export function useEditorViewModel(services: AppServices) {
       setVersionHistoryEntries([]);
       writeProjectNameToUrl(normalizedProject.name);
       setPresentationImportProgress(undefined);
+      const missingFontCount = fontImportResult.warnings.filter(
+        (warning) => warning.code === 'font-missing',
+      ).length;
+      const substitutedFontCount = fontImportResult.warnings.filter(
+        (warning) => warning.code === 'font-substituted',
+      ).length;
+      if (missingFontCount > 0 || substitutedFontCount > 0) {
+        const parts = [
+          missingFontCount > 0
+            ? `${missingFontCount.toLocaleString()} missing font${missingFontCount === 1 ? '' : 's'}`
+            : undefined,
+          substitutedFontCount > 0
+            ? `${substitutedFontCount.toLocaleString()} substituted font${
+                substitutedFontCount === 1 ? '' : 's'
+              }`
+            : undefined,
+        ].filter(Boolean);
+        setPersistenceNotice(`PowerPoint imported with ${parts.join(' and ')}.`);
+      }
     } catch (error) {
       setPresentationImportProgress(undefined);
       pptxImportLogger.error('PowerPoint import failed.', error);

--- a/apps/editor/tests/unit/services/googleFontsImportService.test.ts
+++ b/apps/editor/tests/unit/services/googleFontsImportService.test.ts
@@ -72,6 +72,128 @@ describe('BrowserGoogleFontsImportService', () => {
     expect(createObjectUrl).toHaveBeenCalled();
   });
 
+  it('downloads a compatible Google Font when an imported Office font has a known substitute', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url.startsWith('https://fonts.googleapis.com/css2')) {
+        expect(url).toContain('family=Carlito:wght@400');
+        return Promise.resolve(
+          new Response(
+            `@font-face {
+              font-family: 'Carlito';
+              font-style: normal;
+              font-weight: 400;
+              src: url(https://fonts.gstatic.com/s/carlito/v3/carlito-400.woff2) format('woff2');
+            }`,
+            { status: 200, headers: { 'content-type': 'text/css' } },
+          ),
+        );
+      }
+      if (url === 'https://fonts.gstatic.com/s/carlito/v3/carlito-400.woff2') {
+        return Promise.resolve(
+          new Response(new TextEncoder().encode('font'), {
+            status: 200,
+            headers: { 'content-type': 'font/woff2' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:carlito');
+    const service = new BrowserGoogleFontsImportService({ fetch: fetchMock });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'Calibri', fontStyle: 'normal', fontWeight: 400 },
+    ]);
+
+    expect(result.fonts).toMatchObject({
+      'google-fonts-carlito-normal-400': {
+        family: 'Carlito',
+        requestedFamily: 'Calibri',
+      },
+    });
+    expect(result.resolutions).toEqual([
+      expect.objectContaining({
+        family: 'Carlito',
+        requestedFamily: 'Calibri',
+        status: 'downloaded-compatible',
+      }),
+    ]);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        code: 'font-substituted',
+        message: 'Using Carlito as a compatible substitute for Calibri.',
+        severity: 'info',
+      }),
+    ]);
+  });
+
+  it('selects the requested font face when Google Fonts CSS contains multiple files', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url.startsWith('https://fonts.googleapis.com/css2')) {
+        return Promise.resolve(
+          new Response(
+            `@font-face {
+              font-family: 'Montserrat';
+              font-style: normal;
+              font-weight: 400;
+              src: url(https://fonts.gstatic.com/s/montserrat/v31/montserrat-400.woff2) format('woff2');
+            }
+            @font-face {
+              font-family: 'Montserrat';
+              font-style: normal;
+              font-weight: 700;
+              src: url(https://fonts.gstatic.com/s/montserrat/v31/montserrat-700.woff2) format('woff2');
+            }`,
+            { status: 200, headers: { 'content-type': 'text/css' } },
+          ),
+        );
+      }
+      if (url === 'https://fonts.gstatic.com/s/montserrat/v31/montserrat-700.woff2') {
+        return Promise.resolve(
+          new Response(new TextEncoder().encode('font'), {
+            status: 200,
+            headers: { 'content-type': 'font/woff2' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:montserrat-700');
+    const service = new BrowserGoogleFontsImportService({ fetch: fetchMock });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'Montserrat', fontStyle: 'normal', fontWeight: 700 },
+    ]);
+
+    expect(result.fonts['google-fonts-montserrat-normal-700']?.sourceUrl).toBe(
+      'https://fonts.gstatic.com/s/montserrat/v31/montserrat-700.woff2',
+    );
+  });
+
+  it('marks locally available fonts without downloading a duplicate', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 404 })));
+    const service = new BrowserGoogleFontsImportService({
+      fetch: fetchMock,
+      fontSet: { check: vi.fn(() => true) } as unknown as FontFaceSet,
+    });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'Montserrat', fontStyle: 'normal', fontWeight: 400 },
+    ]);
+
+    expect(result.fonts).toEqual({});
+    expect(result.warnings).toEqual([]);
+    expect(result.resolutions).toEqual([
+      expect.objectContaining({
+        requestedFamily: 'Montserrat',
+        status: 'available-system',
+      }),
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('returns a warning instead of failing when Google Fonts has no exact match', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 400 })));
     const service = new BrowserGoogleFontsImportService({
@@ -85,7 +207,10 @@ describe('BrowserGoogleFontsImportService', () => {
     expect(result.fonts).toEqual({});
     expect(result.warnings[0]?.message).toContain('Missing Font');
     expect(result.warnings).toMatchObject([
-      { code: 'font-download-unavailable', severity: 'warning' },
+      { code: 'font-missing', severity: 'warning' },
+    ]);
+    expect(result.resolutions).toMatchObject([
+      { requestedFamily: 'Missing Font', status: 'missing-needs-user' },
     ]);
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/editor/tests/unit/services/pptxFontRequests.test.ts
+++ b/apps/editor/tests/unit/services/pptxFontRequests.test.ts
@@ -62,7 +62,7 @@ describe('pptxFontRequests', () => {
           fontSize: 20,
           fontWeight: 400,
         },
-        system: {
+        compatibleOffice: {
           id: 'system',
           type: 'text',
           text: 'System',
@@ -76,7 +76,25 @@ describe('pptxFontRequests', () => {
           opacity: 1,
           align: 'left',
           fill: '#111111',
-          fontFamily: 'Arial',
+          fontFamily: 'Calibri',
+          fontSize: 20,
+          fontWeight: 400,
+        },
+        system: {
+          id: 'system-available',
+          type: 'text',
+          text: 'System',
+          x: 0,
+          y: 160,
+          width: 100,
+          height: 30,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          align: 'left',
+          fill: '#111111',
+          fontFamily: 'Verdana',
           fontSize: 20,
           fontWeight: 400,
         },
@@ -86,6 +104,7 @@ describe('pptxFontRequests', () => {
     expect(pptxFontRequests.collect(project)).toEqual([
       { family: 'Montserrat', fontStyle: 'normal', fontWeight: 700 },
       { family: 'Merriweather', fontStyle: 'normal', fontWeight: 400 },
+      { family: 'Calibri', fontStyle: 'normal', fontWeight: 400 },
     ]);
   });
 });

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -89,6 +89,22 @@ function createProjectWithSelectedText(): ProjectDocument {
   };
 }
 
+function createProjectWithImportedTextFont(): ProjectDocument {
+  const project = createProjectWithSelectedText();
+  const text = project.elements['text-test'];
+  if (text?.type !== 'text') return project;
+  return {
+    ...project,
+    elements: {
+      ...project.elements,
+      [text.id]: {
+        ...text,
+        fontFamily: 'American Typewriter',
+      },
+    },
+  };
+}
+
 describe('DesignPanel', () => {
   it('updates selected shape fill and border modes', async () => {
     const user = userEvent.setup();
@@ -204,6 +220,19 @@ describe('DesignPanel', () => {
     expect(headings).toContain('Typography');
     expect(headings).toContain('Selection');
     expect(headings.indexOf('Typography')).toBeLessThan(headings.indexOf('Selection'));
+  });
+
+  it('includes the selected imported font in the font dropdown options', () => {
+    render(
+      <DesignPanel
+        project={createProjectWithImportedTextFont()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+      />,
+    );
+
+    expect(screen.getByLabelText('Selected text font')).toHaveValue('American Typewriter');
+    expect(screen.getByRole('option', { name: 'American Typewriter' })).toBeInTheDocument();
   });
 
   it('keeps selected text style controls in the Style tab only', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -429,6 +429,7 @@ class FailingFontImportService implements FontImportService {
       this.resolveFonts = () => {
         resolve({
           fonts: {},
+          resolutions: [],
           warnings: [
             {
               code: 'font-download-failed',

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -16,7 +16,7 @@ describe('PublicDeckViewer', () => {
       return [];
     },
     resolveAndDownloadFonts(): Promise<FontImportResult> {
-      return Promise.resolve({ fonts: {}, warnings: [] });
+      return Promise.resolve({ fonts: {}, resolutions: [], warnings: [] });
     },
     loadProjectFonts(): Promise<void> {
       return Promise.resolve();


### PR DESCRIPTION
## Summary
- Add structured font resolution metadata to track system availability, exact downloads, compatible substitutes, missing fonts, and failures.
- Expand PPTX font collection and import handling so imported text fonts stay visible in the editor and compatible Google Fonts substitutions are surfaced clearly.
- Show a persistence notice when PowerPoint imports include missing or substituted fonts.
- Add tests covering compatible font substitution, CSS face selection, local font detection, PPTX font collection, and editor font dropdown behavior.

## Testing
- Unit tests added/updated for font import resolution, PPTX font request collection, editor font options, and shared viewer/service contracts.
- Not run (not requested).