### PR TITLE
Refine PPTX import standards and editor layout

### DIFF
--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -13,6 +13,7 @@ import type {
   SlideLayout,
   PresentationTheme,
   PlaceholderRole,
+  TextElement,
   VideoElement,
 } from '../../documents/model';
 import { collectReferencedAssetIds } from '../../assets/assetUsage';
@@ -1093,6 +1094,158 @@ class EditThemeCommand extends SaveThemeCommand {
   override readonly description: string = 'Edit theme';
 }
 
+interface LayoutTextMatch {
+  element: TextElement;
+  placeholder: TextElement;
+}
+
+function isVisibleLayoutPlaceholder(layout: SlideLayout, element: TextElement) {
+  const role = element.placeholderRole;
+  return !role || layout.placeholderVisibility[role] !== false;
+}
+
+function getLayoutTextPlaceholders(layout: SlideLayout) {
+  return layout.elementIds
+    .map((elementId) => layout.elements[elementId])
+    .filter(
+      (element): element is TextElement =>
+        element?.type === 'text' && isVisibleLayoutPlaceholder(layout, element),
+    );
+}
+
+function createPageLayoutPlaceholderId(
+  pageId: string,
+  placeholderId: string,
+  elements: Record<string, DesignElement>,
+) {
+  const baseId = `${pageId}-${placeholderId}`.replace(/[^a-zA-Z0-9_-]/g, '-');
+  if (!elements[baseId]) return baseId;
+
+  let suffix = 2;
+  while (elements[`${baseId}-${suffix}`]) suffix += 1;
+  return `${baseId}-${suffix}`;
+}
+
+function getPageTextElements(project: ProjectDocument, page: Page) {
+  return page.elementIds
+    .map((elementId) => project.elements[elementId])
+    .filter(
+      (element): element is TextElement =>
+        element?.type === 'text' && !element.locked && !element.templateSource,
+    );
+}
+
+function sortTextElementsByReadingPriority(elements: TextElement[]) {
+  return [...elements].sort((left, right) => {
+    if (left.placeholderRole === 'title' && right.placeholderRole !== 'title') return -1;
+    if (right.placeholderRole === 'title' && left.placeholderRole !== 'title') return 1;
+
+    const fontSizeDelta = right.fontSize - left.fontSize;
+    if (Math.abs(fontSizeDelta) > 8) return fontSizeDelta;
+
+    const yDelta = left.y - right.y;
+    if (Math.abs(yDelta) > 12) return yDelta;
+    return left.x - right.x;
+  });
+}
+
+function getFirstRemainingElement(
+  elements: TextElement[],
+  usedElementIds: Set<string>,
+  role?: PlaceholderRole,
+) {
+  return elements.find(
+    (element) =>
+      !usedElementIds.has(element.id) && (role === undefined || element.placeholderRole === role),
+  );
+}
+
+function getFirstRemainingPlaceholder(
+  placeholders: TextElement[],
+  usedPlaceholderIds: Set<string>,
+  role?: PlaceholderRole,
+) {
+  return placeholders.find(
+    (placeholder) =>
+      !usedPlaceholderIds.has(placeholder.id) &&
+      (role === undefined || placeholder.placeholderRole === role),
+  );
+}
+
+function createLayoutTextMatches(elements: TextElement[], placeholders: TextElement[]) {
+  const orderedElements = sortTextElementsByReadingPriority(elements);
+  const matches: LayoutTextMatch[] = [];
+  const usedElementIds = new Set<string>();
+  const usedPlaceholderIds = new Set<string>();
+
+  const addMatch = (element: TextElement | undefined, placeholder: TextElement | undefined) => {
+    if (!element || !placeholder) return;
+    matches.push({ element, placeholder });
+    usedElementIds.add(element.id);
+    usedPlaceholderIds.add(placeholder.id);
+  };
+
+  for (const role of ['title', 'body'] satisfies PlaceholderRole[]) {
+    const explicitElement = getFirstRemainingElement(orderedElements, usedElementIds, role);
+    const rolePlaceholder = getFirstRemainingPlaceholder(placeholders, usedPlaceholderIds, role);
+    addMatch(explicitElement, rolePlaceholder);
+  }
+
+  addMatch(
+    getFirstRemainingElement(orderedElements, usedElementIds),
+    getFirstRemainingPlaceholder(placeholders, usedPlaceholderIds, 'title'),
+  );
+
+  while (true) {
+    const element = getFirstRemainingElement(orderedElements, usedElementIds);
+    const placeholder =
+      getFirstRemainingPlaceholder(placeholders, usedPlaceholderIds, 'body') ??
+      getFirstRemainingPlaceholder(placeholders, usedPlaceholderIds);
+    if (!element || !placeholder) break;
+    addMatch(element, placeholder);
+  }
+
+  return matches;
+}
+
+function getReadableTextHeight(element: TextElement) {
+  const lineCount = Math.max(1, element.text.split('\n').length);
+  return element.fontSize * (element.lineHeight ?? 1.05) * lineCount;
+}
+
+function applyLayoutTextPlaceholder(element: TextElement, placeholder: TextElement): TextElement {
+  return {
+    ...element,
+    x: placeholder.x,
+    y: placeholder.y,
+    width: placeholder.width,
+    height: Math.max(placeholder.height, getReadableTextHeight(element)),
+    rotation: placeholder.rotation,
+    opacity: placeholder.opacity,
+    align: placeholder.align,
+    ...(placeholder.verticalAlign !== undefined
+      ? { verticalAlign: placeholder.verticalAlign }
+      : {}),
+    ...(placeholder.placeholderRole !== undefined
+      ? { placeholderRole: placeholder.placeholderRole }
+      : {}),
+  };
+}
+
+function createSlideTextPlaceholder(
+  pageId: string,
+  placeholder: TextElement,
+  elements: Record<string, DesignElement>,
+): TextElement {
+  const { templateSource, ...slideElement } = placeholder;
+  void templateSource;
+  return {
+    ...slideElement,
+    id: createPageLayoutPlaceholderId(pageId, placeholder.id, elements),
+    locked: false,
+  };
+}
+
 class ApplySlideLayoutCommand implements EditorCommand {
   readonly description = 'Apply slide layout';
 
@@ -1102,11 +1255,33 @@ class ApplySlideLayoutCommand implements EditorCommand {
   ) {}
 
   execute(project: ProjectDocument): ProjectDocument {
-    if (!project.slideLayouts?.[this.layoutId]) return project;
+    const layout = project.slideLayouts?.[this.layoutId];
+    const page = project.pages.find((item) => item.id === this.pageId);
+    if (!layout || !page) return project;
+
+    const elements = { ...project.elements };
+    const pageTextElements = getPageTextElements(project, page);
+    const layoutTextPlaceholders = getLayoutTextPlaceholders(layout);
+    const textMatches = createLayoutTextMatches(pageTextElements, layoutTextPlaceholders);
+    const usedPlaceholderIds = new Set(textMatches.map(({ placeholder }) => placeholder.id));
+    const elementIds = [...page.elementIds];
+
+    for (const { element, placeholder } of textMatches) {
+      elements[element.id] = applyLayoutTextPlaceholder(element, placeholder);
+    }
+
+    for (const placeholder of layoutTextPlaceholders) {
+      if (usedPlaceholderIds.has(placeholder.id)) continue;
+      const element = createSlideTextPlaceholder(page.id, placeholder, elements);
+      elements[element.id] = element;
+      elementIds.push(element.id);
+    }
+
     return {
       ...project,
+      elements,
       pages: project.pages.map((page) =>
-        page.id === this.pageId ? { ...page, layoutId: this.layoutId } : page,
+        page.id === this.pageId ? { ...page, elementIds, layoutId: this.layoutId } : page,
       ),
       updatedAt: projectMutationUtils.getProjectUpdatedAt(),
     };

--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -10,6 +10,9 @@ import type {
   ProjectDocument,
   ShapeElement,
   SlideTransition,
+  SlideLayout,
+  PresentationTheme,
+  PlaceholderRole,
   VideoElement,
 } from '../../documents/model';
 import { collectReferencedAssetIds } from '../../assets/assetUsage';
@@ -1052,6 +1055,114 @@ class TranslateTextElementsCommand implements EditorCommand {
   }
 }
 
+class ApplyThemeCommand implements EditorCommand {
+  readonly description = 'Apply theme';
+
+  constructor(private readonly themeId: string) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    if (!project.themes?.[this.themeId]) return project;
+    return {
+      ...project,
+      themeId: this.themeId,
+      themeGallery: Array.from(new Set([...(project.themeGallery ?? []), this.themeId])),
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
+class SaveThemeCommand implements EditorCommand {
+  readonly description: string = 'Save theme';
+
+  constructor(private readonly theme: PresentationTheme) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    return {
+      ...project,
+      themes: {
+        ...(project.themes ?? {}),
+        [this.theme.id]: this.theme,
+      },
+      themeGallery: Array.from(new Set([...(project.themeGallery ?? []), this.theme.id])),
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
+class EditThemeCommand extends SaveThemeCommand {
+  override readonly description: string = 'Edit theme';
+}
+
+class ApplySlideLayoutCommand implements EditorCommand {
+  readonly description = 'Apply slide layout';
+
+  constructor(
+    private readonly pageId: string,
+    private readonly layoutId: string,
+  ) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    if (!project.slideLayouts?.[this.layoutId]) return project;
+    return {
+      ...project,
+      pages: project.pages.map((page) =>
+        page.id === this.pageId ? { ...page, layoutId: this.layoutId } : page,
+      ),
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
+class SaveSlideLayoutCommand implements EditorCommand {
+  readonly description: string = 'Save slide layout';
+
+  constructor(private readonly layout: SlideLayout) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    return {
+      ...project,
+      slideLayouts: {
+        ...(project.slideLayouts ?? {}),
+        [this.layout.id]: this.layout,
+      },
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
+class EditSlideLayoutCommand extends SaveSlideLayoutCommand {
+  override readonly description: string = 'Edit slide layout';
+}
+
+class ToggleSlideLayoutPlaceholderVisibilityCommand implements EditorCommand {
+  readonly description = 'Toggle slide layout placeholder visibility';
+
+  constructor(
+    private readonly layoutId: string,
+    private readonly role: PlaceholderRole,
+    private readonly visible: boolean,
+  ) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    const layout = project.slideLayouts?.[this.layoutId];
+    if (!layout) return project;
+    return {
+      ...project,
+      slideLayouts: {
+        ...(project.slideLayouts ?? {}),
+        [this.layoutId]: {
+          ...layout,
+          placeholderVisibility: {
+            ...layout.placeholderVisibility,
+            [this.role]: this.visible,
+          },
+        },
+      },
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
 export const basicCommands = {
   AddGeneratedSlideElementCommand: applyGeneratedSlideCommand.AddGeneratedSlideElementCommand,
   PrepareGeneratedSlideCommand: applyGeneratedSlideCommand.PrepareGeneratedSlideCommand,
@@ -1087,4 +1198,11 @@ export const basicCommands = {
   ClearElementAnimationBuildCommand,
   ReorderElementAnimationBuildCommand,
   TranslateTextElementsCommand,
+  ApplyThemeCommand,
+  SaveThemeCommand,
+  EditThemeCommand,
+  ApplySlideLayoutCommand,
+  SaveSlideLayoutCommand,
+  EditSlideLayoutCommand,
+  ToggleSlideLayoutPlaceholderVisibilityCommand,
 };

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -28,6 +28,10 @@ export interface ProjectDocument {
   assets: Record<string, Asset>;
   fonts?: Record<string, ProjectFont>;
   elements: Record<string, DesignElement>;
+  themes?: Record<string, PresentationTheme>;
+  themeId?: string;
+  themeGallery?: string[];
+  slideLayouts?: Record<string, SlideLayout>;
   createdAt: string;
   updatedAt: string;
   importWarnings?: ImportWarning[];
@@ -42,6 +46,7 @@ export interface Page {
   elementIds: string[];
   transition?: SlideTransition;
   animationBuilds?: ElementAnimationBuild[];
+  layoutId?: string;
   speakerNotes?: string;
   visible?: boolean;
 }
@@ -144,6 +149,46 @@ export interface ProjectFont {
 
 export type DesignElement = TextElement | ImageElement | GifElement | VideoElement | ShapeElement;
 
+export type ElementTemplateSource = { layoutId: string; type: 'layout' };
+export type PlaceholderRole = 'body' | 'footer' | 'slideNumber' | 'title';
+
+export interface PresentationTheme {
+  id: string;
+  name: string;
+  palette: ThemePalette;
+  typography: ThemeTypography;
+  preview?: ThemePreview;
+}
+
+export interface ThemePalette {
+  accent: string;
+  background: string;
+  surface: string;
+  text: string;
+  mutedText: string;
+}
+
+export interface ThemeTypography {
+  bodyFontFamily: string;
+  headingFontFamily: string;
+}
+
+export interface ThemePreview {
+  background: string;
+  foreground: string;
+}
+
+export interface SlideLayout {
+  id: string;
+  name: string;
+  background: PageBackground;
+  elementIds: string[];
+  elements: Record<string, DesignElement>;
+  placeholderRoles: PlaceholderRole[];
+  placeholderVisibility: Record<PlaceholderRole, boolean>;
+  thumbnail?: ThemePreview;
+}
+
 export interface BaseElement {
   id: string;
   type: ElementType;
@@ -155,6 +200,8 @@ export interface BaseElement {
   locked: boolean;
   visible: boolean;
   opacity: number;
+  templateSource?: ElementTemplateSource;
+  placeholderRole?: PlaceholderRole;
 }
 
 export interface TextElement extends BaseElement {
@@ -223,4 +270,5 @@ export interface CropRect {
 export interface SelectionState {
   pageId: string;
   elementIds: string[];
+  target?: 'elements' | 'presentation' | 'slide';
 }

--- a/apps/editor/src/services/importing/pptx/pptxImportService.ts
+++ b/apps/editor/src/services/importing/pptx/pptxImportService.ts
@@ -1,5 +1,6 @@
 import type { ProjectDocument } from '../../../domain/documents/model';
 import { pptxImportLogger } from './pptxImportLogger';
+import { pptxPackage } from './pptxPackage';
 import type { PptxImportInput } from './pptxPackageTypes';
 import { pptxParser } from './pptxParser';
 import { pptxProjectMapper } from './pptxProjectMapper';
@@ -19,8 +20,9 @@ export class BrowserPptxImportService {
       fileCount: files.length,
       samplePaths: files.slice(0, 8).map((file) => file.path),
     });
-    const deck = await pptxParser.parse(files, input.file.name);
-    const project = pptxProjectMapper.map(deck, files);
+    const packageModel = await pptxPackage.create(files);
+    const deck = await pptxParser.parse({ package: packageModel, themeCache: new Map() }, input.file.name);
+    const project = pptxProjectMapper.map(deck, packageModel);
     pptxImportLogger.info('Finished PPTX import service.', {
       assetCount: Object.keys(project.assets).length,
       elementCount: Object.keys(project.elements).length,

--- a/apps/editor/src/services/importing/pptx/pptxPackage.ts
+++ b/apps/editor/src/services/importing/pptx/pptxPackage.ts
@@ -1,0 +1,134 @@
+import type { ImportWarning } from '../../../domain/documents/model';
+import type { PptxPackageFile } from './pptxPackageTypes';
+import { pptxFileUtils } from './pptxFileUtils';
+import { pptxXml } from './pptxXml';
+
+export interface PptxRelationship {
+  id: string;
+  target: string;
+  targetMode: 'External' | 'Internal';
+  type: string;
+}
+
+export interface PptxPackage {
+  files: PptxPackageFile[];
+  getContentType(path: string): string | undefined;
+  getFile(path: string): PptxPackageFile | undefined;
+  getRelationships(sourcePath: string): Map<string, PptxRelationship>;
+  readText(path: string | undefined): Promise<string | undefined>;
+  warnings: ImportWarning[];
+}
+
+const CONTENT_TYPES_PATH = '[Content_Types].xml';
+const PACKAGE_RELS_PATH = '_rels/.rels';
+
+function relsPathFor(sourcePath: string) {
+  if (!sourcePath) return PACKAGE_RELS_PATH;
+  const parts = sourcePath.split('/');
+  const fileName = parts.pop() ?? '';
+  return `${parts.join('/')}/_rels/${fileName}.rels`;
+}
+
+async function readText(file: PptxPackageFile | undefined) {
+  if (!file) return undefined;
+  return file.blob.text();
+}
+
+function extensionFor(path: string) {
+  const fileName = path.split('/').at(-1) ?? path;
+  const dotIndex = fileName.lastIndexOf('.');
+  return dotIndex >= 0 ? fileName.slice(dotIndex + 1).toLowerCase() : '';
+}
+
+function parseContentTypes(xml: string | undefined) {
+  const defaults = new Map<string, string>();
+  const overrides = new Map<string, string>();
+  if (!xml) return { defaults, overrides };
+  const document = pptxXml.parseXml(xml);
+  for (const element of pptxXml.descendants(document, 'Default')) {
+    const extension = element.getAttribute('Extension')?.toLowerCase();
+    const contentType = element.getAttribute('ContentType');
+    if (extension && contentType) defaults.set(extension, contentType);
+  }
+  for (const element of pptxXml.descendants(document, 'Override')) {
+    const partName = element.getAttribute('PartName');
+    const contentType = element.getAttribute('ContentType');
+    if (partName && contentType) {
+      overrides.set(pptxFileUtils.normalizePath(partName), contentType);
+    }
+  }
+  return { defaults, overrides };
+}
+
+function parseRelationships(xml: string | undefined, sourcePath: string) {
+  const relationships = new Map<string, PptxRelationship>();
+  if (!xml) return relationships;
+  const document = pptxXml.parseXml(xml);
+  for (const element of pptxXml.descendants(document, 'Relationship')) {
+    const id = element.getAttribute('Id');
+    const type = element.getAttribute('Type');
+    const target = element.getAttribute('Target');
+    if (!id || !type || !target) continue;
+    const targetMode = element.getAttribute('TargetMode') === 'External' ? 'External' : 'Internal';
+    relationships.set(id, {
+      id,
+      type,
+      target: targetMode === 'External' ? target : pptxFileUtils.resolveRelativePath(sourcePath, target),
+      targetMode,
+    });
+  }
+  return relationships;
+}
+
+async function create(files: PptxPackageFile[]): Promise<PptxPackage> {
+  const filesByPath = new Map(files.map((file) => [file.path, file]));
+  const { defaults, overrides } = parseContentTypes(await readText(filesByPath.get(CONTENT_TYPES_PATH)));
+  const relationshipCache = new Map<string, Map<string, PptxRelationship>>();
+  const warnings: ImportWarning[] = [];
+
+  const getContentType = (path: string) =>
+    overrides.get(pptxFileUtils.normalizePath(path)) ??
+    defaults.get(extensionFor(path)) ??
+    pptxFileUtils.getMimeType(path);
+
+  const getRelationships = (sourcePath: string) => {
+    const normalizedSource = pptxFileUtils.normalizePath(sourcePath);
+    const cached = relationshipCache.get(normalizedSource);
+    if (cached) return cached;
+    const relationships = new Map<string, PptxRelationship>();
+    relationshipCache.set(normalizedSource, relationships);
+    return relationships;
+  };
+
+  const pkg: PptxPackage = {
+    files,
+    getContentType,
+    getFile: (path) => filesByPath.get(pptxFileUtils.normalizePath(path)),
+    getRelationships,
+    readText: (path) => readText(path ? filesByPath.get(pptxFileUtils.normalizePath(path)) : undefined),
+    warnings,
+  };
+
+  for (const sourcePath of ['', ...files.map((file) => file.path)]) {
+    const normalizedSource = pptxFileUtils.normalizePath(sourcePath);
+    const relationships = parseRelationships(
+      await readText(filesByPath.get(relsPathFor(normalizedSource))),
+      normalizedSource,
+    );
+    relationshipCache.set(normalizedSource, relationships);
+  }
+
+  if (!filesByPath.has(CONTENT_TYPES_PATH)) {
+    warnings.push({
+      code: 'pptx-missing-content-types',
+      message: 'PowerPoint package is missing [Content_Types].xml; file extensions were used as a fallback.',
+      severity: 'warning',
+    });
+  }
+
+  return pkg;
+}
+
+export const pptxPackage = {
+  create,
+};

--- a/apps/editor/src/services/importing/pptx/pptxParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxParser.ts
@@ -3,9 +3,13 @@ import type {
   AnimationTrigger,
   ElementAnimationBuild,
   ElementAnimationKind,
+  ImportWarning,
+  PlaceholderRole,
+  ShapeKind,
+  ShapeLineEndpoint,
 } from '../../../domain/documents/model';
 import { pptxFileUtils } from './pptxFileUtils';
-import type { PptxPackageFile } from './pptxPackageTypes';
+import type { PptxPackage, PptxRelationship } from './pptxPackage';
 import { pptxXml } from './pptxXml';
 
 export interface PptxRect {
@@ -13,6 +17,11 @@ export interface PptxRect {
   width: number;
   x: number;
   y: number;
+}
+
+export interface PptxTransform extends PptxRect {
+  flipX?: boolean;
+  rotation: number;
 }
 
 export interface PptxTextStyle {
@@ -42,6 +51,10 @@ export type PptxSlideObject =
       frame: PptxRect;
       id: string;
       kind: 'text';
+      opacity?: number;
+      placeholderRole?: PlaceholderRole;
+      rotation?: number;
+      source: 'layout' | 'master' | 'slide';
       sourceShapeId: string;
       style: PptxTextStyle;
       text: string;
@@ -53,32 +66,62 @@ export type PptxSlideObject =
       frame: PptxRect;
       id: string;
       kind: 'image' | 'gif' | 'video';
+      opacity?: number;
+      placeholderRole?: PlaceholderRole;
+      rotation?: number;
+      source: 'layout' | 'master' | 'slide';
       startTrigger?: AnimationTrigger;
       sourceShapeId: string;
+      zIndex: number;
+    }
+  | {
+      endEndpoint?: ShapeLineEndpoint;
+      fill?: string;
+      frame: PptxRect;
+      id: string;
+      kind: 'shape';
+      opacity?: number;
+      placeholderRole?: PlaceholderRole;
+      rotation?: number;
+      shape: ShapeKind;
+      source: 'layout' | 'master' | 'slide';
+      sourceShapeId: string;
+      startEndpoint?: ShapeLineEndpoint;
+      stroke?: string;
+      strokeWidth?: number;
       zIndex: number;
     };
 
 export interface PptxSlide {
   backgroundColor: string;
   id: string;
+  layoutId?: string;
+  layoutName?: string;
+  layoutObjects: PptxSlideObject[];
   name: string;
   animationBuilds: ElementAnimationBuild[];
   objects: PptxSlideObject[];
+  placeholderRoles: PlaceholderRole[];
   speakerNotes?: string;
   transitionEffect: AnimationEffect;
 }
 
-export interface PptxDeck {
-  height: number;
+export interface PptxLayout {
+  backgroundColor: string;
+  id: string;
   name: string;
-  slides: PptxSlide[];
-  width: number;
+  objects: PptxSlideObject[];
+  placeholderRoles: PlaceholderRole[];
+  sourcePath: string;
 }
 
-interface Relationship {
-  id: string;
-  target: string;
-  type: string;
+export interface PptxDeck {
+  height: number;
+  layouts: PptxLayout[];
+  name: string;
+  slides: PptxSlide[];
+  warnings: ImportWarning[];
+  width: number;
 }
 
 interface PptxTextDefaults {
@@ -86,6 +129,20 @@ interface PptxTextDefaults {
   defaultRunProperties: Element | undefined;
   listParagraphProperties: Element | undefined;
   listRunProperties: Element | undefined;
+}
+
+interface PptxTheme {
+  colors: Map<string, string>;
+}
+
+interface ParseContext {
+  package: PptxPackage;
+  themeCache: Map<string, PptxTheme>;
+}
+
+interface ParseScope {
+  groupTransform?: PptxTransform;
+  theme: PptxTheme | undefined;
 }
 
 const DEFAULT_PAGE_WIDTH = 1920;
@@ -106,39 +163,6 @@ const DEFAULT_TEXT_INSETS_EMU = {
   right: 91440,
   top: 45720,
 };
-
-async function readText(file: PptxPackageFile | undefined) {
-  if (!file) return undefined;
-  return file.blob.text();
-}
-
-function findFile(files: PptxPackageFile[], path: string) {
-  return files.find((file) => file.path === path);
-}
-
-function relsPathFor(sourcePath: string) {
-  const parts = sourcePath.split('/');
-  const fileName = parts.pop() ?? '';
-  return `${parts.join('/')}/_rels/${fileName}.rels`;
-}
-
-function parseRelationships(xml: string | undefined, sourcePath: string) {
-  if (!xml) return new Map<string, Relationship>();
-  const document = pptxXml.parseXml(xml);
-  const relationships = new Map<string, Relationship>();
-  for (const element of pptxXml.descendants(document, 'Relationship')) {
-    const id = element.getAttribute('Id');
-    const type = element.getAttribute('Type');
-    const target = element.getAttribute('Target');
-    if (!id || !type || !target) continue;
-    relationships.set(id, {
-      id,
-      type,
-      target: target.startsWith('http') ? target : pptxFileUtils.resolveRelativePath(sourcePath, target),
-    });
-  }
-  return relationships;
-}
 
 function getPresentationSize(document: Document) {
   const size = pptxXml.firstDescendant(document, 'sldSz');
@@ -178,7 +202,7 @@ function localShapeId(element: Element, fallback: string) {
   return nonVisual?.getAttribute('id') ?? fallback;
 }
 
-function parseFrame(element: Element, scaleX: number, scaleY: number): PptxRect | undefined {
+function parseFrame(element: Element, scaleX: number, scaleY: number, groupTransform?: PptxTransform): PptxTransform | undefined {
   const transform = pptxXml.firstDescendant(element, 'xfrm');
   const offset = transform ? pptxXml.firstDescendant(transform, 'off') : undefined;
   const extent = transform ? pptxXml.firstDescendant(transform, 'ext') : undefined;
@@ -187,26 +211,128 @@ function parseFrame(element: Element, scaleX: number, scaleY: number): PptxRect 
   const width = Number(extent?.getAttribute('cx'));
   const height = Number(extent?.getAttribute('cy'));
   if (![x, y, width, height].every(Number.isFinite)) return undefined;
+  const localFrame = {
+    x: x * scaleX,
+    y: y * scaleY,
+    width: Math.max(1, width * scaleX),
+    height: Math.max(1, height * scaleY),
+    rotation: getRotation(transform),
+    ...(transform?.getAttribute('flipH') === '1' ? { flipX: true } : {}),
+  };
+  if (!groupTransform) {
+    return {
+      ...localFrame,
+      x: Math.round(localFrame.x),
+      y: Math.round(localFrame.y),
+      width: Math.round(localFrame.width),
+      height: Math.round(localFrame.height),
+    };
+  }
   return {
-    x: Math.round(x * scaleX),
-    y: Math.round(y * scaleY),
-    width: Math.max(1, Math.round(width * scaleX)),
-    height: Math.max(1, Math.round(height * scaleY)),
+    ...localFrame,
+    x: Math.round(groupTransform.x + localFrame.x),
+    y: Math.round(groupTransform.y + localFrame.y),
+    width: Math.round(localFrame.width),
+    height: Math.round(localFrame.height),
+    rotation: groupTransform.rotation + localFrame.rotation,
   };
 }
 
-function getHexColor(element: ParentNode | undefined, fallback: string) {
+function normalizeColor(value: string) {
+  return `#${value.replace(/^#/, '').toUpperCase()}`;
+}
+
+function clampColor(value: number) {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function applyColorModifier(color: string, element: Element) {
+  const hex = color.replace(/^#/, '');
+  let red = Number.parseInt(hex.slice(0, 2), 16);
+  let green = Number.parseInt(hex.slice(2, 4), 16);
+  let blue = Number.parseInt(hex.slice(4, 6), 16);
+  const shade = Number(pptxXml.firstDescendant(element, 'shade')?.getAttribute('val'));
+  const tint = Number(pptxXml.firstDescendant(element, 'tint')?.getAttribute('val'));
+  const lumMod = Number(pptxXml.firstDescendant(element, 'lumMod')?.getAttribute('val'));
+  const lumOff = Number(pptxXml.firstDescendant(element, 'lumOff')?.getAttribute('val'));
+  if (Number.isFinite(shade) && shade >= 0) {
+    red = (red * shade) / 100000;
+    green = (green * shade) / 100000;
+    blue = (blue * shade) / 100000;
+  }
+  if (Number.isFinite(tint) && tint >= 0) {
+    red += (255 - red) * (tint / 100000);
+    green += (255 - green) * (tint / 100000);
+    blue += (255 - blue) * (tint / 100000);
+  }
+  if (Number.isFinite(lumMod) && lumMod >= 0) {
+    red *= lumMod / 100000;
+    green *= lumMod / 100000;
+    blue *= lumMod / 100000;
+  }
+  if (Number.isFinite(lumOff) && lumOff >= 0) {
+    red += 255 * (lumOff / 100000);
+    green += 255 * (lumOff / 100000);
+    blue += 255 * (lumOff / 100000);
+  }
+  return normalizeColor(
+    [red, green, blue].map((channel) => clampColor(channel).toString(16).padStart(2, '0')).join(''),
+  );
+}
+
+function getThemeColor(theme: PptxTheme | undefined, name: string) {
+  const aliases = new Map([
+    ['bg1', 'lt1'],
+    ['tx1', 'dk1'],
+    ['bg2', 'lt2'],
+    ['tx2', 'dk2'],
+  ]);
+  return theme?.colors.get(name) ?? theme?.colors.get(aliases.get(name) ?? '');
+}
+
+function getHexColor(element: ParentNode | undefined, fallback: string, theme?: PptxTheme) {
   if (!element) return fallback;
-  const color = pptxXml.firstDescendant(element, 'srgbClr')?.getAttribute('val');
-  return color ? `#${color}` : fallback;
+  const color = pptxXml.firstDescendant(element, 'srgbClr');
+  const schemeColor = pptxXml.firstDescendant(element, 'schemeClr');
+  const systemColor = pptxXml.firstDescendant(element, 'sysClr');
+  const rawColor =
+    color?.getAttribute('val') ??
+    systemColor?.getAttribute('lastClr') ??
+    (schemeColor ? getThemeColor(theme, schemeColor.getAttribute('val') ?? '') : undefined);
+  const sourceElement = color ?? schemeColor ?? systemColor;
+  return rawColor && sourceElement ? applyColorModifier(normalizeColor(rawColor), sourceElement) : fallback;
+}
+
+function getOpacity(element: ParentNode | undefined) {
+  if (!element) return undefined;
+  const alpha = Number(pptxXml.firstDescendant(element, 'alpha')?.getAttribute('val'));
+  return Number.isFinite(alpha) ? Math.max(0, Math.min(1, alpha / 100000)) : undefined;
+}
+
+function getRotation(transform: Element | undefined) {
+  const rotation = Number(transform?.getAttribute('rot'));
+  return Number.isFinite(rotation) ? Math.round(rotation / 60000) : 0;
 }
 
 function getPlaceholderType(shape: Element) {
   return pptxXml.firstDescendant(shape, 'ph')?.getAttribute('type');
 }
 
-function hasPlaceholder(shape: Element) {
-  return Boolean(getPlaceholderType(shape));
+function getPlaceholderRole(shape: Element): PlaceholderRole | undefined {
+  const type = getPlaceholderType(shape);
+  if (type === 'title' || type === 'ctrTitle') return 'title';
+  if (type === 'body' || type === 'obj' || type === 'subTitle') return 'body';
+  if (type === 'ftr') return 'footer';
+  if (type === 'sldNum') return 'slideNumber';
+  return undefined;
+}
+
+function getPlaceholderFallbackText(role: PlaceholderRole | undefined) {
+  if (role === 'title') return 'Title';
+  if (role === 'body') return 'Body';
+  if (role === 'footer') return 'Footer';
+  if (role === 'slideNumber') return 'Slide Number';
+  return '';
 }
 
 function getTypeface(...runProperties: Array<Element | undefined>) {
@@ -312,7 +438,12 @@ function getTextAlign(
   return DEFAULT_TEXT_STYLE.align;
 }
 
-function getTextStyle(shape: Element, scaleY: number, textDefaults: PptxTextDefaults): PptxTextStyle {
+function getTextStyle(
+  shape: Element,
+  scaleY: number,
+  textDefaults: PptxTextDefaults,
+  theme: PptxTheme | undefined,
+): PptxTextStyle {
   const paragraph = getFirstParagraph(shape);
   const paragraphProperties = paragraph ? pptxXml.firstDescendant(paragraph, 'pPr') : undefined;
   const runProperties = getFirstRunProperties(paragraph);
@@ -360,6 +491,7 @@ function getTextStyle(shape: Element, scaleY: number, textDefaults: PptxTextDefa
         inheritedRunProperties ??
         shape,
       DEFAULT_TEXT_STYLE.fill,
+      theme,
     ),
     fontFamily: font && !font.startsWith('+') ? font : DEFAULT_TEXT_STYLE.fontFamily,
     fontSize,
@@ -378,9 +510,9 @@ function getTextParagraphs(shape: Element) {
     .join('\n');
 }
 
-async function parseSpeakerNotes(files: PptxPackageFile[], notesPath: string | undefined) {
+async function parseSpeakerNotes(context: ParseContext, notesPath: string | undefined) {
   if (!notesPath) return undefined;
-  const xml = await readText(findFile(files, notesPath));
+  const xml = await context.package.readText(notesPath);
   if (!xml) return undefined;
   const document = pptxXml.parseXml(xml);
   const notesText = pptxXml
@@ -426,19 +558,26 @@ function parseTextObject(
   scaleX: number,
   scaleY: number,
   textDefaults: PptxTextDefaults,
-  idScope = 'slide',
+  scope: ParseScope,
+  idScope: 'layout' | 'master' | 'slide' = 'slide',
 ): PptxSlideObject | undefined {
-  const text = getTextParagraphs(shape);
+  const placeholderRole = getPlaceholderRole(shape);
+  const text = getTextParagraphs(shape) || (idScope === 'slide' ? '' : getPlaceholderFallbackText(placeholderRole));
   if (!text) return undefined;
-  const frame = parseFrame(shape, scaleX, scaleY);
+  const frame = parseFrame(shape, scaleX, scaleY, scope.groupTransform);
   if (!frame) return undefined;
   const shapeId = localShapeId(shape, String(zIndex));
+  const opacity = getOpacity(shape);
   return {
     frame,
     id: `${slideId}-${idScope}-text-${shapeId}`,
     kind: 'text',
+    ...(opacity !== undefined ? { opacity } : {}),
+    ...(placeholderRole ? { placeholderRole } : {}),
+    rotation: frame.rotation,
+    source: idScope,
     sourceShapeId: shapeId,
-    style: getTextStyle(shape, scaleY, textDefaults),
+    style: getTextStyle(shape, scaleY, textDefaults, scope.theme),
     text,
     textBox: getTextBox(shape, scaleX, scaleY),
     zIndex,
@@ -446,46 +585,76 @@ function parseTextObject(
 }
 
 function getRelationshipTarget(
-  relationships: Map<string, Relationship>,
+  context: ParseContext,
+  relationships: Map<string, PptxRelationship>,
   id: string | null | undefined,
+  pageId?: string,
 ) {
-  return id ? relationships.get(id)?.target : undefined;
+  if (!id) return undefined;
+  const relationship = relationships.get(id);
+  if (!relationship) return undefined;
+  if (relationship.targetMode === 'External') {
+    context.package.warnings.push({
+      code: 'pptx-external-relationship',
+      message: `Skipped external PowerPoint relationship: ${relationship.target}`,
+      ...(pageId ? { pageId } : {}),
+      severity: 'warning',
+    });
+    return undefined;
+  }
+  return relationship.target;
 }
 
 function parsePictureObject(
+  context: ParseContext,
   picture: Element,
   slideId: string,
   zIndex: number,
   scaleX: number,
   scaleY: number,
-  relationships: Map<string, Relationship>,
-  idScope = 'slide',
+  relationships: Map<string, PptxRelationship>,
+  scope: ParseScope,
+  idScope: 'layout' | 'master' | 'slide' = 'slide',
 ): PptxSlideObject | undefined {
-  const frame = parseFrame(picture, scaleX, scaleY);
+  const frame = parseFrame(picture, scaleX, scaleY, scope.groupTransform);
   if (!frame) return undefined;
   const videoRelId =
-    pptxXml.firstDescendant(picture, 'videoFile')?.getAttribute('r:link') ??
-    pptxXml.firstDescendant(picture, 'media')?.getAttribute('r:embed');
-  const imageRelId = pptxXml.firstDescendant(picture, 'blip')?.getAttribute('r:embed');
-  const assetPath = getRelationshipTarget(relationships, videoRelId) ?? getRelationshipTarget(relationships, imageRelId);
+    pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'videoFile'), 'link') ??
+    pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'media'), 'embed');
+  const imageRelId = pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'blip'), 'embed');
+  const assetPath =
+    getRelationshipTarget(context, relationships, videoRelId, slideId) ??
+    getRelationshipTarget(context, relationships, imageRelId, slideId);
   if (!assetPath) return undefined;
-  const mimeType = pptxFileUtils.getMimeType(assetPath);
+  const mimeType = context.package.getContentType(assetPath) ?? pptxFileUtils.getMimeType(assetPath);
   const assetType = pptxFileUtils.getAssetType(assetPath, mimeType);
+  if (!assetType) {
+    context.package.warnings.push({
+      code: 'pptx-unsupported-asset',
+      message: `Skipped unsupported PowerPoint asset: ${assetPath}`,
+      pageId: slideId,
+      severity: 'warning',
+    });
+  }
   if (!assetType) return undefined;
   const shapeId = localShapeId(picture, String(zIndex));
+  const opacity = getOpacity(picture);
   return {
     assetPath,
     frame,
     id: `${slideId}-${idScope}-${assetType}-${shapeId}`,
     kind: assetType,
+    ...(opacity !== undefined ? { opacity } : {}),
+    rotation: frame.rotation,
+    source: idScope,
     sourceShapeId: shapeId,
     zIndex,
   };
 }
 
-function getBackgroundColor(document: Document, fallback = '#000000') {
+function getBackgroundColor(document: Document, theme: PptxTheme | undefined, fallback = '#000000') {
   const background = pptxXml.firstDescendant(document, 'bgPr');
-  return getHexColor(background, fallback);
+  return getHexColor(background, fallback, theme);
 }
 
 function getTransitionEffect(document: Document): AnimationEffect {
@@ -614,95 +783,470 @@ function parseAnimationBuilds(
   return builds;
 }
 
-async function parseInheritedObjects(
-  files: PptxPackageFile[],
-  sourcePath: string | undefined,
+function findRelationshipByType(relationships: Map<string, PptxRelationship>, typeSuffix: string) {
+  return Array.from(relationships.values()).find((relationship) =>
+    relationship.type.endsWith(typeSuffix),
+  );
+}
+
+function shapeKindForPreset(preset: string | null | undefined): ShapeKind | undefined {
+  if (!preset) return undefined;
+  if (preset === 'rect') return 'rect';
+  if (preset === 'roundRect') return 'rounded-rect';
+  if (preset === 'ellipse') return 'ellipse';
+  if (preset === 'triangle' || preset === 'rtTriangle') return 'triangle';
+  if (preset === 'diamond') return 'diamond';
+  if (preset === 'parallelogram') return 'parallelogram';
+  if (preset === 'pentagon') return 'pentagon';
+  if (preset === 'line') return 'line';
+  if (preset === 'arc') return 'arc';
+  if (preset.toLowerCase().includes('arrow')) return 'arrow';
+  return undefined;
+}
+
+function getLineEndpoint(value: string | null | undefined): ShapeLineEndpoint | undefined {
+  if (!value) return undefined;
+  if (value === 'triangle') return 'arrow';
+  if (value === 'stealth') return 'open-arrow';
+  if (value === 'oval') return 'circle';
+  if (value === 'diamond') return 'diamond';
+  return undefined;
+}
+
+function getStrokeWidth(line: Element | undefined, scaleY: number) {
+  const width = Number(line?.getAttribute('w'));
+  return Number.isFinite(width) && width > 0 ? Math.max(1, Math.round(width * scaleY)) : undefined;
+}
+
+function parseShapeObject(
+  shape: Element,
   slideId: string,
+  zIndex: number,
+  scaleX: number,
+  scaleY: number,
+  scope: ParseScope,
+  idScope: 'layout' | 'master' | 'slide' = 'slide',
+): PptxSlideObject | undefined {
+  const preset = pptxXml.firstDescendant(shape, 'prstGeom')?.getAttribute('prst');
+  const shapeKind = shapeKindForPreset(preset);
+  if (!shapeKind) return undefined;
+  const frame = parseFrame(shape, scaleX, scaleY, scope.groupTransform);
+  if (!frame) return undefined;
+  const shapeProperties = pptxXml.firstDescendant(shape, 'spPr');
+  const line = shapeProperties ? pptxXml.firstDescendant(shapeProperties, 'ln') : undefined;
+  const shapeId = localShapeId(shape, String(zIndex));
+  const placeholderRole = getPlaceholderRole(shape);
+  const fill = shapeProperties ? getHexColor(pptxXml.firstDescendant(shapeProperties, 'solidFill'), '', scope.theme) : '';
+  const stroke = line ? getHexColor(pptxXml.firstDescendant(line, 'solidFill'), '', scope.theme) : '';
+  const opacity = getOpacity(shapeProperties);
+  const startEndpoint = getLineEndpoint(pptxXml.firstDescendant(line ?? shape, 'headEnd')?.getAttribute('type'));
+  const endEndpoint = getLineEndpoint(pptxXml.firstDescendant(line ?? shape, 'tailEnd')?.getAttribute('type'));
+  const strokeWidth = getStrokeWidth(line, scaleY);
+  return {
+    frame,
+    id: `${slideId}-${idScope}-shape-${shapeId}`,
+    kind: 'shape',
+    ...(fill ? { fill } : {}),
+    ...(stroke ? { stroke } : {}),
+    ...(strokeWidth ? { strokeWidth } : {}),
+    ...(startEndpoint ? { startEndpoint } : {}),
+    ...(endEndpoint ? { endEndpoint } : {}),
+    ...(opacity !== undefined ? { opacity } : {}),
+    ...(placeholderRole ? { placeholderRole } : {}),
+    rotation: frame.rotation,
+    shape: shapeKind,
+    source: idScope,
+    sourceShapeId: shapeId,
+    zIndex,
+  };
+}
+
+function parseGroupTransform(group: Element, scaleX: number, scaleY: number, parent?: PptxTransform) {
+  const frame = parseFrame(group, scaleX, scaleY, parent);
+  return frame;
+}
+
+function getTableColumnWidths(table: Element) {
+  return pptxXml.childElements(pptxXml.firstDescendant(table, 'tblGrid') ?? table, 'gridCol').map((column) => {
+    const width = Number(column.getAttribute('w'));
+    return Number.isFinite(width) && width > 0 ? width : 0;
+  });
+}
+
+function parseTableObjects(
+  frame: PptxTransform,
+  graphicFrame: Element,
+  slideId: string,
+  zIndexStart: number,
   scaleX: number,
   scaleY: number,
   textDefaults: PptxTextDefaults,
-  idScope: 'layout' | 'master',
-) {
-  if (!sourcePath) return [];
-  const xml = await readText(findFile(files, sourcePath));
-  if (!xml) return [];
-  const document = pptxXml.parseXml(xml);
-  const rels = parseRelationships(await readText(findFile(files, relsPathFor(sourcePath))), sourcePath);
-  const tree = pptxXml.firstDescendant(document, 'spTree');
+  scope: ParseScope,
+): PptxSlideObject[] {
+  const table = pptxXml.firstDescendant(graphicFrame, 'tbl');
+  if (!table) return [];
+  const columnWidths = getTableColumnWidths(table);
+  const rowElements = pptxXml.childElements(table, 'tr');
   const objects: PptxSlideObject[] = [];
-  if (tree) {
-    for (const child of pptxXml.childElements(tree)) {
-      if (child.localName === 'sp' && !hasPlaceholder(child)) {
-        const object = parseTextObject(child, slideId, objects.length, scaleX, scaleY, textDefaults, idScope);
-        if (object) objects.push(object);
+  let y = frame.y;
+  rowElements.forEach((row, rowIndex) => {
+    const rawHeight = Number(row.getAttribute('h'));
+    const rowHeight = Number.isFinite(rawHeight) && rawHeight > 0 ? Math.round(rawHeight * scaleY) : frame.height;
+    let x = frame.x;
+    pptxXml.childElements(row, 'tc').forEach((cell, columnIndex) => {
+      const columnWidth = Math.round((columnWidths[columnIndex] ?? 0) * scaleX) || Math.round(frame.width / Math.max(1, columnWidths.length));
+      const cellId = `${slideId}-slide-table-${rowIndex + 1}-${columnIndex + 1}`;
+      const fill = getHexColor(pptxXml.firstDescendant(cell, 'solidFill'), '#FFFFFF', scope.theme);
+      objects.push({
+        fill,
+        frame: { x, y, width: columnWidth, height: rowHeight },
+        id: `${cellId}-shape`,
+        kind: 'shape',
+        opacity: 1,
+        rotation: frame.rotation,
+        shape: 'rect',
+        source: 'slide',
+        sourceShapeId: cellId,
+        stroke: '#FFFFFF',
+        strokeWidth: 1,
+        zIndex: zIndexStart + objects.length,
+      });
+      const text = getTextParagraphs(cell);
+      if (text) {
+        objects.push({
+          frame: { x, y, width: columnWidth, height: rowHeight },
+          id: `${cellId}-text`,
+          kind: 'text',
+          opacity: 1,
+          rotation: frame.rotation,
+          source: 'slide',
+          sourceShapeId: `${cellId}-text`,
+          style: getTextStyle(cell, scaleY, textDefaults, scope.theme),
+          text,
+          textBox: getTextBox(cell, scaleX, scaleY),
+          zIndex: zIndexStart + objects.length,
+        });
       }
-      if (child.localName === 'pic') {
-        const object = parsePictureObject(child, slideId, objects.length, scaleX, scaleY, rels, idScope);
-        if (object) objects.push(object);
+      x += columnWidth;
+    });
+    y += rowHeight;
+  });
+  return objects;
+}
+
+function addUnsupportedGraphicWarnings(
+  context: ParseContext,
+  graphicFrame: Element,
+  slideId: string,
+) {
+  const graphicData = pptxXml.firstDescendant(graphicFrame, 'graphicData');
+  const uri = graphicData?.getAttribute('uri') ?? '';
+  if (uri.includes('/chart')) {
+    context.package.warnings.push({
+      code: 'pptx-unsupported-chart',
+      message: 'Skipped unsupported PowerPoint chart.',
+      pageId: slideId,
+      severity: 'info',
+    });
+  }
+  if (uri.includes('/diagram')) {
+    context.package.warnings.push({
+      code: 'pptx-unsupported-diagram',
+      message: 'Skipped unsupported PowerPoint SmartArt or diagram.',
+      pageId: slideId,
+      severity: 'info',
+    });
+  }
+}
+
+function parseSlideTreeObjects(
+  context: ParseContext,
+  tree: Element | undefined,
+  slideId: string,
+  zIndexStart: number,
+  scaleX: number,
+  scaleY: number,
+  textDefaults: PptxTextDefaults,
+  relationships: Map<string, PptxRelationship>,
+  scope: ParseScope,
+  idScope: 'layout' | 'master' | 'slide' = 'slide',
+): PptxSlideObject[] {
+  const objects: PptxSlideObject[] = [];
+  if (!tree) return objects;
+  for (const child of pptxXml.childElements(tree)) {
+    const zIndex = zIndexStart + objects.length;
+    if (child.localName === 'sp') {
+      const textObject = parseTextObject(child, slideId, zIndex, scaleX, scaleY, textDefaults, scope, idScope);
+      if (textObject) objects.push(textObject);
+      if (!textObject || !getTextParagraphs(child)) {
+        const shapeObject = parseShapeObject(child, slideId, zIndexStart + objects.length, scaleX, scaleY, scope, idScope);
+        if (shapeObject) objects.push(shapeObject);
+      }
+    }
+    if (child.localName === 'pic') {
+      const object = parsePictureObject(context, child, slideId, zIndex, scaleX, scaleY, relationships, scope, idScope);
+      if (object) objects.push(object);
+    }
+    if (child.localName === 'grpSp') {
+      objects.push(
+        ...parseSlideTreeObjects(
+          context,
+          child,
+          slideId,
+          zIndexStart + objects.length,
+          scaleX,
+          scaleY,
+          textDefaults,
+          relationships,
+          {
+            ...scope,
+            ...(parseGroupTransform(child, scaleX, scaleY, scope.groupTransform)
+              ? { groupTransform: parseGroupTransform(child, scaleX, scaleY, scope.groupTransform)! }
+              : {}),
+          },
+          idScope,
+        ),
+      );
+    }
+    if (child.localName === 'graphicFrame') {
+      const frame = parseFrame(child, scaleX, scaleY, scope.groupTransform);
+      if (frame && pptxXml.firstDescendant(child, 'tbl')) {
+        objects.push(...parseTableObjects(frame, child, slideId, zIndexStart + objects.length, scaleX, scaleY, textDefaults, scope));
+      } else {
+        addUnsupportedGraphicWarnings(context, child, slideId);
       }
     }
   }
   return objects;
 }
 
-function findRelationshipByType(relationships: Map<string, Relationship>, typeSuffix: string) {
-  return Array.from(relationships.values()).find((relationship) =>
-    relationship.type.endsWith(typeSuffix),
+async function loadTheme(context: ParseContext, masterPath: string | undefined) {
+  if (!masterPath) return undefined;
+  const cached = context.themeCache.get(masterPath);
+  if (cached) return cached;
+  const themePath = findRelationshipByType(context.package.getRelationships(masterPath), '/theme')?.target;
+  if (!themePath) return undefined;
+  const xml = await context.package.readText(themePath);
+  if (!xml) return undefined;
+  const document = pptxXml.parseXml(xml);
+  const colors = new Map<string, string>();
+  const colorScheme = pptxXml.firstDescendant(document, 'clrScheme');
+  if (colorScheme) {
+    for (const child of pptxXml.childElements(colorScheme)) {
+      const color = getHexColor(child, '');
+      if (color) colors.set(child.localName, color);
+    }
+  }
+  const theme = { colors };
+  context.themeCache.set(masterPath, theme);
+  return theme;
+}
+
+async function parseInheritedObjects(
+  context: ParseContext,
+  sourcePath: string | undefined,
+  slideId: string,
+  scaleX: number,
+  scaleY: number,
+  textDefaults: PptxTextDefaults,
+  scope: ParseScope,
+  idScope: 'layout' | 'master',
+) {
+  if (!sourcePath) return [];
+  const xml = await context.package.readText(sourcePath);
+  if (!xml) return [];
+  const document = pptxXml.parseXml(xml);
+  const rels = context.package.getRelationships(sourcePath);
+  const tree = pptxXml.firstDescendant(document, 'spTree');
+  return parseSlideTreeObjects(
+    context,
+    tree,
+    slideId,
+    0,
+    scaleX,
+    scaleY,
+    textDefaults,
+    rels,
+    scope,
+    idScope,
   );
 }
 
+function getLayoutId(layoutPath: string | undefined) {
+  if (!layoutPath) return undefined;
+  const fileName = layoutPath.split('/').at(-1)?.replace(/\.xml$/i, '') ?? 'layout';
+  const slug = fileName
+    .replace(/[^a-z0-9]+/gi, '-')
+    .replace(/^-|-$/g, '')
+    .trim();
+  return `pptx-layout-${slug || 'layout'}`;
+}
+
+function getLayoutName(layoutPath: string | undefined) {
+  if (!layoutPath) return undefined;
+  return layoutPath.split('/').at(-1)?.replace(/\.xml$/i, '') || undefined;
+}
+
+function getLayoutNameFromDocument(document: Document, layoutPath: string) {
+  const name = pptxXml.firstDescendant(document, 'cSld')?.getAttribute('name')?.trim();
+  return name || getLayoutName(layoutPath) || getLayoutId(layoutPath) || 'Layout';
+}
+
+function getPlaceholderRoles(objects: PptxSlideObject[]) {
+  return Array.from(
+    new Set(
+      objects
+        .map((object) => object.placeholderRole)
+        .filter((role): role is PlaceholderRole => Boolean(role)),
+    ),
+  );
+}
+
+function getRelationshipTargetsInListOrder(
+  relationships: Map<string, PptxRelationship>,
+  listItems: Element[],
+) {
+  return listItems
+    .map((item) => {
+      const relationshipId = pptxXml.getRelationshipAttr(item, 'id');
+      const relationship = relationshipId ? relationships.get(relationshipId) : undefined;
+      return relationship?.targetMode === 'Internal' ? relationship.target : undefined;
+    })
+    .filter((target): target is string => Boolean(target));
+}
+
+async function getMasterLayoutPaths(context: ParseContext, masterPath: string) {
+  const xml = await context.package.readText(masterPath);
+  const relationships = context.package.getRelationships(masterPath);
+  if (!xml) {
+    return Array.from(relationships.values())
+      .filter((relationship) => relationship.type.endsWith('/slideLayout') && relationship.targetMode === 'Internal')
+      .map((relationship) => relationship.target);
+  }
+  const document = pptxXml.parseXml(xml);
+  const orderedPaths = getRelationshipTargetsInListOrder(
+    relationships,
+    pptxXml.descendants(document, 'sldLayoutId'),
+  );
+  if (orderedPaths.length > 0) return orderedPaths;
+  return Array.from(relationships.values())
+    .filter((relationship) => relationship.type.endsWith('/slideLayout') && relationship.targetMode === 'Internal')
+    .map((relationship) => relationship.target);
+}
+
+async function parseLayout(
+  context: ParseContext,
+  layoutPath: string,
+  masterPath: string | undefined,
+  scaleX: number,
+  scaleY: number,
+  textDefaults: PptxTextDefaults,
+): Promise<PptxLayout | undefined> {
+  const layoutId = getLayoutId(layoutPath);
+  if (!layoutId) return undefined;
+  const xml = await context.package.readText(layoutPath);
+  if (!xml) return undefined;
+  const document = pptxXml.parseXml(xml);
+  const relationships = context.package.getRelationships(layoutPath);
+  const resolvedMasterPath =
+    masterPath ?? findRelationshipByType(relationships, '/slideMaster')?.target;
+  const theme = await loadTheme(context, resolvedMasterPath);
+  const scope = { theme };
+  const masterObjects = await parseInheritedObjects(
+    context,
+    resolvedMasterPath,
+    layoutId,
+    scaleX,
+    scaleY,
+    textDefaults,
+    scope,
+    'master',
+  );
+  const tree = pptxXml.firstDescendant(document, 'spTree');
+  const layoutObjects = parseSlideTreeObjects(
+    context,
+    tree,
+    layoutId,
+    masterObjects.length,
+    scaleX,
+    scaleY,
+    textDefaults,
+    relationships,
+    scope,
+    'layout',
+  );
+  const objects = [...masterObjects, ...layoutObjects].map((object, index) => ({
+    ...object,
+    zIndex: index,
+  }));
+  return {
+    backgroundColor: getBackgroundColor(document, theme, '#FFFFFF'),
+    id: layoutId,
+    name: getLayoutNameFromDocument(document, layoutPath),
+    objects,
+    placeholderRoles: getPlaceholderRoles(objects),
+    sourcePath: layoutPath,
+  };
+}
+
 async function parseSlide(
-  files: PptxPackageFile[],
+  context: ParseContext,
   slidePath: string,
   slideIndex: number,
   scaleX: number,
   scaleY: number,
   textDefaults: PptxTextDefaults,
+  layoutsByPath: Map<string, PptxLayout>,
 ) {
-  const xml = await readText(findFile(files, slidePath));
+  const xml = await context.package.readText(slidePath);
   if (!xml) throw new Error(`PowerPoint slide is missing: ${slidePath}`);
   const document = pptxXml.parseXml(xml);
-  const rels = parseRelationships(await readText(findFile(files, relsPathFor(slidePath))), slidePath);
+  const rels = context.package.getRelationships(slidePath);
   const slideId = `pptx-page-${slideIndex + 1}`;
   const layoutPath = findRelationshipByType(rels, '/slideLayout')?.target;
+  const layoutId = getLayoutId(layoutPath);
   const notesPath = findRelationshipByType(rels, '/notesSlide')?.target;
-  const layoutRels = parseRelationships(
-    await readText(findFile(files, layoutPath ? relsPathFor(layoutPath) : '')),
-    layoutPath ?? slidePath,
-  );
+  const layoutRels = layoutPath ? context.package.getRelationships(layoutPath) : new Map<string, PptxRelationship>();
   const masterPath = findRelationshipByType(layoutRels, '/slideMaster')?.target;
-  const speakerNotes = await parseSpeakerNotes(files, notesPath);
-  const masterObjects = await parseInheritedObjects(files, masterPath, slideId, scaleX, scaleY, textDefaults, 'master');
-  const layoutObjects = await parseInheritedObjects(files, layoutPath, slideId, scaleX, scaleY, textDefaults, 'layout');
+  const theme = await loadTheme(context, masterPath);
+  const scope = { theme };
+  const speakerNotes = await parseSpeakerNotes(context, notesPath);
+  const parsedLayout = layoutPath ? layoutsByPath.get(layoutPath) : undefined;
   const tree = pptxXml.firstDescendant(document, 'spTree');
-  const inheritedObjects = [...masterObjects, ...layoutObjects];
-  const objects: PptxSlideObject[] = inheritedObjects.map((object, index) => ({
+  const inheritedObjects = (parsedLayout?.objects ?? []).map((object, index) => ({
     ...object,
     zIndex: index,
   }));
-  if (tree) {
-    for (const child of pptxXml.childElements(tree)) {
-      if (child.localName === 'sp') {
-        const object = parseTextObject(child, slideId, objects.length, scaleX, scaleY, textDefaults);
-        if (object) objects.push(object);
-      }
-      if (child.localName === 'pic') {
-        const object = parsePictureObject(child, slideId, objects.length, scaleX, scaleY, rels);
-        if (object) objects.push(object);
-      }
-    }
-  }
+  const objects: PptxSlideObject[] = [];
+  objects.push(
+    ...parseSlideTreeObjects(
+      context,
+      tree,
+      slideId,
+      objects.length,
+      scaleX,
+      scaleY,
+      textDefaults,
+      rels,
+      scope,
+    ),
+  );
   const videoStartTriggers = getVideoStartTriggers(document, objects);
   for (const object of objects) {
     const startTrigger = videoStartTriggers.get(object.sourceShapeId);
     if (object.kind === 'video' && startTrigger) object.startTrigger = startTrigger;
   }
+  const resolvedLayoutId = parsedLayout?.id ?? layoutId;
   return {
-    backgroundColor: getBackgroundColor(document),
+    backgroundColor: getBackgroundColor(document, theme),
     id: slideId,
+    ...(resolvedLayoutId ? { layoutId: resolvedLayoutId } : {}),
+    ...(parsedLayout?.name ? { layoutName: parsedLayout.name } : {}),
+    layoutObjects: inheritedObjects,
     name: `Slide ${slideIndex + 1}`,
     animationBuilds: parseAnimationBuilds(document, slideId, objects),
     objects,
+    placeholderRoles: parsedLayout?.placeholderRoles ?? getPlaceholderRoles(inheritedObjects),
     ...(speakerNotes ? { speakerNotes } : {}),
     transitionEffect: getTransitionEffect(document),
   };
@@ -712,29 +1256,81 @@ function normalizeName(name: string) {
   return name.replace(/\.pptx$/i, '').trim() || 'Imported PowerPoint';
 }
 
-async function parse(files: PptxPackageFile[], name: string): Promise<PptxDeck> {
-  const presentationXml = await readText(findFile(files, 'ppt/presentation.xml'));
-  if (!presentationXml) throw new Error('PowerPoint package is missing ppt/presentation.xml.');
+function findPresentationPath(context: ParseContext) {
+  const packageRelationship = findRelationshipByType(context.package.getRelationships(''), '/officeDocument');
+  if (packageRelationship?.targetMode === 'Internal') return packageRelationship.target;
+  const legacyPath = 'ppt/presentation.xml';
+  if (context.package.getFile(legacyPath)) {
+    context.package.warnings.push({
+      code: 'pptx-legacy-presentation-path',
+      message: 'PowerPoint package did not declare the presentation part; ppt/presentation.xml was used as a fallback.',
+      severity: 'warning',
+    });
+    return legacyPath;
+  }
+  return undefined;
+}
+
+async function parse(context: ParseContext, name: string): Promise<PptxDeck> {
+  const presentationPath = findPresentationPath(context);
+  if (!presentationPath) throw new Error('PowerPoint package is missing a presentation relationship.');
+  const presentationXml = await context.package.readText(presentationPath);
+  if (!presentationXml) throw new Error(`PowerPoint package is missing presentation part: ${presentationPath}`);
   const presentation = pptxXml.parseXml(presentationXml);
-  const presentationRelationships = parseRelationships(
-    await readText(findFile(files, 'ppt/_rels/presentation.xml.rels')),
-    'ppt/presentation.xml',
-  );
+  const presentationRelationships = context.package.getRelationships(presentationPath);
   const size = getPresentationSize(presentation);
   const textDefaults = getPresentationTextDefaults(presentation);
   const slidePaths = pptxXml
     .descendants(presentation, 'sldId')
-    .map((slide) => presentationRelationships.get(slide.getAttribute('r:id') ?? '')?.target)
+    .map((slide) => presentationRelationships.get(pptxXml.getRelationshipAttr(slide, 'id') ?? '')?.target)
     .filter((path): path is string => Boolean(path));
   if (slidePaths.length === 0) throw new Error('PowerPoint package does not contain slides.');
+  const masterPaths = getRelationshipTargetsInListOrder(
+    presentationRelationships,
+    pptxXml.descendants(presentation, 'sldMasterId'),
+  );
+  const layoutPathEntries: Array<{ layoutPath: string; masterPath?: string }> = [];
+  for (const masterPath of masterPaths) {
+    for (const layoutPath of await getMasterLayoutPaths(context, masterPath)) {
+      layoutPathEntries.push({ layoutPath, masterPath });
+    }
+  }
+  for (const slidePath of slidePaths) {
+    const slideLayoutPath = findRelationshipByType(
+      context.package.getRelationships(slidePath),
+      '/slideLayout',
+    )?.target;
+    if (slideLayoutPath && !layoutPathEntries.some((entry) => entry.layoutPath === slideLayoutPath)) {
+      const slideLayoutRels = context.package.getRelationships(slideLayoutPath);
+      const masterPath = findRelationshipByType(slideLayoutRels, '/slideMaster')?.target;
+      layoutPathEntries.push({ layoutPath: slideLayoutPath, ...(masterPath ? { masterPath } : {}) });
+    }
+  }
+  const layouts = (
+    await Promise.all(
+      layoutPathEntries.map((entry) =>
+        parseLayout(
+          context,
+          entry.layoutPath,
+          entry.masterPath,
+          size.scaleX,
+          size.scaleY,
+          textDefaults,
+        ),
+      ),
+    )
+  ).filter((layout): layout is PptxLayout => Boolean(layout));
+  const layoutsByPath = new Map(layouts.map((layout) => [layout.sourcePath, layout]));
   return {
     height: size.height,
+    layouts,
     name: normalizeName(name),
     slides: await Promise.all(
       slidePaths.map((slidePath, index) =>
-        parseSlide(files, slidePath, index, size.scaleX, size.scaleY, textDefaults),
+        parseSlide(context, slidePath, index, size.scaleX, size.scaleY, textDefaults, layoutsByPath),
       ),
     ),
+    warnings: context.package.warnings,
     width: size.width,
   };
 }

--- a/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
+++ b/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
@@ -1,7 +1,15 @@
-import type { Asset, DesignElement, ImportWarning, Page, ProjectDocument } from '../../../domain/documents/model';
+import type {
+  Asset,
+  DesignElement,
+  ImportWarning,
+  Page,
+  PlaceholderRole,
+  ProjectDocument,
+  SlideLayout,
+} from '../../../domain/documents/model';
 import { pptxFileUtils } from './pptxFileUtils';
-import type { PptxPackageFile } from './pptxPackageTypes';
-import type { PptxDeck, PptxSlideObject } from './pptxParser';
+import type { PptxPackage } from './pptxPackage';
+import type { PptxDeck, PptxLayout, PptxSlideObject } from './pptxParser';
 
 const TEXT_FRAME_FIT = {
   averageCharacterWidth: 0.9,
@@ -22,8 +30,8 @@ function createAssetId(path: string, index: number) {
   return `pptx-asset-${index + 1}-${slug || 'asset'}`;
 }
 
-function createAsset(file: PptxPackageFile, index: number): Asset | undefined {
-  const mimeType = pptxFileUtils.getMimeType(file.path, file.blob.type);
+function createAsset(file: NonNullable<ReturnType<PptxPackage['getFile']>>, index: number, pptxPackage: PptxPackage): Asset | undefined {
+  const mimeType = pptxPackage.getContentType(file.path) ?? pptxFileUtils.getMimeType(file.path, file.blob.type);
   const type = pptxFileUtils.getAssetType(file.path, mimeType);
   if (!type) return undefined;
   const fileName = file.path.split('/').at(-1);
@@ -39,13 +47,13 @@ function createAsset(file: PptxPackageFile, index: number): Asset | undefined {
   };
 }
 
-function getOrCreateAsset(assetPath: string, files: PptxPackageFile[], assets: Record<string, Asset>) {
+function getOrCreateAsset(assetPath: string, pptxPackage: PptxPackage, assets: Record<string, Asset>) {
   const existing = Object.values(assets).find((asset) => asset.fileName === assetPath.split('/').at(-1));
   if (existing) return existing;
-  const fileIndex = files.findIndex((file) => file.path === assetPath);
-  const file = files[fileIndex];
+  const fileIndex = pptxPackage.files.findIndex((item) => item.path === assetPath);
+  const file = pptxPackage.getFile(assetPath);
   if (!file) return undefined;
-  const asset = createAsset(file, fileIndex);
+  const asset = createAsset(file, fileIndex, pptxPackage);
   if (!asset) return undefined;
   assets[asset.id] = asset;
   return asset;
@@ -164,12 +172,13 @@ function getFittedTextFrame(
 
 function mapObject(
   object: PptxSlideObject,
-  files: PptxPackageFile[],
+  pptxPackage: PptxPackage,
   assets: Record<string, Asset>,
   warnings: ImportWarning[],
   pageId: string,
   pageWidth: number,
   pageHeight: number,
+  layoutId?: string,
 ): DesignElement | undefined {
   if (object.kind === 'text') {
     const frame = getFittedTextFrame(object, pageWidth, pageHeight);
@@ -178,14 +187,35 @@ function mapObject(
       type: 'text',
       text: object.text,
       ...frame,
-      rotation: 0,
+      rotation: object.rotation ?? 0,
       locked: false,
       visible: true,
-      opacity: 1,
+      opacity: object.opacity ?? 1,
+      ...(layoutId ? { templateSource: { layoutId, type: 'layout' as const } } : {}),
+      ...(object.placeholderRole ? { placeholderRole: object.placeholderRole } : {}),
       ...object.style,
     };
   }
-  const asset = getOrCreateAsset(object.assetPath, files, assets);
+  if (object.kind === 'shape') {
+    return {
+      id: object.id,
+      type: 'shape',
+      ...object.frame,
+      rotation: object.rotation ?? 0,
+      locked: false,
+      visible: true,
+      opacity: object.opacity ?? 1,
+      ...(layoutId ? { templateSource: { layoutId, type: 'layout' as const } } : {}),
+      ...(object.placeholderRole ? { placeholderRole: object.placeholderRole } : {}),
+      shape: object.shape,
+      ...(object.fill ? { fill: object.fill } : {}),
+      ...(object.stroke ? { stroke: object.stroke } : {}),
+      ...(object.strokeWidth !== undefined ? { strokeWidth: object.strokeWidth } : {}),
+      ...(object.startEndpoint ? { startEndpoint: object.startEndpoint } : {}),
+      ...(object.endEndpoint ? { endEndpoint: object.endEndpoint } : {}),
+    };
+  }
+  const asset = getOrCreateAsset(object.assetPath, pptxPackage, assets);
   if (!asset) {
     warnings.push({
       code: 'pptx-missing-asset',
@@ -199,10 +229,12 @@ function mapObject(
     id: object.id,
     assetId: asset.id,
     ...object.frame,
-    rotation: 0,
+    rotation: object.rotation ?? 0,
     locked: false,
     visible: true,
-    opacity: 1,
+    opacity: object.opacity ?? 1,
+    ...(layoutId ? { templateSource: { layoutId, type: 'layout' as const } } : {}),
+    ...(object.placeholderRole ? { placeholderRole: object.placeholderRole } : {}),
   };
   if (object.kind === 'video') {
     return {
@@ -220,15 +252,93 @@ function mapObject(
   return { ...base, type: 'image' };
 }
 
-function map(deck: PptxDeck, files: PptxPackageFile[]): ProjectDocument {
+const defaultPlaceholderVisibility: Record<PlaceholderRole, boolean> = {
+  body: true,
+  footer: true,
+  slideNumber: true,
+  title: true,
+};
+
+function createLayout(
+  layout: PptxLayout,
+  pptxPackage: PptxPackage,
+  assets: Record<string, Asset>,
+  warnings: ImportWarning[],
+  pageWidth: number,
+  pageHeight: number,
+): SlideLayout | undefined {
+  const elementIds: string[] = [];
+  const elements: Record<string, DesignElement> = {};
+  for (const object of layout.objects.sort((left, right) => left.zIndex - right.zIndex)) {
+    const element = mapObject(
+      object,
+      pptxPackage,
+      assets,
+      warnings,
+      layout.id,
+      pageWidth,
+      pageHeight,
+      layout.id,
+    );
+    if (!element) continue;
+    elements[element.id] = element;
+    elementIds.push(element.id);
+  }
+  return {
+    id: layout.id,
+    name: layout.name,
+    background: { type: 'color', color: layout.backgroundColor },
+    elementIds,
+    elements,
+    placeholderRoles: layout.placeholderRoles,
+    placeholderVisibility: defaultPlaceholderVisibility,
+  };
+}
+
+function createSlideFallbackLayout(
+  slide: PptxDeck['slides'][number],
+  pptxPackage: PptxPackage,
+  assets: Record<string, Asset>,
+  warnings: ImportWarning[],
+  pageWidth: number,
+  pageHeight: number,
+): SlideLayout | undefined {
+  if (!slide.layoutId) return undefined;
+  return createLayout(
+    {
+      backgroundColor: slide.backgroundColor,
+      id: slide.layoutId,
+      name: slide.layoutName ?? slide.layoutId,
+      objects: slide.layoutObjects,
+      placeholderRoles: slide.placeholderRoles,
+      sourcePath: slide.layoutId,
+    },
+    pptxPackage,
+    assets,
+    warnings,
+    pageWidth,
+    pageHeight,
+  );
+}
+
+function map(deck: PptxDeck, pptxPackage: PptxPackage): ProjectDocument {
   const now = new Date().toISOString();
   const assets: Record<string, Asset> = {};
   const elements: Record<string, DesignElement> = {};
-  const warnings: ImportWarning[] = [];
+  const warnings: ImportWarning[] = [...deck.warnings];
+  const slideLayouts: Record<string, SlideLayout> = {};
+  for (const layout of deck.layouts) {
+    const mappedLayout = createLayout(layout, pptxPackage, assets, warnings, deck.width, deck.height);
+    if (mappedLayout) slideLayouts[mappedLayout.id] = mappedLayout;
+  }
   const pages: Page[] = deck.slides.map((slide) => {
     const elementIds: string[] = [];
+    const layout = slide.layoutId && slideLayouts[slide.layoutId]
+      ? undefined
+      : createSlideFallbackLayout(slide, pptxPackage, assets, warnings, deck.width, deck.height);
+    if (layout) slideLayouts[layout.id] = layout;
     for (const object of slide.objects.sort((left, right) => left.zIndex - right.zIndex)) {
-      const element = mapObject(object, files, assets, warnings, slide.id, deck.width, deck.height);
+      const element = mapObject(object, pptxPackage, assets, warnings, slide.id, deck.width, deck.height);
       if (!element) continue;
       elements[element.id] = element;
       elementIds.push(element.id);
@@ -241,6 +351,7 @@ function map(deck: PptxDeck, files: PptxPackageFile[]): ProjectDocument {
       background: { type: 'color', color: slide.backgroundColor },
       elementIds,
       transition: { effect: slide.transitionEffect, delayMs: 0, durationMs: 500 },
+      ...(slide.layoutId ? { layoutId: slide.layoutId } : {}),
       ...(slide.animationBuilds.length > 0
         ? {
             animationBuilds: slide.animationBuilds.filter((build) =>
@@ -260,6 +371,7 @@ function map(deck: PptxDeck, files: PptxPackageFile[]): ProjectDocument {
     assets,
     elements,
     pages,
+    ...(Object.keys(slideLayouts).length > 0 ? { slideLayouts } : {}),
     ...(warnings.length > 0 ? { importWarnings: warnings } : {}),
   };
 }

--- a/apps/editor/src/services/importing/pptx/pptxXml.ts
+++ b/apps/editor/src/services/importing/pptx/pptxXml.ts
@@ -22,6 +22,12 @@ function getAttr(element: Element | undefined, name: string) {
   return element.getAttribute(name) ?? element.getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', name);
 }
 
+function getRelationshipAttr(element: Element | undefined, name: string) {
+  if (!element) return undefined;
+  return element.getAttributeNS('http://schemas.openxmlformats.org/officeDocument/2006/relationships', name) ??
+    element.getAttribute(`r:${name}`);
+}
+
 function textContent(element: ParentNode, localName: string) {
   return descendants(element, localName)
     .map((item) => item.textContent ?? '')
@@ -33,6 +39,7 @@ export const pptxXml = {
   descendants,
   firstDescendant,
   getAttr,
+  getRelationshipAttr,
   parseXml,
   textContent,
 };

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -106,6 +106,8 @@ interface CanvasWorkspaceProps {
   onInsertMedia?: (() => void) | undefined;
   onInsertText?: (() => void) | undefined;
   onOpenAnimations?: (() => void) | undefined;
+  onSelectPresentation?: (() => void) | undefined;
+  onSelectSlide?: (() => void) | undefined;
   onSelectElement?: ((elementId: string, options?: { additive?: boolean }) => void) | undefined;
   onSendSelectedElementBackward?: (() => void) | undefined;
   onTranslateSelectedText?: (() => void) | undefined;
@@ -477,13 +479,14 @@ export function CanvasWorkspace({
   onBackgroundSubjectPick,
   onBringSelectedElementForward,
   onCancelBackgroundSelection,
-  onClearSelection,
   onDeleteSelectedElement,
   onDuplicateSelectedElement,
   onFlipSelectedImage,
   onInsertMedia,
   onInsertText,
   onOpenAnimations,
+  onSelectPresentation,
+  onSelectSlide,
   onSelectElement,
   onSendSelectedElementBackward,
   onTranslateSelectedText,
@@ -1061,11 +1064,16 @@ export function CanvasWorkspace({
       finishCropMode();
       return;
     }
-    onClearSelection?.();
+    onSelectSlide?.();
   }
 
   return (
-    <div className="canvas-workspace ew-viewport-stage">
+    <div
+      className="canvas-workspace ew-viewport-stage"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget) onSelectPresentation?.();
+      }}
+    >
       <div
         className="canvas-frame neon-border"
         aria-label={canvasLabel}

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -4,6 +4,7 @@ import {
   AlignRight,
   Bold,
   CaseSensitive,
+  ChevronDown,
   Download,
   FileVideo,
   Film,
@@ -21,14 +22,16 @@ import {
   Volume2,
   VolumeX,
 } from 'lucide-react';
-import type { FormEvent, RefObject } from 'react';
+import type { CSSProperties, FormEvent, RefObject } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   DesignElement,
   ElementAnimationBuild,
   PageBackground,
+  PresentationTheme,
   ProjectDocument,
   SelectionState,
+  SlideLayout,
   ShapeElement,
   ShapeLineEndpoint,
   TextElement,
@@ -52,6 +55,21 @@ type MovieStartTrigger = ElementAnimationBuild['trigger'];
 const palette = ['#37FD76', '#050D10', '#FFFFFF', '#91999D', '#00779A'];
 const regularTextWeight = 400;
 const boldTextWeight = 800;
+const defaultPresentationTheme: PresentationTheme = {
+  id: 'theme-default',
+  name: 'Default theme',
+  palette: {
+    accent: '#37FD76',
+    background: '#050D10',
+    mutedText: '#91999D',
+    surface: '#0C1417',
+    text: '#FFFFFF',
+  },
+  typography: {
+    bodyFontFamily: 'Open Sans',
+    headingFontFamily: 'Orbitron',
+  },
+};
 const videoRepeatOptions: Array<{ value: VideoRepeatMode; label: string }> = [
   { value: 'none', label: 'None' },
   { value: 'loop', label: 'Loop' },
@@ -81,6 +99,16 @@ interface DesignPanelProps {
   onUpdateTextContent?: (elementId: string, text: string) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
+  onApplyTheme?: (themeId: string) => void;
+  onEditTheme?: (themeId: string) => void;
+  onChangeTheme?: () => void;
+  onApplySlideLayout?: (pageId: string, layoutId: string) => void;
+  onEditSlideLayout?: (layoutId: string) => void;
+  onToggleSlideLayoutPlaceholder?: (
+    layoutId: string,
+    role: 'body' | 'footer' | 'slideNumber' | 'title',
+    visible: boolean,
+  ) => void;
   onAlignSelectedElement?: (mode: AlignMode) => void;
   onSetElementLock?: (elementId: string, locked: boolean) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
@@ -118,6 +146,17 @@ function collectDocumentTextFontFamilies(project: ProjectDocument) {
     .map((element) => element.fontFamily);
 }
 
+function getThemeOptions(project: ProjectDocument) {
+  const importedThemes = Object.values(project.themes ?? {}).filter(
+    (theme) => theme.id !== defaultPresentationTheme.id && theme.palette && theme.typography,
+  );
+  return [defaultPresentationTheme, ...importedThemes];
+}
+
+function getSlideLayoutOptions(project: ProjectDocument) {
+  return Object.values(project.slideLayouts ?? {});
+}
+
 export function DesignPanel({
   project,
   activePageId,
@@ -127,6 +166,12 @@ export function DesignPanel({
   onUpdateTextContent,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
+  onApplyTheme,
+  onEditTheme,
+  onChangeTheme,
+  onApplySlideLayout,
+  onEditSlideLayout,
+  onToggleSlideLayoutPlaceholder,
   onAlignSelectedElement,
   onSetElementLock,
   onSetSelectedElementZOrder,
@@ -144,6 +189,7 @@ export function DesignPanel({
   const [fontDownloadStatus, setFontDownloadStatus] = useState<string | undefined>();
   const page = project.pages.find((item) => item.id === activePageId);
   const selectedElement = getSelectedElement(project, selection);
+  const selectionTarget = selection.target ?? (selectedElement ? 'elements' : 'presentation');
   const backgroundColor = page ? getBackgroundColor(page.background) : '#050D10';
   const projectFontFamilies = useMemo(
     () =>
@@ -210,6 +256,31 @@ export function DesignPanel({
   function submitFontSearch(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setFontSearchQuery(fontSearchInput.trim());
+  }
+
+  if (selectionTarget === 'presentation') {
+    return (
+      <PresentationDesignPanel
+        project={project}
+        page={page}
+        onApplyTheme={onApplyTheme}
+        onChangeTheme={onChangeTheme}
+        onEditTheme={onEditTheme}
+      />
+    );
+  }
+
+  if (selectionTarget === 'slide') {
+    return (
+      <SlideDesignPanel
+        page={page}
+        project={project}
+        onApplySlideLayout={onApplySlideLayout}
+        onEditSlideLayout={onEditSlideLayout}
+        onToggleSlideLayoutPlaceholder={onToggleSlideLayoutPlaceholder}
+        onUpdatePageBackground={onUpdatePageBackground}
+      />
+    );
   }
 
   return (
@@ -305,6 +376,431 @@ export function DesignPanel({
       )}
     </div>
   );
+}
+
+interface PresentationDesignPanelProps {
+  page?: ProjectDocument['pages'][number] | undefined;
+  project: ProjectDocument;
+  onApplyTheme: ((themeId: string) => void) | undefined;
+  onChangeTheme: (() => void) | undefined;
+  onEditTheme: ((themeId: string) => void) | undefined;
+}
+
+function PresentationDesignPanel({
+  page,
+  project,
+  onApplyTheme,
+  onChangeTheme,
+  onEditTheme,
+}: PresentationDesignPanelProps) {
+  const [themePickerOpen, setThemePickerOpen] = useState(false);
+  const themeOptions = getThemeOptions(project);
+  const theme =
+    themeOptions.find((item) => item.id === project.themeId) ??
+    (project.themeId ? project.themes?.[project.themeId] : undefined) ??
+    defaultPresentationTheme;
+  const themeId = theme.id;
+  const themeName = theme?.name ?? 'Custom theme';
+  return (
+    <div className="panel-stack">
+      <PanelSection title="Presentation">
+        <button
+          aria-expanded={themePickerOpen}
+          aria-label={`Open theme picker, current theme ${themeName}`}
+          className="template-preview-card template-preview-button"
+          type="button"
+          onClick={() => setThemePickerOpen((current) => !current)}
+        >
+          <div className="template-filmstrip" aria-hidden="true">
+            <span />
+            <span />
+            <span />
+          </div>
+          <div className="template-preview-copy">
+            <span>Theme</span>
+            <strong>{themeName}</strong>
+          </div>
+          <ChevronDown size={16} aria-hidden="true" />
+        </button>
+        {themePickerOpen ? (
+          <ThemeChooser
+            activeThemeId={themeId}
+            themes={themeOptions}
+            onApplyTheme={(nextThemeId) => {
+              onApplyTheme?.(nextThemeId);
+              setThemePickerOpen(false);
+            }}
+          />
+        ) : null}
+        <div className="template-action-row">
+          <button type="button" onClick={onChangeTheme}>
+            Change theme
+          </button>
+          <button type="button" disabled={!themeId} onClick={() => themeId && onEditTheme?.(themeId)}>
+            Edit theme
+          </button>
+          <button type="button" disabled={!themeId} onClick={() => themeId && onApplyTheme?.(themeId)}>
+            Apply theme
+          </button>
+        </div>
+      </PanelSection>
+
+      <PanelSection title="Slideshow Settings">
+        <label className="template-checkbox-row">
+          <input type="checkbox" />
+          <span>Automatically play upon open</span>
+        </label>
+        <label className="template-checkbox-row">
+          <input type="checkbox" />
+          <span>Loop slideshow</span>
+        </label>
+        <label className="template-checkbox-row">
+          <input type="checkbox" />
+          <span>Restart show if idle for</span>
+        </label>
+      </PanelSection>
+
+      <PanelSection title="Presentation Type">
+        <label className="design-control ew-field-scope">
+          <span>Type</span>
+          <select aria-label="Presentation type" defaultValue="normal">
+            <option value="normal">Normal</option>
+            <option value="kiosk">Kiosk</option>
+            <option value="self-running">Self-running</option>
+          </select>
+        </label>
+        <div className="property-row ew-surface ew-surface-hover ew-compact-row">
+          <span>Slide size</span>
+          <strong>{page ? `${page.width} x ${page.height}` : 'No slide'}</strong>
+        </div>
+      </PanelSection>
+    </div>
+  );
+}
+
+interface SlideDesignPanelProps {
+  page?: ProjectDocument['pages'][number] | undefined;
+  project: ProjectDocument;
+  onApplySlideLayout: ((pageId: string, layoutId: string) => void) | undefined;
+  onEditSlideLayout: ((layoutId: string) => void) | undefined;
+  onToggleSlideLayoutPlaceholder:
+    | ((
+        layoutId: string,
+        role: 'body' | 'footer' | 'slideNumber' | 'title',
+        visible: boolean,
+      ) => void)
+    | undefined;
+  onUpdatePageBackground: ((background: PageBackground) => void) | undefined;
+}
+
+function SlideDesignPanel({
+  page,
+  project,
+  onApplySlideLayout,
+  onEditSlideLayout,
+  onToggleSlideLayoutPlaceholder,
+  onUpdatePageBackground,
+}: SlideDesignPanelProps) {
+  const layout = page?.layoutId ? project.slideLayouts?.[page.layoutId] : undefined;
+  const layoutOptions = getSlideLayoutOptions(project);
+  const [layoutPickerOpen, setLayoutPickerOpen] = useState(false);
+  const layoutId = layout?.id ?? layoutOptions[0]?.id;
+  const layoutName = layout?.name ?? 'Blank';
+  const backgroundColor = page ? getBackgroundColor(page.background) : '#050D10';
+  const visibility = layout?.placeholderVisibility ?? {
+    body: true,
+    footer: true,
+    slideNumber: true,
+    title: true,
+  };
+  return (
+    <div className="panel-stack">
+      <PanelSection title="Slide">
+        <button
+          aria-expanded={layoutPickerOpen}
+          aria-label={`Open layout picker, current layout ${layoutName}`}
+          className="template-preview-card template-preview-card-slide template-preview-button"
+          type="button"
+          onClick={() => setLayoutPickerOpen((current) => !current)}
+        >
+          <div className="template-slide-thumbnail" aria-hidden="true">
+            <span className="template-slide-title" />
+            <span className="template-slide-body" />
+            <span className="template-slide-footer" />
+          </div>
+          <div className="template-preview-copy">
+            <span>Slide layout</span>
+            <strong>{layoutName}</strong>
+          </div>
+          <ChevronDown size={16} aria-hidden="true" />
+        </button>
+        {layoutPickerOpen ? (
+          <SlideLayoutChooser
+            activeLayoutId={layout?.id}
+            layouts={layoutOptions}
+            pageId={page?.id}
+            onApplySlideLayout={(pageId, nextLayoutId) => {
+              onApplySlideLayout?.(pageId, nextLayoutId);
+              setLayoutPickerOpen(false);
+            }}
+          />
+        ) : null}
+        <div className="template-action-row">
+          <button type="button" disabled={!layoutId} onClick={() => layoutId && onEditSlideLayout?.(layoutId)}>
+            Edit layout
+          </button>
+          <button
+            type="button"
+            disabled={!layoutId || !page}
+            onClick={() => page && layoutId && onApplySlideLayout?.(page.id, layoutId)}
+          >
+            Apply layout
+          </button>
+        </div>
+      </PanelSection>
+
+      <PanelSection title="Appearance">
+        {(
+          [
+            ['title', 'Title'],
+            ['body', 'Body'],
+            ['footer', 'Footer'],
+            ['slideNumber', 'Slide number'],
+          ] as const
+        ).map(([role, label]) => (
+          <label className="template-checkbox-row" key={role}>
+            <input
+              checked={visibility[role]}
+              disabled={!layoutId}
+              type="checkbox"
+              onChange={(event) => {
+                if (layoutId) onToggleSlideLayoutPlaceholder?.(layoutId, role, event.target.checked);
+              }}
+            />
+            <span>{label}</span>
+          </label>
+        ))}
+      </PanelSection>
+
+      <PanelSection title="Background">
+        <div className="template-segmented-control" role="group" aria-label="Background mode">
+          <button className="template-segmented-active" type="button">
+            Standard
+          </button>
+          <button type="button">Dynamic</button>
+        </div>
+        <label className="design-control ew-field-scope">
+          <span>Current fill</span>
+          <input
+            aria-label="Slide background color"
+            type="color"
+            value={backgroundColor}
+            onChange={(event) => {
+              onUpdatePageBackground?.({ type: 'color', color: event.target.value });
+            }}
+          />
+        </label>
+        <label className="design-control ew-field-scope">
+          <span>Fill type</span>
+          <select aria-label="Slide fill type" defaultValue="color">
+            <option value="color">Color fill</option>
+          </select>
+        </label>
+      </PanelSection>
+    </div>
+  );
+}
+
+interface ThemeChooserProps {
+  activeThemeId: string;
+  themes: PresentationTheme[];
+  onApplyTheme: (themeId: string) => void;
+}
+
+function ThemeChooser({ activeThemeId, themes, onApplyTheme }: ThemeChooserProps) {
+  return (
+    <div className="template-chooser-shelf" aria-label="Choose a theme" role="region">
+      <div className="template-chooser-title">Choose a theme</div>
+      <div className="theme-choice-list">
+        {themes.map((theme) => (
+          <button
+            aria-current={theme.id === activeThemeId ? 'true' : undefined}
+            className={
+              theme.id === activeThemeId
+                ? 'theme-choice-card theme-choice-card-active'
+                : 'theme-choice-card'
+            }
+            key={theme.id}
+            type="button"
+            onClick={() => onApplyTheme(theme.id)}
+          >
+            <span
+              className="theme-choice-preview"
+              style={
+                {
+                  '--theme-choice-accent': theme.palette.accent,
+                  '--theme-choice-background': theme.palette.background,
+                  '--theme-choice-surface': theme.palette.surface,
+                  '--theme-choice-text': theme.palette.text,
+                } as CSSProperties
+              }
+            >
+              <span />
+              <span />
+              <span />
+            </span>
+            <span className="theme-choice-copy">
+              <strong>{theme.name}</strong>
+              <span>
+                {theme.typography.headingFontFamily} / {theme.typography.bodyFontFamily}
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface SlideLayoutChooserProps {
+  activeLayoutId?: string | undefined;
+  layouts: SlideLayout[];
+  pageId?: string | undefined;
+  onApplySlideLayout: (pageId: string, layoutId: string) => void;
+}
+
+function SlideLayoutChooser({
+  activeLayoutId,
+  layouts,
+  pageId,
+  onApplySlideLayout,
+}: SlideLayoutChooserProps) {
+  return (
+    <div className="template-chooser-shelf" aria-label="Choose a layout" role="region">
+      <div className="template-chooser-title">Choose a layout</div>
+      {layouts.length > 0 ? (
+        <div className="layout-choice-grid">
+          {layouts.map((layout) => (
+            <button
+              aria-current={layout.id === activeLayoutId ? 'true' : undefined}
+              className={
+                layout.id === activeLayoutId
+                  ? 'layout-choice-card layout-choice-card-active'
+                  : 'layout-choice-card'
+              }
+              disabled={!pageId}
+              key={layout.id}
+              type="button"
+              onClick={() => {
+                if (pageId) onApplySlideLayout(pageId, layout.id);
+              }}
+            >
+              <LayoutChoiceThumbnail layout={layout} />
+              <span>{layout.name}</span>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <p className="template-chooser-empty">No imported layouts yet.</p>
+      )}
+    </div>
+  );
+}
+
+function LayoutChoiceThumbnail({ layout }: { layout: SlideLayout }) {
+  const elements = layout.elementIds
+    .map((elementId) => layout.elements[elementId])
+    .filter((element): element is DesignElement => Boolean(element))
+    .filter((element) => element.visible !== false);
+  if (elements.length > 0) {
+    const bounds = getLayoutThumbnailBounds(elements);
+    return (
+      <span className="layout-choice-thumbnail" aria-hidden="true">
+        {elements.map((element) => (
+          <LayoutChoiceElement element={element} key={element.id} bounds={bounds} />
+        ))}
+      </span>
+    );
+  }
+  const roles = new Set(layout.placeholderRoles);
+  return (
+    <span className="layout-choice-thumbnail" aria-hidden="true">
+      {roles.has('title') ? <span className="layout-choice-title" /> : null}
+      {roles.has('body') ? <span className="layout-choice-body" /> : null}
+      {roles.has('footer') ? <span className="layout-choice-footer" /> : null}
+      {roles.has('slideNumber') ? <span className="layout-choice-number" /> : null}
+      {roles.size === 0 ? <span className="layout-choice-blank" /> : null}
+    </span>
+  );
+}
+
+function getLayoutThumbnailBounds(elements: DesignElement[]) {
+  const xValues = elements.flatMap((element) => [element.x, element.x + element.width]);
+  const yValues = elements.flatMap((element) => [element.y, element.y + element.height]);
+  const minX = Math.min(...xValues, 0);
+  const minY = Math.min(...yValues, 0);
+  const maxX = Math.max(...xValues, 1920);
+  const maxY = Math.max(...yValues, 1080);
+  return {
+    minX,
+    minY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+}
+
+function getLayoutElementStyle(
+  element: DesignElement,
+  bounds: ReturnType<typeof getLayoutThumbnailBounds>,
+): CSSProperties {
+  return {
+    left: `${((element.x - bounds.minX) / bounds.width) * 100}%`,
+    top: `${((element.y - bounds.minY) / bounds.height) * 100}%`,
+    width: `${(element.width / bounds.width) * 100}%`,
+    height: `${(element.height / bounds.height) * 100}%`,
+    opacity: element.opacity,
+    transform: element.rotation ? `rotate(${element.rotation}deg)` : undefined,
+  };
+}
+
+function LayoutChoiceElement({
+  bounds,
+  element,
+}: {
+  bounds: ReturnType<typeof getLayoutThumbnailBounds>;
+  element: DesignElement;
+}) {
+  const style = getLayoutElementStyle(element, bounds);
+  if (element.type === 'text') {
+    return (
+      <span
+        className="layout-choice-element layout-choice-text"
+        style={{
+          ...style,
+          color: element.fill,
+          fontWeight: element.fontWeight,
+          justifyContent:
+            element.align === 'center' ? 'center' : element.align === 'right' ? 'flex-end' : 'flex-start',
+        }}
+      >
+        {element.text}
+      </span>
+    );
+  }
+  if (element.type === 'shape') {
+    return (
+      <span
+        className={`layout-choice-element layout-choice-shape layout-choice-shape-${element.shape}`}
+        style={{
+          ...style,
+          background: element.fill ?? 'transparent',
+          borderColor: element.stroke ?? element.fill ?? '#050D10',
+          borderWidth: element.strokeWidth ? 1 : 0,
+        }}
+      />
+    );
+  }
+  return <span className="layout-choice-element layout-choice-media" style={style} />;
 }
 
 interface ElementDesignInspectorProps {

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -715,7 +715,11 @@ function LayoutChoiceThumbnail({ layout }: { layout: SlideLayout }) {
   if (elements.length > 0) {
     const bounds = getLayoutThumbnailBounds(elements);
     return (
-      <span className="layout-choice-thumbnail" aria-hidden="true">
+      <span
+        className="layout-choice-thumbnail"
+        aria-hidden="true"
+        style={getLayoutThumbnailStyle(layout)}
+      >
         {elements.map((element) => (
           <LayoutChoiceElement element={element} key={element.id} bounds={bounds} />
         ))}
@@ -724,7 +728,11 @@ function LayoutChoiceThumbnail({ layout }: { layout: SlideLayout }) {
   }
   const roles = new Set(layout.placeholderRoles);
   return (
-    <span className="layout-choice-thumbnail" aria-hidden="true">
+    <span
+      className="layout-choice-thumbnail"
+      aria-hidden="true"
+      style={getLayoutThumbnailStyle(layout)}
+    >
       {roles.has('title') ? <span className="layout-choice-title" /> : null}
       {roles.has('body') ? <span className="layout-choice-body" /> : null}
       {roles.has('footer') ? <span className="layout-choice-footer" /> : null}
@@ -732,6 +740,31 @@ function LayoutChoiceThumbnail({ layout }: { layout: SlideLayout }) {
       {roles.size === 0 ? <span className="layout-choice-blank" /> : null}
     </span>
   );
+}
+
+function getLayoutPreviewInk(backgroundColor: string) {
+  const normalized = backgroundColor.replace('#', '');
+  const fullHex =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map((value) => `${value}${value}`)
+          .join('')
+      : normalized;
+  const red = Number.parseInt(fullHex.slice(0, 2), 16);
+  const green = Number.parseInt(fullHex.slice(2, 4), 16);
+  const blue = Number.parseInt(fullHex.slice(4, 6), 16);
+  if (![red, green, blue].every(Number.isFinite)) return '#182124';
+  const luminance = (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+  return luminance > 0.62 ? '#1E2528' : '#F5F7F3';
+}
+
+function getLayoutThumbnailStyle(layout: SlideLayout): CSSProperties {
+  const background = layout.background.type === 'color' ? layout.background.color : '#F8FAF7';
+  return {
+    '--layout-preview-background': background,
+    '--layout-preview-ink': getLayoutPreviewInk(background),
+  } as CSSProperties;
 }
 
 function getLayoutThumbnailBounds(elements: DesignElement[]) {
@@ -772,19 +805,18 @@ function LayoutChoiceElement({
 }) {
   const style = getLayoutElementStyle(element, bounds);
   if (element.type === 'text') {
+    const roleClass = element.placeholderRole
+      ? ` layout-choice-placeholder layout-choice-placeholder-${element.placeholderRole}`
+      : ' layout-choice-text-run';
     return (
       <span
-        className="layout-choice-element layout-choice-text"
+        className={`layout-choice-element layout-choice-text${roleClass}`}
         style={{
           ...style,
-          color: element.fill,
-          fontWeight: element.fontWeight,
           justifyContent:
             element.align === 'center' ? 'center' : element.align === 'right' ? 'flex-end' : 'flex-start',
         }}
-      >
-        {element.text}
-      </span>
+      />
     );
   }
   if (element.type === 'shape') {

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -108,6 +108,18 @@ interface LeftToolPanelProps {
   onUpdateTextContent?: ((elementId: string, text: string) => void) | undefined;
   onUpdateMediaPlayback?: ((elementId: string, patch: MediaPlaybackPatch) => void) | undefined;
   onUpdatePageBackground?: ((background: PageBackground) => void) | undefined;
+  onApplyTheme?: ((themeId: string) => void) | undefined;
+  onEditTheme?: ((themeId: string) => void) | undefined;
+  onChangeTheme?: (() => void) | undefined;
+  onApplySlideLayout?: ((pageId: string, layoutId: string) => void) | undefined;
+  onEditSlideLayout?: ((layoutId: string) => void) | undefined;
+  onToggleSlideLayoutPlaceholder?:
+    | ((
+        layoutId: string,
+        role: 'body' | 'footer' | 'slideNumber' | 'title',
+        visible: boolean,
+      ) => void)
+    | undefined;
   onReplaceVideoAsset?: ((elementId: string, file: File) => void) | undefined;
   onClearPageTransition?: (() => void) | undefined;
   onSetPageTransition?: ((transition: SlideTransition) => void) | undefined;
@@ -192,6 +204,12 @@ export function LeftToolPanel({
   onUpdateTextContent,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
+  onApplyTheme,
+  onEditTheme,
+  onChangeTheme,
+  onApplySlideLayout,
+  onEditSlideLayout,
+  onToggleSlideLayoutPlaceholder,
   onReplaceVideoAsset,
   onClearPageTransition,
   onSetPageTransition,
@@ -308,6 +326,12 @@ export function LeftToolPanel({
             {...(onUpdateTextContent ? { onUpdateTextContent } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
+            {...(onApplyTheme ? { onApplyTheme } : {})}
+            {...(onEditTheme ? { onEditTheme } : {})}
+            {...(onChangeTheme ? { onChangeTheme } : {})}
+            {...(onApplySlideLayout ? { onApplySlideLayout } : {})}
+            {...(onEditSlideLayout ? { onEditSlideLayout } : {})}
+            {...(onToggleSlideLayoutPlaceholder ? { onToggleSlideLayoutPlaceholder } : {})}
             {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}
             {...(onSetElementAnimationBuilds ? { onSetElementAnimationBuilds } : {})}
           />

--- a/apps/editor/src/ui/editor/panels/RightPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/RightPanel.tsx
@@ -60,6 +60,16 @@ interface RightPanelProps {
   onUpdateTextContent?: (elementId: string, text: string) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
   onUpdatePageBackground?: (background: PageBackground) => void;
+  onApplyTheme?: (themeId: string) => void;
+  onEditTheme?: (themeId: string) => void;
+  onChangeTheme?: () => void;
+  onApplySlideLayout?: (pageId: string, layoutId: string) => void;
+  onEditSlideLayout?: (layoutId: string) => void;
+  onToggleSlideLayoutPlaceholder?: (
+    layoutId: string,
+    role: 'body' | 'footer' | 'slideNumber' | 'title',
+    visible: boolean,
+  ) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
   onReplaceVideoAsset?: (elementId: string, file: File) => void;
   onSetElementAnimationBuilds?: (elementIds: string[], patch: ElementAnimationPatch) => void;
@@ -108,6 +118,12 @@ export function RightPanel({
   onUpdateTextContent,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
+  onApplyTheme,
+  onEditTheme,
+  onChangeTheme,
+  onApplySlideLayout,
+  onEditSlideLayout,
+  onToggleSlideLayoutPlaceholder,
   onSetSelectedElementZOrder,
   onReplaceVideoAsset,
   onSetElementAnimationBuilds,
@@ -165,6 +181,12 @@ export function RightPanel({
             {...(onUpdateTextContent ? { onUpdateTextContent } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}
+            {...(onApplyTheme ? { onApplyTheme } : {})}
+            {...(onEditTheme ? { onEditTheme } : {})}
+            {...(onChangeTheme ? { onChangeTheme } : {})}
+            {...(onApplySlideLayout ? { onApplySlideLayout } : {})}
+            {...(onEditSlideLayout ? { onEditSlideLayout } : {})}
+            {...(onToggleSlideLayoutPlaceholder ? { onToggleSlideLayoutPlaceholder } : {})}
             {...(onReplaceVideoAsset ? { onReplaceVideoAsset } : {})}
             {...(onSetElementAnimationBuilds ? { onSetElementAnimationBuilds } : {})}
           />

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -983,6 +983,14 @@ export function EditorShell({ services }: EditorShellProps) {
           onUpdateTextContent={isHistoryReadOnly ? undefined : vm.updateTextContent}
           onUpdateMediaPlayback={isHistoryReadOnly ? undefined : vm.updateMediaPlayback}
           onUpdatePageBackground={isHistoryReadOnly ? undefined : vm.updatePageBackground}
+          onApplyTheme={isHistoryReadOnly ? undefined : vm.applyTheme}
+          onEditTheme={isHistoryReadOnly ? undefined : vm.editTheme}
+          onChangeTheme={isHistoryReadOnly ? undefined : vm.changeTheme}
+          onApplySlideLayout={isHistoryReadOnly ? undefined : vm.applySlideLayout}
+          onEditSlideLayout={isHistoryReadOnly ? undefined : vm.editSlideLayout}
+          onToggleSlideLayoutPlaceholder={
+            isHistoryReadOnly ? undefined : vm.toggleSlideLayoutPlaceholder
+          }
           onReplaceVideoAsset={
             isHistoryReadOnly
               ? undefined
@@ -1217,6 +1225,8 @@ export function EditorShell({ services }: EditorShellProps) {
                   }
             }
             onOpenFontPanel={isHistoryReadOnly ? undefined : openDesignFontList}
+            onSelectPresentation={isHistoryReadOnly ? undefined : vm.selectPresentation}
+            onSelectSlide={isHistoryReadOnly ? undefined : vm.selectSlideBackground}
             onSelectElement={isHistoryReadOnly ? undefined : selectElement}
             onSendSelectedElementBackward={
               isHistoryReadOnly

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -611,6 +611,9 @@ export function useEditorViewModel(services: AppServices) {
   const activePageIdRef = useRef(activePageId);
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
   const selectedElementIdsRef = useRef(selectedElementIds);
+  const [selectionTarget, setSelectionTarget] = useState<NonNullable<SelectionState['target']>>(
+    'presentation',
+  );
   const [history, setHistory] = useState<EditorHistory>({ past: [], future: [] });
   const [zoomPercent, setZoomPercent] = useState(100);
   const [pagesPanelOpen, setPagesPanelOpen] = useState(false);
@@ -735,8 +738,8 @@ export function useEditorViewModel(services: AppServices) {
   const skipNextProjectSaveRef = useRef(shouldRestoreStoredProject);
   const lastVersionProjectRef = useRef<ProjectDocument>(initialProject);
   const selection = useMemo<SelectionState>(
-    () => ({ pageId: activePageId, elementIds: selectedElementIds }),
-    [activePageId, selectedElementIds],
+    () => ({ pageId: activePageId, elementIds: selectedElementIds, target: selectionTarget }),
+    [activePageId, selectedElementIds, selectionTarget],
   );
   const selectedImageElement = useMemo<ImageElement | undefined>(() => {
     if (selectedElementIds.length !== 1) return undefined;
@@ -1592,6 +1595,7 @@ export function useEditorViewModel(services: AppServices) {
       if (options?.selectedElementIds !== undefined) {
         selectedElementIdsRef.current = options.selectedElementIds;
         setSelectedElementIds(options.selectedElementIds);
+        setSelectionTarget(options.selectedElementIds.length > 0 ? 'elements' : 'slide');
       }
       return nextProject;
     });
@@ -1616,6 +1620,7 @@ export function useEditorViewModel(services: AppServices) {
     clearBackgroundPreview();
     clearBackgroundPreparation();
     clearBackgroundSelectionPoints();
+    setSelectionTarget('elements');
     setSelectedElementIds((currentSelection) => {
       if (!options?.additive) return [elementId];
       if (currentSelection.includes(elementId)) {
@@ -1637,6 +1642,7 @@ export function useEditorViewModel(services: AppServices) {
     clearBackgroundPreview();
     clearBackgroundPreparation();
     clearBackgroundSelectionPoints();
+    setSelectionTarget('elements');
     setSelectedElementIds(selectableElementIds);
   }
 
@@ -1646,6 +1652,27 @@ export function useEditorViewModel(services: AppServices) {
     clearBackgroundPreview();
     clearBackgroundPreparation();
     clearBackgroundSelectionPoints();
+    setSelectionTarget('presentation');
+    setSelectedElementIds([]);
+  }
+
+  function selectSlideBackground() {
+    setBackgroundSelectionMode(false);
+    setBackgroundSelectionNotice(undefined);
+    clearBackgroundPreview();
+    clearBackgroundPreparation();
+    clearBackgroundSelectionPoints();
+    setSelectionTarget('slide');
+    setSelectedElementIds([]);
+  }
+
+  function selectPresentation() {
+    setBackgroundSelectionMode(false);
+    setBackgroundSelectionNotice(undefined);
+    clearBackgroundPreview();
+    clearBackgroundPreparation();
+    clearBackgroundSelectionPoints();
+    setSelectionTarget('presentation');
     setSelectedElementIds([]);
   }
 
@@ -2458,6 +2485,52 @@ export function useEditorViewModel(services: AppServices) {
       new basicCommands.UpdatePageBackgroundCommand(activePageId, background).execute(
         currentProject,
       ),
+    );
+  }
+
+  function applyTheme(themeId: string) {
+    commitProject((currentProject) =>
+      new basicCommands.ApplyThemeCommand(themeId).execute(currentProject),
+    );
+  }
+
+  function editTheme(themeId: string) {
+    const theme = projectRef.current.themes?.[themeId];
+    if (!theme) return;
+    commitProject((currentProject) => new basicCommands.EditThemeCommand(theme).execute(currentProject));
+  }
+
+  function changeTheme() {
+    const themeId = projectRef.current.themeId ?? Object.keys(projectRef.current.themes ?? {})[0];
+    if (!themeId) return;
+    applyTheme(themeId);
+  }
+
+  function applySlideLayout(pageId: string, layoutId: string) {
+    commitProject((currentProject) =>
+      new basicCommands.ApplySlideLayoutCommand(pageId, layoutId).execute(currentProject),
+    );
+  }
+
+  function editSlideLayout(layoutId: string) {
+    const layout = projectRef.current.slideLayouts?.[layoutId];
+    if (!layout) return;
+    commitProject((currentProject) =>
+      new basicCommands.EditSlideLayoutCommand(layout).execute(currentProject),
+    );
+  }
+
+  function toggleSlideLayoutPlaceholder(
+    layoutId: string,
+    role: 'body' | 'footer' | 'slideNumber' | 'title',
+    visible: boolean,
+  ) {
+    commitProject((currentProject) =>
+      new basicCommands.ToggleSlideLayoutPlaceholderVisibilityCommand(
+        layoutId,
+        role,
+        visible,
+      ).execute(currentProject),
     );
   }
 
@@ -4214,6 +4287,8 @@ export function useEditorViewModel(services: AppServices) {
     selectElement,
     selectAllElementsOnActivePage,
     clearSelection,
+    selectSlideBackground,
+    selectPresentation,
     selectPage,
     activateScrolledPage,
     addPage,
@@ -4252,6 +4327,12 @@ export function useEditorViewModel(services: AppServices) {
     downloadFontForSelection,
     updateMediaPlayback,
     updatePageBackground,
+    applyTheme,
+    editTheme,
+    changeTheme,
+    applySlideLayout,
+    editSlideLayout,
+    toggleSlideLayoutPlaceholder,
     clearPageTransition,
     setPageTransition,
     setElementAnimationBuilds,

--- a/apps/editor/src/ui/styles/design-panel.css
+++ b/apps/editor/src/ui/styles/design-panel.css
@@ -319,9 +319,12 @@
   width: 100%;
   aspect-ratio: 16 / 9;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 4px;
-  background: #fbfcfb;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 3px;
+  background: var(--layout-preview-background, #fbfcfb);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--layout-preview-ink, #182124) 14%, transparent),
+    0 6px 16px rgba(0, 0, 0, 0.24);
 }
 
 .layout-choice-thumbnail span {
@@ -335,22 +338,22 @@
 .layout-choice-footer,
 .layout-choice-number,
 .layout-choice-blank {
-  background: #050d10;
+  border: 1px dashed color-mix(in srgb, var(--layout-preview-ink, #182124) 78%, transparent);
+  background: transparent;
 }
 
 .layout-choice-title {
   left: 8%;
   top: 15%;
   width: 42%;
-  height: 8%;
+  height: 14%;
 }
 
 .layout-choice-body {
   left: 8%;
-  top: 34%;
+  top: 36%;
   width: 72%;
-  height: 22%;
-  opacity: 0.24;
+  height: 30%;
 }
 
 .layout-choice-footer {
@@ -374,7 +377,7 @@
   top: 44%;
   width: 18%;
   height: 12%;
-  opacity: 0.12;
+  opacity: 0.42;
 }
 
 .layout-choice-element {
@@ -386,15 +389,81 @@
 }
 
 .layout-choice-text {
-  display: flex;
-  align-items: center;
+  display: block;
   overflow: hidden;
-  background: transparent;
-  color: #050d10;
-  font-size: clamp(3px, 0.48vw, 7px);
-  line-height: 1.05;
-  text-align: left;
-  white-space: nowrap;
+}
+
+.layout-choice-placeholder {
+  border: 1px dashed color-mix(in srgb, var(--layout-preview-ink, #182124) 78%, transparent);
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 36%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 36%, transparent)
+    )
+    8% 24% / 46% 6% no-repeat,
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 22%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 22%, transparent)
+    )
+    8% 52% / 72% 5% no-repeat;
+}
+
+.layout-choice-placeholder-title {
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 58%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 58%, transparent)
+    )
+    7% 28% / 68% 10% no-repeat,
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 28%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 28%, transparent)
+    )
+    7% 60% / 88% 7% no-repeat;
+}
+
+.layout-choice-placeholder-body {
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 34%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 34%, transparent)
+    )
+    7% 18% / 58% 5% no-repeat,
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 24%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 24%, transparent)
+    )
+    7% 40% / 82% 5% no-repeat,
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 18%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 18%, transparent)
+    )
+    7% 62% / 70% 5% no-repeat;
+}
+
+.layout-choice-placeholder-footer,
+.layout-choice-placeholder-slideNumber {
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 30%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 30%, transparent)
+    )
+    center / 72% 24% no-repeat;
+}
+
+.layout-choice-text-run {
+  border-radius: 1px;
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 68%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 68%, transparent)
+    )
+    0 22% / 72% 9% no-repeat,
+    linear-gradient(
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 34%, transparent),
+      color-mix(in srgb, var(--layout-preview-ink, #182124) 34%, transparent)
+    )
+    0 56% / 92% 7% no-repeat;
 }
 
 .layout-choice-shape {

--- a/apps/editor/src/ui/styles/design-panel.css
+++ b/apps/editor/src/ui/styles/design-panel.css
@@ -60,3 +60,461 @@
   padding: 0;
   accent-color: var(--ew-green);
 }
+
+.template-preview-card {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 74px;
+  padding: 10px;
+  border: 1px solid rgba(55, 253, 118, 0.16);
+  border-radius: 8px;
+  background: linear-gradient(135deg, rgba(55, 253, 118, 0.08), rgba(255, 255, 255, 0.03));
+}
+
+.template-preview-button {
+  width: 100%;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.template-preview-button:hover,
+.template-preview-button:focus-visible {
+  border-color: rgba(55, 253, 118, 0.45);
+  box-shadow: 0 0 24px rgba(55, 253, 118, 0.1);
+  outline: none;
+}
+
+.template-filmstrip,
+.template-slide-thumbnail {
+  position: relative;
+  width: 72px;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+  background: #f8faf9;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+}
+
+.template-filmstrip span,
+.template-slide-thumbnail span {
+  position: absolute;
+  display: block;
+  border-radius: 2px;
+  background: #050d10;
+}
+
+.template-filmstrip span:nth-child(1) {
+  left: 8px;
+  top: 8px;
+  width: 32px;
+  height: 4px;
+}
+
+.template-filmstrip span:nth-child(2) {
+  left: 8px;
+  top: 17px;
+  width: 48px;
+  height: 3px;
+  opacity: 0.5;
+}
+
+.template-filmstrip span:nth-child(3) {
+  left: 8px;
+  bottom: 8px;
+  width: 18px;
+  height: 3px;
+  opacity: 0.36;
+}
+
+.template-slide-title {
+  left: 8px;
+  top: 8px;
+  width: 38px;
+  height: 5px;
+}
+
+.template-slide-body {
+  left: 8px;
+  top: 20px;
+  width: 54px;
+  height: 12px;
+  opacity: 0.28;
+}
+
+.template-slide-footer {
+  right: 8px;
+  bottom: 7px;
+  width: 16px;
+  height: 3px;
+  opacity: 0.45;
+}
+
+.template-preview-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.template-preview-copy span {
+  color: var(--ew-muted);
+  font-size: 11px;
+}
+
+.template-preview-copy strong {
+  overflow: hidden;
+  color: var(--ew-text);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.template-action-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.template-action-row button,
+.template-segmented-control button {
+  min-height: 34px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ew-text);
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.template-action-row button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.template-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  color: var(--ew-text);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.template-checkbox-row input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--ew-green);
+}
+
+.template-segmented-control {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  padding: 3px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.template-segmented-control button {
+  min-height: 30px;
+  border: 0;
+  background: transparent;
+}
+
+.template-segmented-control .template-segmented-active {
+  background: var(--ew-green);
+  color: #050d10;
+}
+
+.template-chooser-shelf {
+  position: relative;
+  display: grid;
+  gap: 12px;
+  max-height: min(560px, 62vh);
+  padding: 12px;
+  overflow: auto;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 12px;
+  background:
+    linear-gradient(145deg, rgba(11, 19, 21, 0.96), rgba(11, 19, 21, 0.82)),
+    radial-gradient(circle at 20% 0%, rgba(55, 253, 118, 0.16), transparent 38%);
+  box-shadow:
+    0 24px 60px rgba(0, 0, 0, 0.46),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.template-chooser-shelf::before {
+  position: absolute;
+  top: -7px;
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  border-left: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(11, 19, 21, 0.96);
+  content: '';
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.template-chooser-title {
+  position: sticky;
+  top: -12px;
+  z-index: 1;
+  padding: 2px 0 4px;
+  background: rgba(11, 19, 21, 0.92);
+  color: var(--ew-muted);
+  font-size: 12px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.layout-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px 10px;
+}
+
+.layout-choice-card {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ew-muted);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-align: center;
+  cursor: pointer;
+}
+
+.layout-choice-card > span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.layout-choice-card:hover,
+.layout-choice-card:focus-visible,
+.layout-choice-card-active {
+  color: var(--ew-text);
+  outline: none;
+}
+
+.layout-choice-card:hover .layout-choice-thumbnail,
+.layout-choice-card:focus-visible .layout-choice-thumbnail,
+.layout-choice-card-active .layout-choice-thumbnail {
+  border-color: rgba(55, 253, 118, 0.62);
+  box-shadow: 0 0 0 1px rgba(55, 253, 118, 0.16), 0 10px 28px rgba(0, 0, 0, 0.36);
+}
+
+.layout-choice-thumbnail {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 4px;
+  background: #fbfcfb;
+}
+
+.layout-choice-thumbnail span {
+  position: absolute;
+  display: block;
+  border-radius: 2px;
+}
+
+.layout-choice-title,
+.layout-choice-body,
+.layout-choice-footer,
+.layout-choice-number,
+.layout-choice-blank {
+  background: #050d10;
+}
+
+.layout-choice-title {
+  left: 8%;
+  top: 15%;
+  width: 42%;
+  height: 8%;
+}
+
+.layout-choice-body {
+  left: 8%;
+  top: 34%;
+  width: 72%;
+  height: 22%;
+  opacity: 0.24;
+}
+
+.layout-choice-footer {
+  left: 8%;
+  bottom: 14%;
+  width: 26%;
+  height: 5%;
+  opacity: 0.38;
+}
+
+.layout-choice-number {
+  right: 8%;
+  bottom: 13%;
+  width: 10%;
+  height: 7%;
+  opacity: 0.42;
+}
+
+.layout-choice-blank {
+  left: 41%;
+  top: 44%;
+  width: 18%;
+  height: 12%;
+  opacity: 0.12;
+}
+
+.layout-choice-element {
+  position: absolute;
+  box-sizing: border-box;
+  min-width: 2px;
+  min-height: 2px;
+  transform-origin: center;
+}
+
+.layout-choice-text {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  background: transparent;
+  color: #050d10;
+  font-size: clamp(3px, 0.48vw, 7px);
+  line-height: 1.05;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.layout-choice-shape {
+  border-style: solid;
+}
+
+.layout-choice-shape-ellipse {
+  border-radius: 999px;
+}
+
+.layout-choice-shape-rounded-rect {
+  border-radius: 5px;
+}
+
+.layout-choice-shape-line,
+.layout-choice-shape-arrow {
+  height: 2px !important;
+  min-height: 2px;
+}
+
+.layout-choice-media {
+  border: 1px solid rgba(5, 13, 16, 0.22);
+  background:
+    linear-gradient(135deg, rgba(5, 13, 16, 0.12), rgba(5, 13, 16, 0.02)),
+    #eef3f0;
+}
+
+.template-chooser-empty {
+  margin: 0;
+  color: var(--ew-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.theme-choice-list {
+  display: grid;
+  gap: 8px;
+}
+
+.theme-choice-card {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  min-height: 58px;
+  padding: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--ew-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.theme-choice-card:hover,
+.theme-choice-card:focus-visible,
+.theme-choice-card-active {
+  border-color: rgba(55, 253, 118, 0.52);
+  outline: none;
+  box-shadow: 0 0 18px rgba(55, 253, 118, 0.08);
+}
+
+.theme-choice-preview {
+  position: relative;
+  display: block;
+  width: 64px;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 4px;
+  background: var(--theme-choice-background);
+}
+
+.theme-choice-preview span {
+  position: absolute;
+  display: block;
+  border-radius: 2px;
+}
+
+.theme-choice-preview span:nth-child(1) {
+  left: 8px;
+  top: 8px;
+  width: 28px;
+  height: 5px;
+  background: var(--theme-choice-text);
+}
+
+.theme-choice-preview span:nth-child(2) {
+  left: 8px;
+  top: 19px;
+  width: 42px;
+  height: 10px;
+  background: var(--theme-choice-surface);
+}
+
+.theme-choice-preview span:nth-child(3) {
+  right: 8px;
+  bottom: 7px;
+  width: 18px;
+  height: 4px;
+  background: var(--theme-choice-accent);
+}
+
+.theme-choice-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.theme-choice-copy strong,
+.theme-choice-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-choice-copy strong {
+  font-size: 12px;
+}
+
+.theme-choice-copy span {
+  color: var(--ew-muted);
+  font-size: 10px;
+}

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -41,7 +41,7 @@ function createTemplateFixture(): ProjectDocument {
         id: 'layout-title',
         name: 'Title',
         background: { type: 'color', color: '#101010' },
-        elementIds: ['layout-title-text'],
+        elementIds: ['layout-title-text', 'layout-body-text'],
         elements: {
           'layout-title-text': {
             id: 'layout-title-text',
@@ -63,8 +63,30 @@ function createTemplateFixture(): ProjectDocument {
             placeholderRole: 'title',
             templateSource: { layoutId: 'layout-title', type: 'layout' },
           },
+          'layout-body-text': {
+            id: 'layout-body-text',
+            type: 'text',
+            text: 'Template body',
+            x: 128,
+            y: 300,
+            width: 980,
+            height: 180,
+            rotation: 0,
+            locked: false,
+            visible: true,
+            opacity: 0.86,
+            fontFamily: 'Open Sans',
+            fontSize: 34,
+            fontWeight: 500,
+            fill: '#CFE6D6',
+            align: 'center',
+            lineHeight: 1.2,
+            verticalAlign: 'middle',
+            placeholderRole: 'body',
+            templateSource: { layoutId: 'layout-title', type: 'layout' },
+          },
         },
-        placeholderRoles: ['title'],
+        placeholderRoles: ['title', 'body'],
         placeholderVisibility: {
           body: true,
           footer: true,
@@ -874,6 +896,137 @@ describe('editor commands', () => {
     });
     expect(next.pages[0]?.elementIds).toEqual(project.pages[0]?.elementIds);
     expect(next.elements['layout-title-text']).toBeUndefined();
+    expect(next.elements['layout-body-text']).toBeUndefined();
+  });
+
+  it('fits slide title and subtitle text into the applied layout placeholders', () => {
+    const project = createTemplateFixture();
+    const next = new basicCommands.ApplySlideLayoutCommand('page-1', 'layout-title').execute(
+      project,
+    );
+
+    expect(next.pages[0]?.elementIds).toEqual(project.pages[0]?.elementIds);
+    expect(next.elements['text-title']).toMatchObject({
+      id: 'text-title',
+      type: 'text',
+      text: 'AI Design Revolution',
+      x: 96,
+      y: 96,
+      width: 640,
+      height: 120,
+      fontFamily: 'Orbitron',
+      fontSize: 96,
+      fontWeight: 800,
+      fill: '#37FD76',
+      align: 'left',
+      placeholderRole: 'title',
+    });
+    expect(next.elements['text-subtitle']).toMatchObject({
+      id: 'text-subtitle',
+      type: 'text',
+      text: 'Browser-native creative automation',
+      x: 128,
+      y: 300,
+      width: 980,
+      height: 180,
+      opacity: 0.86,
+      fontFamily: 'Open Sans',
+      fontSize: 40,
+      fontWeight: 600,
+      fill: '#FFFFFF',
+      align: 'center',
+      verticalAlign: 'middle',
+      placeholderRole: 'body',
+    });
+    expect(next.elements['image-hero']).toEqual(project.elements['image-hero']);
+  });
+
+  it('creates editable placeholder text when applying a layout to an empty slide', () => {
+    const project = {
+      ...createTemplateFixture(),
+      pages: [
+        {
+          id: 'page-empty',
+          name: 'Empty slide',
+          width: 1920,
+          height: 1080,
+          background: { type: 'color' as const, color: '#000000' },
+          elementIds: [],
+        },
+      ],
+      elements: {},
+    };
+    const next = new basicCommands.ApplySlideLayoutCommand('page-empty', 'layout-title').execute(
+      project,
+    );
+
+    expect(next.pages[0]).toMatchObject({
+      id: 'page-empty',
+      layoutId: 'layout-title',
+      elementIds: ['page-empty-layout-title-text', 'page-empty-layout-body-text'],
+    });
+    expect(next.elements['page-empty-layout-title-text']).toMatchObject({
+      type: 'text',
+      text: 'Template title',
+      x: 96,
+      y: 96,
+      width: 640,
+      height: 120,
+      placeholderRole: 'title',
+    });
+    expect(next.elements['page-empty-layout-title-text']).not.toHaveProperty('templateSource');
+    expect(next.elements['page-empty-layout-body-text']).toMatchObject({
+      type: 'text',
+      text: 'Template body',
+      x: 128,
+      y: 300,
+      width: 980,
+      height: 180,
+      placeholderRole: 'body',
+    });
+    expect(next.slideLayouts?.['layout-title']?.elements['layout-title-text']).toHaveProperty(
+      'templateSource',
+    );
+  });
+
+  it('adds editable text placeholders for layout slots missing from a populated slide', () => {
+    const project = createTemplateFixture();
+    const { 'text-subtitle': removedSubtitle, ...elements } = project.elements;
+    void removedSubtitle;
+    const partialProject = {
+      ...project,
+      elements,
+      pages: project.pages.map((page) =>
+        page.id === 'page-1'
+          ? { ...page, elementIds: page.elementIds.filter((elementId) => elementId !== 'text-subtitle') }
+          : page,
+      ),
+    };
+    const next = new basicCommands.ApplySlideLayoutCommand('page-1', 'layout-title').execute(
+      partialProject,
+    );
+
+    expect(next.pages[0]?.elementIds).toEqual([
+      'image-hero',
+      'text-title',
+      'page-1-layout-body-text',
+    ]);
+    expect(next.elements['text-title']).toMatchObject({
+      text: 'AI Design Revolution',
+      x: 96,
+      y: 96,
+      placeholderRole: 'title',
+    });
+    expect(next.elements['page-1-layout-body-text']).toMatchObject({
+      type: 'text',
+      text: 'Template body',
+      x: 128,
+      y: 300,
+      width: 980,
+      height: 180,
+      placeholderRole: 'body',
+    });
+    expect(next.elements['page-1-layout-title-text']).toBeUndefined();
   });
 
   it('applies a theme without creating slide elements from template text', () => {

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -1,6 +1,6 @@
 import { basicCommands } from '../../../../src/domain/commands/elements/basicCommands';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
-import type { ShapeElement } from '../../../../src/domain/documents/model';
+import type { ProjectDocument, ShapeElement } from '../../../../src/domain/documents/model';
 
 function createShapeFixture(overrides: Partial<ShapeElement> = {}) {
   const project = sampleProject.createSampleProject();
@@ -30,6 +30,66 @@ function createShapeFixture(overrides: Partial<ShapeElement> = {}) {
     pages: project.pages.map((page) =>
       page.id === 'page-1' ? { ...page, elementIds: [...page.elementIds, shape.id] } : page,
     ),
+  };
+}
+
+function createTemplateFixture(): ProjectDocument {
+  return {
+    ...sampleProject.createSampleProject(),
+    slideLayouts: {
+      'layout-title': {
+        id: 'layout-title',
+        name: 'Title',
+        background: { type: 'color', color: '#101010' },
+        elementIds: ['layout-title-text'],
+        elements: {
+          'layout-title-text': {
+            id: 'layout-title-text',
+            type: 'text',
+            text: 'Template title',
+            x: 96,
+            y: 96,
+            width: 640,
+            height: 120,
+            rotation: 0,
+            locked: false,
+            visible: true,
+            opacity: 1,
+            fontFamily: 'Inter',
+            fontSize: 52,
+            fontWeight: 700,
+            fill: '#FFFFFF',
+            align: 'left',
+            placeholderRole: 'title',
+            templateSource: { layoutId: 'layout-title', type: 'layout' },
+          },
+        },
+        placeholderRoles: ['title'],
+        placeholderVisibility: {
+          body: true,
+          footer: true,
+          slideNumber: true,
+          title: true,
+        },
+      },
+    },
+    themes: {
+      'theme-studio': {
+        id: 'theme-studio',
+        name: 'Studio',
+        palette: {
+          accent: '#37FD76',
+          background: '#050D10',
+          mutedText: '#91999D',
+          surface: '#0C1417',
+          text: '#FFFFFF',
+        },
+        typography: {
+          bodyFontFamily: 'Inter',
+          headingFontFamily: 'Orbitron',
+        },
+      },
+    },
   };
 }
 
@@ -800,5 +860,31 @@ describe('editor commands', () => {
     expect(renamed.pages[0]?.name).toBe('Launch Slide');
     expect(hidden.pages[0]).toMatchObject({ id: 'page-copy', visible: false });
     expect(project.pages.map((page) => page.id)).toEqual(['page-1', 'page-copy']);
+  });
+
+  it('applies a slide layout without deleting user-authored elements', () => {
+    const project = createTemplateFixture();
+    const next = new basicCommands.ApplySlideLayoutCommand('page-1', 'layout-title').execute(
+      project,
+    );
+
+    expect(next.pages[0]).toMatchObject({
+      id: 'page-1',
+      layoutId: 'layout-title',
+    });
+    expect(next.pages[0]?.elementIds).toEqual(project.pages[0]?.elementIds);
+    expect(next.elements['layout-title-text']).toBeUndefined();
+  });
+
+  it('applies a theme without creating slide elements from template text', () => {
+    const project = createTemplateFixture();
+    const next = new basicCommands.ApplyThemeCommand('theme-studio').execute(project);
+
+    expect(next.themeId).toBe('theme-studio');
+    expect(next.elements['layout-title-text']).toBeUndefined();
+    expect(next.slideLayouts?.['layout-title']?.elements['layout-title-text']).toMatchObject({
+      text: 'Template title',
+      templateSource: { layoutId: 'layout-title', type: 'layout' },
+    });
   });
 });

--- a/apps/editor/tests/unit/services/pptxImportService.test.ts
+++ b/apps/editor/tests/unit/services/pptxImportService.test.ts
@@ -9,6 +9,9 @@ vi.stubGlobal('URL', {
 const presentationXml = `<?xml version="1.0" encoding="UTF-8"?>
 <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <p:sldSz cx="9144000" cy="5143500"/>
+  <p:sldMasterIdLst>
+    <p:sldMasterId id="2147483648" r:id="rIdMaster"/>
+  </p:sldMasterIdLst>
   <p:sldIdLst>
     <p:sldId id="256" r:id="rId1"/>
   </p:sldIdLst>
@@ -25,6 +28,7 @@ const presentationXml = `<?xml version="1.0" encoding="UTF-8"?>
 const presentationRels = `<?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+  <Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
 </Relationships>`;
 
 const slideRels = `<?xml version="1.0" encoding="UTF-8"?>
@@ -39,11 +43,12 @@ const slideRels = `<?xml version="1.0" encoding="UTF-8"?>
 const layoutRels = `<?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
   <Relationship Id="rIdLayoutImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/layout-icon.png"/>
+  <Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
 </Relationships>`;
 
 const layoutXml = `<?xml version="1.0" encoding="UTF-8"?>
 <p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
-  <p:cSld>
+  <p:cSld name="Statement">
     <p:spTree>
       <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
       <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></a:xfrm></p:grpSpPr>
@@ -65,6 +70,40 @@ const layoutXml = `<?xml version="1.0" encoding="UTF-8"?>
     </p:spTree>
   </p:cSld>
 </p:sldLayout>`;
+
+const unusedLayoutXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld name="Title &amp; Photo">
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="31" name="Photo title"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="457200" y="457200"/><a:ext cx="3657600" cy="457200"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Photo title</a:t></a:r></a:p></p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="32" name="Photo placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="pic"/></p:nvPr></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="4572000" y="914400"/><a:ext cx="1828800" cy="2743200"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sldLayout>`;
+
+const masterRels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdLayout1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+  <Relationship Id="rIdLayout2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>
+</Relationships>`;
+
+const masterXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld name="21_BasicWhite"><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+  <p:sldLayoutIdLst>
+    <p:sldLayoutId id="1" r:id="rIdLayout1"/>
+    <p:sldLayoutId id="2" r:id="rIdLayout2"/>
+  </p:sldLayoutIdLst>
+</p:sldMaster>`;
 
 const slideXml = `<?xml version="1.0" encoding="UTF-8"?>
 <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main">
@@ -167,12 +206,158 @@ function createPptxFixture(slideContents = slideXml) {
     { path: 'ppt/slides/_rels/slide1.xml.rels', contents: slideRels },
     { path: 'ppt/notesSlides/notesSlide1.xml', contents: notesSlideXml },
     { path: 'ppt/slideLayouts/slideLayout1.xml', contents: layoutXml },
+    { path: 'ppt/slideLayouts/slideLayout2.xml', contents: unusedLayoutXml },
     { path: 'ppt/slideLayouts/_rels/slideLayout1.xml.rels', contents: layoutRels },
+    { path: 'ppt/slideMasters/slideMaster1.xml', contents: masterXml },
+    { path: 'ppt/slideMasters/_rels/slideMaster1.xml.rels', contents: masterRels },
     { path: 'ppt/media/image1.png', contents: new Uint8Array([137, 80, 78, 71]) },
     { path: 'ppt/media/layout-icon.png', contents: new Uint8Array([137, 80, 78, 71]) },
     { path: 'ppt/media/poster1.png', contents: new Uint8Array([137, 80, 78, 71]) },
     { path: 'ppt/media/media1.mp4', contents: new Uint8Array([0, 0, 0, 24]) },
   ]);
+}
+
+const contentTypesXml = `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/deck/main.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/deck/media/photo.dat" ContentType="image/png"/>
+</Types>`;
+
+const packageRels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPresentation" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="deck/main.xml"/>
+</Relationships>`;
+
+const standardPresentationXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:sldSz cx="9144000" cy="5143500"/>
+  <p:sldIdLst>
+    <p:sldId id="256" r:id="rIdSlide"/>
+  </p:sldIdLst>
+</p:presentation>`;
+
+const standardPresentationRels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdSlide" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slideA.xml"/>
+</Relationships>`;
+
+const standardSlideRels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdLayout" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../layouts/layoutA.xml"/>
+  <Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/photo.dat"/>
+  <Relationship Id="rIdExternal" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="https://example.com/external.png" TargetMode="External"/>
+  <Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
+</Relationships>`;
+
+const standardLayoutRels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../masters/masterA.xml"/>
+</Relationships>`;
+
+const standardMasterRels = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdTheme" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/themeA.xml"/>
+</Relationships>`;
+
+const standardLayoutXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+</p:sldLayout>`;
+
+const standardMasterXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+</p:sldMaster>`;
+
+const standardThemeXml = `<?xml version="1.0" encoding="UTF-8"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <a:themeElements>
+    <a:clrScheme name="LocalStudio">
+      <a:dk1><a:srgbClr val="111111"/></a:dk1>
+      <a:lt1><a:srgbClr val="ffffff"/></a:lt1>
+      <a:accent1><a:srgbClr val="ff9900"/></a:accent1>
+    </a:clrScheme>
+  </a:themeElements>
+</a:theme>`;
+
+const standardSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <p:cSld>
+    <p:bg><p:bgPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></p:bgPr></p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="10" name="Theme shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm rot="5400000"><a:off x="914400" y="914400"/><a:ext cx="914400" cy="457200"/></a:xfrm>
+          <a:prstGeom prst="roundRect"><a:avLst/></a:prstGeom>
+          <a:solidFill><a:schemeClr val="accent1"/></a:solidFill>
+          <a:ln w="25400"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill></a:ln>
+        </p:spPr>
+      </p:sp>
+      <p:grpSp>
+        <p:nvGrpSpPr><p:cNvPr id="20" name="Group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+        <p:grpSpPr><a:xfrm><a:off x="1828800" y="914400"/><a:ext cx="1828800" cy="914400"/><a:chOff x="0" y="0"/><a:chExt cx="1828800" cy="914400"/></a:xfrm></p:grpSpPr>
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="21" name="Grouped diamond"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="0" y="0"/><a:ext cx="457200" cy="457200"/></a:xfrm>
+            <a:prstGeom prst="diamond"><a:avLst/></a:prstGeom>
+            <a:solidFill><a:srgbClr val="00aa66"/></a:solidFill>
+          </p:spPr>
+        </p:sp>
+      </p:grpSp>
+      <p:graphicFrame>
+        <p:nvGraphicFramePr><p:cNvPr id="30" name="Table"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr>
+        <p:xfrm><a:off x="914400" y="2286000"/><a:ext cx="1828800" cy="914400"/></p:xfrm>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+          <a:tbl>
+            <a:tblGrid><a:gridCol w="914400"/><a:gridCol w="914400"/></a:tblGrid>
+            <a:tr h="457200">
+              <a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Cell A</a:t></a:r></a:p></a:txBody><a:tcPr><a:solidFill><a:srgbClr val="222222"/></a:solidFill></a:tcPr></a:tc>
+              <a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Cell B</a:t></a:r></a:p></a:txBody><a:tcPr><a:solidFill><a:srgbClr val="333333"/></a:solidFill></a:tcPr></a:tc>
+            </a:tr>
+          </a:tbl>
+        </a:graphicData></a:graphic>
+      </p:graphicFrame>
+      <p:graphicFrame>
+        <p:nvGraphicFramePr><p:cNvPr id="40" name="Chart"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr>
+        <p:xfrm><a:off x="4572000" y="914400"/><a:ext cx="914400" cy="914400"/></p:xfrm>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rIdChart"/></a:graphicData></a:graphic>
+      </p:graphicFrame>
+      <p:pic>
+        <p:nvPicPr><p:cNvPr id="50" name="Content-type image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+        <p:blipFill><a:blip r:embed="rIdImage"/></p:blipFill>
+        <p:spPr><a:xfrm><a:off x="4572000" y="2286000"/><a:ext cx="914400" cy="457200"/></a:xfrm></p:spPr>
+      </p:pic>
+      <p:pic>
+        <p:nvPicPr><p:cNvPr id="51" name="External image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+        <p:blipFill><a:blip r:embed="rIdExternal"/></p:blipFill>
+        <p:spPr><a:xfrm><a:off x="4572000" y="3200400"/><a:ext cx="914400" cy="457200"/></a:xfrm></p:spPr>
+      </p:pic>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+function createStandardsFixture() {
+  return createStoredPptxFile([
+    { path: '[Content_Types].xml', contents: contentTypesXml },
+    { path: '_rels/.rels', contents: packageRels },
+    { path: 'deck/main.xml', contents: standardPresentationXml },
+    { path: 'deck/_rels/main.xml.rels', contents: standardPresentationRels },
+    { path: 'deck/slides/slideA.xml', contents: standardSlideXml },
+    { path: 'deck/slides/_rels/slideA.xml.rels', contents: standardSlideRels },
+    { path: 'deck/layouts/layoutA.xml', contents: standardLayoutXml },
+    { path: 'deck/layouts/_rels/layoutA.xml.rels', contents: standardLayoutRels },
+    { path: 'deck/masters/masterA.xml', contents: standardMasterXml },
+    { path: 'deck/masters/_rels/masterA.xml.rels', contents: standardMasterRels },
+    { path: 'deck/theme/themeA.xml', contents: standardThemeXml },
+    { path: 'deck/media/photo.dat', contents: new Uint8Array([137, 80, 78, 71]) },
+    { path: 'deck/charts/chart1.xml', contents: '<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>' },
+  ], 'standards.pptx');
 }
 
 describe('BrowserPptxImportService', () => {
@@ -249,14 +434,47 @@ describe('BrowserPptxImportService', () => {
       fontWeight: 700,
       lineHeight: 1.05,
     });
-    expect(authorElement).toMatchObject({
-      locked: false,
+    expect(authorElement).toBeUndefined();
+    expect(project.pages[0]?.layoutId).toBe('pptx-layout-slideLayout1');
+    const importedLayout = project.slideLayouts?.['pptx-layout-slideLayout1'];
+    expect(importedLayout).toMatchObject({
+      id: 'pptx-layout-slideLayout1',
+      name: 'Statement',
+      placeholderVisibility: {
+        body: true,
+        footer: true,
+        slideNumber: true,
+        title: true,
+      },
+    });
+    expect(importedLayout?.placeholderRoles).toEqual(expect.arrayContaining(['title']));
+    const unusedLayout = project.slideLayouts?.['pptx-layout-slideLayout2'];
+    expect(unusedLayout).toMatchObject({
+      id: 'pptx-layout-slideLayout2',
+      name: 'Title & Photo',
+    });
+    expect(unusedLayout?.placeholderRoles).toEqual(expect.arrayContaining(['title']));
+    expect(importedLayout?.elementIds).toEqual(
+      expect.arrayContaining([
+        'pptx-layout-slideLayout1-layout-image-20',
+        'pptx-layout-slideLayout1-layout-text-22',
+        'pptx-layout-slideLayout1-layout-text-21',
+      ]),
+    );
+    expect(importedLayout?.elements['pptx-layout-slideLayout1-layout-image-20']).toMatchObject({
+      templateSource: { layoutId: 'pptx-layout-slideLayout1', type: 'layout' },
+      type: 'image',
+    });
+    expect(importedLayout?.elements['pptx-layout-slideLayout1-layout-text-22']).toMatchObject({
+      templateSource: { layoutId: 'pptx-layout-slideLayout1', type: 'layout' },
       text: 'Erick Wendel',
       type: 'text',
-      x: 147,
-      y: 23,
-      width: 603,
-      height: 116,
+    });
+    expect(importedLayout?.elements['pptx-layout-slideLayout1-layout-text-21']).toMatchObject({
+      placeholderRole: 'title',
+      templateSource: { layoutId: 'pptx-layout-slideLayout1', type: 'layout' },
+      text: 'Title Text',
+      type: 'text',
     });
     expect(defaultSizedElement).toMatchObject({
       fontSize: 160,
@@ -273,7 +491,7 @@ describe('BrowserPptxImportService', () => {
     }
     expect(inheritedCenteredElement.align).toBe('center');
     expect(project.pages[0]?.elementIds.some((elementId) => elementId.includes('placeholder'))).toBe(false);
-    expect(imageElements).toHaveLength(2);
+    expect(imageElements).toHaveLength(1);
     expect(imageElement).toMatchObject({ locked: false, type: 'image' });
     expect(videoElement).toMatchObject({
       autoplayInPreview: true,
@@ -330,5 +548,47 @@ describe('BrowserPptxImportService', () => {
         }),
       }),
     ).rejects.toThrow('PowerPoint file is corrupt');
+  });
+
+  it('uses OPC relationships, content types, theme colors, shapes, groups, tables, and import warnings', async () => {
+    const service = new BrowserPptxImportService();
+    const project = await service.importPowerPoint({ file: createStandardsFixture() });
+
+    expect(project.pages).toHaveLength(1);
+    expect(project.pages[0]?.background).toEqual({ type: 'color', color: '#FF9900' });
+
+    const elements = Object.values(project.elements);
+    const themeShape = elements.find((element) => element.type === 'shape' && element.id.includes('shape-10'));
+    const groupedShape = elements.find((element) => element.type === 'shape' && element.id.includes('shape-21'));
+    const imageAsset = Object.values(project.assets).find((asset) => asset.fileName === 'photo.dat');
+    const tableTexts = elements
+      .filter((element) => element.type === 'text')
+      .filter((element) => ['Cell A', 'Cell B'].includes(element.text))
+      .map((element) => element.text)
+      .sort();
+
+    expect(themeShape).toMatchObject({
+      type: 'shape',
+      shape: 'rounded-rect',
+      fill: '#FF9900',
+      stroke: '#111111',
+      strokeWidth: 5,
+      rotation: 90,
+    });
+    expect(groupedShape).toMatchObject({
+      type: 'shape',
+      shape: 'diamond',
+      fill: '#00AA66',
+      x: 384,
+      y: 192,
+    });
+    expect(tableTexts).toEqual(['Cell A', 'Cell B']);
+    expect(imageAsset).toMatchObject({ fileName: 'photo.dat', mimeType: 'image/png', type: 'image' });
+    expect(project.importWarnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'pptx-external-relationship', severity: 'warning' }),
+        expect.objectContaining({ code: 'pptx-unsupported-chart', severity: 'info' }),
+      ]),
+    );
   });
 });

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -241,22 +241,26 @@ describe('CanvasWorkspace', () => {
     expect(container.querySelector('.canvas-accessible-text')).not.toBeInTheDocument();
   });
 
-  it('clears selection when the empty canvas background is clicked', () => {
-    const onClearSelection = vi.fn();
+  it('selects slide and presentation surfaces from canvas clicks', () => {
+    const onSelectPresentation = vi.fn();
+    const onSelectSlide = vi.fn();
     const { container } = render(
       <CanvasWorkspace
         project={sampleProject.createSampleProject()}
         activePageId="page-1"
         selection={{ pageId: 'page-1', elementIds: ['image-hero'] }}
-        onClearSelection={onClearSelection}
+        onSelectPresentation={onSelectPresentation}
+        onSelectSlide={onSelectSlide}
       />,
     );
 
     const canvas = container.querySelector('canvas');
     expect(canvas).toBeInTheDocument();
     fireEvent.mouseDown(canvas!);
+    fireEvent.pointerDown(container.querySelector('.canvas-workspace')!);
 
-    expect(onClearSelection).toHaveBeenCalledTimes(1);
+    expect(onSelectSlide).toHaveBeenCalledTimes(1);
+    expect(onSelectPresentation).toHaveBeenCalledTimes(1);
   });
 
   it('marks active animation preview state and advances click-triggered builds', () => {

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -105,7 +105,234 @@ function createProjectWithImportedTextFont(): ProjectDocument {
   };
 }
 
+function createProjectWithTemplates(): ProjectDocument {
+  return {
+    ...sampleProject.createSampleProject(),
+    themeId: 'theme-studio',
+    themeGallery: ['theme-studio'],
+    themes: {
+      'theme-imported': {
+        id: 'theme-imported',
+        name: 'Imported theme',
+        palette: {
+          accent: '#00AEEF',
+          background: '#101820',
+          mutedText: '#9AA6B2',
+          surface: '#17212B',
+          text: '#F7FAFC',
+        },
+        typography: {
+          bodyFontFamily: 'Inter',
+          headingFontFamily: 'Space Grotesk',
+        },
+      },
+      'theme-studio': {
+        id: 'theme-studio',
+        name: 'Studio theme',
+        palette: {
+          accent: '#37FD76',
+          background: '#050D10',
+          mutedText: '#91999D',
+          surface: '#0C1417',
+          text: '#FFFFFF',
+        },
+        typography: {
+          bodyFontFamily: 'Inter',
+          headingFontFamily: 'Orbitron',
+        },
+      },
+    },
+    slideLayouts: {
+      'layout-title': {
+        id: 'layout-title',
+        name: 'Title',
+        background: { type: 'color', color: '#050D10' },
+        elementIds: ['layout-title-text'],
+        elements: {
+          'layout-title-text': {
+            id: 'layout-title-text',
+            type: 'text',
+            text: 'Presentation Title',
+            x: 120,
+            y: 140,
+            width: 720,
+            height: 120,
+            rotation: 0,
+            locked: false,
+            visible: true,
+            opacity: 1,
+            fontFamily: 'Inter',
+            fontSize: 44,
+            fontWeight: 800,
+            fill: '#050D10',
+            align: 'left',
+            placeholderRole: 'title',
+            templateSource: { layoutId: 'layout-title', type: 'layout' },
+          },
+        },
+        placeholderRoles: ['title'],
+        placeholderVisibility: {
+          body: true,
+          footer: true,
+          slideNumber: true,
+          title: true,
+        },
+      },
+      'layout-statement': {
+        id: 'layout-statement',
+        name: 'Statement',
+        background: { type: 'color', color: '#050D10' },
+        elementIds: ['layout-statement-text'],
+        elements: {
+          'layout-statement-text': {
+            id: 'layout-statement-text',
+            type: 'text',
+            text: 'Statement',
+            x: 520,
+            y: 420,
+            width: 480,
+            height: 90,
+            rotation: 0,
+            locked: false,
+            visible: true,
+            opacity: 1,
+            fontFamily: 'Inter',
+            fontSize: 38,
+            fontWeight: 800,
+            fill: '#050D10',
+            align: 'center',
+            placeholderRole: 'title',
+            templateSource: { layoutId: 'layout-statement', type: 'layout' },
+          },
+        },
+        placeholderRoles: ['title', 'body'],
+        placeholderVisibility: {
+          body: true,
+          footer: true,
+          slideNumber: true,
+          title: true,
+        },
+      },
+    },
+    pages: sampleProject.createSampleProject().pages.map((page) =>
+      page.id === 'page-1' ? { ...page, layoutId: 'layout-statement' } : page,
+    ),
+  };
+}
+
 describe('DesignPanel', () => {
+  it('shows presentation theme actions when the presentation is selected', async () => {
+    const user = userEvent.setup();
+    const onApplyTheme = vi.fn();
+    const onChangeTheme = vi.fn();
+    const onEditTheme = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithTemplates()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [], target: 'presentation' }}
+        onApplyTheme={onApplyTheme}
+        onChangeTheme={onChangeTheme}
+        onEditTheme={onEditTheme}
+      />,
+    );
+
+    expect(screen.getByText('Studio theme')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Change theme' }));
+    await user.click(screen.getByRole('button', { name: 'Edit theme' }));
+    await user.click(screen.getByRole('button', { name: 'Apply theme' }));
+
+    expect(onChangeTheme).toHaveBeenCalledOnce();
+    expect(onEditTheme).toHaveBeenCalledWith('theme-studio');
+    expect(onApplyTheme).toHaveBeenCalledWith('theme-studio');
+  });
+
+  it('opens a theme picker from the theme preview with default and imported themes', async () => {
+    const user = userEvent.setup();
+    const onApplyTheme = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithTemplates()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [], target: 'presentation' }}
+        onApplyTheme={onApplyTheme}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Open theme picker, current theme Studio theme' }),
+    );
+
+    expect(screen.getByRole('region', { name: 'Choose a theme' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Default theme/ })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Imported theme/ }));
+
+    expect(onApplyTheme).toHaveBeenCalledWith('theme-imported');
+  });
+
+  it('shows slide layout and background controls when the slide background is selected', async () => {
+    const user = userEvent.setup();
+    const onApplySlideLayout = vi.fn();
+    const onEditSlideLayout = vi.fn();
+    const onToggleSlideLayoutPlaceholder = vi.fn();
+    const onUpdatePageBackground = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithTemplates()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [], target: 'slide' }}
+        onApplySlideLayout={onApplySlideLayout}
+        onEditSlideLayout={onEditSlideLayout}
+        onToggleSlideLayoutPlaceholder={onToggleSlideLayoutPlaceholder}
+        onUpdatePageBackground={onUpdatePageBackground}
+      />,
+    );
+
+    expect(screen.getByText('Statement')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Edit layout' }));
+    await user.click(screen.getByRole('button', { name: 'Apply layout' }));
+    await user.click(screen.getByLabelText('Title'));
+    fireEvent.change(screen.getByLabelText('Slide background color'), {
+      target: { value: '#112233' },
+    });
+
+    expect(onEditSlideLayout).toHaveBeenCalledWith('layout-statement');
+    expect(onApplySlideLayout).toHaveBeenCalledWith('page-1', 'layout-statement');
+    expect(onToggleSlideLayoutPlaceholder).toHaveBeenCalledWith(
+      'layout-statement',
+      'title',
+      false,
+    );
+    expect(onUpdatePageBackground).toHaveBeenCalledWith({ type: 'color', color: '#112233' });
+  });
+
+  it('opens a slide layout picker from the layout preview and applies the chosen layout', async () => {
+    const user = userEvent.setup();
+    const onApplySlideLayout = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithTemplates()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [], target: 'slide' }}
+        onApplySlideLayout={onApplySlideLayout}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Open layout picker, current layout Statement' }),
+    );
+
+    expect(screen.getByRole('region', { name: 'Choose a layout' })).toBeInTheDocument();
+    expect(screen.getByText('Presentation Title')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Title' }));
+
+    expect(onApplySlideLayout).toHaveBeenCalledWith('page-1', 'layout-title');
+  });
+
   it('updates selected shape fill and border modes', async () => {
     const user = userEvent.setup();
     const onUpdateElementStyle = vi.fn();

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -327,7 +327,7 @@ describe('DesignPanel', () => {
     );
 
     expect(screen.getByRole('region', { name: 'Choose a layout' })).toBeInTheDocument();
-    expect(screen.getByText('Presentation Title')).toBeInTheDocument();
+    expect(screen.queryByText('Presentation Title')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Title' }));
 
     expect(onApplySlideLayout).toHaveBeenCalledWith('page-1', 'layout-title');


### PR DESCRIPTION
## Summary
- Tighten PPTX parsing, packaging, and project mapping to align imported slides with editor standards
- Update document and command models to better support import-driven element creation
- Adjust editor shell, canvas, and side panels to accommodate the new import flow and design panel behavior
- Add and update unit coverage for command handling, PPTX import service, and editor UI components

## Testing
- Unit tests added/updated for PPTX import service, basic commands, CanvasWorkspace, and DesignPanel
- Not run (not requested)