### PR TITLE
Fix mobile presenter publishing and remote session handling

### DIFF
--- a/apps/editor/src/services/presenter/presenterSessionService.ts
+++ b/apps/editor/src/services/presenter/presenterSessionService.ts
@@ -7,12 +7,13 @@ import type {
   PresenterWindowCommand,
 } from './presenterSessionTypes';
 import {
-  InMemoryPresenterRemoteSignalingService,
-  type RegisterPresenterRemoteSessionInput,
-} from '@localstudio/presenter-remote/signaling-service';
-import { PresenterRemoteSignalingClient } from '@localstudio/presenter-remote/signaling-client';
+  PresenterRemotePeerControlHost,
+  type PresenterRemotePeerControlHostOptions,
+} from '@localstudio/presenter-remote/peer-control-host';
+import type { RegisterPresenterRemoteSessionInput } from '@localstudio/presenter-remote/signaling-service';
 import type {
   PresenterRemoteCommand,
+  PresenterRemotePeerSession,
   PresenterRemoteSlidePreview,
   PresenterRemoteSlidePreviewElement,
   PresenterRemoteUpcomingSlidePreview,
@@ -23,6 +24,11 @@ import type {
 
 type OpenPresenterWindow = (url: string, target: string, features: string) => Window | null;
 type ResolveRemoteControlOrigin = (origin: string) => Promise<string | undefined>;
+type PresenterRemotePeerControl = {
+  close: () => void;
+  open: () => Promise<PresenterRemotePeerSession>;
+  publishState: (state: PresenterRemoteState) => void;
+};
 type PresenterRemoteSignaling = {
   closeSession: (code: string) => boolean | Promise<unknown>;
   publishState: (code: string, state: PresenterRemoteState) => boolean | Promise<unknown>;
@@ -31,12 +37,16 @@ type PresenterRemoteSignaling = {
   ) => PresenterRemoteSession | Promise<PresenterRemoteSession>;
   takeCommands: (code: string) => PresenterRemoteCommand[] | Promise<PresenterRemoteCommand[]>;
 };
+type CreatePresenterRemotePeerControlHost = (
+  options: PresenterRemotePeerControlHostOptions,
+) => PresenterRemotePeerControl;
 
 interface BrowserPresenterSessionServiceOptions {
   href?: string;
   openWindow?: OpenPresenterWindow;
   presenterDeviceId?: string | undefined;
   randomId?: () => string;
+  remotePeerControlHostFactory?: CreatePresenterRemotePeerControlHost | undefined;
   remoteSignalingService?: PresenterRemoteSignaling | undefined;
   resolveRemoteControlOrigin?: ResolveRemoteControlOrigin | undefined;
   targetWindow?: Window;
@@ -86,7 +96,8 @@ export class BrowserPresenterSessionService {
   private readonly presenterDeviceId: string;
   private readonly randomId: () => string;
   private readonly resolveRemoteControlOrigin: ResolveRemoteControlOrigin;
-  private readonly remoteSignalingService: PresenterRemoteSignaling;
+  private readonly legacyRemoteSignalingService: PresenterRemoteSignaling | undefined;
+  private readonly remotePeerControlHostFactory: CreatePresenterRemotePeerControlHost;
   private readonly targetWindow: Window;
   private popupWindow: Window | null = null;
   private presenterTimer: PresenterRemoteTimerState | undefined;
@@ -95,6 +106,8 @@ export class BrowserPresenterSessionService {
   private remoteSession: PresenterRemoteSessionMetadata | undefined;
   private remoteSessionStartedAt = 0;
   private remoteStatePublishSequence = 0;
+  private remoteCommandHandler: ((command: PresenterRemoteCommand) => void) | undefined;
+  private remotePeerControlHost: PresenterRemotePeerControl | undefined;
   private sessionId: string | undefined;
 
   constructor(options: BrowserPresenterSessionServiceOptions = {}) {
@@ -109,8 +122,10 @@ export class BrowserPresenterSessionService {
     this.randomId = options.randomId ?? createSessionId;
     this.resolveRemoteControlOrigin =
       options.resolveRemoteControlOrigin ?? resolveRemoteControlOrigin;
-    this.remoteSignalingService =
-      options.remoteSignalingService ?? createDefaultRemoteSignalingService();
+    this.remotePeerControlHostFactory =
+      options.remotePeerControlHostFactory ??
+      createDefaultRemotePeerControlHostFactory();
+    this.legacyRemoteSignalingService = options.remoteSignalingService;
   }
 
   openPresenterWindow(): PresenterWindowOpenResult {
@@ -148,7 +163,7 @@ export class BrowserPresenterSessionService {
       };
       this.popupWindow.postMessage(message, this.origin);
     }
-    if (this.remoteSession) {
+    if (this.remoteSession && this.legacyRemoteSignalingService) {
       const publishSequence = ++this.remoteStatePublishSequence;
       const sessionCode = this.remoteSession.code;
       void this.createRemoteState(
@@ -157,7 +172,19 @@ export class BrowserPresenterSessionService {
         this.remoteSessionStartedAt ? Date.now() - this.remoteSessionStartedAt : 0,
       ).then((remoteState) => {
         if (publishSequence !== this.remoteStatePublishSequence) return;
-        void Promise.resolve(this.remoteSignalingService.publishState(sessionCode, remoteState));
+        void Promise.resolve(this.legacyRemoteSignalingService?.publishState(sessionCode, remoteState));
+      });
+      return;
+    }
+    if (this.remoteSession) {
+      const publishSequence = ++this.remoteStatePublishSequence;
+      void this.createRemoteState(
+        payload,
+        this.remoteSession.connectedControllerCount,
+        this.remoteSessionStartedAt ? Date.now() - this.remoteSessionStartedAt : 0,
+      ).then((remoteState) => {
+        if (publishSequence !== this.remoteStatePublishSequence) return;
+        this.remotePeerControlHost?.publishState(remoteState);
       });
     }
   }
@@ -165,8 +192,10 @@ export class BrowserPresenterSessionService {
   closePresenterWindow() {
     if (this.popupWindow && !this.popupWindow.closed) this.popupWindow.close();
     this.popupWindow = null;
-    if (this.remoteSession)
-      void Promise.resolve(this.remoteSignalingService.closeSession(this.remoteSession.code));
+    if (this.legacyRemoteSignalingService && this.remoteSession)
+      void Promise.resolve(this.legacyRemoteSignalingService.closeSession(this.remoteSession.code));
+    this.remotePeerControlHost?.close();
+    this.remotePeerControlHost = undefined;
     this.remoteSession = undefined;
     this.sessionId = undefined;
   }
@@ -175,13 +204,32 @@ export class BrowserPresenterSessionService {
     input: RegisterPresenterRemoteSessionInput,
   ): Promise<PresenterRemoteSessionMetadata> {
     if (this.remoteSession) return this.remoteSession;
-    const session = await this.remoteSignalingService.registerSession({
-      ...input,
+    if (this.legacyRemoteSignalingService) {
+      const session = await this.legacyRemoteSignalingService.registerSession({
+        ...input,
+        presenterDeviceId: input.presenterDeviceId ?? this.presenterDeviceId,
+      });
+      const remoteOrigin = (await this.resolveRemoteControlOrigin(this.origin)) ?? this.origin;
+      const qrUrl = new URL('/joystick/', remoteOrigin);
+      qrUrl.searchParams.set('code', session.code);
+      this.remoteSession = {
+        ...session,
+        qrUrl: qrUrl.toString(),
+      };
+      this.remoteSessionStartedAt = Date.now();
+      return this.remoteSession;
+    }
+    const host = this.remotePeerControlHostFactory({
+      onCommand: (command) => this.remoteCommandHandler?.(command),
       presenterDeviceId: input.presenterDeviceId ?? this.presenterDeviceId,
+      presenterLabel: input.presenterLabel,
+      ttlMs: input.ttlMs,
     });
+    this.remotePeerControlHost = host;
+    const session = await host.open();
     const remoteOrigin = (await this.resolveRemoteControlOrigin(this.origin)) ?? this.origin;
     const qrUrl = new URL('/joystick/', remoteOrigin);
-    qrUrl.searchParams.set('code', session.code);
+    qrUrl.searchParams.set('peer', session.controlPeerId);
     this.remoteSession = {
       ...session,
       qrUrl: qrUrl.toString(),
@@ -196,6 +244,13 @@ export class BrowserPresenterSessionService {
 
   subscribeToCommands(handler: (command: PresenterWindowCommand) => void) {
     const handleRemoteCommand = (command: PresenterRemoteCommand) => {
+      if (
+        command.command === 'pause-timer' ||
+        command.command === 'reset-timer' ||
+        command.command === 'resume-timer'
+      ) {
+        this.postPresenterCommand(command);
+      }
       if (command.command === 'update-notes') {
         handler({ command: command.command, notes: command.notes, pageId: command.pageId });
         return;
@@ -206,6 +261,7 @@ export class BrowserPresenterSessionService {
       }
       handler({ command: command.command });
     };
+    this.remoteCommandHandler = handleRemoteCommand;
     const listener = (event: MessageEvent) => {
       if (event.origin !== this.origin) return;
       if (!isPresenterCommandMessage(event.data)) return;
@@ -223,6 +279,11 @@ export class BrowserPresenterSessionService {
         if (this.lastPresenterPayload) this.publishState(this.lastPresenterPayload);
         return;
       }
+      if (command === 'update-stream-peer') {
+        if (event.data.peerId !== undefined && typeof event.data.peerId !== 'string') return;
+        handler({ command, peerId: event.data.peerId });
+        return;
+      }
       if (
         command === 'close' ||
         command === 'next' ||
@@ -238,30 +299,26 @@ export class BrowserPresenterSessionService {
     };
     this.targetWindow.addEventListener('message', listener);
     let takingRemoteCommands = false;
-    const remoteIntervalId = this.targetWindow.setInterval(() => {
-      if (!this.remoteSession) return;
-      if (takingRemoteCommands) return;
-      takingRemoteCommands = true;
-      void Promise.resolve(this.remoteSignalingService.takeCommands(this.remoteSession.code))
-        .then((commands) => {
-          for (const command of commands) {
-            if (
-              command.command === 'pause-timer' ||
-              command.command === 'reset-timer' ||
-              command.command === 'resume-timer'
-            ) {
-              this.postPresenterCommand(command);
-            }
-            handleRemoteCommand(command);
-          }
-        })
-        .finally(() => {
-          takingRemoteCommands = false;
-        });
-    }, 250);
+    const remoteIntervalId = this.legacyRemoteSignalingService
+      ? this.targetWindow.setInterval(() => {
+          if (!this.remoteSession || !this.legacyRemoteSignalingService) return;
+          if (takingRemoteCommands) return;
+          takingRemoteCommands = true;
+          void Promise.resolve(this.legacyRemoteSignalingService.takeCommands(this.remoteSession.code))
+            .then((commands) => {
+              for (const command of commands) {
+                handleRemoteCommand(command);
+              }
+            })
+            .finally(() => {
+              takingRemoteCommands = false;
+            });
+        }, 250)
+      : 0;
     return () => {
+      this.remoteCommandHandler = undefined;
       this.targetWindow.removeEventListener('message', listener);
-      this.targetWindow.clearInterval(remoteIntervalId);
+      if (remoteIntervalId) this.targetWindow.clearInterval(remoteIntervalId);
     };
   }
 
@@ -317,11 +374,40 @@ function isPresenterRemoteTimerState(value: unknown): value is PresenterRemoteTi
   );
 }
 
-function createDefaultRemoteSignalingService(): PresenterRemoteSignaling {
-  if (!isTestRuntime() && typeof fetch === 'function') {
-    return new PresenterRemoteSignalingClient({ endpoint: '/__localstudio/presenter-remote' });
+class TestPresenterRemotePeerControlHost implements PresenterRemotePeerControl {
+  private readonly options: PresenterRemotePeerControlHostOptions;
+  private lastState: PresenterRemoteState | undefined;
+
+  constructor(options: PresenterRemotePeerControlHostOptions) {
+    this.options = options;
   }
-  return new InMemoryPresenterRemoteSignalingService();
+
+  open(): Promise<PresenterRemotePeerSession> {
+    const controlPeerId = 'ABCD-1234';
+    return Promise.resolve({
+      code: controlPeerId,
+      connectedControllerCount: 0,
+      controlPeerId,
+      expiresAt: new Date((this.options.now ?? Date.now)() + this.options.ttlMs).toISOString(),
+      presenterDeviceId: this.options.presenterDeviceId ?? this.options.presenterLabel,
+      presenterLabel: this.options.presenterLabel,
+      sessionId: 'test-peer-session',
+      transport: 'peerjs',
+    });
+  }
+
+  publishState(state: PresenterRemoteState) {
+    this.lastState = state;
+  }
+
+  close() {
+    this.lastState = undefined;
+  }
+}
+
+function createDefaultRemotePeerControlHostFactory(): CreatePresenterRemotePeerControlHost {
+  if (isTestRuntime()) return (hostOptions) => new TestPresenterRemotePeerControlHost(hostOptions);
+  return (hostOptions) => new PresenterRemotePeerControlHost(hostOptions);
 }
 
 function isTestRuntime() {
@@ -380,7 +466,14 @@ function createRemoteState(
       previewMode: 'stream',
       shortcuts: ['previous', 'next', 'pause-timer', 'reset-timer'],
       slidePreview,
-      stream: { enabled: true, fps: 8, height: 340, width: 390 },
+      stream: {
+        enabled: true,
+        fps: 8,
+        height: 340,
+        peerId: payload.streamPeerId,
+        transport: 'peerjs',
+        width: 390,
+      },
       timer,
       type: 'state',
       upcomingSlidePreviews,

--- a/apps/editor/src/services/presenter/presenterSessionService.ts
+++ b/apps/editor/src/services/presenter/presenterSessionService.ts
@@ -14,6 +14,7 @@ import type { RegisterPresenterRemoteSessionInput } from '@localstudio/presenter
 import type {
   PresenterRemoteCommand,
   PresenterRemotePeerSession,
+  PresenterRemotePreviewBatch,
   PresenterRemoteSlidePreview,
   PresenterRemoteSlidePreviewElement,
   PresenterRemoteUpcomingSlidePreview,
@@ -21,12 +22,14 @@ import type {
   PresenterRemoteState,
   PresenterRemoteTimerState,
 } from '@localstudio/presenter-remote/protocol';
+import { presenterRemoteDebugLog } from '@localstudio/presenter-remote/debug-log';
 
 type OpenPresenterWindow = (url: string, target: string, features: string) => Window | null;
 type ResolveRemoteControlOrigin = (origin: string) => Promise<string | undefined>;
 type PresenterRemotePeerControl = {
   close: () => void;
   open: () => Promise<PresenterRemotePeerSession>;
+  publishPreviewBatch: (batch: PresenterRemotePreviewBatch) => void;
   publishState: (state: PresenterRemoteState) => void;
 };
 type PresenterRemoteSignaling = {
@@ -62,9 +65,10 @@ function createSessionId() {
 }
 
 const presenterDeviceIdKey = 'localstudio.presenter.deviceId';
-const remotePreviewMaxInlineAssetLength = 80_000;
-const remotePreviewThumbnailMaxEdge = 240;
-const remotePreviewThumbnailQuality = 0.55;
+const remotePreviewBatchMaxBytes = 10_000;
+const remotePreviewMaxInlineAssetLength = 10_000;
+const remotePreviewThumbnailMaxEdge = 96;
+const remotePreviewThumbnailQuality = 0.32;
 
 function getOrCreatePresenterDeviceId(targetWindow: Window) {
   try {
@@ -108,6 +112,7 @@ export class BrowserPresenterSessionService {
   private remoteStatePublishSequence = 0;
   private remoteCommandHandler: ((command: PresenterRemoteCommand) => void) | undefined;
   private remotePeerControlHost: PresenterRemotePeerControl | undefined;
+  private remoteSessionOpening: Promise<PresenterRemoteSessionMetadata> | undefined;
   private sessionId: string | undefined;
 
   constructor(options: BrowserPresenterSessionServiceOptions = {}) {
@@ -123,8 +128,7 @@ export class BrowserPresenterSessionService {
     this.resolveRemoteControlOrigin =
       options.resolveRemoteControlOrigin ?? resolveRemoteControlOrigin;
     this.remotePeerControlHostFactory =
-      options.remotePeerControlHostFactory ??
-      createDefaultRemotePeerControlHostFactory();
+      options.remotePeerControlHostFactory ?? createDefaultRemotePeerControlHostFactory();
     this.legacyRemoteSignalingService = options.remoteSignalingService;
   }
 
@@ -166,26 +170,46 @@ export class BrowserPresenterSessionService {
     if (this.remoteSession && this.legacyRemoteSignalingService) {
       const publishSequence = ++this.remoteStatePublishSequence;
       const sessionCode = this.remoteSession.code;
+      void Promise.resolve(
+        this.legacyRemoteSignalingService.publishState(
+          sessionCode,
+          createRemoteStateSkeleton(
+            payload,
+            this.remoteSession.connectedControllerCount,
+            this.getCurrentPresenterTimer(
+              payload.timer,
+              this.remoteSessionStartedAt ? Date.now() - this.remoteSessionStartedAt : 0,
+            ),
+          ),
+        ),
+      );
       void this.createRemoteState(
         payload,
         this.remoteSession.connectedControllerCount,
         this.remoteSessionStartedAt ? Date.now() - this.remoteSessionStartedAt : 0,
-      ).then((remoteState) => {
-        if (publishSequence !== this.remoteStatePublishSequence) return;
-        void Promise.resolve(this.legacyRemoteSignalingService?.publishState(sessionCode, remoteState));
-      });
+      )
+        .then((remoteState) => {
+          if (publishSequence !== this.remoteStatePublishSequence) return;
+          void Promise.resolve(
+            this.legacyRemoteSignalingService?.publishState(sessionCode, remoteState),
+          );
+        })
+        .catch((error: unknown) => {
+          presenterRemoteDebugLog.error('Failed to create legacy remote state.', error);
+        });
       return;
     }
     if (this.remoteSession) {
-      const publishSequence = ++this.remoteStatePublishSequence;
-      void this.createRemoteState(
-        payload,
-        this.remoteSession.connectedControllerCount,
-        this.remoteSessionStartedAt ? Date.now() - this.remoteSessionStartedAt : 0,
-      ).then((remoteState) => {
-        if (publishSequence !== this.remoteStatePublishSequence) return;
-        this.remotePeerControlHost?.publishState(remoteState);
-      });
+      this.remotePeerControlHost?.publishState(
+        createRemoteStateSkeleton(
+          payload,
+          this.remoteSession.connectedControllerCount,
+          this.getCurrentPresenterTimer(
+            payload.timer,
+            this.remoteSessionStartedAt ? Date.now() - this.remoteSessionStartedAt : 0,
+          ),
+        ),
+      );
     }
   }
 
@@ -197,6 +221,7 @@ export class BrowserPresenterSessionService {
     this.remotePeerControlHost?.close();
     this.remotePeerControlHost = undefined;
     this.remoteSession = undefined;
+    this.remoteSessionOpening = undefined;
     this.sessionId = undefined;
   }
 
@@ -204,6 +229,16 @@ export class BrowserPresenterSessionService {
     input: RegisterPresenterRemoteSessionInput,
   ): Promise<PresenterRemoteSessionMetadata> {
     if (this.remoteSession) return this.remoteSession;
+    if (this.remoteSessionOpening) return this.remoteSessionOpening;
+    this.remoteSessionOpening = this.createRemoteControlSession(input).finally(() => {
+      this.remoteSessionOpening = undefined;
+    });
+    return this.remoteSessionOpening;
+  }
+
+  private async createRemoteControlSession(
+    input: RegisterPresenterRemoteSessionInput,
+  ): Promise<PresenterRemoteSessionMetadata> {
     if (this.legacyRemoteSignalingService) {
       const session = await this.legacyRemoteSignalingService.registerSession({
         ...input,
@@ -235,6 +270,7 @@ export class BrowserPresenterSessionService {
       qrUrl: qrUrl.toString(),
     };
     this.remoteSessionStartedAt = Date.now();
+    if (this.lastPresenterPayload) this.publishState(this.lastPresenterPayload);
     return this.remoteSession;
   }
 
@@ -244,6 +280,10 @@ export class BrowserPresenterSessionService {
 
   subscribeToCommands(handler: (command: PresenterWindowCommand) => void) {
     const handleRemoteCommand = (command: PresenterRemoteCommand) => {
+      if (command.command === 'request-previews') {
+        void this.publishPreviewBatch(command.pageIds, command.requestId);
+        return;
+      }
       if (
         command.command === 'pause-timer' ||
         command.command === 'reset-timer' ||
@@ -304,7 +344,9 @@ export class BrowserPresenterSessionService {
           if (!this.remoteSession || !this.legacyRemoteSignalingService) return;
           if (takingRemoteCommands) return;
           takingRemoteCommands = true;
-          void Promise.resolve(this.legacyRemoteSignalingService.takeCommands(this.remoteSession.code))
+          void Promise.resolve(
+            this.legacyRemoteSignalingService.takeCommands(this.remoteSession.code),
+          )
             .then((commands) => {
               for (const command of commands) {
                 handleRemoteCommand(command);
@@ -333,6 +375,20 @@ export class BrowserPresenterSessionService {
       },
       this.origin,
     );
+  }
+
+  private async publishPreviewBatch(pageIds: string[], requestId: string | undefined) {
+    if (!this.lastPresenterPayload || !this.remotePeerControlHost) return;
+    try {
+      const batches = await createRemotePreviewBatches(
+        this.lastPresenterPayload,
+        pageIds,
+        requestId,
+      );
+      for (const batch of batches) this.remotePeerControlHost.publishPreviewBatch(batch);
+    } catch (error) {
+      presenterRemoteDebugLog.error('Failed to create PeerJS preview batch.', error);
+    }
   }
 
   private createRemoteState(
@@ -400,6 +456,11 @@ class TestPresenterRemotePeerControlHost implements PresenterRemotePeerControl {
     this.lastState = state;
   }
 
+  publishPreviewBatch(batch: PresenterRemotePreviewBatch) {
+    void batch;
+    // Test host only records current state; preview transport is covered by host tests.
+  }
+
   close() {
     this.lastState = undefined;
   }
@@ -412,6 +473,59 @@ function createDefaultRemotePeerControlHostFactory(): CreatePresenterRemotePeerC
 
 function isTestRuntime() {
   return import.meta.env.MODE === 'test';
+}
+
+function createRemoteStateSkeleton(
+  payload: PresenterStatePayload,
+  connectedControllerCount: number,
+  timer: PresenterRemoteTimerState,
+): PresenterRemoteState {
+  const activePageIndex = Math.max(
+    0,
+    payload.project.pages.findIndex((page) => page.id === payload.activePageId),
+  );
+  const activePage = payload.project.pages[activePageIndex] ?? payload.project.pages[0];
+  const nextPage = payload.project.pages[activePageIndex + 1];
+  const activePageBuilds = activePage ? getRemoteBuildInfo(payload, activePage) : undefined;
+  return {
+    activePageId: activePage?.id ?? payload.activePageId,
+    activePageIndex,
+    activePageName: activePage?.name,
+    builds: activePageBuilds?.total ? activePageBuilds : undefined,
+    buildsRemaining: activePageBuilds?.remaining ?? 0,
+    connectedControllerCount,
+    deckName: payload.project.name,
+    nextPageName: nextPage?.name,
+    notes: activePage?.speakerNotes ?? '',
+    pageCount: payload.project.pages.length,
+    pages: payload.project.pages.map((page) => ({
+      id: page.id,
+      name: page.name,
+    })),
+    presenterMode: payload.presenterMode ?? 'presenting',
+    commandAvailability: [
+      'previous',
+      'next',
+      'go-to-page',
+      'pause-timer',
+      'resume-timer',
+      'reset-timer',
+      'play-pause-movie',
+    ],
+    previewMode: 'stream',
+    shortcuts: ['previous', 'next', 'pause-timer', 'reset-timer'],
+    stream: {
+      enabled: true,
+      fps: 8,
+      height: 340,
+      peerId: payload.streamPeerId,
+      transport: 'peerjs',
+      width: 390,
+    },
+    timer,
+    type: 'state',
+    upcomingSlidePreviews: [],
+  };
 }
 
 function createRemoteState(
@@ -429,6 +543,7 @@ function createRemoteState(
     activePage && payload.animationPreview?.pageId === activePage.id
       ? new Set(payload.animationPreview.hiddenElementIds)
       : undefined;
+  const activePageBuilds = activePage ? getRemoteBuildInfo(payload, activePage) : undefined;
   const pages = payload.project.pages.map((page) => ({
     id: page.id,
     name: page.name,
@@ -442,53 +557,63 @@ function createRemoteState(
       payload.project.pages.slice(activePageIndex + 1, activePageIndex + 4),
     ),
   ]).then(([slidePreview, upcomingSlidePreviews]) => ({
-      activePageId: activePage?.id ?? payload.activePageId,
-      activePageIndex,
-      activePageName: activePage?.name,
-      buildsRemaining: activePage ? getRemoteBuildsRemaining(payload, activePage) : 0,
-      connectedControllerCount,
-      deckName: payload.project.name,
-      nextPageName: nextPage?.name,
-      nextSlidePreview: upcomingSlidePreviews[0]?.preview,
-      notes: activePage?.speakerNotes ?? '',
-      pageCount: payload.project.pages.length,
-      pages,
-      presenterMode: payload.presenterMode ?? 'presenting',
-      commandAvailability: [
-        'previous',
-        'next',
-        'go-to-page',
-        'pause-timer',
-        'resume-timer',
-        'reset-timer',
-        'play-pause-movie',
-      ],
-      previewMode: 'stream',
-      shortcuts: ['previous', 'next', 'pause-timer', 'reset-timer'],
-      slidePreview,
-      stream: {
-        enabled: true,
-        fps: 8,
-        height: 340,
-        peerId: payload.streamPeerId,
-        transport: 'peerjs',
-        width: 390,
-      },
-      timer,
-      type: 'state',
-      upcomingSlidePreviews,
-    }));
+    activePageId: activePage?.id ?? payload.activePageId,
+    activePageIndex,
+    activePageName: activePage?.name,
+    builds: activePageBuilds?.total ? activePageBuilds : undefined,
+    buildsRemaining: activePageBuilds?.remaining ?? 0,
+    connectedControllerCount,
+    deckName: payload.project.name,
+    nextPageName: nextPage?.name,
+    nextSlidePreview: upcomingSlidePreviews[0]?.preview,
+    notes: activePage?.speakerNotes ?? '',
+    pageCount: payload.project.pages.length,
+    pages,
+    presenterMode: payload.presenterMode ?? 'presenting',
+    commandAvailability: [
+      'previous',
+      'next',
+      'go-to-page',
+      'pause-timer',
+      'resume-timer',
+      'reset-timer',
+      'play-pause-movie',
+    ],
+    previewMode: 'stream',
+    shortcuts: ['previous', 'next', 'pause-timer', 'reset-timer'],
+    slidePreview,
+    stream: {
+      enabled: true,
+      fps: 8,
+      height: 340,
+      peerId: payload.streamPeerId,
+      transport: 'peerjs',
+      width: 390,
+    },
+    timer,
+    type: 'state',
+    upcomingSlidePreviews,
+  }));
 }
 
-function getRemoteBuildsRemaining(payload: PresenterStatePayload, page: Page) {
+function getRemoteBuildInfo(payload: PresenterStatePayload, page: Page) {
   const validBuilds = (page.animationBuilds ?? []).filter((build) =>
     page.elementIds.includes(build.elementId),
   );
-  if (validBuilds.length === 0) return 0;
-  if (payload.animationPreview?.pageId !== page.id) return validBuilds.length;
-  if (payload.animationPreview.phase === 'complete') return 0;
+  if (validBuilds.length === 0) return { current: 0, remaining: 0, total: 0 };
+  if (payload.animationPreview?.pageId !== page.id) {
+    return { current: 1, remaining: validBuilds.length, total: validBuilds.length };
+  }
+  if (payload.animationPreview.phase === 'complete') {
+    return { current: validBuilds.length, remaining: 0, total: validBuilds.length };
+  }
   const hiddenElementIds = new Set(payload.animationPreview.hiddenElementIds);
-  return validBuilds.filter((build) => hiddenElementIds.has(build.elementId)).length;
+  const remaining = validBuilds.filter((build) => hiddenElementIds.has(build.elementId)).length;
+  return {
+    current: Math.min(validBuilds.length, Math.max(1, validBuilds.length - remaining + 1)),
+    remaining,
+    total: validBuilds.length,
+  };
 }
 
 function createUpcomingSlidePreviews(
@@ -504,6 +629,62 @@ function createUpcomingSlidePreviews(
       })),
     ),
   );
+}
+
+async function createRemotePreviewBatches(
+  payload: PresenterStatePayload,
+  requestedPageIds: string[],
+  requestId: string | undefined,
+): Promise<PresenterRemotePreviewBatch[]> {
+  const pageIds = new Set(requestedPageIds.slice(0, 5));
+  const activePageIndex = Math.max(
+    0,
+    payload.project.pages.findIndex((page) => page.id === payload.activePageId),
+  );
+  const activePage = payload.project.pages[activePageIndex];
+  const hiddenElementIds =
+    activePage && payload.animationPreview?.pageId === activePage.id
+      ? new Set(payload.animationPreview.hiddenElementIds)
+      : undefined;
+  const previews = await Promise.all(
+    payload.project.pages
+      .filter((page) => pageIds.has(page.id))
+      .map(async (page) => ({
+        id: page.id,
+        name: page.name,
+        preview: await createSlidePreview(
+          payload.project,
+          page,
+          page.id === activePage?.id ? hiddenElementIds : undefined,
+        ),
+      })),
+  );
+  return createPreviewBatches(previews, requestId);
+}
+
+function createPreviewBatches(
+  previews: PresenterRemotePreviewBatch['previews'],
+  requestId: string | undefined,
+) {
+  const batches: PresenterRemotePreviewBatch[] = [];
+  let currentBatch: PresenterRemotePreviewBatch['previews'] = [];
+  for (const preview of previews) {
+    const candidateBatch = {
+      previews: [...currentBatch, preview],
+      requestId,
+      type: 'preview-batch' as const,
+    };
+    if (currentBatch.length > 0 && getJsonByteLength(candidateBatch) > remotePreviewBatchMaxBytes) {
+      batches.push({ previews: currentBatch, requestId, type: 'preview-batch' });
+      currentBatch = [preview];
+      continue;
+    }
+    currentBatch = candidateBatch.previews;
+  }
+  if (currentBatch.length > 0) {
+    batches.push({ previews: currentBatch, requestId, type: 'preview-batch' });
+  }
+  return batches;
 }
 
 async function createSlidePreview(
@@ -613,30 +794,47 @@ function createThumbnailDataUrl(assetUrl: string) {
     const timeoutId = window.setTimeout(() => resolve(undefined), 250);
     image.onload = () => {
       window.clearTimeout(timeoutId);
-      const sourceWidth = image.naturalWidth || image.width;
-      const sourceHeight = image.naturalHeight || image.height;
-      if (!sourceWidth || !sourceHeight) {
+      try {
+        const sourceWidth = image.naturalWidth || image.width;
+        const sourceHeight = image.naturalHeight || image.height;
+        if (!sourceWidth || !sourceHeight) {
+          resolve(undefined);
+          return;
+        }
+        const scale = Math.min(
+          1,
+          remotePreviewThumbnailMaxEdge / Math.max(sourceWidth, sourceHeight),
+        );
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(sourceWidth * scale));
+        canvas.height = Math.max(1, Math.round(sourceHeight * scale));
+        const context = canvas.getContext('2d');
+        if (!context) {
+          resolve(undefined);
+          return;
+        }
+        context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        resolve(canvas.toDataURL('image/jpeg', remotePreviewThumbnailQuality));
+      } catch (error) {
+        presenterRemoteDebugLog.warn('Remote preview thumbnail generation failed.', error);
         resolve(undefined);
-        return;
       }
-      const scale = Math.min(1, remotePreviewThumbnailMaxEdge / Math.max(sourceWidth, sourceHeight));
-      const canvas = document.createElement('canvas');
-      canvas.width = Math.max(1, Math.round(sourceWidth * scale));
-      canvas.height = Math.max(1, Math.round(sourceHeight * scale));
-      const context = canvas.getContext('2d');
-      if (!context) {
-        resolve(undefined);
-        return;
-      }
-      context.drawImage(image, 0, 0, canvas.width, canvas.height);
-      resolve(canvas.toDataURL('image/jpeg', remotePreviewThumbnailQuality));
     };
     image.onerror = () => {
       window.clearTimeout(timeoutId);
+      presenterRemoteDebugLog.warn('Remote preview thumbnail image failed to load.');
       resolve(undefined);
     };
     image.src = assetUrl;
   });
+}
+
+function getJsonByteLength(value: unknown) {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
 }
 
 function isLoopbackOrigin(origin: string) {

--- a/apps/editor/src/services/presenter/presenterSessionService.ts
+++ b/apps/editor/src/services/presenter/presenterSessionService.ts
@@ -200,6 +200,7 @@ export class BrowserPresenterSessionService {
       return;
     }
     if (this.remoteSession) {
+      const publishSequence = ++this.remoteStatePublishSequence;
       this.remotePeerControlHost?.publishState(
         createRemoteStateSkeleton(
           payload,
@@ -210,6 +211,18 @@ export class BrowserPresenterSessionService {
           ),
         ),
       );
+      void this.createRemoteState(
+        payload,
+        this.remoteSession.connectedControllerCount,
+        this.remoteSessionStartedAt ? Date.now() - this.remoteSessionStartedAt : 0,
+      )
+        .then((remoteState) => {
+          if (publishSequence !== this.remoteStatePublishSequence) return;
+          this.remotePeerControlHost?.publishState(remoteState);
+        })
+        .catch((error: unknown) => {
+          presenterRemoteDebugLog.error('Failed to create PeerJS remote state.', error);
+        });
     }
   }
 

--- a/apps/editor/src/services/presenter/presenterSessionTypes.ts
+++ b/apps/editor/src/services/presenter/presenterSessionTypes.ts
@@ -1,12 +1,15 @@
 import type { ProjectDocument } from '../../domain/documents/model';
 import type { AnimationPreviewState } from '../../ui/editor/animation/useAnimationPreviewController';
 import type {
+  PresenterRemotePeerSession,
   PresenterRemoteSession,
   PresenterRemoteTimerState,
 } from '@localstudio/presenter-remote/protocol';
 
 export type PresenterRemoteSessionMetadata = PresenterRemoteSession & {
+  controlPeerId?: PresenterRemotePeerSession['controlPeerId'] | undefined;
   qrUrl: string;
+  transport?: PresenterRemotePeerSession['transport'] | undefined;
 };
 
 export interface PresenterStatePayload {
@@ -15,6 +18,7 @@ export interface PresenterStatePayload {
   project: ProjectDocument;
   presenterMode?: 'presenting' | 'ready' | undefined;
   remoteSession?: PresenterRemoteSessionMetadata | undefined;
+  streamPeerId?: string | undefined;
   timer?: PresenterRemoteTimerState | undefined;
 }
 
@@ -29,6 +33,7 @@ export type PresenterWindowCommand =
   | { command: 'resume-timer' }
   | { command: 'start-presenting' }
   | { command: 'update-timer'; timer: PresenterRemoteTimerState }
+  | { command: 'update-stream-peer'; peerId?: string | undefined }
   | { command: 'update-notes'; notes: string; pageId: string };
 
 export interface PresenterStateMessage {

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -26,10 +26,7 @@ import { ScrollingCanvasWorkspace } from '../canvas/ScrollingCanvasWorkspace';
 import { SettingsPanel } from '../panels/SettingsPanel';
 import { TopToolbar } from '../toolbars/TopToolbar';
 import { VersionHistoryPanel } from '../panels/VersionHistoryPanel';
-import {
-  presentationMovieControls,
-  type MovieHoldState,
-} from '../media/presentationMovieControls';
+import { presentationMovieControls, type MovieHoldState } from '../media/presentationMovieControls';
 import { useEditorViewModel } from '../state/useEditorViewModel';
 import { SharePanel } from '../../share/SharePanel';
 import {
@@ -83,14 +80,20 @@ export function EditorShell({ services }: EditorShellProps) {
   const [slideNavigatorOpen, setSlideNavigatorOpen] = useState(false);
   const [slideNavigatorIndex, setSlideNavigatorIndex] = useState(0);
   const [presentationPaused, setPresentationPaused] = useState(false);
-  const [presentationBlankScreen, setPresentationBlankScreen] = useState<'black' | 'white' | undefined>();
+  const [presentationBlankScreen, setPresentationBlankScreen] = useState<
+    'black' | 'white' | undefined
+  >();
   const [presentationCursorHidden, setPresentationCursorHidden] = useState(false);
   const [slideNumberVisible, setSlideNumberVisible] = useState(false);
   const [presenterSessionId, setPresenterSessionId] = useState<string | undefined>();
-  const [presenterRemoteSession, setPresenterRemoteSession] = useState<PresenterRemoteSessionMetadata | undefined>();
+  const [presenterRemoteSession, setPresenterRemoteSession] = useState<
+    PresenterRemoteSessionMetadata | undefined
+  >();
   const [presenterRemotePanelOpen, setPresenterRemotePanelOpen] = useState(false);
   const [presenterRemoteUnavailable, setPresenterRemoteUnavailable] = useState(false);
-  const [presenterRemoteStreamPeerId, setPresenterRemoteStreamPeerId] = useState<string | undefined>();
+  const [presenterRemoteStreamPeerId, setPresenterRemoteStreamPeerId] = useState<
+    string | undefined
+  >();
   const [remotePresenterActive, setRemotePresenterActive] = useState(false);
   const [presenterViewError, setPresenterViewError] = useState<string | undefined>();
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
@@ -204,7 +207,9 @@ export function EditorShell({ services }: EditorShellProps) {
       .catch(() => {
         setPresenterRemoteUnavailable(true);
         setPresenterRemotePanelOpen(false);
-        setPresenterViewError('Remote control is unavailable on this host. Presenter view is still active.');
+        setPresenterViewError(
+          'Remote control is unavailable on this host. Presenter view is still active.',
+        );
       });
     presenterFullscreenEnteredRef.current = false;
     setAudienceFullscreenPromptOpen(true);
@@ -225,17 +230,23 @@ export function EditorShell({ services }: EditorShellProps) {
     void vm.toggleFullscreen(workspaceRef.current);
   }
 
-  const playPresentationPageAt = useCallback((index: number) => {
-    const pageId = vm.project.pages[index]?.id;
-    if (!pageId) return false;
-    setSlideNavigatorIndex(index);
-    vm.playPresentationPreview(pageId);
-    return true;
-  }, [vm]);
+  const playPresentationPageAt = useCallback(
+    (index: number) => {
+      const pageId = vm.project.pages[index]?.id;
+      if (!pageId) return false;
+      setSlideNavigatorIndex(index);
+      vm.playPresentationPreview(pageId);
+      return true;
+    },
+    [vm],
+  );
 
-  const playRelativePresentationSlide = useCallback((offset: -1 | 1) => {
-    return playPresentationPageAt(activePageIndex + offset);
-  }, [activePageIndex, playPresentationPageAt]);
+  const playRelativePresentationSlide = useCallback(
+    (offset: -1 | 1) => {
+      return playPresentationPageAt(activePageIndex + offset);
+    },
+    [activePageIndex, playPresentationPageAt],
+  );
 
   function getPresentationVideos() {
     return Array.from(slideFrameRef.current?.querySelectorAll('video') ?? []);
@@ -479,10 +490,7 @@ export function EditorShell({ services }: EditorShellProps) {
           return;
         }
       }
-      if (
-        isPreviewNavigationActive &&
-        !isEditableTarget
-      ) {
+      if (isPreviewNavigationActive && !isEditableTarget) {
         const lowerKey = event.key.toLowerCase();
         if (event.key === '?' || (event.key === '/' && event.shiftKey)) {
           event.preventDefault();
@@ -574,9 +582,7 @@ export function EditorShell({ services }: EditorShellProps) {
           event.key === ' ' ||
           event.key === 'Enter';
         const isPreviousPreviewKey =
-          event.key === 'ArrowLeft' ||
-          event.key === 'ArrowUp' ||
-          event.key === 'PageUp';
+          event.key === 'ArrowLeft' || event.key === 'ArrowUp' || event.key === 'PageUp';
         if (event.key === '[') {
           event.preventDefault();
           vm.rewindPresentationPreview();
@@ -754,8 +760,12 @@ export function EditorShell({ services }: EditorShellProps) {
       presenterFullscreenEnteredRef.current = true;
       return;
     }
-    if (presenterFullscreenEnteredRef.current) closePresenterViewSession();
-  }, [presenterSessionId, vm.isFullscreen]);
+    if (presenterFullscreenEnteredRef.current) {
+      presenterFullscreenEnteredRef.current = false;
+      if (presenterRemoteSession) return;
+      queueMicrotask(closePresenterViewSession);
+    }
+  }, [presenterRemoteSession, presenterSessionId, vm.isFullscreen]);
 
   useEffect(() => {
     if (!presenterRemoteSession) return;
@@ -1131,7 +1141,12 @@ export function EditorShell({ services }: EditorShellProps) {
             />
           ) : null}
           {slideNavigatorOpen ? (
-            <div className="presentation-slide-navigator" role="dialog" aria-modal="true" aria-label="Slide navigator">
+            <div
+              className="presentation-slide-navigator"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Slide navigator"
+            >
               <div className="presentation-slide-navigator-header">
                 <h2>Slide Navigator</h2>
                 <button
@@ -1334,7 +1349,9 @@ export function EditorShell({ services }: EditorShellProps) {
                       vm.updatePageSpeakerNotes(activePage.id, event.target.value)
                     }
                   />
-                  <span className="speaker-notes-count">{activePage.speakerNotes?.length ?? 0}/5000</span>
+                  <span className="speaker-notes-count">
+                    {activePage.speakerNotes?.length ?? 0}/5000
+                  </span>
                 </div>
               ) : null}
             </section>
@@ -1369,8 +1386,8 @@ export function EditorShell({ services }: EditorShellProps) {
                 </button>
                 <h2 id="audience-fullscreen-title">Audience Window</h2>
                 <p>
-                  This window is what your audience sees. Drag it to the screen your
-                  audience will be looking at and enter full screen mode.
+                  This window is what your audience sees. Drag it to the screen your audience will
+                  be looking at and enter full screen mode.
                 </p>
                 <button
                   className="audience-fullscreen-primary"

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -89,6 +89,8 @@ export function EditorShell({ services }: EditorShellProps) {
   const [presenterSessionId, setPresenterSessionId] = useState<string | undefined>();
   const [presenterRemoteSession, setPresenterRemoteSession] = useState<PresenterRemoteSessionMetadata | undefined>();
   const [presenterRemotePanelOpen, setPresenterRemotePanelOpen] = useState(false);
+  const [presenterRemoteUnavailable, setPresenterRemoteUnavailable] = useState(false);
+  const [presenterRemoteStreamPeerId, setPresenterRemoteStreamPeerId] = useState<string | undefined>();
   const [remotePresenterActive, setRemotePresenterActive] = useState(false);
   const [presenterViewError, setPresenterViewError] = useState<string | undefined>();
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
@@ -163,6 +165,8 @@ export function EditorShell({ services }: EditorShellProps) {
     setAudienceFullscreenPromptOpen(false);
     setPresenterRemoteSession(undefined);
     setPresenterRemotePanelOpen(false);
+    setPresenterRemoteUnavailable(false);
+    setPresenterRemoteStreamPeerId(undefined);
     setRemotePresenterActive(false);
     setPresenterSessionId(undefined);
   }
@@ -178,6 +182,7 @@ export function EditorShell({ services }: EditorShellProps) {
       return;
     }
     setPresenterViewError(undefined);
+    setPresenterRemoteUnavailable(false);
     setRemotePresenterActive(true);
     setPresenterSessionId(result.sessionId);
     setPresenterRemotePanelOpen(true);
@@ -193,7 +198,13 @@ export function EditorShell({ services }: EditorShellProps) {
           animationPreview: vm.animationPreview,
           presenterMode: 'presenting',
           project: vm.project,
+          streamPeerId: presenterRemoteStreamPeerId,
         });
+      })
+      .catch(() => {
+        setPresenterRemoteUnavailable(true);
+        setPresenterRemotePanelOpen(false);
+        setPresenterViewError('Remote control is unavailable on this host. Presenter view is still active.');
       });
     presenterFullscreenEnteredRef.current = false;
     setAudienceFullscreenPromptOpen(true);
@@ -204,9 +215,10 @@ export function EditorShell({ services }: EditorShellProps) {
         animationPreview: vm.animationPreview,
         presenterMode: 'presenting',
         project: vm.project,
+        streamPeerId: presenterRemoteStreamPeerId,
       });
     }, 0);
-  }, [presenterSessionId, vm]);
+  }, [presenterRemoteStreamPeerId, presenterSessionId, vm]);
 
   function enterAudienceFullscreen() {
     setAudienceFullscreenPromptOpen(false);
@@ -631,6 +643,7 @@ export function EditorShell({ services }: EditorShellProps) {
   useEffect(() => {
     const pageId = vm.activePageId;
     if (!pageId) return undefined;
+    if (presenterRemoteUnavailable) return undefined;
     let cancelled = false;
     const service = getPresenterSessionService();
     void service
@@ -646,15 +659,29 @@ export function EditorShell({ services }: EditorShellProps) {
           animationPreview: vm.animationPreview,
           presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
           project: vm.project,
+          streamPeerId: presenterRemoteStreamPeerId,
         });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPresenterRemoteUnavailable(true);
+        setPresenterRemotePanelOpen(false);
       });
     return () => {
       cancelled = true;
     };
-  }, [presenterSessionId, remotePresenterActive, vm.activePageId, vm.animationPreview, vm.project]);
+  }, [
+    presenterRemoteStreamPeerId,
+    presenterRemoteUnavailable,
+    presenterSessionId,
+    remotePresenterActive,
+    vm.activePageId,
+    vm.animationPreview,
+    vm.project,
+  ]);
 
   useEffect(() => {
-    if (!presenterRemoteSession) return undefined;
+    if (!presenterRemoteSession && !presenterSessionId) return undefined;
     return getPresenterSessionService().subscribeToCommands((message) => {
       if (message.command === 'start-presenting') {
         const firstPageId = vm.project.pages[0]?.id ?? vm.activePageId;
@@ -668,6 +695,7 @@ export function EditorShell({ services }: EditorShellProps) {
           animationPreview: vm.animationPreview,
           presenterMode: 'presenting',
           project: vm.project,
+          streamPeerId: presenterRemoteStreamPeerId,
         });
         return;
       }
@@ -690,12 +718,17 @@ export function EditorShell({ services }: EditorShellProps) {
         vm.updatePageSpeakerNotes(message.pageId, message.notes);
         return;
       }
+      if (message.command === 'update-stream-peer') {
+        setPresenterRemoteStreamPeerId(message.peerId);
+        return;
+      }
       if (message.command === 'request-state') {
         getPresenterSessionService().publishState({
           activePageId: vm.activePageId,
           animationPreview: vm.animationPreview,
           presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
           project: vm.project,
+          streamPeerId: presenterRemoteStreamPeerId,
         });
         return;
       }
@@ -703,7 +736,14 @@ export function EditorShell({ services }: EditorShellProps) {
         closePresenterViewSession();
       }
     });
-  }, [advancePresentationPreviewFromUserAction, presenterRemoteSession, presenterSessionId, remotePresenterActive, vm]);
+  }, [
+    advancePresentationPreviewFromUserAction,
+    presenterRemoteSession,
+    presenterRemoteStreamPeerId,
+    presenterSessionId,
+    remotePresenterActive,
+    vm,
+  ]);
 
   useEffect(() => {
     if (!presenterSessionId) {
@@ -724,8 +764,17 @@ export function EditorShell({ services }: EditorShellProps) {
       animationPreview: vm.animationPreview,
       presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
       project: vm.project,
+      streamPeerId: presenterRemoteStreamPeerId,
     });
-  }, [presenterRemoteSession, presenterSessionId, remotePresenterActive, vm.activePageId, vm.animationPreview, vm.project]);
+  }, [
+    presenterRemoteSession,
+    presenterRemoteStreamPeerId,
+    presenterSessionId,
+    remotePresenterActive,
+    vm.activePageId,
+    vm.animationPreview,
+    vm.project,
+  ]);
 
   useEffect(() => {
     if (!presenterRemotePanelOpen) return;

--- a/apps/editor/src/ui/presenter/PresenterRemotePanel.tsx
+++ b/apps/editor/src/ui/presenter/PresenterRemotePanel.tsx
@@ -34,13 +34,18 @@ export function PresenterRemotePanel({ session }: PresenterRemotePanelProps) {
   }, [session.qrUrl]);
 
   async function copyRemoteLink() {
-    await navigator.clipboard?.writeText(session.qrUrl);
-    setCopyStatus('copied');
+    try {
+      await navigator.clipboard?.writeText(session.qrUrl);
+      setCopyStatus('copied');
+    } catch {
+      setCopyStatus('idle');
+    }
   }
 
   return (
     <section
       className="presenter-remote-panel"
+      data-remote-url={session.qrUrl}
       aria-label="Remote control this presentation"
     >
       <header className="presenter-remote-header">

--- a/apps/editor/src/ui/presenter/PresenterRemotePanel.tsx
+++ b/apps/editor/src/ui/presenter/PresenterRemotePanel.tsx
@@ -12,6 +12,32 @@ function formatExpiry(expiresAt: string) {
   return `${remainingHours}h remaining`;
 }
 
+async function writeTextToClipboard(text: string) {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall back to the selection-based copy path below.
+  }
+
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'fixed';
+  textArea.style.top = '0';
+  textArea.style.left = '-9999px';
+  document.body.append(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    return document.execCommand('copy');
+  } finally {
+    textArea.remove();
+  }
+}
+
 export function PresenterRemotePanel({ session }: PresenterRemotePanelProps) {
   const [qrCodeUrl, setQrCodeUrl] = useState('');
   const [copyStatus, setCopyStatus] = useState<'copied' | 'idle'>('idle');
@@ -34,12 +60,8 @@ export function PresenterRemotePanel({ session }: PresenterRemotePanelProps) {
   }, [session.qrUrl]);
 
   async function copyRemoteLink() {
-    try {
-      await navigator.clipboard?.writeText(session.qrUrl);
-      setCopyStatus('copied');
-    } catch {
-      setCopyStatus('idle');
-    }
+    const copied = await writeTextToClipboard(session.qrUrl);
+    setCopyStatus(copied ? 'copied' : 'idle');
   }
 
   return (
@@ -60,15 +82,15 @@ export function PresenterRemotePanel({ session }: PresenterRemotePanelProps) {
           <p>Scan the code or open the link from another device.</p>
         </div>
         {qrCodeUrl ? (
-          <img
-            className="presenter-remote-qr"
-            src={qrCodeUrl}
-            alt="Remote control QR code"
-          />
+          <img className="presenter-remote-qr" src={qrCodeUrl} alt="Remote control QR code" />
         ) : (
           <div className="presenter-remote-qr presenter-remote-qr-loading" aria-hidden="true" />
         )}
-        <button type="button" className="presenter-remote-copy" onClick={() => void copyRemoteLink()}>
+        <button
+          type="button"
+          className="presenter-remote-copy"
+          onClick={() => void copyRemoteLink()}
+        >
           <span className="material-symbols-outlined" aria-hidden="true">
             link
           </span>

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -19,10 +19,6 @@ import {
 import { PresenterRemotePanel } from './PresenterRemotePanel';
 import { presenterRemoteMirror } from './presenterRemoteMirror';
 import { presenterRemoteStreamPublisher } from './presenterRemoteStreamPublisher';
-import type {
-  PresenterRemoteCommand,
-  PresenterRemoteStreamPreference,
-} from '@localstudio/presenter-remote/protocol';
 import { presenterRemoteTimerFormat } from '@localstudio/presenter-remote/timer-format';
 
 interface PresenterViewProps {
@@ -38,7 +34,6 @@ const notesMinWidthPx = 280;
 const notesMaxWidthPx = 760;
 const presenterMainMinWidthPx = 520;
 const defaultRemoteStreamSize = presenterRemoteMirror.size;
-const maxRemoteStreamSize = { height: 1120, width: 1280 };
 const presenterShortcutActions = [
   'next-build',
   'previous-build',
@@ -168,7 +163,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
   const [notesPanelWidth, setNotesPanelWidth] = useState(getInitialNotesWidth);
   const [keyboardShortcutsMode, setKeyboardShortcutsMode] = useState<'dialog' | 'popover' | undefined>();
   const [remotePanelOpen, setRemotePanelOpen] = useState(false);
-  const [remoteStreamSize, setRemoteStreamSize] = useState(defaultRemoteStreamSize);
+  const remoteStreamSize = defaultRemoteStreamSize;
   const [slideNavigatorOpen, setSlideNavigatorOpen] = useState(false);
   const [slideNavigatorIndex, setSlideNavigatorIndex] = useState(0);
   const [introDismissed, setIntroDismissed] = useState(getInitialIntroDismissed);
@@ -386,39 +381,6 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     postCommand({ command: 'reset-timer' });
     publishTimerState({ elapsedMs: 0, paused: false });
   }, [postCommand, publishTimerState]);
-
-  const handleRemoteStreamCommand = useCallback((command: PresenterRemoteCommand) => {
-    if (command.command === 'go-to-page') {
-      postCommand({ command: 'go-to-page', pageId: command.pageId });
-      return;
-    }
-    if (command.command === 'update-notes') {
-      postCommand({ command: 'update-notes', notes: command.notes, pageId: command.pageId });
-      return;
-    }
-    if (
-      command.command === 'pause-timer' ||
-      command.command === 'reset-timer' ||
-      command.command === 'resume-timer'
-    ) {
-      applyTimerCommand(command.command);
-      return;
-    }
-    postCommand({ command: command.command });
-  }, [applyTimerCommand, postCommand]);
-
-  const handleRemoteStreamPreference = useCallback((preference: PresenterRemoteStreamPreference) => {
-    setRemoteStreamSize({
-      height: Math.max(
-        defaultRemoteStreamSize.height,
-        Math.min(maxRemoteStreamSize.height, Math.round(preference.height)),
-      ),
-      width: Math.max(
-        defaultRemoteStreamSize.width,
-        Math.min(maxRemoteStreamSize.width, Math.round(preference.width)),
-      ),
-    });
-  }, []);
 
   function getPresenterVideos() {
     return Array.from(presenterStageRef.current?.querySelectorAll('video') ?? []);
@@ -736,9 +698,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     remoteStreamPublisherRef.current?.stop();
     const publisher = presenterRemoteStreamPublisher.create({
       canvas,
-      onCommand: handleRemoteStreamCommand,
-      onStreamPreference: handleRemoteStreamPreference,
-      sessionCode,
+      onPeerId: (peerId) => postCommand({ command: 'update-stream-peer', peerId }),
     });
     remoteStreamPublisherRef.current = publisher;
     publisher.start();
@@ -746,7 +706,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       publisher.stop();
       if (remoteStreamPublisherRef.current === publisher) remoteStreamPublisherRef.current = undefined;
     };
-  }, [handleRemoteStreamCommand, handleRemoteStreamPreference, snapshot?.remoteSession?.code]);
+  }, [postCommand, snapshot?.remoteSession?.code]);
 
   const introOverlay = !introDismissed ? (
     <div className="presenter-intro-backdrop" role="presentation">

--- a/apps/editor/src/ui/presenter/presenterRemoteStreamPublisher.ts
+++ b/apps/editor/src/ui/presenter/presenterRemoteStreamPublisher.ts
@@ -1,164 +1,39 @@
-import {
-  presenterRemoteProtocol,
-  type PresenterRemoteCommand,
-  type PresenterRemoteStreamPreference,
-} from '@localstudio/presenter-remote/protocol';
-import { PresenterRemoteSignalingClient } from '@localstudio/presenter-remote/signaling-client';
-import { presenterRemoteWebRtc } from '@localstudio/presenter-remote/webrtc';
+import { PresenterRemotePeerStreamPublisher } from '@localstudio/presenter-remote/peer-stream-publisher';
 
 interface PresenterRemoteStreamPublisherOptions {
   canvas: HTMLCanvasElement;
-  onCommand: (command: PresenterRemoteCommand) => void;
-  onStreamPreference?: ((preference: PresenterRemoteStreamPreference) => void) | undefined;
-  sessionCode: string;
-  signalingClient?: PresenterRemoteSignalingClient | undefined;
-}
-
-interface PresenterRemoteStreamConnection {
-  icePollIntervalId: number;
-  peerConnection: RTCPeerConnection;
-  sender: RTCRtpSender | undefined;
+  onPeerId: (peerId: string | undefined) => void;
 }
 
 class PresenterRemoteStreamPublisher {
   private readonly canvas: HTMLCanvasElement;
-  private readonly connections = new Map<string, PresenterRemoteStreamConnection>();
-  private readonly onCommand: (command: PresenterRemoteCommand) => void;
-  private readonly onStreamPreference: ((preference: PresenterRemoteStreamPreference) => void) | undefined;
-  private readonly sessionCode: string;
-  private readonly signalingClient: PresenterRemoteSignalingClient;
+  private readonly onPeerId: (peerId: string | undefined) => void;
   private fps = 8;
-  private offerPollIntervalId = 0;
+  private publisher: PresenterRemotePeerStreamPublisher | undefined;
   private stream: MediaStream | undefined;
 
   constructor(options: PresenterRemoteStreamPublisherOptions) {
     this.canvas = options.canvas;
-    this.onCommand = options.onCommand;
-    this.onStreamPreference = options.onStreamPreference;
-    this.sessionCode = options.sessionCode;
-    this.signalingClient = options.signalingClient ?? new PresenterRemoteSignalingClient({
-      endpoint: '/__localstudio/presenter-remote',
-    });
+    this.onPeerId = options.onPeerId;
   }
 
   start() {
     if (typeof this.canvas.captureStream !== 'function') return;
     this.stream = this.canvas.captureStream(this.fps);
-    this.offerPollIntervalId = window.setInterval(() => {
-      void this.answerPendingOffers();
-    }, 800);
-    void this.answerPendingOffers();
+    this.publisher = new PresenterRemotePeerStreamPublisher({ stream: this.stream });
+    void this.publisher.start().then((peerId) => {
+      this.onPeerId(peerId);
+    }).catch(() => {
+      this.onPeerId(undefined);
+    });
   }
 
   stop() {
-    window.clearInterval(this.offerPollIntervalId);
-    for (const [controllerId, connection] of this.connections) {
-      window.clearInterval(connection.icePollIntervalId);
-      connection.peerConnection.close();
-      void this.signalingClient.closeController(this.sessionCode, controllerId).catch(() => undefined);
-    }
-    this.connections.clear();
+    this.publisher?.stop();
+    this.publisher = undefined;
     this.stream?.getTracks().forEach((track) => track.stop());
     this.stream = undefined;
-  }
-
-  private async answerPendingOffers() {
-    const stream = this.stream;
-    if (!stream) return;
-    const offers = await this.signalingClient.takeControllerOffers(this.sessionCode).catch(() => []);
-    for (const offer of offers) {
-      if (this.connections.has(offer.controllerId)) continue;
-      await this.answerOffer(offer.controllerId, offer.offerSdp, stream);
-    }
-  }
-
-  private async answerOffer(controllerId: string, offerSdp: string, stream: MediaStream) {
-    const peerConnection = new RTCPeerConnection(presenterRemoteWebRtc.peerConfig);
-    const videoTrack = stream.getVideoTracks()[0];
-    const sender = videoTrack ? peerConnection.addTrack(videoTrack, stream) : undefined;
-    peerConnection.ondatachannel = (event) => {
-      event.channel.onmessage = (messageEvent) => {
-        const parsed = parseStreamMessage(messageEvent.data);
-        if (!parsed) return;
-        if (parsed.type === 'stream-preference') {
-          this.applyStreamPreference(parsed);
-          this.onStreamPreference?.(parsed);
-          return;
-        }
-        this.onCommand(parsed);
-      };
-    };
-    peerConnection.onicecandidate = (event) => {
-      if (!event.candidate) return;
-      void this.signalingClient.publishIceCandidate(this.sessionCode, controllerId, {
-        candidate: event.candidate.toJSON(),
-        target: 'controller',
-      });
-    };
-    peerConnection.onconnectionstatechange = () => {
-      if (peerConnection.connectionState !== 'closed' && peerConnection.connectionState !== 'failed') return;
-      this.closeConnection(controllerId);
-    };
-    await peerConnection.setRemoteDescription({ sdp: offerSdp, type: 'offer' });
-    const answer = await peerConnection.createAnswer();
-    await peerConnection.setLocalDescription(answer);
-    await this.signalingClient.publishAnswer(this.sessionCode, controllerId, answer.sdp ?? '');
-    const icePollIntervalId = window.setInterval(() => {
-      void this.takeControllerIce(controllerId, peerConnection);
-    }, 500);
-    this.connections.set(controllerId, { icePollIntervalId, peerConnection, sender });
-  }
-
-  private applyStreamPreference(preference: PresenterRemoteStreamPreference) {
-    const nextFps = clampFps(preference.fps);
-    if (this.fps === nextFps) return;
-    this.fps = nextFps;
-    if (typeof this.canvas.captureStream !== 'function') return;
-    const previousStream = this.stream;
-    const nextStream = this.canvas.captureStream(this.fps);
-    const nextTrack = nextStream.getVideoTracks()[0];
-    this.stream = nextStream;
-    if (nextTrack) {
-      for (const connection of this.connections.values()) {
-        void connection.sender?.replaceTrack(nextTrack).catch(() => undefined);
-      }
-    }
-    previousStream?.getTracks().forEach((track) => track.stop());
-  }
-
-  private async takeControllerIce(controllerId: string, peerConnection: RTCPeerConnection) {
-    const candidates = await this.signalingClient
-      .takeIceCandidates(this.sessionCode, controllerId, 'presenter')
-      .catch(() => []);
-    for (const candidate of candidates) {
-      await peerConnection.addIceCandidate(candidate).catch(() => undefined);
-    }
-  }
-
-  private closeConnection(controllerId: string) {
-    const connection = this.connections.get(controllerId);
-    if (!connection) return;
-    window.clearInterval(connection.icePollIntervalId);
-    connection.peerConnection.close();
-    this.connections.delete(controllerId);
-    void this.signalingClient.closeController(this.sessionCode, controllerId).catch(() => undefined);
-  }
-}
-
-function clampFps(value: number) {
-  if (!Number.isFinite(value)) return 8;
-  return Math.max(4, Math.min(15, Math.round(value)));
-}
-
-function parseStreamMessage(value: unknown) {
-  if (typeof value !== 'string') return undefined;
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    if (presenterRemoteProtocol.isCommand(parsed)) return parsed;
-    if (presenterRemoteProtocol.isStreamPreference(parsed)) return parsed;
-    return undefined;
-  } catch {
-    return undefined;
+    this.onPeerId(undefined);
   }
 }
 

--- a/apps/editor/tests/unit/services/presenterRemoteSessionService.test.ts
+++ b/apps/editor/tests/unit/services/presenterRemoteSessionService.test.ts
@@ -1,7 +1,109 @@
 import { describe, expect, it, vi } from 'vitest';
 import { sampleProject } from '../../../src/domain/projects/sampleProject';
 import { BrowserPresenterSessionService } from '../../../src/services/presenter/presenterSessionService';
+import { PresenterRemotePeerControlClient } from '@localstudio/presenter-remote/peer-control-client';
+import { PresenterRemotePeerControlHost } from '@localstudio/presenter-remote/peer-control-host';
 import { InMemoryPresenterRemoteSignalingService } from '@localstudio/presenter-remote/signaling-service';
+import type {
+  PresenterRemoteCommand,
+  PresenterRemoteState,
+} from '@localstudio/presenter-remote/protocol';
+import type { DataConnection, Peer } from 'peerjs';
+
+type PeerEventMap = {
+  connection: DataConnection;
+  error: Error;
+  open: string;
+};
+
+type DataConnectionEventMap = {
+  close: undefined;
+  data: unknown;
+  error: Error;
+  open: undefined;
+};
+
+class TestPeer {
+  readonly destroy = vi.fn();
+  readonly id = '';
+  readonly open: boolean = false;
+  private readonly listeners = new Map<keyof PeerEventMap, Array<(payload: never) => void>>();
+
+  emit<EventName extends keyof PeerEventMap>(eventName: EventName, payload: PeerEventMap[EventName]) {
+    for (const listener of this.listeners.get(eventName) ?? []) {
+      listener(payload as never);
+    }
+  }
+
+  on<EventName extends keyof PeerEventMap>(
+    eventName: EventName,
+    listener: (payload: PeerEventMap[EventName]) => void,
+  ) {
+    const listeners = this.listeners.get(eventName) ?? [];
+    listeners.push(listener);
+    this.listeners.set(eventName, listeners);
+    return this as unknown as Peer;
+  }
+}
+
+class TestClientPeer extends TestPeer {
+  readonly connection = new TestDataConnection();
+  readonly connect = vi.fn(() => this.connection as unknown as DataConnection);
+  override readonly open = true;
+}
+
+class TestClosedClientPeer extends TestPeer {
+  readonly connection = new TestDataConnection();
+  readonly connect = vi.fn(() => this.connection as unknown as DataConnection);
+}
+
+class TestDataConnection {
+  readonly close = vi.fn(() => {
+    this.open = false;
+    this.emit('close', undefined);
+  });
+  readonly send = vi.fn(() => Promise.resolve());
+  open = true;
+  private readonly listeners = new Map<
+    keyof DataConnectionEventMap,
+    Array<(payload: never) => void>
+  >();
+
+  emit<EventName extends keyof DataConnectionEventMap>(
+    eventName: EventName,
+    payload: DataConnectionEventMap[EventName],
+  ) {
+    for (const listener of this.listeners.get(eventName) ?? []) {
+      listener(payload as never);
+    }
+  }
+
+  on<EventName extends keyof DataConnectionEventMap>(
+    eventName: EventName,
+    listener: (payload: DataConnectionEventMap[EventName]) => void,
+  ) {
+    const listeners = this.listeners.get(eventName) ?? [];
+    listeners.push(listener);
+    this.listeners.set(eventName, listeners);
+    return this as unknown as DataConnection;
+  }
+}
+
+function createRemoteState(): PresenterRemoteState {
+  return {
+    activePageId: 'page-1',
+    activePageIndex: 0,
+    buildsRemaining: 0,
+    connectedControllerCount: 0,
+    deckName: 'Launch Deck',
+    notes: '',
+    pageCount: 1,
+    presenterMode: 'presenting',
+    shortcuts: ['previous', 'next'],
+    timer: { elapsedMs: 0, paused: false },
+    type: 'state',
+  };
+}
 
 describe('BrowserPresenterSessionService remote control', () => {
   it('registers a remote control session with QR metadata', async () => {
@@ -452,6 +554,130 @@ describe('BrowserPresenterSessionService remote control', () => {
 
     expect(commandHandler).toHaveBeenCalledWith({ command: 'next' });
     unsubscribe();
+    vi.useRealTimers();
+  });
+});
+
+describe('PresenterRemotePeerControlHost', () => {
+  it('fails opening when PeerJS Cloud does not assign a control peer id', async () => {
+    vi.useFakeTimers();
+    const peer = new TestPeer();
+    const host = new PresenterRemotePeerControlHost({
+      connectionTimeoutMs: 25,
+      peerFactory: () => peer as unknown as Peer,
+      presenterLabel: 'MacBook Pro',
+      ttlMs: 60_000,
+    });
+
+    const openPromise = host.open();
+    const handledOpenPromise = openPromise.catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(await handledOpenPromise).toEqual(new Error('PeerJS host connection timed out.'));
+    vi.useRealTimers();
+  });
+
+  it('opens a PeerJS control peer, broadcasts state, receives commands, and closes cleanly', async () => {
+    const peer = new TestPeer();
+    const connection = new TestDataConnection();
+    const onCommand = vi.fn();
+    const host = new PresenterRemotePeerControlHost({
+      now: () => new Date('2026-07-04T12:00:00.000Z').getTime(),
+      onCommand,
+      peerFactory: () => peer as unknown as Peer,
+      presenterDeviceId: 'presenter-device-1',
+      presenterLabel: 'MacBook Pro',
+      ttlMs: 60_000,
+    });
+
+    const openPromise = host.open();
+    peer.emit('open', 'control-peer-1');
+    const session = await openPromise;
+    peer.emit('connection', connection as unknown as DataConnection);
+    connection.emit('open', undefined);
+
+    expect(session).toMatchObject({
+      code: 'control-peer-1',
+      controlPeerId: 'control-peer-1',
+      expiresAt: '2026-07-04T12:01:00.000Z',
+      presenterDeviceId: 'presenter-device-1',
+      presenterLabel: 'MacBook Pro',
+      transport: 'peerjs',
+    });
+
+    const state = createRemoteState();
+    host.publishState(state);
+
+    expect(connection.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activePageId: 'page-1',
+        connectedControllerCount: 1,
+        type: 'state',
+      }),
+    );
+
+    const commands: PresenterRemoteCommand[] = [
+      { command: 'next', type: 'command' },
+      { command: 'previous', type: 'command' },
+      { command: 'go-to-page', pageId: 'page-1', type: 'command' },
+      { command: 'pause-timer', type: 'command' },
+      { command: 'update-notes', notes: 'Updated', pageId: 'page-1', type: 'command' },
+    ];
+    for (const command of commands) connection.emit('data', command);
+
+    expect(onCommand).toHaveBeenCalledTimes(commands.length);
+    for (const command of commands) expect(onCommand).toHaveBeenCalledWith(command);
+
+    host.close();
+
+    expect(connection.close).toHaveBeenCalled();
+    expect(peer.destroy).toHaveBeenCalled();
+  });
+});
+
+describe('PresenterRemotePeerControlClient', () => {
+  it('requests state when the PeerJS data connection is already open', async () => {
+    const peer = new TestClientPeer();
+    const onStatusChange = vi.fn();
+    const client = new PresenterRemotePeerControlClient({
+      onState: vi.fn(),
+      onStatusChange,
+      peerFactory: () => peer as unknown as Peer,
+      presenterPeerId: 'control-peer-1',
+    });
+
+    await client.start();
+
+    expect(peer.connect).toHaveBeenCalledWith(
+      'control-peer-1',
+      expect.objectContaining({ label: 'localstudio-presenter-control' }),
+    );
+    expect(peer.connection.send).toHaveBeenCalledWith({
+      command: 'request-state',
+      type: 'command',
+    });
+    expect(onStatusChange).toHaveBeenCalledWith('connected');
+  });
+
+  it('reports a failed status when the PeerJS control connection times out', async () => {
+    vi.useFakeTimers();
+    const peer = new TestClosedClientPeer();
+    const onStatusChange = vi.fn();
+    const client = new PresenterRemotePeerControlClient({
+      connectionTimeoutMs: 25,
+      onState: vi.fn(),
+      onStatusChange,
+      peerFactory: () => peer as unknown as Peer,
+      presenterPeerId: 'missing-peer',
+    });
+
+    const startPromise = client.start();
+    const handledStartPromise = startPromise.catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(await handledStartPromise).toEqual(new Error('PeerJS connection timed out.'));
+    expect(onStatusChange).toHaveBeenCalledWith('connecting');
+    expect(onStatusChange).toHaveBeenCalledWith('failed');
     vi.useRealTimers();
   });
 });

--- a/apps/editor/tests/unit/services/presenterRemoteSessionService.test.ts
+++ b/apps/editor/tests/unit/services/presenterRemoteSessionService.test.ts
@@ -6,6 +6,7 @@ import { PresenterRemotePeerControlHost } from '@localstudio/presenter-remote/pe
 import { InMemoryPresenterRemoteSignalingService } from '@localstudio/presenter-remote/signaling-service';
 import type {
   PresenterRemoteCommand,
+  PresenterRemotePreviewBatch,
   PresenterRemoteState,
 } from '@localstudio/presenter-remote/protocol';
 import type { DataConnection, Peer } from 'peerjs';
@@ -29,7 +30,10 @@ class TestPeer {
   readonly open: boolean = false;
   private readonly listeners = new Map<keyof PeerEventMap, Array<(payload: never) => void>>();
 
-  emit<EventName extends keyof PeerEventMap>(eventName: EventName, payload: PeerEventMap[EventName]) {
+  emit<EventName extends keyof PeerEventMap>(
+    eventName: EventName,
+    payload: PeerEventMap[EventName],
+  ) {
     for (const listener of this.listeners.get(eventName) ?? []) {
       listener(payload as never);
     }
@@ -62,7 +66,10 @@ class TestDataConnection {
     this.open = false;
     this.emit('close', undefined);
   });
-  readonly send = vi.fn(() => Promise.resolve());
+  readonly send = vi.fn((payload?: unknown) => {
+    void payload;
+    return Promise.resolve();
+  });
   open = true;
   private readonly listeners = new Map<
     keyof DataConnectionEventMap,
@@ -207,6 +214,7 @@ describe('BrowserPresenterSessionService remote control', () => {
         stream: { enabled: true, fps: 8, height: 340, width: 390 },
         type: 'state',
       });
+      expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
     });
     const publishedState = signalingService.getPublishedState('ABCD-1234');
     expect(publishedState?.slidePreview?.elements.length).toBeGreaterThan(0);
@@ -219,6 +227,140 @@ describe('BrowserPresenterSessionService remote control', () => {
     expect(publishedState?.upcomingSlidePreviews).toHaveLength(
       Math.min(3, project.pages.length - 1),
     );
+  });
+
+  it('publishes a lightweight PeerJS state before rich slide preview generation completes', async () => {
+    const popup = {
+      location: { href: '' },
+      postMessage: vi.fn(),
+      closed: false,
+    } as unknown as Window;
+    const peerHost = {
+      close: vi.fn(),
+      open: vi.fn(() =>
+        Promise.resolve({
+          code: 'control-peer-1',
+          connectedControllerCount: 0,
+          controlPeerId: 'control-peer-1',
+          expiresAt: '2026-07-04T12:01:00.000Z',
+          presenterDeviceId: 'presenter-device-1',
+          presenterLabel: 'MacBook Pro',
+          sessionId: 'peer-session-1',
+          transport: 'peerjs' as const,
+        }),
+      ),
+      publishPreviewBatch: vi.fn(),
+      publishState: vi.fn(),
+    };
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/?project=Demo',
+      openWindow: vi.fn(() => popup),
+      presenterDeviceId: 'presenter-device-1',
+      randomId: () => 'session-1',
+      remotePeerControlHostFactory: () => peerHost,
+    });
+    const project = sampleProject.createSampleProject();
+
+    service.openPresenterWindow();
+    await service.openRemoteControlSession({ presenterLabel: 'MacBook Pro', ttlMs: 60_000 });
+    service.publishState({
+      activePageId: project.pages[0]!.id,
+      animationPreview: undefined,
+      presenterMode: 'presenting',
+      project,
+      streamPeerId: 'stream-peer-1',
+    });
+
+    const firstPublishedState = peerHost.publishState.mock.calls[0]?.[0] as
+      | PresenterRemoteState
+      | undefined;
+    expect(firstPublishedState).toMatchObject({
+      activePageId: project.pages[0]!.id,
+      pageCount: project.pages.length,
+      previewMode: 'stream',
+      type: 'state',
+    });
+    expect(firstPublishedState?.stream?.peerId).toBe('stream-peer-1');
+    await vi.waitFor(() => {
+      expect(
+        peerHost.publishState.mock.calls.some((call) => {
+          const state = call[0] as PresenterRemoteState | undefined;
+          return Boolean(state?.slidePreview?.elements);
+        }),
+      ).toBe(true);
+    });
+  });
+
+  it('publishes requested PeerJS slide previews in bounded batches', async () => {
+    const popup = {
+      location: { href: '' },
+      postMessage: vi.fn(),
+      closed: false,
+    } as unknown as Window;
+    const peerHost = {
+      close: vi.fn(),
+      open: vi.fn(() =>
+        Promise.resolve({
+          code: 'control-peer-1',
+          connectedControllerCount: 0,
+          controlPeerId: 'control-peer-1',
+          expiresAt: '2026-07-04T12:01:00.000Z',
+          presenterDeviceId: 'presenter-device-1',
+          presenterLabel: 'MacBook Pro',
+          sessionId: 'peer-session-1',
+          transport: 'peerjs' as const,
+        }),
+      ),
+      publishPreviewBatch: vi.fn(),
+      publishState: vi.fn(),
+    };
+    let peerOptions:
+      | { onCommand?: ((command: PresenterRemoteCommand) => void) | undefined }
+      | undefined;
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/?project=Demo',
+      openWindow: vi.fn(() => popup),
+      presenterDeviceId: 'presenter-device-1',
+      randomId: () => 'session-1',
+      remotePeerControlHostFactory: (options) => {
+        peerOptions = options;
+        return peerHost;
+      },
+    });
+    const project = sampleProject.createSampleProject();
+
+    service.openPresenterWindow();
+    const unsubscribe = service.subscribeToCommands(vi.fn());
+    await service.openRemoteControlSession({ presenterLabel: 'MacBook Pro', ttlMs: 60_000 });
+    service.publishState({
+      activePageId: project.pages[0]!.id,
+      animationPreview: undefined,
+      presenterMode: 'presenting',
+      project,
+      streamPeerId: 'stream-peer-1',
+    });
+
+    peerOptions?.onCommand?.({
+      command: 'request-previews',
+      pageIds: project.pages.slice(0, 6).map((page) => page.id),
+      requestId: 'first-five',
+      type: 'command',
+    });
+
+    await vi.waitFor(() => {
+      expect(peerHost.publishPreviewBatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: 'first-five',
+          type: 'preview-batch',
+        }),
+      );
+    });
+    const batch = peerHost.publishPreviewBatch.mock.calls[0]?.[0] as
+      | PresenterRemotePreviewBatch
+      | undefined;
+    expect(batch?.previews).toHaveLength(Math.min(5, project.pages.length));
+    expect(batch?.previews[0]?.preview).toBeDefined();
+    unsubscribe();
   });
 
   it('does not publish portable slide preview asset URLs in stream-mode state', async () => {
@@ -256,7 +398,7 @@ describe('BrowserPresenterSessionService remote control', () => {
     });
 
     await vi.waitFor(() => {
-      expect(signalingService.getPublishedState('ABCD-1234')?.previewMode).toBe('stream');
+      expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
     });
     const publishedState = signalingService.getPublishedState('ABCD-1234');
 
@@ -319,7 +461,7 @@ describe('BrowserPresenterSessionService remote control', () => {
     });
 
     await vi.waitFor(() => {
-      expect(signalingService.getPublishedState('ABCD-1234')?.previewMode).toBe('stream');
+      expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
     });
     const publishedState = signalingService.getPublishedState('ABCD-1234');
     const serializedState = JSON.stringify(publishedState);
@@ -410,6 +552,7 @@ describe('BrowserPresenterSessionService remote control', () => {
 
     await vi.waitFor(() => {
       expect(signalingService.getPublishedState('ABCD-1234')?.buildsRemaining).toBe(1);
+      expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
     });
     expect(signalingService.getPublishedState('ABCD-1234')).toMatchObject({
       buildsRemaining: 1,
@@ -595,6 +738,7 @@ describe('PresenterRemotePeerControlHost', () => {
     const session = await openPromise;
     peer.emit('connection', connection as unknown as DataConnection);
     connection.emit('open', undefined);
+    connection.open = false;
 
     expect(session).toMatchObject({
       code: 'control-peer-1',
@@ -616,11 +760,41 @@ describe('PresenterRemotePeerControlHost', () => {
       }),
     );
 
+    host.publishPreviewBatch({
+      previews: [
+        {
+          id: 'page-1',
+          name: 'Slide 1',
+          preview: {
+            backgroundColor: '#000000',
+            elements: [],
+            height: 1080,
+            width: 1920,
+          },
+        },
+      ],
+      requestId: 'preview-window-1',
+      type: 'preview-batch',
+    });
+
+    expect(connection.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'preview-window-1',
+        type: 'preview-batch',
+      }),
+    );
+
     const commands: PresenterRemoteCommand[] = [
       { command: 'next', type: 'command' },
       { command: 'previous', type: 'command' },
       { command: 'go-to-page', pageId: 'page-1', type: 'command' },
       { command: 'pause-timer', type: 'command' },
+      {
+        command: 'request-previews',
+        pageIds: ['page-1'],
+        requestId: 'preview-window-1',
+        type: 'command',
+      },
       { command: 'update-notes', notes: 'Updated', pageId: 'page-1', type: 'command' },
     ];
     for (const command of commands) connection.emit('data', command);
@@ -632,6 +806,105 @@ describe('PresenterRemotePeerControlHost', () => {
 
     expect(connection.close).toHaveBeenCalled();
     expect(peer.destroy).toHaveBeenCalled();
+  });
+
+  it('strips rich previews from oversized PeerJS state payloads', async () => {
+    const peer = new TestPeer();
+    const connection = new TestDataConnection();
+    const host = new PresenterRemotePeerControlHost({
+      peerFactory: () => peer as unknown as Peer,
+      presenterLabel: 'MacBook Pro',
+      ttlMs: 60_000,
+    });
+
+    const openPromise = host.open();
+    peer.emit('open', 'control-peer-1');
+    await openPromise;
+    peer.emit('connection', connection as unknown as DataConnection);
+    connection.emit('open', undefined);
+
+    host.publishState({
+      ...createRemoteState(),
+      pages: [
+        {
+          id: 'page-1',
+          name: 'Slide 1',
+          preview: {
+            backgroundColor: '#000000',
+            elements: [
+              {
+                height: 1080,
+                id: 'large-image',
+                kind: 'image',
+                opacity: 1,
+                rotation: 0,
+                width: 1920,
+                x: 0,
+                y: 0,
+                assetUrl: `data:image/png;base64,${'a'.repeat(140_000)}`,
+              },
+            ],
+            height: 1080,
+            width: 1920,
+          },
+        },
+      ],
+      slidePreview: {
+        backgroundColor: '#000000',
+        elements: [
+          {
+            fill: '#ffffff',
+            fontFamily: 'Inter',
+            fontSize: 24,
+            fontWeight: 700,
+            height: 100,
+            id: 'large-text',
+            kind: 'text',
+            opacity: 1,
+            rotation: 0,
+            text: 'a'.repeat(140_000),
+            width: 800,
+            x: 0,
+            y: 0,
+            align: 'left',
+          },
+        ],
+        height: 1080,
+        width: 1920,
+      },
+      stream: {
+        enabled: true,
+        fps: 8,
+        height: 340,
+        peerId: 'stream-peer-1',
+        transport: 'peerjs',
+        width: 390,
+      },
+      upcomingSlidePreviews: [
+        {
+          pageId: 'page-2',
+          pageName: 'Next',
+          preview: {
+            backgroundColor: '#000000',
+            elements: [],
+            height: 1080,
+            width: 1920,
+          },
+        },
+      ],
+    });
+
+    const lastSentState = connection.send.mock.calls.at(-1)?.[0] as
+      | PresenterRemoteState
+      | undefined;
+    expect(lastSentState).toMatchObject({
+      activePageId: 'page-1',
+      pages: [{ id: 'page-1', name: 'Slide 1' }],
+      slidePreview: undefined,
+      upcomingSlidePreviews: [],
+    });
+    expect(lastSentState?.pages?.[0]?.preview).toBeUndefined();
+    expect(lastSentState?.stream?.peerId).toBe('stream-peer-1');
   });
 });
 

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -824,7 +824,9 @@ describe('EditorShell', () => {
     await openLeftTab(user, 'Elements');
 
     expect(await screen.findByText('API Key is invalid')).toBeInTheDocument();
-    expect(screen.queryByText('Unsplash image search failed with 401 Unauthorized.')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Unsplash image search failed with 401 Unauthorized.'),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Configure media integrations' }));
 
@@ -1292,7 +1294,10 @@ describe('EditorShell', () => {
     expect(importService.importCalls[0]?.file.name).toBe('deck.pptx');
 
     act(() => {
-      importService.resolveImport?.({ ...services.initialProject, name: 'Imported PowerPoint Deck' });
+      importService.resolveImport?.({
+        ...services.initialProject,
+        name: 'Imported PowerPoint Deck',
+      });
     });
 
     expect(
@@ -2017,10 +2022,12 @@ describe('EditorShell', () => {
       await Promise.resolve();
     });
 
-    expect(screen.queryByRole('region', { name: 'Remote control this presentation' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('region', { name: 'Remote control this presentation' }),
+    ).not.toBeInTheDocument();
   });
 
-  it('opens presenter view with an audience fullscreen prompt and closes the popup on fullscreen exit', async () => {
+  it('opens presenter view with an audience fullscreen prompt and keeps the remote session on fullscreen exit', async () => {
     const user = userEvent.setup();
     let fullscreenElement: Element | null = null;
     const popupClose = vi.fn();
@@ -2058,7 +2065,9 @@ describe('EditorShell', () => {
     expect(openWindow).toHaveBeenCalledTimes(1);
     expect(popup.location.href).toContain('presenter=1');
     expect(screen.getByRole('dialog', { name: 'Audience Window' })).toBeInTheDocument();
-    expect(screen.getByRole('region', { name: 'Remote control this presentation' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('region', { name: 'Remote control this presentation' }),
+    ).toBeInTheDocument();
     expect(await screen.findByRole('img', { name: 'Remote control QR code' })).toHaveAttribute(
       'src',
       expect.stringContaining('data:image/png'),
@@ -2068,7 +2077,9 @@ describe('EditorShell', () => {
 
     await user.click(screen.getByLabelText('Canvas workspace'));
 
-    expect(screen.queryByRole('region', { name: 'Remote control this presentation' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('region', { name: 'Remote control this presentation' }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Enter full screen mode' }));
 
@@ -2081,9 +2092,7 @@ describe('EditorShell', () => {
     fullscreenElement = null;
     document.dispatchEvent(new Event('fullscreenchange'));
 
-    await waitFor(() => {
-      expect(popupClose).toHaveBeenCalledTimes(1);
-    });
+    expect(popupClose).not.toHaveBeenCalled();
   });
 
   it('hides page insert controls in fullscreen presenter mode and restores a clean editor state on exit', async () => {
@@ -2509,7 +2518,9 @@ describe('EditorShell', () => {
     expect(screen.getByText('Supported formats')).toBeInTheDocument();
     expect(screen.getByText('info')).toHaveClass('media-import-info-icon');
     expect(screen.getByText(/Video import supports MP4 and WebM files/)).toBeInTheDocument();
-    expect(screen.queryByRole('progressbar', { name: 'Media import progress' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('progressbar', { name: 'Media import progress' }),
+    ).not.toBeInTheDocument();
     expect(createObjectUrl).not.toHaveBeenCalled();
     expect(
       Object.values(repository.savedProjects.at(-1)?.assets ?? {}).some(
@@ -2795,9 +2806,7 @@ describe('EditorShell', () => {
     const user = userEvent.setup();
     const services = createAppServices();
     const translator = new RecordingTranslatorService();
-    translator.detectLanguage
-      .mockResolvedValueOnce('en')
-      .mockResolvedValueOnce('cy');
+    translator.detectLanguage.mockResolvedValueOnce('en').mockResolvedValueOnce('cy');
     translator.prepareTranslation.mockRejectedValueOnce(
       new Error('Chrome Built-in AI translation is not ready for cy to pt.'),
     );

--- a/apps/editor/tests/unit/ui/presenter/PresenterRemotePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/presenter/PresenterRemotePanel.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PresenterRemotePanel } from '../../../../src/ui/presenter/PresenterRemotePanel';
+
+vi.mock('qrcode', () => ({
+  default: {
+    toDataURL: vi.fn().mockResolvedValue('data:image/png;base64,remote-qr'),
+  },
+}));
+
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand');
+
+describe('PresenterRemotePanel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (clipboardDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, 'clipboard');
+    }
+    if (execCommandDescriptor) {
+      Object.defineProperty(document, 'execCommand', execCommandDescriptor);
+    } else {
+      Reflect.deleteProperty(document, 'execCommand');
+    }
+  });
+
+  it('falls back to selection copy when clipboard writeText is unavailable', async () => {
+    const user = userEvent.setup();
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockRejectedValue(new Error('Clipboard blocked')),
+      },
+    });
+
+    render(
+      <PresenterRemotePanel
+        session={{
+          code: 'peer-1',
+          connectedControllerCount: 0,
+          expiresAt: '2026-07-05T04:00:00.000Z',
+          presenterDeviceId: 'device-1',
+          presenterLabel: 'Presenter',
+          qrUrl: 'http://192.168.0.141:4288/joystick/?peer=peer-1',
+          sessionId: 'session-1',
+          transport: 'peerjs',
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy remote link' }));
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+  });
+});

--- a/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
+++ b/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
@@ -1,31 +1,23 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type {
-  PresenterRemoteCommand,
-  PresenterRemoteStreamPreference,
-} from '@localstudio/presenter-remote/protocol';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import { PresenterView } from '../../../../src/ui/presenter/PresenterView';
 
 const remoteStreamPublisherMock = vi.hoisted(() => {
-  let onCommand: ((command: PresenterRemoteCommand) => void) | undefined;
-  let onStreamPreference: ((preference: PresenterRemoteStreamPreference) => void) | undefined;
+  let onPeerId: ((peerId: string | undefined) => void) | undefined;
   const publisher = {
     start: vi.fn(),
     stop: vi.fn(),
   };
   return {
     create: vi.fn((options: {
-      onCommand: (command: PresenterRemoteCommand) => void;
-      onStreamPreference?: (preference: PresenterRemoteStreamPreference) => void;
+      onPeerId: (peerId: string | undefined) => void;
     }) => {
-      onCommand = options.onCommand;
-      onStreamPreference = options.onStreamPreference;
+      onPeerId = options.onPeerId;
       return publisher;
     }),
-    getOnCommand: () => onCommand,
-    getOnStreamPreference: () => onStreamPreference,
+    getOnPeerId: () => onPeerId,
     publisher,
   };
 });
@@ -366,7 +358,7 @@ describe('PresenterView', () => {
     );
   });
 
-  it('applies timer commands received through the remote stream channel', () => {
+  it('announces the presenter stream peer id to the editor session', () => {
     const opener = { postMessage: vi.fn() };
     Object.defineProperty(window, 'opener', {
       configurable: true,
@@ -387,10 +379,12 @@ describe('PresenterView', () => {
               remoteSession: {
                 code: 'ABCD-1234',
                 connectedControllerCount: 1,
+                controlPeerId: 'ABCD-1234',
                 expiresAt: '2026-07-04T12:00:00.000Z',
                 presenterLabel: 'MacBook Pro',
                 qrUrl: 'https://localstudio.test/joystick',
                 sessionId: 'remote-session-1',
+                transport: 'peerjs',
               },
             },
             sessionId: 'session-1',
@@ -401,83 +395,34 @@ describe('PresenterView', () => {
       );
     });
 
+    const onPeerId = remoteStreamPublisherMock.getOnPeerId();
+    expect(onPeerId).toBeDefined();
     act(() => {
-      vi.advanceTimersByTime(79_000);
-    });
-    const onCommand = remoteStreamPublisherMock.getOnCommand();
-    expect(onCommand).toBeDefined();
-    act(() => {
-      onCommand?.({ command: 'pause-timer', type: 'command' });
+      onPeerId?.('stream-peer-1');
     });
 
-    expect(screen.getByText('01:19')).toBeInTheDocument();
     expect(opener.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        command: 'update-timer',
-        timer: { elapsedMs: 79_000, paused: true, updatedAtEpochMs: Date.now() },
+        command: 'update-stream-peer',
+        peerId: 'stream-peer-1',
+        sessionId: 'session-1',
+        source: 'localstudio-presenter-window',
+        type: 'command',
       }),
       window.location.origin,
     );
 
     act(() => {
-      onCommand?.({ command: 'reset-timer', type: 'command' });
+      onPeerId?.(undefined);
     });
 
-    expect(screen.getByText('00:00')).toBeInTheDocument();
     expect(opener.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        command: 'update-timer',
-        timer: { elapsedMs: 0, paused: false, updatedAtEpochMs: Date.now() },
+        command: 'update-stream-peer',
+        peerId: undefined,
       }),
       window.location.origin,
     );
-  });
-
-  it('applies remote stream quality preferences to the mirror canvas', () => {
-    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
-    render(<PresenterView sessionId="session-1" />);
-    const project = sampleProject.createSampleProject();
-    act(() => {
-      window.dispatchEvent(
-        new MessageEvent('message', {
-          origin: window.location.origin,
-          data: {
-            payload: {
-              activePageId: 'page-1',
-              animationPreview: undefined,
-              project,
-              remoteSession: {
-                code: 'ABCD-1234',
-                connectedControllerCount: 1,
-                expiresAt: '2026-07-04T12:00:00.000Z',
-                presenterLabel: 'MacBook Pro',
-                qrUrl: 'https://localstudio.test/joystick',
-                sessionId: 'remote-session-1',
-              },
-            },
-            sessionId: 'session-1',
-            source: 'localstudio-presenter-main',
-            type: 'state',
-          },
-        }),
-      );
-    });
-
-    const onStreamPreference = remoteStreamPublisherMock.getOnStreamPreference();
-    expect(onStreamPreference).toBeDefined();
-    act(() => {
-      onStreamPreference?.({
-        fps: 12,
-        height: 1020,
-        quality: 'high',
-        type: 'stream-preference',
-        width: 1170,
-      });
-    });
-
-    const canvas = document.querySelector<HTMLCanvasElement>('.presenter-remote-mirror-canvas');
-    expect(canvas?.width).toBe(1170);
-    expect(canvas?.height).toBe(1020);
   });
 
   it('formats presenter timer with hours after sixty minutes', () => {

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -2,7 +2,6 @@ import react from '@vitejs/plugin-react';
 import { defineConfig, type Connect } from 'vite';
 import { localNetworkOriginRoute } from '../../scripts/vite/localNetworkOriginRoute';
 import { localPowerPointSampleRoute } from '../../scripts/vite/localPowerPointSampleRoute';
-import { presenterRemoteSignalingRoute } from '../../scripts/vite/presenterRemoteSignalingRoute';
 
 const siteBase = process.env.LOCALSTUDIO_BASE_PATH ?? '/';
 const editorBase = new URL('editor/', `https://localstudio.invalid${siteBase}`).pathname;
@@ -54,7 +53,6 @@ export default defineConfig({
   plugins: [
     localNetworkOriginRoute(),
     localPowerPointSampleRoute(),
-    presenterRemoteSignalingRoute(),
     webMcpRouteAlias(),
     react(),
   ],

--- a/apps/joystick/src/app/JoystickApp.tsx
+++ b/apps/joystick/src/app/JoystickApp.tsx
@@ -17,7 +17,8 @@ import {
   InMemoryPresenterRemoteSignalingService,
   type RegisterPresenterRemoteSessionInput,
 } from '@localstudio/presenter-remote/signaling-service';
-import { PresenterRemoteSignalingClient } from '@localstudio/presenter-remote/signaling-client';
+import { PresenterRemotePeerControlClient } from '@localstudio/presenter-remote/peer-control-client';
+import { PresenterRemotePeerStreamReceiver } from '@localstudio/presenter-remote/peer-stream-receiver';
 import type {
   PresenterRemoteCommand,
   PresenterRemoteSlidePreview,
@@ -26,10 +27,6 @@ import type {
   PresenterRemoteState,
   PresenterRemoteStreamPreference,
 } from '@localstudio/presenter-remote/protocol';
-import {
-  presenterRemoteStreamReceiver,
-  type PresenterRemoteStreamSignaling,
-} from './presenterRemoteStreamReceiver';
 
 interface JoystickSignalingService {
   connectController?:
@@ -72,40 +69,29 @@ function getInitialCode(initialUrl: string) {
   return presenterRemoteSessionCode.normalize(url.searchParams.get('code') ?? '');
 }
 
-function createDefaultSignalingService(): JoystickSignalingService {
-  if (typeof fetch === 'function') {
-    return new PresenterRemoteSignalingClient({ endpoint: '/__localstudio/presenter-remote' });
+function normalizePeerInput(value: string) {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) return '';
+  try {
+    const url = new URL(trimmedValue);
+    return url.searchParams.get('peer')?.trim() ?? trimmedValue;
+  } catch {
+    return trimmedValue;
   }
+}
+
+function getInitialPeerId(initialUrl: string) {
+  const url = new URL(initialUrl);
+  return normalizePeerInput(url.searchParams.get('peer') ?? '');
+}
+
+function createFallbackSignalingService(): JoystickSignalingService {
   const service: JoystickSignalingService = new InMemoryPresenterRemoteSignalingService();
   const seedSession: RegisterPresenterRemoteSessionInput | undefined = undefined;
   if (seedSession && service instanceof InMemoryPresenterRemoteSignalingService) {
     service.registerSession(seedSession);
   }
   return service;
-}
-
-function createStreamSignalingAdapter(
-  signalingService: JoystickSignalingService,
-): PresenterRemoteStreamSignaling {
-  const candidate = signalingService as unknown as PresenterRemoteStreamSignaling & {
-    createControllerOffer?: ((...args: unknown[]) => unknown) | undefined;
-  };
-  return {
-    closeController: candidate.closeController?.bind(candidate),
-    createControllerOffer:
-      typeof candidate.createControllerOffer === 'function'
-        ? (code, controllerId, offerSdp) => {
-            if (candidate.createControllerOffer?.length === 1) {
-              void candidate.createControllerOffer({ controllerId, offerSdp, sessionCode: code });
-              return;
-            }
-            void candidate.createControllerOffer?.(code, controllerId, offerSdp);
-          }
-        : undefined,
-    getAnswer: candidate.getAnswer?.bind(candidate),
-    publishIceCandidate: candidate.publishIceCandidate?.bind(candidate),
-    takeIceCandidates: candidate.takeIceCandidates?.bind(candidate),
-  };
 }
 
 function getLocalStorage() {
@@ -605,14 +591,16 @@ export function JoystickApp({
   initialUrl = window.location.href,
   signalingService: providedSignalingService,
 }: JoystickAppProps) {
-  const defaultSignalingService = useMemo(() => createDefaultSignalingService(), []);
-  const signalingService = providedSignalingService ?? defaultSignalingService;
+  const fallbackSignalingService = useMemo(() => createFallbackSignalingService(), []);
+  const signalingService = providedSignalingService ?? fallbackSignalingService;
   const [code, setCode] = useState(() => getInitialCode(initialUrl));
+  const [peerId, setPeerId] = useState(() => getInitialPeerId(initialUrl));
   const [lastCommand, setLastCommand] = useState<string | undefined>();
   const [remoteState, setRemoteState] = useState<PresenterRemoteState | undefined>();
   const [remoteStateReceivedAt, setRemoteStateReceivedAt] = useState(0);
   const [session, setSession] = useState<PresenterRemoteSession | undefined>();
   const [resolvingSession, setResolvingSession] = useState(true);
+  const [peerConnectionFailed, setPeerConnectionFailed] = useState(false);
   const [timerNow, setTimerNow] = useState(() => Date.now());
   const [slideNavigatorOpen, setSlideNavigatorOpen] = useState(false);
   const [notesFontSize, setNotesFontSize] = useState(28);
@@ -621,12 +609,12 @@ export function JoystickApp({
   const [remoteStreamStatus, setRemoteStreamStatus] = useState<
     'connected' | 'connecting' | 'failed' | 'idle'
   >('idle');
-  const remoteStreamReceiverRef = useRef<
-    ReturnType<typeof presenterRemoteStreamReceiver.create> | undefined
-  >(undefined);
+  const peerControlClientRef = useRef<PresenterRemotePeerControlClient | undefined>(undefined);
+  const remoteStreamReceiverRef = useRef<PresenterRemotePeerStreamReceiver | undefined>(undefined);
   const sessionCode = session?.code;
 
   useEffect(() => {
+    if (peerId) return;
     let cancelled = false;
     async function resolveSession() {
       setResolvingSession(true);
@@ -678,17 +666,66 @@ export function JoystickApp({
     return () => {
       cancelled = true;
     };
-  }, [code, controllerId, signalingService]);
+  }, [code, controllerId, peerId, signalingService]);
+
+  useEffect(() => {
+    if (!peerId) return undefined;
+    let cancelled = false;
+    const client = new PresenterRemotePeerControlClient({
+      onState: (nextState) => {
+        if (cancelled) return;
+        setPeerConnectionFailed(false);
+        setRemoteState(nextState);
+        setRemoteStateReceivedAt(Date.now());
+        setSession({
+          code: peerId,
+          connectedControllerCount: nextState.connectedControllerCount,
+          expiresAt: '',
+          presenterDeviceId: peerId,
+          presenterLabel: 'Presenter device',
+          sessionId: peerId,
+        });
+        setResolvingSession(false);
+      },
+      onStatusChange: (nextStatus) => {
+        if (cancelled) return;
+        if (nextStatus === 'connecting') {
+          setPeerConnectionFailed(false);
+          setResolvingSession(true);
+          return;
+        }
+        if (nextStatus === 'failed') {
+          setPeerConnectionFailed(true);
+          setResolvingSession(false);
+          setSession(undefined);
+        }
+      },
+      presenterPeerId: peerId,
+    });
+    peerControlClientRef.current = client;
+    void client.start().catch(() => {
+      if (!cancelled) {
+        setPeerConnectionFailed(true);
+        setResolvingSession(false);
+        setSession(undefined);
+      }
+    });
+    return () => {
+      cancelled = true;
+      client.close();
+      if (peerControlClientRef.current === client) peerControlClientRef.current = undefined;
+    };
+  }, [peerId]);
 
   const status: 'connected' | 'needs-code' = session ? 'connected' : 'needs-code';
-  const displayedCode = code || session?.code || '';
+  const displayedRemoteInput = peerId || code || session?.code || '';
 
   useEffect(() => {
-    if (session) rememberSuccessfulSession(session);
-  }, [session]);
+    if (session && !peerId) rememberSuccessfulSession(session);
+  }, [peerId, session]);
 
   useEffect(() => {
-    if (!sessionCode || !signalingService.getPublishedState) return;
+    if (peerId || !sessionCode || !signalingService.getPublishedState) return;
     const currentSessionCode = sessionCode;
     let cancelled = false;
     async function refreshState() {
@@ -706,33 +743,34 @@ export function JoystickApp({
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [sessionCode, signalingService]);
+  }, [peerId, sessionCode, signalingService]);
 
   useEffect(() => {
-    if (!sessionCode) return;
+    if (!peerId && !sessionCode) return;
     const intervalId = window.setInterval(() => setTimerNow(Date.now()), 1000);
     return () => window.clearInterval(intervalId);
-  }, [sessionCode]);
+  }, [peerId, sessionCode]);
 
   useEffect(() => {
     const shouldUseStream = Boolean(
-      sessionCode &&
+      peerId &&
       remoteState?.presenterMode === 'presenting' &&
       remoteState.previewMode === 'stream' &&
-      remoteState.stream?.enabled,
+      remoteState.stream?.enabled &&
+      remoteState.stream.transport === 'peerjs' &&
+      remoteState.stream.peerId,
     );
-    if (!sessionCode || !shouldUseStream) {
+    const streamPeerId = remoteState?.stream?.peerId;
+    if (!peerId || !streamPeerId || !shouldUseStream) {
       remoteStreamReceiverRef.current?.stop();
       remoteStreamReceiverRef.current = undefined;
       return;
     }
     remoteStreamReceiverRef.current?.stop();
-    const receiver = presenterRemoteStreamReceiver.create({
-      controllerId,
+    const receiver = new PresenterRemotePeerStreamReceiver({
       onStatusChange: setRemoteStreamStatus,
       onStream: setRemoteStream,
-      sessionCode,
-      signaling: createStreamSignalingAdapter(signalingService),
+      streamPeerId,
     });
     remoteStreamReceiverRef.current = receiver;
     void receiver.start();
@@ -741,12 +779,12 @@ export function JoystickApp({
       if (remoteStreamReceiverRef.current === receiver) remoteStreamReceiverRef.current = undefined;
     };
   }, [
-    controllerId,
+    peerId,
     remoteState?.presenterMode,
     remoteState?.previewMode,
     remoteState?.stream?.enabled,
-    sessionCode,
-    signalingService,
+    remoteState?.stream?.peerId,
+    remoteState?.stream?.transport,
   ]);
 
   const connectionLabel = useMemo(() => {
@@ -755,26 +793,25 @@ export function JoystickApp({
       remoteState?.connectedControllerCount ?? session?.connectedControllerCount ?? 0,
     );
     if (status === 'connected') return `Connected (${connectedControllerCount})`;
-    if (status === 'needs-code') return 'Enter code';
+    if (status === 'needs-code') return peerId && resolvingSession ? 'Connecting' : 'Enter remote link';
     return 'Disconnected';
-  }, [remoteState, session, status]);
+  }, [peerId, remoteState, resolvingSession, session, status]);
 
   function sendRemoteCommand(command: PresenterRemoteCommand) {
-    if (!session) return;
-    const sentOverStream = remoteStreamReceiverRef.current?.sendCommand(command) ?? false;
-    if (sentOverStream) {
-      setLastCommand(command.command);
-      if (command.command !== 'go-to-page') return;
+    if (peerId) {
+      if (peerControlClientRef.current?.sendCommand(command)) setLastCommand(command.command);
+      return;
     }
+    if (!session) return;
     void Promise.resolve(signalingService.publishCommand(session.code, command, controllerId)).then(
       () => {
-        if (!sentOverStream) setLastCommand(command.command);
+        setLastCommand(command.command);
       },
     );
   }
 
   const sendStreamPreference = useCallback((preference: PresenterRemoteStreamPreference) => {
-    remoteStreamReceiverRef.current?.sendStreamPreference(preference);
+    void preference;
   }, []);
 
   function sendCommand(command: JoystickSimpleCommand) {
@@ -795,7 +832,7 @@ export function JoystickApp({
   }
 
   const connected = status === 'connected' && Boolean(session);
-  const displayedRemoteState = sessionCode ? remoteState : undefined;
+  const displayedRemoteState = peerId || sessionCode ? remoteState : undefined;
   const slidePosition = displayedRemoteState
     ? `${displayedRemoteState.activePageIndex + 1} / ${displayedRemoteState.pageCount}`
     : connected
@@ -1014,30 +1051,33 @@ export function JoystickApp({
       {!connected ? (
         <section className="joystick-pairing-panel" aria-label="Pair remote">
           <div className="joystick-code-row">
-            <label htmlFor="session-code">Code</label>
+            <label htmlFor="session-code">Remote link</label>
             <input
               id="session-code"
               inputMode="text"
-              maxLength={9}
-              value={displayedCode}
-              onChange={(event) =>
-                setCode(presenterRemoteSessionCode.normalize(event.target.value))
-              }
+              value={displayedRemoteInput}
+              onChange={(event) => {
+                const value = event.target.value;
+                setPeerId(normalizePeerInput(value));
+                setCode(presenterRemoteSessionCode.normalize(value));
+              }}
             />
             <button
               type="button"
-              onClick={() => setCode(displayedCode)}
-              disabled={!presenterRemoteSessionCode.isValid(displayedCode)}
+              onClick={() => setPeerId(normalizePeerInput(displayedRemoteInput))}
+              disabled={!displayedRemoteInput.trim()}
             >
               Join
             </button>
           </div>
           {session ? (
             <p className="joystick-presenter-name">{session.presenterLabel}</p>
+          ) : peerId && peerConnectionFailed ? (
+            <p className="joystick-help">Could not connect to that presenter. Check the remote link and try again.</p>
           ) : resolvingSession ? (
             <p className="joystick-help">Looking for the presenter session...</p>
           ) : (
-            <p className="joystick-help">Enter the code shown on the presenter screen.</p>
+            <p className="joystick-help">Open the presenter remote link or paste its peer id.</p>
           )}
         </section>
       ) : null}

--- a/apps/joystick/src/app/JoystickApp.tsx
+++ b/apps/joystick/src/app/JoystickApp.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { MouseEvent, PointerEvent, TouchEvent } from 'react';
+import type { CSSProperties, MouseEvent, PointerEvent, TouchEvent } from 'react';
 import {
   ChevronLeft,
   List,
@@ -21,6 +21,7 @@ import { PresenterRemotePeerControlClient } from '@localstudio/presenter-remote/
 import { PresenterRemotePeerStreamReceiver } from '@localstudio/presenter-remote/peer-stream-receiver';
 import type {
   PresenterRemoteCommand,
+  PresenterRemotePreviewBatch,
   PresenterRemoteSlidePreview,
   PresenterRemoteSlidePreviewElement,
   PresenterRemoteSession,
@@ -85,6 +86,17 @@ function getInitialPeerId(initialUrl: string) {
   return normalizePeerInput(url.searchParams.get('peer') ?? '');
 }
 
+function createPeerSession(peerId: string, connectedControllerCount: number) {
+  return {
+    code: peerId,
+    connectedControllerCount,
+    expiresAt: '',
+    presenterDeviceId: peerId,
+    presenterLabel: 'Presenter device',
+    sessionId: peerId,
+  };
+}
+
 function createFallbackSignalingService(): JoystickSignalingService {
   const service: JoystickSignalingService = new InMemoryPresenterRemoteSignalingService();
   const seedSession: RegisterPresenterRemoteSessionInput | undefined = undefined;
@@ -129,8 +141,10 @@ function setStoredStringList(key: string, values: string[]) {
 function addStoredStringListValue(key: string, value: string) {
   if (!value) return;
   const existingValues = getStoredStringList(key);
-  const values = [value, ...existingValues.filter((existingValue) => existingValue !== value)]
-    .slice(0, 20);
+  const values = [
+    value,
+    ...existingValues.filter((existingValue) => existingValue !== value),
+  ].slice(0, 20);
   setStoredStringList(key, values);
 }
 
@@ -396,15 +410,33 @@ function StreamPreview({
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLButtonElement>(null);
+  const playbackBlockedRef = useRef(false);
   const swipeHandlers = useHorizontalSwipeNavigation(onNavigate);
 
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
+    video.autoplay = true;
+    video.controls = false;
+    video.defaultMuted = true;
+    video.disablePictureInPicture = true;
+    video.muted = true;
+    video.playsInline = true;
     video.srcObject = stream;
-    const playPromise = video.play();
-    void playPromise?.catch(() => undefined);
+    const requestPlayback = () => {
+      const playPromise = video.play();
+      void playPromise
+        ?.then(() => {
+          playbackBlockedRef.current = false;
+        })
+        .catch(() => {
+          playbackBlockedRef.current = true;
+        });
+    };
+    requestPlayback();
+    const frameId = window.requestAnimationFrame(requestPlayback);
     return () => {
+      window.cancelAnimationFrame(frameId);
       if (video.srcObject === stream) video.srcObject = null;
     };
   }, [stream]);
@@ -428,6 +460,18 @@ function StreamPreview({
   }, [onStreamPreference, stream]);
 
   function handleClick() {
+    const video = videoRef.current;
+    if (video && playbackBlockedRef.current) {
+      const playPromise = video.play();
+      void playPromise
+        ?.then(() => {
+          playbackBlockedRef.current = false;
+        })
+        .catch(() => {
+          playbackBlockedRef.current = true;
+        });
+      return;
+    }
     onNavigate('next');
   }
 
@@ -440,7 +484,30 @@ function StreamPreview({
       onClick={handleClick}
       {...swipeHandlers}
     >
-      <video ref={videoRef} autoPlay className="joystick-stream-video" muted playsInline />
+      <video
+        ref={videoRef}
+        autoPlay
+        className="joystick-stream-video"
+        controls={false}
+        disablePictureInPicture
+        muted
+        onCanPlay={() => {
+          const video = videoRef.current;
+          if (!video || !video.paused) return;
+          void video.play()?.catch(() => {
+            playbackBlockedRef.current = true;
+          });
+        }}
+        onLoadedMetadata={() => {
+          const video = videoRef.current;
+          if (!video) return;
+          void video.play()?.catch(() => {
+            playbackBlockedRef.current = true;
+          });
+        }}
+        playsInline
+        preload="auto"
+      />
     </button>
   );
 }
@@ -484,14 +551,7 @@ function UpcomingSlideStrip({
   renderMediaAssets?: boolean;
 }) {
   if (previews.length === 0) {
-    return (
-      <section
-        className="joystick-upcoming-strip joystick-upcoming-strip-empty"
-        aria-label="Upcoming slides"
-      >
-        <span>End of deck</span>
-      </section>
-    );
+    return null;
   }
 
   return (
@@ -587,6 +647,71 @@ function SlideNavigatorSheet({
   );
 }
 
+function mergePreviewBatchIntoState(
+  state: PresenterRemoteState,
+  batch: PresenterRemotePreviewBatch,
+): PresenterRemoteState {
+  if (batch.previews.length === 0) return state;
+  const previewsByPageId = new Map(batch.previews.map((page) => [page.id, page.preview]));
+  const pages = state.pages?.map((page) => {
+    if (!previewsByPageId.has(page.id)) return page;
+    return {
+      ...page,
+      preview: previewsByPageId.get(page.id),
+    };
+  });
+  const activePagePreview = previewsByPageId.get(state.activePageId) ?? state.slidePreview;
+  const upcomingSlidePreviews =
+    pages?.slice(state.activePageIndex + 1, state.activePageIndex + 4).flatMap((page) => {
+      const preview =
+        page.preview ??
+        state.upcomingSlidePreviews?.find((upcomingPreview) => upcomingPreview.pageId === page.id)
+          ?.preview;
+      if (!preview) return [];
+      return [
+        {
+          pageId: page.id,
+          pageName: page.name,
+          preview,
+        },
+      ];
+    }) ?? state.upcomingSlidePreviews;
+  return {
+    ...state,
+    nextSlidePreview: upcomingSlidePreviews?.[0]?.preview ?? state.nextSlidePreview,
+    pages,
+    slidePreview: activePagePreview,
+    upcomingSlidePreviews,
+  };
+}
+
+function getUpcomingSlidePreviews(
+  displayedRemoteState: PresenterRemoteState | undefined,
+): NonNullable<PresenterRemoteState['upcomingSlidePreviews']> {
+  if (!displayedRemoteState) return [];
+  const pages = displayedRemoteState.pages ?? [];
+  const existingPreviews = displayedRemoteState.upcomingSlidePreviews ?? [];
+  if (pages.length === 0) return existingPreviews;
+  const upcomingPages = pages.slice(
+    displayedRemoteState.activePageIndex + 1,
+    displayedRemoteState.activePageIndex + 4,
+  );
+  if (upcomingPages.length === 0) return existingPreviews;
+  const derivedPreviews = upcomingPages.map((page, index) => ({
+    pageId: page.id,
+    pageName: page.name,
+    preview:
+      page.preview ??
+      existingPreviews.find((preview) => preview.pageId === page.id)?.preview ??
+      (index === 0 ? displayedRemoteState.nextSlidePreview : undefined),
+  }));
+  const derivedPageIds = new Set(derivedPreviews.map((preview) => preview.pageId));
+  return [
+    ...derivedPreviews,
+    ...existingPreviews.filter((preview) => !derivedPageIds.has(preview.pageId)),
+  ];
+}
+
 export function JoystickApp({
   initialUrl = window.location.href,
   signalingService: providedSignalingService,
@@ -609,7 +734,9 @@ export function JoystickApp({
   const [remoteStreamStatus, setRemoteStreamStatus] = useState<
     'connected' | 'connecting' | 'failed' | 'idle'
   >('idle');
+  const [streamNotesHeight, setStreamNotesHeight] = useState(280);
   const peerControlClientRef = useRef<PresenterRemotePeerControlClient | undefined>(undefined);
+  const requestedPreviewBatchKeysRef = useRef(new Set<string>());
   const remoteStreamReceiverRef = useRef<PresenterRemotePeerStreamReceiver | undefined>(undefined);
   const sessionCode = session?.code;
 
@@ -625,10 +752,9 @@ export function JoystickApp({
       if (requestedCode && presenterRemoteSessionCode.isValid(requestedCode)) {
         const foundSession = await signalingService.lookupSession(requestedCode);
         if (foundSession) {
-          const connectedSession =
-            signalingService.connectController
-              ? await signalingService.connectController(requestedCode, controllerId)
-              : foundSession;
+          const connectedSession = signalingService.connectController
+            ? await signalingService.connectController(requestedCode, controllerId)
+            : foundSession;
           if (!cancelled) {
             setCode(requestedCode);
             setSession(connectedSession);
@@ -638,12 +764,13 @@ export function JoystickApp({
         }
       }
 
-      const trustedSession = getNewestTrustedSession(await (signalingService.listSessions?.() ?? []));
+      const trustedSession = getNewestTrustedSession(
+        await (signalingService.listSessions?.() ?? []),
+      );
       if (trustedSession) {
-        const connectedSession =
-          signalingService.connectController
-            ? await signalingService.connectController(trustedSession.code, controllerId)
-            : trustedSession;
+        const connectedSession = signalingService.connectController
+          ? await signalingService.connectController(trustedSession.code, controllerId)
+          : trustedSession;
         if (!cancelled) {
           const trustedCode = presenterRemoteSessionCode.normalize(trustedSession.code);
           setCode(trustedCode);
@@ -672,19 +799,18 @@ export function JoystickApp({
     if (!peerId) return undefined;
     let cancelled = false;
     const client = new PresenterRemotePeerControlClient({
+      onPreviewBatch: (batch) => {
+        if (cancelled) return;
+        setRemoteState((currentState) =>
+          currentState ? mergePreviewBatchIntoState(currentState, batch) : currentState,
+        );
+      },
       onState: (nextState) => {
         if (cancelled) return;
         setPeerConnectionFailed(false);
         setRemoteState(nextState);
         setRemoteStateReceivedAt(Date.now());
-        setSession({
-          code: peerId,
-          connectedControllerCount: nextState.connectedControllerCount,
-          expiresAt: '',
-          presenterDeviceId: peerId,
-          presenterLabel: 'Presenter device',
-          sessionId: peerId,
-        });
+        setSession(createPeerSession(peerId, nextState.connectedControllerCount));
         setResolvingSession(false);
       },
       onStatusChange: (nextStatus) => {
@@ -692,6 +818,12 @@ export function JoystickApp({
         if (nextStatus === 'connecting') {
           setPeerConnectionFailed(false);
           setResolvingSession(true);
+          return;
+        }
+        if (nextStatus === 'connected') {
+          setPeerConnectionFailed(false);
+          setSession((currentSession) => currentSession ?? createPeerSession(peerId, 1));
+          setResolvingSession(false);
           return;
         }
         if (nextStatus === 'failed') {
@@ -710,8 +842,10 @@ export function JoystickApp({
         setSession(undefined);
       }
     });
+    const requestedPreviewBatchKeys = requestedPreviewBatchKeysRef.current;
     return () => {
       cancelled = true;
+      requestedPreviewBatchKeys.clear();
       client.close();
       if (peerControlClientRef.current === client) peerControlClientRef.current = undefined;
     };
@@ -750,6 +884,26 @@ export function JoystickApp({
     const intervalId = window.setInterval(() => setTimerNow(Date.now()), 1000);
     return () => window.clearInterval(intervalId);
   }, [peerId, sessionCode]);
+
+  useEffect(() => {
+    if (!peerId || !remoteState?.pages?.length) return;
+    const windowStartIndex = Math.max(0, remoteState.activePageIndex + 1);
+    const requestedPages = remoteState.pages
+      .slice(windowStartIndex, windowStartIndex + 5)
+      .filter((page) => !page.preview)
+      .map((page) => page.id);
+    if (requestedPages.length === 0) return;
+    const requestKey = `${remoteState.deckName}:${requestedPages.join(',')}`;
+    if (requestedPreviewBatchKeysRef.current.has(requestKey)) return;
+    requestedPreviewBatchKeysRef.current.add(requestKey);
+    const command: PresenterRemoteCommand = {
+      command: 'request-previews',
+      pageIds: requestedPages,
+      requestId: requestKey,
+      type: 'command',
+    };
+    if (peerControlClientRef.current?.sendCommand(command)) setLastCommand(command.command);
+  }, [peerId, remoteState?.activePageIndex, remoteState?.deckName, remoteState?.pages]);
 
   useEffect(() => {
     const shouldUseStream = Boolean(
@@ -793,7 +947,8 @@ export function JoystickApp({
       remoteState?.connectedControllerCount ?? session?.connectedControllerCount ?? 0,
     );
     if (status === 'connected') return `Connected (${connectedControllerCount})`;
-    if (status === 'needs-code') return peerId && resolvingSession ? 'Connecting' : 'Enter remote link';
+    if (status === 'needs-code')
+      return peerId && resolvingSession ? 'Connecting' : 'Enter remote link';
     return 'Disconnected';
   }, [peerId, remoteState, resolvingSession, session, status]);
 
@@ -841,7 +996,20 @@ export function JoystickApp({
   const currentStatusLabel = displayedRemoteState
     ? `Current: Slide ${displayedRemoteState.activePageIndex + 1} of ${displayedRemoteState.pageCount}`
     : 'Current: Waiting';
-  const buildsRemainingLabel = `Builds remaining: ${displayedRemoteState?.buildsRemaining ?? 0}`;
+  const buildMetadata = displayedRemoteState?.builds;
+  const buildsRemaining = displayedRemoteState?.buildsRemaining ?? 0;
+  const buildsRemainingLabel =
+    buildMetadata && buildMetadata.remaining > 0
+      ? `Build ${buildMetadata.current} of ${buildMetadata.total}`
+      : buildsRemaining > 0
+        ? `Builds remaining: ${buildsRemaining}`
+        : undefined;
+  const buildsIndicatorText =
+    buildMetadata && buildMetadata.remaining > 0
+      ? `🪄${buildMetadata.current}/${buildMetadata.total}`
+      : buildsRemaining > 0
+        ? `🪄${buildsRemaining}`
+        : undefined;
   const notes = displayedRemoteState?.notes.trim();
   const timerElapsedMs = displayedRemoteState
     ? displayedRemoteState.timer.elapsedMs +
@@ -858,17 +1026,33 @@ export function JoystickApp({
   const streamModeActive =
     connected && displayedRemoteState?.previewMode === 'stream' && remoteStream;
   const renderStructuredMediaAssets = displayedRemoteState?.previewMode !== 'stream';
-  const upcomingSlidePreviews =
-    displayedRemoteState?.upcomingSlidePreviews ??
-    (displayedRemoteState?.nextSlidePreview
-      ? [
-          {
-            pageId: pages[displayedRemoteState.activePageIndex + 1]?.id ?? 'next-slide',
-            pageName: displayedRemoteState.nextPageName ?? 'Next slide',
-            preview: displayedRemoteState.nextSlidePreview,
-          },
-        ]
-      : []);
+  const upcomingSlidePreviews = getUpcomingSlidePreviews(displayedRemoteState);
+
+  function handleStreamNotesResizeStart(event: PointerEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    const startY = event.clientY;
+    const startHeight = streamNotesHeight;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    document.body.style.userSelect = 'none';
+
+    function handlePointerMove(moveEvent: globalThis.PointerEvent) {
+      const nextHeight = startHeight - (moveEvent.clientY - startY);
+      const maxHeight = Math.max(180, Math.round(window.innerHeight * 0.68));
+      setStreamNotesHeight(Math.max(132, Math.min(maxHeight, nextHeight)));
+    }
+
+    function handlePointerEnd() {
+      document.body.style.userSelect = '';
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+    }
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+  }
 
   if (presenterReady) {
     return (
@@ -894,7 +1078,15 @@ export function JoystickApp({
 
   if (streamModeActive) {
     return (
-      <main className="joystick-app joystick-app-stream" aria-label="Presentation remote control">
+      <main
+        className="joystick-app joystick-app-stream"
+        aria-label="Presentation remote control"
+        style={
+          {
+            '--joystick-stream-notes-height': `${streamNotesHeight}px`,
+          } as CSSProperties
+        }
+      >
         <header className="joystick-stream-topbar">
           <span className="joystick-page-count" aria-label="Slide position">
             {slidePosition}
@@ -906,7 +1098,40 @@ export function JoystickApp({
           <span className="joystick-timer" aria-label="Presentation timer">
             {timerLabel}
           </span>
-          <span>{buildsRemainingLabel}</span>
+          <div className="joystick-stream-top-controls" aria-label="Remote controls">
+            <button
+              type="button"
+              onClick={() => navigateSlide('previous')}
+              aria-label="Previous slide"
+            >
+              <ChevronLeft size={20} />
+            </button>
+            <button
+              type="button"
+              onClick={() => sendRemoteCommand({ command: timerToggleCommand, type: 'command' })}
+              aria-label={timerPaused ? 'Resume timer' : 'Pause timer'}
+            >
+              {timerPaused ? <Play size={20} /> : <Pause size={20} />}
+            </button>
+            <button
+              type="button"
+              onClick={() => sendCommand('reset-timer')}
+              aria-label="Reset timer"
+            >
+              <TimerReset size={20} />
+            </button>
+            <button
+              type="button"
+              disabled={pages.length === 0}
+              onClick={() => setSlideNavigatorOpen(true)}
+              aria-label="Show slide navigation"
+            >
+              <List size={20} />
+            </button>
+          </div>
+          <span className="joystick-builds-indicator" aria-label={buildsRemainingLabel}>
+            {buildsIndicatorText}
+          </span>
         </header>
         <section className="joystick-stream-stage" aria-label="Streamed presenter preview">
           <StreamPreview
@@ -920,8 +1145,16 @@ export function JoystickApp({
           onGoToPage={(pageId) =>
             sendRemoteCommand({ command: 'go-to-page', pageId, type: 'command' })
           }
-          renderMediaAssets={false}
+          renderMediaAssets
         />
+        <button
+          type="button"
+          className="joystick-stream-notes-resize"
+          aria-label="Resize presenter notes"
+          onPointerDown={handleStreamNotesResizeStart}
+        >
+          <span aria-hidden="true" />
+        </button>
         <section className="joystick-stream-notes" aria-label="Presenter notes">
           <div className="joystick-stream-notes-toolbar" aria-label="Notes controls">
             <span>Notes</span>
@@ -957,34 +1190,6 @@ export function JoystickApp({
             </div>
           )}
         </section>
-        <div className="joystick-stream-controls" aria-label="Remote controls">
-          <span>{connectionLabel}</span>
-          <button
-            type="button"
-            onClick={() => navigateSlide('previous')}
-            aria-label="Previous slide"
-          >
-            <ChevronLeft size={22} />
-          </button>
-          <button
-            type="button"
-            onClick={() => sendRemoteCommand({ command: timerToggleCommand, type: 'command' })}
-            aria-label={timerPaused ? 'Resume timer' : 'Pause timer'}
-          >
-            {timerPaused ? <Play size={22} /> : <Pause size={22} />}
-          </button>
-          <button type="button" onClick={() => sendCommand('reset-timer')} aria-label="Reset timer">
-            <TimerReset size={22} />
-          </button>
-          <button
-            type="button"
-            disabled={pages.length === 0}
-            onClick={() => setSlideNavigatorOpen(true)}
-            aria-label="Show slide navigation"
-          >
-            <List size={22} />
-          </button>
-        </div>
         {remoteStreamStatus === 'failed' ? (
           <p className="joystick-stream-status">Stream unavailable. Using fallback controls.</p>
         ) : null}
@@ -996,7 +1201,7 @@ export function JoystickApp({
               sendRemoteCommand({ command: 'go-to-page', pageId, type: 'command' })
             }
             pages={pages}
-            renderMediaAssets={false}
+            renderMediaAssets
             upcomingSlidePreviews={upcomingSlidePreviews}
           />
         ) : null}
@@ -1045,7 +1250,7 @@ export function JoystickApp({
 
       <section className="joystick-presenter-meta" aria-label="Presenter status">
         <span>{currentStatusLabel}</span>
-        <span>{buildsRemainingLabel}</span>
+        {buildsRemainingLabel ? <span>{buildsRemainingLabel}</span> : null}
       </section>
 
       {!connected ? (
@@ -1073,7 +1278,9 @@ export function JoystickApp({
           {session ? (
             <p className="joystick-presenter-name">{session.presenterLabel}</p>
           ) : peerId && peerConnectionFailed ? (
-            <p className="joystick-help">Could not connect to that presenter. Check the remote link and try again.</p>
+            <p className="joystick-help">
+              Could not connect to that presenter. Check the remote link and try again.
+            </p>
           ) : resolvingSession ? (
             <p className="joystick-help">Looking for the presenter session...</p>
           ) : (

--- a/apps/joystick/src/app/JoystickApp.tsx
+++ b/apps/joystick/src/app/JoystickApp.tsx
@@ -400,14 +400,19 @@ function SlideCanvas({
 }
 
 function StreamPreview({
+  fallbackPreview,
   onNavigate,
   onStreamPreference,
+  renderFallbackMediaAssets = true,
   stream,
 }: {
+  fallbackPreview: PresenterRemoteSlidePreview | undefined;
   onNavigate: (direction: 'next' | 'previous') => void;
   onStreamPreference: (preference: PresenterRemoteStreamPreference) => void;
+  renderFallbackMediaAssets?: boolean;
   stream: MediaStream;
 }) {
+  const [videoPlaying, setVideoPlaying] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLButtonElement>(null);
   const playbackBlockedRef = useRef(false);
@@ -423,14 +428,17 @@ function StreamPreview({
     video.muted = true;
     video.playsInline = true;
     video.srcObject = stream;
+    setVideoPlaying(false);
     const requestPlayback = () => {
       const playPromise = video.play();
       void playPromise
         ?.then(() => {
           playbackBlockedRef.current = false;
+          setVideoPlaying(true);
         })
         .catch(() => {
           playbackBlockedRef.current = true;
+          setVideoPlaying(false);
         });
     };
     requestPlayback();
@@ -466,9 +474,11 @@ function StreamPreview({
       void playPromise
         ?.then(() => {
           playbackBlockedRef.current = false;
+          setVideoPlaying(true);
         })
         .catch(() => {
           playbackBlockedRef.current = true;
+          setVideoPlaying(false);
         });
       return;
     }
@@ -479,11 +489,18 @@ function StreamPreview({
     <button
       type="button"
       ref={containerRef}
-      className="joystick-stream-hit-target"
+      className={
+        videoPlaying
+          ? 'joystick-stream-hit-target joystick-stream-hit-target-video-ready'
+          : 'joystick-stream-hit-target'
+      }
       aria-label="Presenter stream preview"
       onClick={handleClick}
       {...swipeHandlers}
     >
+      <span className="joystick-stream-fallback" aria-hidden="true">
+        <SlideCanvas preview={fallbackPreview} renderMediaAssets={renderFallbackMediaAssets} />
+      </span>
       <video
         ref={videoRef}
         autoPlay
@@ -494,17 +511,36 @@ function StreamPreview({
         onCanPlay={() => {
           const video = videoRef.current;
           if (!video || !video.paused) return;
-          void video.play()?.catch(() => {
-            playbackBlockedRef.current = true;
-          });
+          void video
+            .play()
+            ?.then(() => {
+              playbackBlockedRef.current = false;
+              setVideoPlaying(true);
+            })
+            .catch(() => {
+              playbackBlockedRef.current = true;
+              setVideoPlaying(false);
+            });
         }}
         onLoadedMetadata={() => {
           const video = videoRef.current;
           if (!video) return;
-          void video.play()?.catch(() => {
-            playbackBlockedRef.current = true;
-          });
+          void video
+            .play()
+            ?.then(() => {
+              playbackBlockedRef.current = false;
+              setVideoPlaying(true);
+            })
+            .catch(() => {
+              playbackBlockedRef.current = true;
+              setVideoPlaying(false);
+            });
         }}
+        onPlaying={() => {
+          playbackBlockedRef.current = false;
+          setVideoPlaying(true);
+        }}
+        onWaiting={() => setVideoPlaying(false)}
         playsInline
         preload="auto"
       />
@@ -545,10 +581,12 @@ function UpcomingSlideStrip({
   onGoToPage,
   previews,
   renderMediaAssets = true,
+  startSlideNumber,
 }: {
   onGoToPage: (pageId: string) => void;
   previews: NonNullable<PresenterRemoteState['upcomingSlidePreviews']>;
   renderMediaAssets?: boolean;
+  startSlideNumber: number;
 }) {
   if (previews.length === 0) {
     return null;
@@ -556,18 +594,21 @@ function UpcomingSlideStrip({
 
   return (
     <section className="joystick-upcoming-strip" aria-label="Upcoming slides">
-      {previews.map((item, index) => (
-        <button
-          type="button"
-          className="joystick-upcoming-thumb"
-          key={item.pageId}
-          aria-label={`Go to upcoming slide ${index + 1}: ${item.pageName}`}
-          onClick={() => onGoToPage(item.pageId)}
-        >
-          <span>Next {index + 1}</span>
-          <SlideCanvas compact preview={item.preview} renderMediaAssets={renderMediaAssets} />
-        </button>
-      ))}
+      {previews.map((item, index) => {
+        const slideNumber = startSlideNumber + index;
+        return (
+          <button
+            type="button"
+            className="joystick-upcoming-thumb"
+            key={item.pageId}
+            aria-label={`Go to slide ${slideNumber}: ${item.pageName}`}
+            onClick={() => onGoToPage(item.pageId)}
+          >
+            <span>Slide {slideNumber}</span>
+            <SlideCanvas compact preview={item.preview} renderMediaAssets={renderMediaAssets} />
+          </button>
+        );
+      })}
     </section>
   );
 }
@@ -738,6 +779,11 @@ export function JoystickApp({
   const peerControlClientRef = useRef<PresenterRemotePeerControlClient | undefined>(undefined);
   const requestedPreviewBatchKeysRef = useRef(new Set<string>());
   const remoteStreamReceiverRef = useRef<PresenterRemotePeerStreamReceiver | undefined>(undefined);
+  const streamMainRef = useRef<HTMLElement>(null);
+  const streamTopbarRef = useRef<HTMLElement>(null);
+  const streamStageRef = useRef<HTMLElement>(null);
+  const streamUpcomingRef = useRef<HTMLDivElement>(null);
+  const streamResizeRef = useRef<HTMLButtonElement>(null);
   const sessionCode = session?.code;
 
   useEffect(() => {
@@ -1027,6 +1073,37 @@ export function JoystickApp({
     connected && displayedRemoteState?.previewMode === 'stream' && remoteStream;
   const renderStructuredMediaAssets = displayedRemoteState?.previewMode !== 'stream';
   const upcomingSlidePreviews = getUpcomingSlidePreviews(displayedRemoteState);
+  const upcomingStartSlideNumber = (displayedRemoteState?.activePageIndex ?? 0) + 2;
+
+  function getStreamNotesHeightBounds() {
+    const minHeight = 132;
+    const main = streamMainRef.current;
+    if (!main) return { max: Math.max(180, Math.round(window.innerHeight * 0.68)), min: minHeight };
+    const styles = window.getComputedStyle(main);
+    const rowGap = Number.parseFloat(styles.rowGap || styles.gap || '0') || 0;
+    const paddingTop = Number.parseFloat(styles.paddingTop || '0') || 0;
+    const paddingBottom = Number.parseFloat(styles.paddingBottom || '0') || 0;
+    const reservedElements = [
+      streamTopbarRef.current,
+      streamStageRef.current,
+      streamUpcomingRef.current,
+      streamResizeRef.current,
+    ];
+    const reservedHeight = reservedElements.reduce(
+      (total, element) => total + (element?.getBoundingClientRect().height ?? 0),
+      0,
+    );
+    const visibleRows = reservedElements.filter(Boolean).length + 1;
+    const reservedGaps = rowGap * Math.max(0, visibleRows - 1);
+    const maxHeight = Math.floor(
+      main.getBoundingClientRect().height -
+        paddingTop -
+        paddingBottom -
+        reservedHeight -
+        reservedGaps,
+    );
+    return { max: Math.max(minHeight, maxHeight), min: minHeight };
+  }
 
   function handleStreamNotesResizeStart(event: PointerEvent<HTMLButtonElement>) {
     event.preventDefault();
@@ -1038,8 +1115,8 @@ export function JoystickApp({
 
     function handlePointerMove(moveEvent: globalThis.PointerEvent) {
       const nextHeight = startHeight - (moveEvent.clientY - startY);
-      const maxHeight = Math.max(180, Math.round(window.innerHeight * 0.68));
-      setStreamNotesHeight(Math.max(132, Math.min(maxHeight, nextHeight)));
+      const bounds = getStreamNotesHeightBounds();
+      setStreamNotesHeight(Math.max(bounds.min, Math.min(bounds.max, nextHeight)));
     }
 
     function handlePointerEnd() {
@@ -1079,6 +1156,7 @@ export function JoystickApp({
   if (streamModeActive) {
     return (
       <main
+        ref={streamMainRef}
         className="joystick-app joystick-app-stream"
         aria-label="Presentation remote control"
         style={
@@ -1087,7 +1165,7 @@ export function JoystickApp({
           } as CSSProperties
         }
       >
-        <header className="joystick-stream-topbar">
+        <header ref={streamTopbarRef} className="joystick-stream-topbar">
           <span className="joystick-page-count" aria-label="Slide position">
             {slidePosition}
           </span>
@@ -1133,21 +1211,30 @@ export function JoystickApp({
             {buildsIndicatorText}
           </span>
         </header>
-        <section className="joystick-stream-stage" aria-label="Streamed presenter preview">
+        <section
+          ref={streamStageRef}
+          className="joystick-stream-stage"
+          aria-label="Streamed presenter preview"
+        >
           <StreamPreview
+            fallbackPreview={displayedRemoteState?.slidePreview}
             stream={remoteStream}
             onNavigate={navigateSlide}
             onStreamPreference={sendStreamPreference}
           />
         </section>
-        <UpcomingSlideStrip
-          previews={upcomingSlidePreviews}
-          onGoToPage={(pageId) =>
-            sendRemoteCommand({ command: 'go-to-page', pageId, type: 'command' })
-          }
-          renderMediaAssets
-        />
+        <div ref={streamUpcomingRef}>
+          <UpcomingSlideStrip
+            previews={upcomingSlidePreviews}
+            onGoToPage={(pageId) =>
+              sendRemoteCommand({ command: 'go-to-page', pageId, type: 'command' })
+            }
+            renderMediaAssets
+            startSlideNumber={upcomingStartSlideNumber}
+          />
+        </div>
         <button
+          ref={streamResizeRef}
           type="button"
           className="joystick-stream-notes-resize"
           aria-label="Resize presenter notes"
@@ -1303,6 +1390,7 @@ export function JoystickApp({
           sendRemoteCommand({ command: 'go-to-page', pageId, type: 'command' })
         }
         renderMediaAssets={renderStructuredMediaAssets}
+        startSlideNumber={upcomingStartSlideNumber}
       />
 
       <section className="joystick-notes-panel" aria-label="Presenter notes">

--- a/apps/joystick/src/styles/joystick.css
+++ b/apps/joystick/src/styles/joystick.css
@@ -47,7 +47,7 @@ input {
   grid-template-rows:
     auto
     auto
-    minmax(62px, auto)
+    86px
     22px
     minmax(132px, var(--joystick-stream-notes-height, 280px));
   gap: 6px;
@@ -154,8 +154,8 @@ input {
 .joystick-stream-stage {
   width: 100%;
   min-height: 0;
-  max-height: min(32dvh, 340px);
-  aspect-ratio: 390 / 340;
+  max-height: min(36dvh, 360px);
+  aspect-ratio: 16 / 9;
   align-self: start;
   display: grid;
   place-items: stretch;
@@ -168,8 +168,10 @@ input {
 .joystick-stream-hit-target {
   width: 100%;
   min-height: 0;
+  position: relative;
   display: grid;
   place-items: stretch;
+  overflow: hidden;
   padding: 0;
   border: 0;
   background: #020805;
@@ -177,13 +179,43 @@ input {
   touch-action: pan-y;
 }
 
+.joystick-stream-fallback,
 .joystick-stream-video {
+  grid-area: 1 / 1;
   width: 100%;
   height: 100%;
+}
+
+.joystick-stream-fallback {
+  display: grid;
+  place-items: stretch;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.joystick-stream-fallback .joystick-slide-canvas {
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.joystick-stream-video {
   display: block;
   object-fit: contain;
   object-position: center top;
+  opacity: 0;
   background: #020805;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.joystick-stream-hit-target-video-ready .joystick-stream-fallback {
+  opacity: 0;
+}
+
+.joystick-stream-hit-target-video-ready .joystick-stream-video {
+  opacity: 1;
 }
 
 .joystick-stream-notes {
@@ -575,6 +607,7 @@ input {
 .joystick-app-stream .joystick-upcoming-strip {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 6px;
+  height: 86px;
   min-height: 0;
   padding: 0;
   overflow: hidden;
@@ -583,14 +616,16 @@ input {
 .joystick-app-stream .joystick-upcoming-thumb {
   grid-template-rows: 16px minmax(0, 1fr);
   gap: 4px;
-  min-height: 70px;
+  height: 86px;
+  min-height: 0;
   padding: 5px;
   border-color: rgba(241, 245, 238, 0.14);
   background: rgba(241, 245, 238, 0.045);
 }
 
 .joystick-app-stream .joystick-upcoming-thumb .joystick-slide-canvas {
-  max-height: 50px;
+  height: 58px;
+  max-height: 58px;
 }
 
 .joystick-notes-panel {

--- a/apps/joystick/src/styles/joystick.css
+++ b/apps/joystick/src/styles/joystick.css
@@ -44,8 +44,13 @@ input {
 .joystick-app-stream {
   position: relative;
   display: grid;
-  grid-template-rows: auto minmax(210px, 32dvh) auto minmax(0, 1fr) auto;
-  gap: 8px;
+  grid-template-rows:
+    auto
+    auto
+    minmax(62px, auto)
+    22px
+    minmax(132px, var(--joystick-stream-notes-height, 280px));
+  gap: 6px;
   min-height: 100vh;
   min-height: 100dvh;
   height: 100dvh;
@@ -57,10 +62,10 @@ input {
 .joystick-stream-topbar {
   min-width: 0;
   display: grid;
-  grid-template-columns: auto 8px minmax(80px, 1fr) auto;
+  grid-template-columns: auto 8px minmax(72px, 1fr) auto auto;
   align-items: center;
-  gap: 10px;
-  min-height: 34px;
+  gap: 8px;
+  min-height: 42px;
   color: var(--ls-text);
   font-size: 12px;
   font-weight: 900;
@@ -69,10 +74,38 @@ input {
 .joystick-stream-topbar > span:last-child {
   min-width: 0;
   overflow: hidden;
-  color: var(--ls-muted);
   text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.joystick-builds-indicator {
+  justify-self: end;
+  color: var(--ls-green-fixed);
+  font-family: var(--ls-font-display);
+  font-size: 14px;
+}
+
+.joystick-stream-top-controls {
+  display: grid;
+  grid-template-columns: repeat(4, 38px);
+  gap: 6px;
+}
+
+.joystick-stream-top-controls button {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid rgba(241, 245, 238, 0.22);
+  border-radius: 8px;
+  background: rgba(241, 245, 238, 0.06);
+  color: var(--ls-cyan);
+}
+
+.joystick-stream-top-controls button:disabled {
+  opacity: 0.42;
 }
 
 .joystick-topbar,
@@ -119,7 +152,11 @@ input {
 }
 
 .joystick-stream-stage {
+  width: 100%;
   min-height: 0;
+  max-height: min(32dvh, 340px);
+  aspect-ratio: 390 / 340;
+  align-self: start;
   display: grid;
   place-items: stretch;
   overflow: hidden;
@@ -145,6 +182,7 @@ input {
   height: 100%;
   display: block;
   object-fit: contain;
+  object-position: center top;
   background: #020805;
 }
 
@@ -189,12 +227,15 @@ input {
 
 .joystick-stream-notes-content {
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 18px 18px 24px;
   color: #102015;
   font-weight: 500;
   line-height: 1.16;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .joystick-stream-empty-notes {
@@ -229,6 +270,30 @@ input {
   font-size: 12px;
   font-weight: 800;
   backdrop-filter: blur(18px);
+}
+
+.joystick-stream-notes-resize {
+  width: 100%;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: ns-resize;
+  touch-action: none;
+}
+
+.joystick-stream-notes-resize span {
+  width: 68px;
+  height: 5px;
+  border-radius: 999px;
+  background: rgba(241, 245, 238, 0.34);
+}
+
+.joystick-stream-notes-resize:focus-visible {
+  outline: 2px solid var(--ls-green);
+  outline-offset: 2px;
 }
 
 .joystick-stream-controls span {
@@ -505,6 +570,27 @@ input {
 .joystick-upcoming-thumb:focus-visible {
   outline: 2px solid var(--ls-green);
   outline-offset: 3px;
+}
+
+.joystick-app-stream .joystick-upcoming-strip {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  min-height: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.joystick-app-stream .joystick-upcoming-thumb {
+  grid-template-rows: 16px minmax(0, 1fr);
+  gap: 4px;
+  min-height: 70px;
+  padding: 5px;
+  border-color: rgba(241, 245, 238, 0.14);
+  background: rgba(241, 245, 238, 0.045);
+}
+
+.joystick-app-stream .joystick-upcoming-thumb .joystick-slide-canvas {
+  max-height: 50px;
 }
 
 .joystick-notes-panel {

--- a/apps/joystick/src/styles/joystick.css
+++ b/apps/joystick/src/styles/joystick.css
@@ -609,7 +609,6 @@ input {
   font-family: var(--ls-font-display);
   font-size: 14px;
   letter-spacing: 0;
-  text-transform: uppercase;
 }
 
 .joystick-code-row button {

--- a/apps/joystick/tests/unit/JoystickApp.test.tsx
+++ b/apps/joystick/tests/unit/JoystickApp.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JoystickApp } from '../../src/app/JoystickApp';
@@ -547,6 +547,79 @@ describe('JoystickApp', () => {
     });
   });
 
+  it('keeps the structured slide visible when stream autoplay is blocked', async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockRejectedValue(new Error('Autoplay blocked'));
+    render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
+    const client = peerControlClientMock.instances[0];
+    expect(client).toBeDefined();
+
+    act(() => {
+      client?.emitState({
+        activePageId: 'page-1',
+        activePageIndex: 0,
+        buildsRemaining: 0,
+        connectedControllerCount: 1,
+        deckName: 'Launch Deck',
+        notes: '',
+        pageCount: 2,
+        pages: [
+          { id: 'page-1', name: 'Intro' },
+          { id: 'page-2', name: 'Roadmap' },
+        ],
+        presenterMode: 'presenting',
+        previewMode: 'stream',
+        shortcuts: ['previous', 'next'],
+        slidePreview: {
+          backgroundColor: '#050d10',
+          elements: [
+            {
+              align: 'center',
+              fill: '#ffffff',
+              fontFamily: 'Inter',
+              fontSize: 96,
+              fontWeight: 800,
+              height: 160,
+              id: 'title',
+              kind: 'text',
+              opacity: 1,
+              rotation: 0,
+              text: 'Autoplay fallback slide',
+              width: 1200,
+              x: 360,
+              y: 420,
+            },
+          ],
+          height: 1080,
+          width: 1920,
+        },
+        stream: {
+          enabled: true,
+          fps: 8,
+          height: 340,
+          peerId: 'stream-peer-1',
+          transport: 'peerjs',
+          width: 390,
+        },
+        timer: { elapsedMs: 0, paused: false },
+        type: 'state',
+      });
+    });
+
+    act(() => {
+      peerStreamReceiverMock.latestReceiver?.emitStream({} as MediaStream);
+      peerStreamReceiverMock.latestReceiver?.emitStatus('connected');
+    });
+
+    expect(
+      await screen.findByRole('button', { name: 'Presenter stream preview' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Autoplay fallback slide')).toBeInTheDocument();
+    expect(playSpy).toHaveBeenCalled();
+    playSpy.mockRestore();
+  });
+
   it('shows a retryable message after a PeerJS control error', async () => {
     render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
     const client = peerControlClientMock.instances[0];
@@ -821,15 +894,9 @@ describe('JoystickApp', () => {
       'src',
       'https://cdn.localstudio.test/demo.mp4',
     );
-    expect(
-      screen.getByRole('button', { name: 'Go to upcoming slide 1: Budget' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Go to upcoming slide 2: Demo' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Go to upcoming slide 3: Close' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to slide 3: Budget' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to slide 4: Demo' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to slide 5: Close' })).toBeInTheDocument();
     expect(screen.getByLabelText('Slide position')).toHaveTextContent('2 / 5');
     expect(screen.getByText('Talk through the launch timeline.')).toBeInTheDocument();
   });
@@ -894,7 +961,7 @@ describe('JoystickApp', () => {
       />,
     );
 
-    await user.click(await screen.findByRole('button', { name: 'Go to upcoming slide 3: Close' }));
+    await user.click(await screen.findByRole('button', { name: 'Go to slide 4: Close' }));
 
     expect(service.takeCommands('ABCD-1234')).toEqual([
       { command: 'go-to-page', pageId: 'page-4', type: 'command' },
@@ -965,7 +1032,11 @@ describe('JoystickApp', () => {
     expect(
       container.querySelectorAll('.joystick-slide-navigator-thumb .joystick-slide-canvas'),
     ).toHaveLength(3);
-    await user.click(screen.getByRole('button', { name: 'Go to slide 3: Budget' }));
+    await user.click(
+      within(screen.getByRole('dialog', { name: 'Slide navigation' })).getByRole('button', {
+        name: 'Go to slide 3: Budget',
+      }),
+    );
 
     expect(service.takeCommands('ABCD-1234')).toEqual([
       { command: 'go-to-page', pageId: 'page-3', type: 'command' },

--- a/apps/joystick/tests/unit/JoystickApp.test.tsx
+++ b/apps/joystick/tests/unit/JoystickApp.test.tsx
@@ -3,23 +3,32 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JoystickApp } from '../../src/app/JoystickApp';
 import { InMemoryPresenterRemoteSignalingService } from '@localstudio/presenter-remote/signaling-service';
-import type { PresenterRemoteState } from '@localstudio/presenter-remote/protocol';
+import type {
+  PresenterRemotePreviewBatch,
+  PresenterRemoteState,
+} from '@localstudio/presenter-remote/protocol';
 
 const peerControlClientMock = vi.hoisted(() => ({
   instances: [] as Array<{
     close: ReturnType<typeof vi.fn>;
+    emitPreviewBatch: (batch: PresenterRemotePreviewBatch) => void;
     emitState: (state: PresenterRemoteState) => void;
     emitStatus: (status: 'connected' | 'connecting' | 'failed') => void;
     sendCommand: ReturnType<typeof vi.fn>;
     start: ReturnType<typeof vi.fn>;
   }>,
-  create: vi.fn(function MockPresenterRemotePeerControlClient(this: unknown, options: {
-    onState: (state: PresenterRemoteState) => void;
-    onStatusChange?: (status: 'connected' | 'connecting' | 'failed') => void;
-    presenterPeerId: string;
-  }) {
+  create: vi.fn(function MockPresenterRemotePeerControlClient(
+    this: unknown,
+    options: {
+      onPreviewBatch?: (batch: PresenterRemotePreviewBatch) => void;
+      onState: (state: PresenterRemoteState) => void;
+      onStatusChange?: (status: 'connected' | 'connecting' | 'failed') => void;
+      presenterPeerId: string;
+    },
+  ) {
     const client = {
       close: vi.fn(),
+      emitPreviewBatch: (batch: PresenterRemotePreviewBatch) => options.onPreviewBatch?.(batch),
       emitState: (state: PresenterRemoteState) => options.onState(state),
       emitStatus: (status: 'connected' | 'connecting' | 'failed') =>
         options.onStatusChange?.(status),
@@ -43,11 +52,14 @@ const peerStreamReceiverMock = vi.hoisted(() => ({
         stop: ReturnType<typeof vi.fn>;
       }
     | undefined,
-  create: vi.fn(function MockPresenterRemotePeerStreamReceiver(this: unknown, options: {
-    onStatusChange: (status: 'connected' | 'connecting' | 'failed') => void;
-    onStream: (stream: MediaStream | undefined) => void;
-    streamPeerId: string;
-  }) {
+  create: vi.fn(function MockPresenterRemotePeerStreamReceiver(
+    this: unknown,
+    options: {
+      onStatusChange: (status: 'connected' | 'connecting' | 'failed') => void;
+      onStream: (stream: MediaStream | undefined) => void;
+      streamPeerId: string;
+    },
+  ) {
     const receiver = {
       emitStatus: (status: 'connected' | 'connecting' | 'failed') => options.onStatusChange(status),
       emitStream: (stream: MediaStream | undefined) => options.onStream(stream),
@@ -221,11 +233,13 @@ describe('JoystickApp', () => {
 
     expect(await screen.findByLabelText('Connected (1)')).toBeInTheDocument();
     expect(getTestLocalStorage().getItem('localstudio.joystick.lastCode')).toBe('ABCD-1234');
-    expect(JSON.parse(getTestLocalStorage().getItem('localstudio.joystick.approvedCodes') ?? '[]')).toEqual([
-      'ABCD-1234',
-    ]);
     expect(
-      JSON.parse(getTestLocalStorage().getItem('localstudio.joystick.trustedPresenterDeviceIds') ?? '[]'),
+      JSON.parse(getTestLocalStorage().getItem('localstudio.joystick.approvedCodes') ?? '[]'),
+    ).toEqual(['ABCD-1234']);
+    expect(
+      JSON.parse(
+        getTestLocalStorage().getItem('localstudio.joystick.trustedPresenterDeviceIds') ?? '[]',
+      ),
     ).toEqual(['presenter-macbook']);
   });
 
@@ -253,7 +267,10 @@ describe('JoystickApp', () => {
       type: 'state',
     });
     getTestLocalStorage().setItem('localstudio.joystick.lastCode', 'ABCD-1234');
-    getTestLocalStorage().setItem('localstudio.joystick.approvedCodes', JSON.stringify(['ABCD-1234']));
+    getTestLocalStorage().setItem(
+      'localstudio.joystick.approvedCodes',
+      JSON.stringify(['ABCD-1234']),
+    );
     getTestLocalStorage().setItem(
       'localstudio.joystick.trustedPresenterDeviceIds',
       JSON.stringify(['presenter-macbook']),
@@ -265,10 +282,9 @@ describe('JoystickApp', () => {
 
     expect(await screen.findByText('Current: Slide 1 of 1')).toBeInTheDocument();
     expect(getTestLocalStorage().getItem('localstudio.joystick.lastCode')).toBe('EFGH-5678');
-    expect(JSON.parse(getTestLocalStorage().getItem('localstudio.joystick.approvedCodes') ?? '[]')).toEqual([
-      'EFGH-5678',
-      'ABCD-1234',
-    ]);
+    expect(
+      JSON.parse(getTestLocalStorage().getItem('localstudio.joystick.approvedCodes') ?? '[]'),
+    ).toEqual(['EFGH-5678', 'ABCD-1234']);
   });
 
   it('requires a remote link even when one legacy presentation is active if the phone is not paired', async () => {
@@ -282,7 +298,9 @@ describe('JoystickApp', () => {
       <JoystickApp initialUrl="https://localstudio.test/joystick" signalingService={service} />,
     );
 
-    expect(await screen.findByText('Open the presenter remote link or paste its peer id.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Open the presenter remote link or paste its peer id.'),
+    ).toBeInTheDocument();
     expect(screen.queryByText('MacBook Pro')).not.toBeInTheDocument();
   });
 
@@ -300,7 +318,9 @@ describe('JoystickApp', () => {
       <JoystickApp initialUrl="https://localstudio.test/joystick" signalingService={service} />,
     );
 
-    expect(await screen.findByText('Open the presenter remote link or paste its peer id.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Open the presenter remote link or paste its peer id.'),
+    ).toBeInTheDocument();
     expect(screen.queryByText('MacBook Pro')).not.toBeInTheDocument();
   });
 
@@ -353,21 +373,21 @@ describe('JoystickApp', () => {
 
     act(() => {
       client?.emitState({
-      activePageId: 'page-1',
-      activePageIndex: 0,
-      buildsRemaining: 0,
-      connectedControllerCount: 1,
-      deckName: 'Launch Deck',
-      notes: '',
-      pageCount: 2,
-      pages: [
-        { id: 'page-1', name: 'Intro' },
-        { id: 'page-2', name: 'Roadmap' },
-      ],
-      presenterMode: 'presenting',
-      shortcuts: ['previous', 'next'],
-      timer: { elapsedMs: 0, paused: false },
-      type: 'state',
+        activePageId: 'page-1',
+        activePageIndex: 0,
+        buildsRemaining: 0,
+        connectedControllerCount: 1,
+        deckName: 'Launch Deck',
+        notes: '',
+        pageCount: 2,
+        pages: [
+          { id: 'page-1', name: 'Intro' },
+          { id: 'page-2', name: 'Roadmap' },
+        ],
+        presenterMode: 'presenting',
+        shortcuts: ['previous', 'next'],
+        timer: { elapsedMs: 0, paused: false },
+        type: 'state',
       });
     });
 
@@ -382,6 +402,94 @@ describe('JoystickApp', () => {
     expect(screen.getByText('Command sent: go-to-page')).toBeInTheDocument();
   });
 
+  it('requests PeerJS previews in batches and applies incoming preview batches', async () => {
+    render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
+    const client = peerControlClientMock.instances[0];
+    expect(client).toBeDefined();
+
+    act(() => {
+      client?.emitState({
+        activePageId: 'page-1',
+        activePageIndex: 0,
+        buildsRemaining: 0,
+        connectedControllerCount: 1,
+        deckName: 'Launch Deck',
+        notes: '',
+        pageCount: 6,
+        pages: [
+          { id: 'page-1', name: 'Intro' },
+          { id: 'page-2', name: 'Roadmap' },
+          { id: 'page-3', name: 'Demo' },
+          { id: 'page-4', name: 'Pricing' },
+          { id: 'page-5', name: 'Close' },
+          { id: 'page-6', name: 'Appendix' },
+        ],
+        presenterMode: 'presenting',
+        shortcuts: ['previous', 'next'],
+        timer: { elapsedMs: 0, paused: false },
+        type: 'state',
+      });
+    });
+
+    await waitFor(() =>
+      expect(client?.sendCommand).toHaveBeenCalledWith({
+        command: 'request-previews',
+        pageIds: ['page-2', 'page-3', 'page-4', 'page-5', 'page-6'],
+        requestId: 'Launch Deck:page-2,page-3,page-4,page-5,page-6',
+        type: 'command',
+      }),
+    );
+
+    act(() => {
+      client?.emitPreviewBatch({
+        previews: [
+          {
+            id: 'page-1',
+            name: 'Intro',
+            preview: {
+              backgroundColor: '#000000',
+              elements: [
+                {
+                  align: 'left',
+                  fill: '#ffffff',
+                  fontFamily: 'Inter',
+                  fontSize: 48,
+                  fontWeight: 700,
+                  height: 100,
+                  id: 'title',
+                  kind: 'text',
+                  opacity: 1,
+                  rotation: 0,
+                  text: 'Preview loaded',
+                  width: 800,
+                  x: 0,
+                  y: 0,
+                },
+              ],
+              height: 1080,
+              width: 1920,
+            },
+          },
+        ],
+        requestId: 'Launch Deck:page-1,page-2,page-3,page-4,page-5',
+        type: 'preview-batch',
+      });
+    });
+
+    expect(await screen.findByText('Preview loaded')).toBeInTheDocument();
+  });
+
+  it('shows the PeerJS data connection as connected before the first presenter state arrives', async () => {
+    render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
+
+    expect(await screen.findByLabelText('Connected (1)')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Could not connect to that presenter. Check the remote link and try again.',
+      ),
+    ).toBeNull();
+  });
+
   it('starts a PeerJS media receiver when presenter state includes a stream peer', async () => {
     const user = userEvent.setup();
     render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
@@ -390,34 +498,36 @@ describe('JoystickApp', () => {
 
     act(() => {
       client?.emitState({
-      activePageId: 'page-1',
-      activePageIndex: 0,
-      buildsRemaining: 0,
-      connectedControllerCount: 1,
-      deckName: 'Launch Deck',
-      notes: '',
-      pageCount: 2,
-      pages: [
-        { id: 'page-1', name: 'Intro' },
-        { id: 'page-2', name: 'Roadmap' },
-      ],
-      presenterMode: 'presenting',
-      previewMode: 'stream',
-      shortcuts: ['previous', 'next'],
-      stream: {
-        enabled: true,
-        fps: 8,
-        height: 340,
-        peerId: 'stream-peer-1',
-        transport: 'peerjs',
-        width: 390,
-      },
-      timer: { elapsedMs: 0, paused: false },
-      type: 'state',
+        activePageId: 'page-1',
+        activePageIndex: 0,
+        buildsRemaining: 0,
+        connectedControllerCount: 1,
+        deckName: 'Launch Deck',
+        notes: '',
+        pageCount: 2,
+        pages: [
+          { id: 'page-1', name: 'Intro' },
+          { id: 'page-2', name: 'Roadmap' },
+        ],
+        presenterMode: 'presenting',
+        previewMode: 'stream',
+        shortcuts: ['previous', 'next'],
+        stream: {
+          enabled: true,
+          fps: 8,
+          height: 340,
+          peerId: 'stream-peer-1',
+          transport: 'peerjs',
+          width: 390,
+        },
+        timer: { elapsedMs: 0, paused: false },
+        type: 'state',
       });
     });
 
-    expect(await screen.findByRole('button', { name: 'Current slide preview' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Current slide preview' }),
+    ).toBeInTheDocument();
     await waitFor(() =>
       expect(peerStreamReceiverMock.create).toHaveBeenCalledWith(
         expect.objectContaining({ streamPeerId: 'stream-peer-1' }),
@@ -447,7 +557,9 @@ describe('JoystickApp', () => {
     });
 
     expect(
-      await screen.findByText('Could not connect to that presenter. Check the remote link and try again.'),
+      await screen.findByText(
+        'Could not connect to that presenter. Check the remote link and try again.',
+      ),
     ).toBeInTheDocument();
   });
 

--- a/apps/joystick/tests/unit/JoystickApp.test.tsx
+++ b/apps/joystick/tests/unit/JoystickApp.test.tsx
@@ -1,38 +1,70 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JoystickApp } from '../../src/app/JoystickApp';
 import { InMemoryPresenterRemoteSignalingService } from '@localstudio/presenter-remote/signaling-service';
+import type { PresenterRemoteState } from '@localstudio/presenter-remote/protocol';
 
-const streamReceiverMock = vi.hoisted(() => ({
+const peerControlClientMock = vi.hoisted(() => ({
+  instances: [] as Array<{
+    close: ReturnType<typeof vi.fn>;
+    emitState: (state: PresenterRemoteState) => void;
+    emitStatus: (status: 'connected' | 'connecting' | 'failed') => void;
+    sendCommand: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+  }>,
+  create: vi.fn(function MockPresenterRemotePeerControlClient(this: unknown, options: {
+    onState: (state: PresenterRemoteState) => void;
+    onStatusChange?: (status: 'connected' | 'connecting' | 'failed') => void;
+    presenterPeerId: string;
+  }) {
+    const client = {
+      close: vi.fn(),
+      emitState: (state: PresenterRemoteState) => options.onState(state),
+      emitStatus: (status: 'connected' | 'connecting' | 'failed') =>
+        options.onStatusChange?.(status),
+      sendCommand: vi.fn(() => true),
+      start: vi.fn(() => {
+        options.onStatusChange?.('connected');
+        return Promise.resolve();
+      }),
+    };
+    peerControlClientMock.instances.push(client);
+    return client;
+  }),
+}));
+
+const peerStreamReceiverMock = vi.hoisted(() => ({
   latestReceiver: undefined as
     | {
-        sendCommand: ReturnType<typeof vi.fn>;
-        sendStreamPreference: ReturnType<typeof vi.fn>;
+        emitStatus: (status: 'connected' | 'connecting' | 'failed') => void;
+        emitStream: (stream: MediaStream | undefined) => void;
         start: ReturnType<typeof vi.fn>;
         stop: ReturnType<typeof vi.fn>;
       }
     | undefined,
-  create: vi.fn((options: {
-    onStatusChange: (status: 'connected') => void;
+  create: vi.fn(function MockPresenterRemotePeerStreamReceiver(this: unknown, options: {
+    onStatusChange: (status: 'connected' | 'connecting' | 'failed') => void;
     onStream: (stream: MediaStream | undefined) => void;
-  }) => {
+    streamPeerId: string;
+  }) {
     const receiver = {
-      sendCommand: vi.fn(() => true),
-      sendStreamPreference: vi.fn(() => true),
-      start: vi.fn(() => {
-        options.onStream({} as MediaStream);
-        options.onStatusChange('connected');
-      }),
+      emitStatus: (status: 'connected' | 'connecting' | 'failed') => options.onStatusChange(status),
+      emitStream: (stream: MediaStream | undefined) => options.onStream(stream),
+      start: vi.fn(() => Promise.resolve()),
       stop: vi.fn(),
     };
-    streamReceiverMock.latestReceiver = receiver;
+    peerStreamReceiverMock.latestReceiver = receiver;
     return receiver;
   }),
 }));
 
-vi.mock('../../src/app/presenterRemoteStreamReceiver', () => ({
-  presenterRemoteStreamReceiver: streamReceiverMock,
+vi.mock('@localstudio/presenter-remote/peer-control-client', () => ({
+  PresenterRemotePeerControlClient: peerControlClientMock.create,
+}));
+
+vi.mock('@localstudio/presenter-remote/peer-stream-receiver', () => ({
+  PresenterRemotePeerStreamReceiver: peerStreamReceiverMock.create,
 }));
 
 const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
@@ -86,8 +118,10 @@ describe('JoystickApp', () => {
   beforeEach(() => {
     restoreLocalStorage();
     getTestLocalStorage().clear();
-    streamReceiverMock.create.mockClear();
-    streamReceiverMock.latestReceiver = undefined;
+    peerControlClientMock.create.mockClear();
+    peerControlClientMock.instances.length = 0;
+    peerStreamReceiverMock.create.mockClear();
+    peerStreamReceiverMock.latestReceiver = undefined;
   });
 
   afterEach(() => {
@@ -237,7 +271,7 @@ describe('JoystickApp', () => {
     ]);
   });
 
-  it('requires a code even when one presentation is active if the phone is not paired', async () => {
+  it('requires a remote link even when one legacy presentation is active if the phone is not paired', async () => {
     const service = new InMemoryPresenterRemoteSignalingService({
       randomCode: () => 'ABCD-1234',
       randomId: () => 'session-1',
@@ -248,13 +282,11 @@ describe('JoystickApp', () => {
       <JoystickApp initialUrl="https://localstudio.test/joystick" signalingService={service} />,
     );
 
-    expect(
-      await screen.findByText('Enter the code shown on the presenter screen.'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Open the presenter remote link or paste its peer id.')).toBeInTheDocument();
     expect(screen.queryByText('MacBook Pro')).not.toBeInTheDocument();
   });
 
-  it('requires a code when multiple presentations are active', async () => {
+  it('requires a remote link when multiple legacy presentations are active', async () => {
     const codes = ['ABCD-1234', 'EFGH-5678'];
     const ids = ['session-1', 'session-2'];
     const service = new InMemoryPresenterRemoteSignalingService({
@@ -268,9 +300,7 @@ describe('JoystickApp', () => {
       <JoystickApp initialUrl="https://localstudio.test/joystick" signalingService={service} />,
     );
 
-    expect(
-      await screen.findByText('Enter the code shown on the presenter screen.'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Open the presenter remote link or paste its peer id.')).toBeInTheDocument();
     expect(screen.queryByText('MacBook Pro')).not.toBeInTheDocument();
   });
 
@@ -315,14 +345,14 @@ describe('JoystickApp', () => {
     ]);
   });
 
-  it('sends slide jump commands through the streamed data channel with signaling backup', async () => {
+  it('connects from a peer URL and sends slide commands over the PeerJS data connection', async () => {
     const user = userEvent.setup();
-    const service = new InMemoryPresenterRemoteSignalingService({
-      randomCode: () => 'ABCD-1234',
-      randomId: () => 'session-1',
-    });
-    service.registerSession({ presenterLabel: 'MacBook Pro', ttlMs: 60_000 });
-    service.publishState('ABCD-1234', {
+    render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
+    const client = peerControlClientMock.instances[0];
+    expect(client).toBeDefined();
+
+    act(() => {
+      client?.emitState({
       activePageId: 'page-1',
       activePageIndex: 0,
       buildsRemaining: 0,
@@ -335,39 +365,31 @@ describe('JoystickApp', () => {
         { id: 'page-2', name: 'Roadmap' },
       ],
       presenterMode: 'presenting',
-      previewMode: 'stream',
       shortcuts: ['previous', 'next'],
-      stream: { enabled: true, fps: 8, height: 340, width: 390 },
       timer: { elapsedMs: 0, paused: false },
       type: 'state',
+      });
     });
 
-    render(
-      <JoystickApp
-        initialUrl="https://localstudio.test/joystick?code=ABCD-1234"
-        signalingService={service}
-      />,
-    );
-
-    const preview = await screen.findByRole('button', { name: 'Presenter stream preview' });
+    const preview = await screen.findByRole('button', { name: 'Current slide preview' });
     await user.click(preview);
 
-    expect(streamReceiverMock.latestReceiver?.sendCommand).toHaveBeenCalledWith(
-      { command: 'go-to-page', pageId: 'page-2', type: 'command' },
-    );
-    expect(service.takeCommands('ABCD-1234')).toEqual([
-      { command: 'go-to-page', pageId: 'page-2', type: 'command' },
-    ]);
+    expect(client?.sendCommand).toHaveBeenCalledWith({
+      command: 'go-to-page',
+      pageId: 'page-2',
+      type: 'command',
+    });
+    expect(screen.getByText('Command sent: go-to-page')).toBeInTheDocument();
   });
 
-  it('falls back to signaling commands when the streamed data channel is unavailable', async () => {
+  it('starts a PeerJS media receiver when presenter state includes a stream peer', async () => {
     const user = userEvent.setup();
-    const service = new InMemoryPresenterRemoteSignalingService({
-      randomCode: () => 'ABCD-1234',
-      randomId: () => 'session-1',
-    });
-    service.registerSession({ presenterLabel: 'MacBook Pro', ttlMs: 60_000 });
-    service.publishState('ABCD-1234', {
+    render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
+    const client = peerControlClientMock.instances[0];
+    expect(client).toBeDefined();
+
+    act(() => {
+      client?.emitState({
       activePageId: 'page-1',
       activePageIndex: 0,
       buildsRemaining: 0,
@@ -382,23 +404,51 @@ describe('JoystickApp', () => {
       presenterMode: 'presenting',
       previewMode: 'stream',
       shortcuts: ['previous', 'next'],
-      stream: { enabled: true, fps: 8, height: 340, width: 390 },
+      stream: {
+        enabled: true,
+        fps: 8,
+        height: 340,
+        peerId: 'stream-peer-1',
+        transport: 'peerjs',
+        width: 390,
+      },
       timer: { elapsedMs: 0, paused: false },
       type: 'state',
+      });
     });
 
-    render(<JoystickApp initialUrl="https://localstudio.test/joystick?code=ABCD-1234" signalingService={service} />);
-
-    const preview = await screen.findByRole('button', { name: 'Presenter stream preview' });
-    streamReceiverMock.latestReceiver?.sendCommand.mockReturnValue(false);
-    await user.click(preview);
-
-    expect(streamReceiverMock.latestReceiver?.sendCommand).toHaveBeenCalledWith(
-      { command: 'go-to-page', pageId: 'page-2', type: 'command' },
+    expect(await screen.findByRole('button', { name: 'Current slide preview' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(peerStreamReceiverMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({ streamPeerId: 'stream-peer-1' }),
+      ),
     );
-    expect(service.takeCommands('ABCD-1234')).toEqual([
-      { command: 'go-to-page', pageId: 'page-2', type: 'command' },
-    ]);
+
+    act(() => {
+      peerStreamReceiverMock.latestReceiver?.emitStream({} as MediaStream);
+      peerStreamReceiverMock.latestReceiver?.emitStatus('connected');
+    });
+    await user.click(await screen.findByRole('button', { name: 'Presenter stream preview' }));
+
+    expect(client?.sendCommand).toHaveBeenCalledWith({
+      command: 'go-to-page',
+      pageId: 'page-2',
+      type: 'command',
+    });
+  });
+
+  it('shows a retryable message after a PeerJS control error', async () => {
+    render(<JoystickApp initialUrl="https://localstudio.test/joystick?peer=control-peer-1" />);
+    const client = peerControlClientMock.instances[0];
+    expect(client).toBeDefined();
+
+    act(() => {
+      client?.emitStatus('failed');
+    });
+
+    expect(
+      await screen.findByText('Could not connect to that presenter. Check the remote link and try again.'),
+    ).toBeInTheDocument();
   });
 
   it('sends slide jump commands from horizontal swipes on the slide preview', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1367,6 +1367,15 @@
       "resolved": "packages/presenter-remote",
       "link": true
     },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -4550,6 +4559,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/peerjs": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
+      "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^2.8.0",
+        "eventemitter3": "^4.0.7",
+        "peerjs-js-binarypack": "^2.1.0",
+        "webrtc-adapter": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs-js-binarypack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
+      "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4946,6 +4993,12 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -5722,6 +5775,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -6061,7 +6127,10 @@
     },
     "packages/presenter-remote": {
       "name": "@localstudio/presenter-remote",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dependencies": {
+        "peerjs": "^1.5.5"
+      }
     }
   }
 }

--- a/packages/presenter-remote/package.json
+++ b/packages/presenter-remote/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./debug-log": "./src/debug-log.ts",
     "./ice": "./src/ice.ts",
     "./peer-control-client": "./src/peer-control-client.ts",
     "./peer-control-host": "./src/peer-control-host.ts",

--- a/packages/presenter-remote/package.json
+++ b/packages/presenter-remote/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "exports": {
     "./ice": "./src/ice.ts",
+    "./peer-control-client": "./src/peer-control-client.ts",
+    "./peer-control-host": "./src/peer-control-host.ts",
+    "./peer-stream-publisher": "./src/peer-stream-publisher.ts",
+    "./peer-stream-receiver": "./src/peer-stream-receiver.ts",
     "./protocol": "./src/protocol.ts",
     "./session-code": "./src/session-code.ts",
     "./signaling-client": "./src/signaling-client.ts",
@@ -14,5 +18,8 @@
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit --pretty false"
+  },
+  "dependencies": {
+    "peerjs": "^1.5.5"
   }
 }

--- a/packages/presenter-remote/src/debug-log.ts
+++ b/packages/presenter-remote/src/debug-log.ts
@@ -1,0 +1,28 @@
+type DebugLogLevel = 'error' | 'info' | 'warn';
+
+function write(level: DebugLogLevel, message: string, detail?: unknown) {
+  const prefix = '[LocalStudio presenter remote]';
+  if (detail === undefined) {
+    globalThis.console[level](prefix, message);
+    return;
+  }
+  globalThis.console[level](prefix, message, stringifyDetail(detail));
+}
+
+function stringifyDetail(detail: unknown) {
+  if (detail instanceof Error) {
+    return `${detail.name}: ${detail.message}`;
+  }
+  if (typeof detail === 'string') return detail;
+  try {
+    return JSON.stringify(detail);
+  } catch {
+    return String(detail);
+  }
+}
+
+export const presenterRemoteDebugLog = {
+  error: (message: string, detail?: unknown) => write('error', message, detail),
+  info: (message: string, detail?: unknown) => write('info', message, detail),
+  warn: (message: string, detail?: unknown) => write('warn', message, detail),
+};

--- a/packages/presenter-remote/src/peer-control-client.ts
+++ b/packages/presenter-remote/src/peer-control-client.ts
@@ -1,0 +1,97 @@
+import { Peer, type DataConnection, type PeerOptions } from 'peerjs';
+import {
+  presenterRemoteProtocol,
+  type PresenterRemoteCommand,
+  type PresenterRemoteState,
+} from './protocol';
+
+export interface PresenterRemotePeerControlClientOptions {
+  connectionTimeoutMs?: number | undefined;
+  onState: (state: PresenterRemoteState) => void;
+  onStatusChange?: ((status: 'connected' | 'connecting' | 'failed') => void) | undefined;
+  peerFactory?: (() => Peer) | undefined;
+  peerOptions?: PeerOptions | undefined;
+  presenterPeerId: string;
+}
+
+function oncePeerOpen(peer: Peer) {
+  if (peer.open) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    peer.on('open', () => resolve());
+    peer.on('error', reject);
+  });
+}
+
+function rejectAfter(timeoutMs: number) {
+  return new Promise<never>((_, reject) => {
+    window.setTimeout(() => reject(new Error('PeerJS connection timed out.')), timeoutMs);
+  });
+}
+
+export class PresenterRemotePeerControlClient {
+  private connection: DataConnection | undefined;
+  private readonly options: PresenterRemotePeerControlClientOptions;
+  private peer: Peer | undefined;
+
+  constructor(options: PresenterRemotePeerControlClientOptions) {
+    this.options = options;
+  }
+
+  async start() {
+    if (this.connection) return;
+    this.options.onStatusChange?.('connecting');
+    const peer = this.options.peerFactory?.() ??
+      (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
+    this.peer = peer;
+    const timeoutMs = this.options.connectionTimeoutMs ?? 12_000;
+    await Promise.race([oncePeerOpen(peer), rejectAfter(timeoutMs)]).catch((error: unknown) => {
+      this.options.onStatusChange?.('failed');
+      throw error;
+    });
+    const connection = peer.connect(this.options.presenterPeerId, {
+      label: 'localstudio-presenter-control',
+      serialization: 'json',
+    });
+    this.connection = connection;
+    let connectionOpened = false;
+    const timeoutId = window.setTimeout(() => {
+      if (connectionOpened) return;
+      this.options.onStatusChange?.('failed');
+      connection.close();
+    }, timeoutMs);
+    const handleConnectionOpen = () => {
+      if (connectionOpened) return;
+      connectionOpened = true;
+      window.clearTimeout(timeoutId);
+      this.options.onStatusChange?.('connected');
+      void connection.send({
+        command: 'request-state',
+        type: 'command',
+      } satisfies PresenterRemoteCommand);
+    };
+    connection.on('open', handleConnectionOpen);
+    connection.on('data', (data) => {
+      if (presenterRemoteProtocol.isState(data)) this.options.onState(data);
+    });
+    const handleConnectionFailure = () => {
+      window.clearTimeout(timeoutId);
+      this.options.onStatusChange?.('failed');
+    };
+    connection.on('close', handleConnectionFailure);
+    connection.on('error', handleConnectionFailure);
+    if (connection.open) handleConnectionOpen();
+  }
+
+  sendCommand(command: PresenterRemoteCommand) {
+    if (!this.connection?.open) return false;
+    void this.connection.send(command);
+    return true;
+  }
+
+  close() {
+    this.connection?.close();
+    this.peer?.destroy();
+    this.connection = undefined;
+    this.peer = undefined;
+  }
+}

--- a/packages/presenter-remote/src/peer-control-client.ts
+++ b/packages/presenter-remote/src/peer-control-client.ts
@@ -2,11 +2,14 @@ import { Peer, type DataConnection, type PeerOptions } from 'peerjs';
 import {
   presenterRemoteProtocol,
   type PresenterRemoteCommand,
+  type PresenterRemotePreviewBatch,
   type PresenterRemoteState,
 } from './protocol';
+import { presenterRemoteDebugLog } from './debug-log';
 
 export interface PresenterRemotePeerControlClientOptions {
   connectionTimeoutMs?: number | undefined;
+  onPreviewBatch?: ((batch: PresenterRemotePreviewBatch) => void) | undefined;
   onState: (state: PresenterRemoteState) => void;
   onStatusChange?: ((status: 'connected' | 'connecting' | 'failed') => void) | undefined;
   peerFactory?: (() => Peer) | undefined;
@@ -29,6 +32,7 @@ function rejectAfter(timeoutMs: number) {
 }
 
 export class PresenterRemotePeerControlClient {
+  private closed = false;
   private connection: DataConnection | undefined;
   private readonly options: PresenterRemotePeerControlClientOptions;
   private peer: Peer | undefined;
@@ -39,15 +43,28 @@ export class PresenterRemotePeerControlClient {
 
   async start() {
     if (this.connection) return;
+    this.closed = false;
     this.options.onStatusChange?.('connecting');
-    const peer = this.options.peerFactory?.() ??
+    const peer =
+      this.options.peerFactory?.() ??
       (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
     this.peer = peer;
     const timeoutMs = this.options.connectionTimeoutMs ?? 12_000;
+    presenterRemoteDebugLog.info('Opening control client peer.', {
+      presenterPeerId: this.options.presenterPeerId,
+    });
+    peer.on('error', (error) => presenterRemoteDebugLog.error('Control client peer error.', error));
     await Promise.race([oncePeerOpen(peer), rejectAfter(timeoutMs)]).catch((error: unknown) => {
+      if (this.closed) return;
+      presenterRemoteDebugLog.error('Control client peer failed to open.', error);
       this.options.onStatusChange?.('failed');
       throw error;
     });
+    if (this.closed) {
+      peer.destroy();
+      return;
+    }
+    presenterRemoteDebugLog.info('Control client peer opened.');
     const connection = peer.connect(this.options.presenterPeerId, {
       label: 'localstudio-presenter-control',
       serialization: 'json',
@@ -55,14 +72,17 @@ export class PresenterRemotePeerControlClient {
     this.connection = connection;
     let connectionOpened = false;
     const timeoutId = window.setTimeout(() => {
-      if (connectionOpened) return;
+      if (connectionOpened || this.closed) return;
       this.options.onStatusChange?.('failed');
       connection.close();
     }, timeoutMs);
     const handleConnectionOpen = () => {
-      if (connectionOpened) return;
+      if (connectionOpened || this.closed) return;
       connectionOpened = true;
       window.clearTimeout(timeoutId);
+      presenterRemoteDebugLog.info('Control data connection opened.', {
+        presenterPeerId: this.options.presenterPeerId,
+      });
       this.options.onStatusChange?.('connected');
       void connection.send({
         command: 'request-state',
@@ -71,24 +91,53 @@ export class PresenterRemotePeerControlClient {
     };
     connection.on('open', handleConnectionOpen);
     connection.on('data', (data) => {
-      if (presenterRemoteProtocol.isState(data)) this.options.onState(data);
+      if (presenterRemoteProtocol.isPreviewBatch(data)) {
+        presenterRemoteDebugLog.info('Control preview batch received.', {
+          previewCount: data.previews.length,
+          requestId: data.requestId,
+        });
+        this.options.onPreviewBatch?.(data);
+        return;
+      }
+      if (!presenterRemoteProtocol.isState(data)) {
+        presenterRemoteDebugLog.warn(
+          'Control data message ignored because it is not remote state.',
+        );
+        return;
+      }
+      presenterRemoteDebugLog.info('Control remote state received.', {
+        activePageId: data.activePageId,
+        pageCount: data.pageCount,
+        streamPeerId: data.stream?.peerId,
+      });
+      this.options.onState(data);
     });
-    const handleConnectionFailure = () => {
+    const handleConnectionFailure = (error?: unknown) => {
+      if (this.closed) return;
       window.clearTimeout(timeoutId);
+      presenterRemoteDebugLog.warn('Control data connection failed or closed.', error);
       this.options.onStatusChange?.('failed');
     };
-    connection.on('close', handleConnectionFailure);
+    connection.on('close', () => handleConnectionFailure());
     connection.on('error', handleConnectionFailure);
     if (connection.open) handleConnectionOpen();
   }
 
   sendCommand(command: PresenterRemoteCommand) {
     if (!this.connection?.open) return false;
-    void this.connection.send(command);
+    try {
+      void this.connection.send(command);
+      presenterRemoteDebugLog.info('Control command sent.', { command: command.command });
+    } catch (error) {
+      presenterRemoteDebugLog.error('Failed to send control command.', error);
+      return false;
+    }
     return true;
   }
 
   close() {
+    this.closed = true;
+    presenterRemoteDebugLog.info('Closing control client peer.');
     this.connection?.close();
     this.peer?.destroy();
     this.connection = undefined;

--- a/packages/presenter-remote/src/peer-control-host.ts
+++ b/packages/presenter-remote/src/peer-control-host.ts
@@ -2,9 +2,14 @@ import { Peer, type DataConnection, type PeerOptions } from 'peerjs';
 import {
   presenterRemoteProtocol,
   type PresenterRemoteCommand,
+  type PresenterRemoteMessage,
+  type PresenterRemotePreviewBatch,
   type PresenterRemoteSession,
   type PresenterRemoteState,
 } from './protocol';
+import { presenterRemoteDebugLog } from './debug-log';
+
+const peerDataChannelMaxStateBytes = 16_000;
 
 export interface PresenterRemotePeerSession extends PresenterRemoteSession {
   controlPeerId: string;
@@ -58,14 +63,18 @@ export class PresenterRemotePeerControlHost {
 
   async open(): Promise<PresenterRemotePeerSession> {
     if (this.session) return this.session;
-    const peer = this.options.peerFactory?.() ??
+    const peer =
+      this.options.peerFactory?.() ??
       (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
     this.peer = peer;
+    presenterRemoteDebugLog.info('Opening control host peer.');
     peer.on('connection', (connection) => this.registerConnection(connection));
+    peer.on('error', (error) => presenterRemoteDebugLog.error('Control host peer error.', error));
     const controlPeerId = await Promise.race([
       oncePeerOpen(peer),
       rejectAfter(this.options.connectionTimeoutMs ?? 12_000),
     ]);
+    presenterRemoteDebugLog.info('Control host peer opened.', { controlPeerId });
     this.session = {
       code: controlPeerId,
       connectedControllerCount: 0,
@@ -80,16 +89,34 @@ export class PresenterRemotePeerControlHost {
   }
 
   publishState(state: PresenterRemoteState) {
-    this.lastState = {
+    this.lastState = createDataChannelSafeState({
       ...state,
       connectedControllerCount: this.connections.size,
-    };
+    });
+    presenterRemoteDebugLog.info('Publishing remote state.', {
+      activePageId: this.lastState.activePageId,
+      connectedControllerCount: this.connections.size,
+      hasSlidePreview: Boolean(this.lastState.slidePreview),
+      streamPeerId: this.lastState.stream?.peerId,
+    });
     for (const connection of this.connections) {
-      if (connection.open) void connection.send(this.lastState);
+      this.sendMessage(connection, this.lastState, 'remote state');
+    }
+  }
+
+  publishPreviewBatch(batch: PresenterRemotePreviewBatch) {
+    presenterRemoteDebugLog.info('Publishing preview batch.', {
+      previewCount: batch.previews.length,
+      requestId: batch.requestId,
+      stateBytes: getJsonByteLength(batch),
+    });
+    for (const connection of this.connections) {
+      this.sendMessage(connection, batch, 'preview batch');
     }
   }
 
   close() {
+    presenterRemoteDebugLog.info('Closing control host peer.');
     for (const connection of this.connections) connection.close();
     this.connections.clear();
     this.peer?.destroy();
@@ -99,31 +126,96 @@ export class PresenterRemotePeerControlHost {
   }
 
   private registerConnection(connection: DataConnection) {
+    presenterRemoteDebugLog.info('Control connection received.');
     const addConnection = () => {
       this.connections.add(connection);
+      presenterRemoteDebugLog.info('Control connection opened.', {
+        connectedControllerCount: this.connections.size,
+      });
       if (this.lastState) {
-        void connection.send({
-          ...this.lastState,
-          connectedControllerCount: this.connections.size,
-        });
+        this.sendMessage(
+          connection,
+          {
+            ...this.lastState,
+            connectedControllerCount: this.connections.size,
+          },
+          'initial remote state',
+        );
       }
     };
     connection.on('open', addConnection);
     if (connection.open) addConnection();
     connection.on('data', (data) => {
       if (!presenterRemoteProtocol.isCommand(data)) return;
-      if (data.command === 'request-state' && this.lastState && connection.open) {
-        void connection.send({
-          ...this.lastState,
-          connectedControllerCount: this.connections.size,
-        });
+      presenterRemoteDebugLog.info('Control command received.', { command: data.command });
+      if (data.command === 'request-state' && this.lastState) {
+        this.sendMessage(
+          connection,
+          {
+            ...this.lastState,
+            connectedControllerCount: this.connections.size,
+          },
+          'requested remote state',
+        );
       }
       this.onCommand?.(data);
     });
     const removeConnection = () => {
       this.connections.delete(connection);
+      presenterRemoteDebugLog.info('Control connection closed.', {
+        connectedControllerCount: this.connections.size,
+      });
     };
     connection.on('close', removeConnection);
-    connection.on('error', removeConnection);
+    connection.on('error', (error) => {
+      presenterRemoteDebugLog.error('Control connection error.', error);
+      removeConnection();
+    });
+  }
+
+  private sendMessage(connection: DataConnection, message: PresenterRemoteMessage, label: string) {
+    try {
+      presenterRemoteDebugLog.info(`Sending ${label} over data connection.`, {
+        pagesWithPreviewCount:
+          message.type === 'state'
+            ? (message.pages?.filter((page) => Boolean(page.preview)).length ?? 0)
+            : message.previews.filter((page) => Boolean(page.preview)).length,
+        stateBytes: getJsonByteLength(message),
+      });
+      void connection.send(message);
+    } catch (error) {
+      presenterRemoteDebugLog.error(`Failed to send ${label}.`, error);
+    }
+  }
+}
+
+function createDataChannelSafeState(state: PresenterRemoteState): PresenterRemoteState {
+  const stateBytes = getJsonByteLength(state);
+  if (stateBytes <= peerDataChannelMaxStateBytes) return state;
+  const safeState: PresenterRemoteState = {
+    ...state,
+    nextSlidePreview: undefined,
+    pages: state.pages?.map((page) => ({
+      id: page.id,
+      name: page.name,
+    })),
+    slidePreview: undefined,
+    upcomingSlidePreviews: [],
+  };
+  presenterRemoteDebugLog.warn(
+    'Remote state was too large for PeerJS data channel; using stream-only state.',
+    {
+      safeBytes: getJsonByteLength(safeState),
+      stateBytes,
+    },
+  );
+  return safeState;
+}
+
+function getJsonByteLength(value: unknown) {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
   }
 }

--- a/packages/presenter-remote/src/peer-control-host.ts
+++ b/packages/presenter-remote/src/peer-control-host.ts
@@ -1,0 +1,129 @@
+import { Peer, type DataConnection, type PeerOptions } from 'peerjs';
+import {
+  presenterRemoteProtocol,
+  type PresenterRemoteCommand,
+  type PresenterRemoteSession,
+  type PresenterRemoteState,
+} from './protocol';
+
+export interface PresenterRemotePeerSession extends PresenterRemoteSession {
+  controlPeerId: string;
+  transport: 'peerjs';
+}
+
+export interface PresenterRemotePeerControlHostOptions {
+  connectionTimeoutMs?: number | undefined;
+  now?: (() => number) | undefined;
+  onCommand?: ((command: PresenterRemoteCommand) => void) | undefined;
+  peerFactory?: (() => Peer) | undefined;
+  peerOptions?: PeerOptions | undefined;
+  presenterDeviceId?: string | undefined;
+  presenterLabel: string;
+  ttlMs: number;
+}
+
+function createSessionId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  return `peer-session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function oncePeerOpen(peer: Peer) {
+  if (peer.open && peer.id) return Promise.resolve(peer.id);
+  return new Promise<string>((resolve, reject) => {
+    peer.on('open', resolve);
+    peer.on('error', reject);
+  });
+}
+
+function rejectAfter(timeoutMs: number) {
+  return new Promise<never>((_, reject) => {
+    window.setTimeout(() => reject(new Error('PeerJS host connection timed out.')), timeoutMs);
+  });
+}
+
+export class PresenterRemotePeerControlHost {
+  private readonly connections = new Set<DataConnection>();
+  private readonly now: () => number;
+  private readonly onCommand: ((command: PresenterRemoteCommand) => void) | undefined;
+  private readonly options: PresenterRemotePeerControlHostOptions;
+  private lastState: PresenterRemoteState | undefined;
+  private peer: Peer | undefined;
+  private session: PresenterRemotePeerSession | undefined;
+
+  constructor(options: PresenterRemotePeerControlHostOptions) {
+    this.now = options.now ?? Date.now;
+    this.onCommand = options.onCommand;
+    this.options = options;
+  }
+
+  async open(): Promise<PresenterRemotePeerSession> {
+    if (this.session) return this.session;
+    const peer = this.options.peerFactory?.() ??
+      (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
+    this.peer = peer;
+    peer.on('connection', (connection) => this.registerConnection(connection));
+    const controlPeerId = await Promise.race([
+      oncePeerOpen(peer),
+      rejectAfter(this.options.connectionTimeoutMs ?? 12_000),
+    ]);
+    this.session = {
+      code: controlPeerId,
+      connectedControllerCount: 0,
+      controlPeerId,
+      expiresAt: new Date(this.now() + this.options.ttlMs).toISOString(),
+      presenterDeviceId: this.options.presenterDeviceId ?? this.options.presenterLabel,
+      presenterLabel: this.options.presenterLabel,
+      sessionId: createSessionId(),
+      transport: 'peerjs',
+    };
+    return this.session;
+  }
+
+  publishState(state: PresenterRemoteState) {
+    this.lastState = {
+      ...state,
+      connectedControllerCount: this.connections.size,
+    };
+    for (const connection of this.connections) {
+      if (connection.open) void connection.send(this.lastState);
+    }
+  }
+
+  close() {
+    for (const connection of this.connections) connection.close();
+    this.connections.clear();
+    this.peer?.destroy();
+    this.peer = undefined;
+    this.session = undefined;
+    this.lastState = undefined;
+  }
+
+  private registerConnection(connection: DataConnection) {
+    const addConnection = () => {
+      this.connections.add(connection);
+      if (this.lastState) {
+        void connection.send({
+          ...this.lastState,
+          connectedControllerCount: this.connections.size,
+        });
+      }
+    };
+    connection.on('open', addConnection);
+    if (connection.open) addConnection();
+    connection.on('data', (data) => {
+      if (!presenterRemoteProtocol.isCommand(data)) return;
+      if (data.command === 'request-state' && this.lastState && connection.open) {
+        void connection.send({
+          ...this.lastState,
+          connectedControllerCount: this.connections.size,
+        });
+      }
+      this.onCommand?.(data);
+    });
+    const removeConnection = () => {
+      this.connections.delete(connection);
+    };
+    connection.on('close', removeConnection);
+    connection.on('error', removeConnection);
+  }
+}

--- a/packages/presenter-remote/src/peer-stream-publisher.ts
+++ b/packages/presenter-remote/src/peer-stream-publisher.ts
@@ -1,0 +1,45 @@
+import { Peer, type MediaConnection, type PeerOptions } from 'peerjs';
+
+export interface PresenterRemotePeerStreamPublisherOptions {
+  peerFactory?: (() => Peer) | undefined;
+  peerOptions?: PeerOptions | undefined;
+  stream: MediaStream;
+}
+
+function oncePeerOpen(peer: Peer) {
+  if (peer.open && peer.id) return Promise.resolve(peer.id);
+  return new Promise<string>((resolve, reject) => {
+    peer.on('open', resolve);
+    peer.on('error', reject);
+  });
+}
+
+export class PresenterRemotePeerStreamPublisher {
+  private readonly calls = new Set<MediaConnection>();
+  private readonly options: PresenterRemotePeerStreamPublisherOptions;
+  private peer: Peer | undefined;
+
+  constructor(options: PresenterRemotePeerStreamPublisherOptions) {
+    this.options = options;
+  }
+
+  async start() {
+    const peer = this.options.peerFactory?.() ??
+      (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
+    this.peer = peer;
+    peer.on('call', (call) => {
+      this.calls.add(call);
+      call.on('close', () => this.calls.delete(call));
+      call.on('error', () => this.calls.delete(call));
+      call.answer(this.options.stream);
+    });
+    return oncePeerOpen(peer);
+  }
+
+  stop() {
+    for (const call of this.calls) call.close();
+    this.calls.clear();
+    this.peer?.destroy();
+    this.peer = undefined;
+  }
+}

--- a/packages/presenter-remote/src/peer-stream-publisher.ts
+++ b/packages/presenter-remote/src/peer-stream-publisher.ts
@@ -1,4 +1,5 @@
 import { Peer, type MediaConnection, type PeerOptions } from 'peerjs';
+import { presenterRemoteDebugLog } from './debug-log';
 
 export interface PresenterRemotePeerStreamPublisherOptions {
   peerFactory?: (() => Peer) | undefined;
@@ -24,19 +25,37 @@ export class PresenterRemotePeerStreamPublisher {
   }
 
   async start() {
-    const peer = this.options.peerFactory?.() ??
+    const peer =
+      this.options.peerFactory?.() ??
       (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
     this.peer = peer;
-    peer.on('call', (call) => {
-      this.calls.add(call);
-      call.on('close', () => this.calls.delete(call));
-      call.on('error', () => this.calls.delete(call));
-      call.answer(this.options.stream);
+    presenterRemoteDebugLog.info('Opening stream publisher peer.', {
+      trackCount: this.options.stream.getTracks().length,
     });
-    return oncePeerOpen(peer);
+    peer.on('error', (error) =>
+      presenterRemoteDebugLog.error('Stream publisher peer error.', error),
+    );
+    peer.on('call', (call) => {
+      presenterRemoteDebugLog.info('Stream publisher media call received.');
+      this.calls.add(call);
+      call.on('close', () => {
+        presenterRemoteDebugLog.info('Stream publisher media call closed.');
+        this.calls.delete(call);
+      });
+      call.on('error', (error) => {
+        presenterRemoteDebugLog.error('Stream publisher media call error.', error);
+        this.calls.delete(call);
+      });
+      call.answer(this.options.stream);
+      presenterRemoteDebugLog.info('Stream publisher answered media call.');
+    });
+    const peerId = await oncePeerOpen(peer);
+    presenterRemoteDebugLog.info('Stream publisher peer opened.', { peerId });
+    return peerId;
   }
 
   stop() {
+    presenterRemoteDebugLog.info('Closing stream publisher peer.');
     for (const call of this.calls) call.close();
     this.calls.clear();
     this.peer?.destroy();

--- a/packages/presenter-remote/src/peer-stream-receiver.ts
+++ b/packages/presenter-remote/src/peer-stream-receiver.ts
@@ -1,4 +1,5 @@
 import { Peer, type MediaConnection, type PeerOptions } from 'peerjs';
+import { presenterRemoteDebugLog } from './debug-log';
 
 export interface PresenterRemotePeerStreamReceiverOptions {
   onStatusChange: (status: 'connected' | 'connecting' | 'failed') => void;
@@ -19,6 +20,7 @@ function oncePeerOpen(peer: Peer) {
 export class PresenterRemotePeerStreamReceiver {
   private call: MediaConnection | undefined;
   private readonly options: PresenterRemotePeerStreamReceiverOptions;
+  private outgoingStream: MediaStream | undefined;
   private peer: Peer | undefined;
 
   constructor(options: PresenterRemotePeerStreamReceiverOptions) {
@@ -27,25 +29,63 @@ export class PresenterRemotePeerStreamReceiver {
 
   async start() {
     this.options.onStatusChange('connecting');
-    const peer = this.options.peerFactory?.() ??
+    const peer =
+      this.options.peerFactory?.() ??
       (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
     this.peer = peer;
+    presenterRemoteDebugLog.info('Opening stream receiver peer.', {
+      streamPeerId: this.options.streamPeerId,
+    });
+    peer.on('error', (error) =>
+      presenterRemoteDebugLog.error('Stream receiver peer error.', error),
+    );
     await oncePeerOpen(peer);
-    const call = peer.call(this.options.streamPeerId, new MediaStream());
+    presenterRemoteDebugLog.info('Stream receiver peer opened.');
+    this.outgoingStream = createReceiverOfferStream();
+    const call = peer.call(this.options.streamPeerId, this.outgoingStream);
     this.call = call;
+    presenterRemoteDebugLog.info('Stream receiver media call started.', {
+      streamPeerId: this.options.streamPeerId,
+    });
     call.on('stream', (stream) => {
+      presenterRemoteDebugLog.info('Stream receiver media stream received.', {
+        trackCount: stream.getTracks().length,
+      });
       this.options.onStream(stream);
       this.options.onStatusChange('connected');
     });
-    call.on('close', () => this.options.onStatusChange('failed'));
-    call.on('error', () => this.options.onStatusChange('failed'));
+    call.on('close', () => {
+      presenterRemoteDebugLog.warn('Stream receiver media call closed.');
+      this.options.onStatusChange('failed');
+    });
+    call.on('error', (error) => {
+      presenterRemoteDebugLog.error('Stream receiver media call error.', error);
+      this.options.onStatusChange('failed');
+    });
   }
 
   stop() {
+    presenterRemoteDebugLog.info('Closing stream receiver peer.');
     this.call?.close();
     this.peer?.destroy();
+    this.outgoingStream?.getTracks().forEach((track) => track.stop());
     this.call = undefined;
+    this.outgoingStream = undefined;
     this.peer = undefined;
     this.options.onStream(undefined);
   }
+}
+
+function createReceiverOfferStream() {
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext('2d');
+    context?.fillRect(0, 0, 1, 1);
+    if (typeof canvas.captureStream === 'function') {
+      return canvas.captureStream(1);
+    }
+  }
+  return new MediaStream();
 }

--- a/packages/presenter-remote/src/peer-stream-receiver.ts
+++ b/packages/presenter-remote/src/peer-stream-receiver.ts
@@ -1,0 +1,51 @@
+import { Peer, type MediaConnection, type PeerOptions } from 'peerjs';
+
+export interface PresenterRemotePeerStreamReceiverOptions {
+  onStatusChange: (status: 'connected' | 'connecting' | 'failed') => void;
+  onStream: (stream: MediaStream | undefined) => void;
+  peerFactory?: (() => Peer) | undefined;
+  peerOptions?: PeerOptions | undefined;
+  streamPeerId: string;
+}
+
+function oncePeerOpen(peer: Peer) {
+  if (peer.open) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    peer.on('open', () => resolve());
+    peer.on('error', reject);
+  });
+}
+
+export class PresenterRemotePeerStreamReceiver {
+  private call: MediaConnection | undefined;
+  private readonly options: PresenterRemotePeerStreamReceiverOptions;
+  private peer: Peer | undefined;
+
+  constructor(options: PresenterRemotePeerStreamReceiverOptions) {
+    this.options = options;
+  }
+
+  async start() {
+    this.options.onStatusChange('connecting');
+    const peer = this.options.peerFactory?.() ??
+      (this.options.peerOptions ? new Peer(this.options.peerOptions) : new Peer());
+    this.peer = peer;
+    await oncePeerOpen(peer);
+    const call = peer.call(this.options.streamPeerId, new MediaStream());
+    this.call = call;
+    call.on('stream', (stream) => {
+      this.options.onStream(stream);
+      this.options.onStatusChange('connected');
+    });
+    call.on('close', () => this.options.onStatusChange('failed'));
+    call.on('error', () => this.options.onStatusChange('failed'));
+  }
+
+  stop() {
+    this.call?.close();
+    this.peer?.destroy();
+    this.call = undefined;
+    this.peer = undefined;
+    this.options.onStream(undefined);
+  }
+}

--- a/packages/presenter-remote/src/protocol.ts
+++ b/packages/presenter-remote/src/protocol.ts
@@ -4,6 +4,7 @@ export type PresenterRemoteCommand =
   | { command: 'next'; type: 'command' }
   | { command: 'pause-timer'; type: 'command' }
   | { command: 'previous'; type: 'command' }
+  | { command: 'request-previews'; pageIds: string[]; requestId?: string; type: 'command' }
   | { command: 'request-state'; type: 'command' }
   | { command: 'reset-timer'; type: 'command' }
   | { command: 'resume-timer'; type: 'command' }
@@ -98,6 +99,13 @@ export interface PresenterRemoteState {
   activePageId: string;
   activePageIndex: number;
   activePageName?: string | undefined;
+  builds?:
+    | {
+        current: number;
+        remaining: number;
+        total: number;
+      }
+    | undefined;
   buildsRemaining: number;
   commandAvailability?: string[] | undefined;
   connectedControllerCount: number;
@@ -125,6 +133,14 @@ export interface PresenterRemoteState {
   type: 'state';
   upcomingSlidePreviews?: PresenterRemoteUpcomingSlidePreview[] | undefined;
 }
+
+export interface PresenterRemotePreviewBatch {
+  previews: PresenterRemotePageSummary[];
+  requestId?: string | undefined;
+  type: 'preview-batch';
+}
+
+export type PresenterRemoteMessage = PresenterRemotePreviewBatch | PresenterRemoteState;
 
 export interface PresenterRemoteSession {
   code: string;
@@ -241,6 +257,13 @@ function isCommand(value: unknown): value is PresenterRemoteCommand {
     return true;
   }
   if (value.command === 'go-to-page') return typeof value.pageId === 'string';
+  if (value.command === 'request-previews') {
+    return (
+      Array.isArray(value.pageIds) &&
+      value.pageIds.every((pageId) => typeof pageId === 'string') &&
+      (value.requestId === undefined || typeof value.requestId === 'string')
+    );
+  }
   if (value.command === 'update-notes') {
     return typeof value.pageId === 'string' && typeof value.notes === 'string';
   }
@@ -273,6 +296,11 @@ function isState(value: unknown): value is PresenterRemoteState {
     typeof value.activePageId === 'string' &&
     typeof value.activePageIndex === 'number' &&
     (value.activePageName === undefined || typeof value.activePageName === 'string') &&
+    (value.builds === undefined ||
+      (isRecord(value.builds) &&
+        typeof value.builds.current === 'number' &&
+        typeof value.builds.remaining === 'number' &&
+        typeof value.builds.total === 'number')) &&
     typeof value.buildsRemaining === 'number' &&
     (value.commandAvailability === undefined || isStringArray(value.commandAvailability)) &&
     typeof value.connectedControllerCount === 'number' &&
@@ -300,6 +328,16 @@ function isState(value: unknown): value is PresenterRemoteState {
   );
 }
 
+function isPreviewBatch(value: unknown): value is PresenterRemotePreviewBatch {
+  return (
+    isRecord(value) &&
+    value.type === 'preview-batch' &&
+    Array.isArray(value.previews) &&
+    value.previews.every(isPageSummary) &&
+    (value.requestId === undefined || typeof value.requestId === 'string')
+  );
+}
+
 function isSession(value: unknown): value is PresenterRemoteSession {
   if (!isRecord(value)) return false;
   return (
@@ -314,6 +352,7 @@ function isSession(value: unknown): value is PresenterRemoteSession {
 
 export const presenterRemoteProtocol = {
   isCommand,
+  isPreviewBatch,
   isSession,
   isState,
   isStreamPreference,

--- a/packages/presenter-remote/src/protocol.ts
+++ b/packages/presenter-remote/src/protocol.ts
@@ -116,6 +116,8 @@ export interface PresenterRemoteState {
         enabled: boolean;
         fps: number;
         height: number;
+        peerId?: string | undefined;
+        transport?: 'peerjs' | undefined;
         width: number;
       }
     | undefined;
@@ -133,6 +135,11 @@ export interface PresenterRemoteSession {
   sessionId: string;
 }
 
+export interface PresenterRemotePeerSession extends PresenterRemoteSession {
+  controlPeerId: string;
+  transport: 'peerjs';
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object';
 }
@@ -147,6 +154,8 @@ function isStreamMetadata(value: unknown) {
     typeof value.enabled === 'boolean' &&
     typeof value.fps === 'number' &&
     typeof value.height === 'number' &&
+    (value.peerId === undefined || typeof value.peerId === 'string') &&
+    (value.transport === undefined || value.transport === 'peerjs') &&
     typeof value.width === 'number'
   );
 }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { createServer as createViteServer } from 'vite';
 
 const host = '0.0.0.0';
-const port = 4173;
+const port = getPort();
 
 const apps = [
   {
@@ -135,3 +135,12 @@ async function shutdown(code = 0) {
 
 process.on('SIGINT', () => void shutdown(0));
 process.on('SIGTERM', () => void shutdown(0));
+
+function getPort() {
+  const rawPort = process.env.PORT ?? '4173';
+  const parsedPort = Number.parseInt(rawPort, 10);
+  if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65_535) {
+    throw new Error(`Invalid PORT value: ${rawPort}`);
+  }
+  return parsedPort;
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -51,8 +51,9 @@ for (const app of apps) {
 
 httpServer.on('request', (request, response) => {
   const app =
-    viteServers.find((candidate) => candidate.base !== '/' && request.url?.startsWith(candidate.base)) ??
-    viteServers.find((candidate) => candidate.base === '/');
+    viteServers.find(
+      (candidate) => candidate.base !== '/' && request.url?.startsWith(candidate.base),
+    ) ?? viteServers.find((candidate) => candidate.base === '/');
   if (shouldServeIndex(request.url)) {
     void serveIndex(app, request, response);
     return;


### PR DESCRIPTION
## Summary
- Tighten presenter remote session lifecycle and protocol handling for mobile publishing flows.
- Update editor and presenter UI wiring to support the revised remote stream behavior.
- Refresh joystick UI and associated tests to align with the new presenter interaction path.

## Testing
- Updated unit coverage across presenter session, editor shell, and presenter UI modules.
- Updated joystick unit tests.
- Not run (not requested).