### PR TITLE
Fix permission handling when creating browser project folders

### DIFF
--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -339,10 +339,15 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     const requestedProjectDirectoryName =
       options?.projectDirectoryName?.trim() ||
       (this.parentDirectoryHandle && projectName?.trim() ? projectName.trim() : undefined);
+    let hasParentDirectoryPermission = false;
 
     if (!this.directoryHandle) {
       const pickDirectory = this.options.pickDirectory ?? getBrowserDirectoryPicker();
       const selectedDirectoryHandle = await pickDirectory();
+      if (requestedProjectDirectoryName) {
+        await this.ensureReadWritePermission(selectedDirectoryHandle);
+        hasParentDirectoryPermission = true;
+      }
       this.parentDirectoryHandle = requestedProjectDirectoryName ? selectedDirectoryHandle : null;
       this.projectDirectoryName = requestedProjectDirectoryName ?? selectedDirectoryHandle.name ?? null;
       this.directoryHandle = requestedProjectDirectoryName
@@ -355,6 +360,8 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       this.parentDirectoryHandle &&
       requestedProjectDirectoryName !== this.projectDirectoryName
     ) {
+      await this.ensureReadWritePermission(this.parentDirectoryHandle);
+      hasParentDirectoryPermission = true;
       this.directoryHandle = await this.parentDirectoryHandle.getDirectoryHandle(
         requestedProjectDirectoryName,
         { create: true },
@@ -362,7 +369,9 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       this.projectDirectoryName = requestedProjectDirectoryName;
     }
     const directoryHandle = this.directoryHandle;
-    await this.ensureReadWritePermission(directoryHandle);
+    if (!hasParentDirectoryPermission) {
+      await this.ensureReadWritePermission(directoryHandle);
+    }
     await this.recentProjectStore.save(directoryHandle, projectName);
     return directoryHandle;
   }

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
@@ -44,7 +44,11 @@ class MockFileHandle {
 }
 
 class MockDirectoryHandle {
-  constructor(readonly name = 'LocalStudio Project') {}
+  constructor(
+    readonly name = 'LocalStudio Project',
+    private readonly permissionState: PermissionState = 'granted',
+    private readonly childPermissionState: PermissionState = permissionState,
+  ) {}
 
   readonly files = new Map<string, string | Blob>();
   readonly directories = new Map<string, MockDirectoryHandle>();
@@ -59,17 +63,20 @@ class MockDirectoryHandle {
   getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<MockDirectoryHandle> {
     if (!this.directories.has(name)) {
       if (!options?.create) throw new DOMException('Not found', 'NotFoundError');
-      this.directories.set(name, new MockDirectoryHandle(name));
+      this.directories.set(
+        name,
+        new MockDirectoryHandle(name, this.childPermissionState, this.childPermissionState),
+      );
     }
     return Promise.resolve(this.directories.get(name)!);
   }
 
   queryPermission(): Promise<PermissionState> {
-    return Promise.resolve('granted');
+    return Promise.resolve(this.permissionState);
   }
 
   requestPermission(): Promise<PermissionState> {
-    return Promise.resolve('granted');
+    return Promise.resolve(this.permissionState);
   }
 
   removeEntry(name: string): Promise<void> {
@@ -144,6 +151,23 @@ describe('BrowserFileSystemProjectRepository', () => {
 
   it('creates a named child project folder during initial persistence setup', async () => {
     const parentDirectory = new MockDirectoryHandle('Projects');
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory: () => Promise.resolve(parentDirectory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+    const project = { ...sampleProject.createSampleProject(), name: 'Launch Deck' };
+
+    await repository.saveProject(project, { projectDirectoryName: 'Launch Deck' });
+
+    const projectDirectory = parentDirectory.directories.get('Launch Deck')!;
+    expect(projectDirectory).toBeDefined();
+    expect(JSON.parse(await readMockText(projectDirectory.files.get('project.json')!))).toMatchObject({
+      name: 'Launch Deck',
+    });
+  });
+
+  it('uses the picked parent permission when creating the named project folder', async () => {
+    const parentDirectory = new MockDirectoryHandle('Projects', 'granted', 'denied');
     const repository = new BrowserFileSystemProjectRepository({
       pickDirectory: () => Promise.resolve(parentDirectory as unknown as FileSystemDirectoryHandle),
       recentProjectStore: new MemoryRecentProjectHandleStore(),


### PR DESCRIPTION
## Summary
- Request read/write permission on the picked parent directory before creating a named project folder
- Avoid a redundant permission prompt on the child directory when the parent permission already covers the save flow
- Extend the unit test coverage for parent-directory saves with a denied child permission state

## Testing
- Added unit coverage for saving into a named project folder from a picked parent directory
- Not run (not requested)