### PR TITLE
Generate video thumbnails for remote presenter previews

### DIFF
--- a/apps/editor/src/services/presenter/presenterSessionService.ts
+++ b/apps/editor/src/services/presenter/presenterSessionService.ts
@@ -763,8 +763,14 @@ function createSlidePreviewElement(
     }));
   }
   if (element.type === 'gif' || element.type === 'video') {
-    return Promise.resolve({
+    const asset = project.assets[element.assetId];
+    const posterFrameSeconds =
+      element.type === 'video'
+        ? element.posterFrameSeconds ?? element.trimStartSeconds
+        : undefined;
+    return createPreviewMediaAssetUrl(asset?.objectUrl, element.type, posterFrameSeconds).then((assetUrl) => ({
       ...frame,
+      assetUrl,
       autoplay:
         element.type === 'gif' ? element.playing : element.autoplayInPreview || element.playing,
       controls: element.type === 'video' ? element.controls : false,
@@ -772,7 +778,7 @@ function createSlidePreviewElement(
       loop: element.type === 'gif' ? element.playing : element.loop,
       mediaType: element.type,
       muted: element.type === 'video' ? element.muted : true,
-    });
+    }));
   }
   return Promise.resolve({
     ...frame,
@@ -798,6 +804,23 @@ async function createPreviewAssetUrl(assetUrl: string | undefined) {
     return createThumbnailDataUrl(assetUrl).catch(() => undefined);
   }
   return assetUrl;
+}
+
+async function createPreviewMediaAssetUrl(
+  assetUrl: string | undefined,
+  mediaType: 'gif' | 'video',
+  posterFrameSeconds: number | undefined,
+) {
+  if (!assetUrl) return undefined;
+  if (mediaType === 'gif') return createPreviewAssetUrl(assetUrl);
+  if (isTestRuntime() && /^https?:\/\//.test(assetUrl)) {
+    return undefined;
+  }
+  if (assetUrl.startsWith('data:image/')) return createPreviewAssetUrl(assetUrl);
+  if (assetUrl.startsWith('data:') || assetUrl.startsWith('blob:') || /^https?:\/\//.test(assetUrl)) {
+    return createVideoThumbnailDataUrl(assetUrl, posterFrameSeconds).catch(() => undefined);
+  }
+  return undefined;
 }
 
 function createThumbnailDataUrl(assetUrl: string) {
@@ -839,6 +862,97 @@ function createThumbnailDataUrl(assetUrl: string) {
       resolve(undefined);
     };
     image.src = assetUrl;
+  });
+}
+
+function createVideoThumbnailDataUrl(assetUrl: string, posterFrameSeconds: number | undefined) {
+  if (typeof document === 'undefined') return Promise.resolve(undefined);
+  return new Promise<string | undefined>((resolve) => {
+    const video = document.createElement('video');
+    let settled = false;
+    const timeoutId = window.setTimeout(() => {
+      finish(undefined);
+    }, 1500);
+
+    function cleanup() {
+      window.clearTimeout(timeoutId);
+      video.onerror = null;
+      video.onloadeddata = null;
+      video.onloadedmetadata = null;
+      video.onseeked = null;
+      video.removeAttribute('src');
+      try {
+        video.load();
+      } catch {
+        // Some test and embedded browser media implementations expose load() without implementing it.
+      }
+    }
+
+    function finish(dataUrl: string | undefined) {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(dataUrl);
+    }
+
+    function resolveWithFrame() {
+      try {
+        const sourceWidth = video.videoWidth;
+        const sourceHeight = video.videoHeight;
+        if (!sourceWidth || !sourceHeight) {
+          finish(undefined);
+          return;
+        }
+        const scale = Math.min(
+          1,
+          remotePreviewThumbnailMaxEdge / Math.max(sourceWidth, sourceHeight),
+        );
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(sourceWidth * scale));
+        canvas.height = Math.max(1, Math.round(sourceHeight * scale));
+        const context = canvas.getContext('2d');
+        if (!context) {
+          finish(undefined);
+          return;
+        }
+        context.drawImage(video, 0, 0, canvas.width, canvas.height);
+        finish(canvas.toDataURL('image/jpeg', remotePreviewThumbnailQuality));
+      } catch (error) {
+        presenterRemoteDebugLog.warn('Remote preview video thumbnail generation failed.', error);
+        finish(undefined);
+      }
+    }
+
+    function handleLoadedMetadata() {
+      const targetTime = Math.max(0, posterFrameSeconds ?? 0);
+      if (!Number.isFinite(targetTime) || Math.abs(video.currentTime - targetTime) < 0.05) {
+        resolveWithFrame();
+        return;
+      }
+      try {
+        video.currentTime = Math.min(targetTime, video.duration || targetTime);
+      } catch {
+        resolveWithFrame();
+      }
+    }
+
+    video.crossOrigin = 'anonymous';
+    video.muted = true;
+    video.playsInline = true;
+    video.preload = 'metadata';
+    video.onloadedmetadata = handleLoadedMetadata;
+    video.onseeked = resolveWithFrame;
+    video.onloadeddata = () => {
+      if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA && video.currentTime === 0) {
+        resolveWithFrame();
+      }
+    };
+    video.onerror = () => {
+      presenterRemoteDebugLog.warn('Remote preview video thumbnail failed to load.');
+      finish(undefined);
+    };
+    video.src = assetUrl;
+    video.load();
   });
 }
 

--- a/apps/editor/tests/unit/services/presenterRemoteSessionService.test.ts
+++ b/apps/editor/tests/unit/services/presenterRemoteSessionService.test.ts
@@ -565,6 +565,114 @@ describe('BrowserPresenterSessionService remote control', () => {
     );
   });
 
+  it('publishes generated video thumbnails for remote slide previews', async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const fakeCanvas = {
+      getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+      height: 0,
+      toDataURL: vi.fn(() => 'data:image/jpeg;base64,video-thumbnail'),
+      width: 0,
+    };
+    const fakeVideo = {
+      crossOrigin: '',
+      currentTime: 0,
+      duration: 12,
+      load: vi.fn(),
+      muted: false,
+      onerror: undefined as (() => void) | undefined,
+      onloadeddata: undefined as (() => void) | undefined,
+      onloadedmetadata: undefined as (() => void) | undefined,
+      onseeked: undefined as (() => void) | undefined,
+      playsInline: false,
+      preload: '',
+      readyState: 2,
+      removeAttribute: vi.fn(),
+      src: '',
+      videoHeight: 720,
+      videoWidth: 1280,
+    };
+    const createElement = vi.spyOn(document, 'createElement');
+    createElement.mockImplementation((tagName: string) => {
+      if (tagName === 'video') return fakeVideo as unknown as HTMLVideoElement;
+      if (tagName === 'canvas') return fakeCanvas as unknown as HTMLCanvasElement;
+      return originalCreateElement(tagName);
+    });
+    const popup = {
+      location: { href: '' },
+      postMessage: vi.fn(),
+      closed: false,
+    } as unknown as Window;
+    const signalingService = new InMemoryPresenterRemoteSignalingService({
+      randomCode: () => 'ABCD-1234',
+      randomId: () => 'remote-session-1',
+    });
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/?project=Demo',
+      openWindow: vi.fn(() => popup),
+      randomId: () => 'session-1',
+      remoteSignalingService: signalingService,
+    });
+    service.openPresenterWindow();
+    await service.openRemoteControlSession({ presenterLabel: 'MacBook Pro', ttlMs: 60_000 });
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0]!;
+    project.assets['video-thumbnail-asset'] = {
+      id: 'video-thumbnail-asset',
+      mimeType: 'video/mp4',
+      name: 'Thumbnail demo',
+      objectUrl: 'blob:thumbnail-demo',
+      storage: 'remote',
+      type: 'video',
+    };
+    project.elements['video-thumbnail-element'] = {
+      assetId: 'video-thumbnail-asset',
+      autoplayInPreview: false,
+      controls: false,
+      durationSeconds: 12,
+      height: 360,
+      id: 'video-thumbnail-element',
+      locked: false,
+      loop: false,
+      muted: true,
+      opacity: 1,
+      posterFrameSeconds: 4,
+      rotation: 0,
+      trimStartSeconds: 1,
+      type: 'video',
+      visible: true,
+      width: 640,
+      x: 80,
+      y: 90,
+    };
+    page.elementIds = ['video-thumbnail-element'];
+
+    service.publishState({
+      activePageId: page.id,
+      animationPreview: undefined,
+      project,
+    });
+
+    await vi.waitFor(() => expect(fakeVideo.onloadedmetadata).toBeTypeOf('function'));
+    fakeVideo.onloadedmetadata?.();
+    fakeVideo.onseeked?.();
+    await vi.waitFor(() => {
+      expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
+    });
+    const publishedState = signalingService.getPublishedState('ABCD-1234');
+    const videoElement = publishedState?.slidePreview?.elements.find(
+      (element) => element.id === 'video-thumbnail-element',
+    );
+
+    expect(fakeVideo.currentTime).toBe(4);
+    expect(videoElement).toMatchObject({
+      assetUrl: 'data:image/jpeg;base64,video-thumbnail',
+      kind: 'media',
+      mediaType: 'video',
+    });
+    expect(JSON.stringify(publishedState)).not.toContain('blob:thumbnail-demo');
+    createElement.mockRestore();
+  });
+
   it('publishes the presenter timer state received from the presenter window', async () => {
     const popup = {
       location: { href: '' },


### PR DESCRIPTION
## Summary
- Render preview thumbnails for remote video elements when publishing remote slide state.
- Use the element's poster frame timing when available, falling back to trim start for the preview frame.
- Avoid exposing raw blob URLs in published remote preview payloads.
- Add coverage for remote video thumbnail generation and preview serialization.

## Testing
- Added a unit test that simulates remote video preview rendering and verifies the generated thumbnail URL and frame timing.
- Confirmed the published preview omits the original blob asset URL.