### PR TITLE
Fix persistence target selection and history slide refocus

### DIFF
--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -14,6 +14,7 @@ import { TextSelectionToolbar } from '../toolbars/TextSelectionToolbar';
 type CanvasWorkspaceProps = ComponentProps<typeof CanvasWorkspace>;
 
 interface ScrollingCanvasWorkspaceProps extends CanvasWorkspaceProps {
+  activePageFocusKey?: number | undefined;
   canTranslateCurrentSlide?: boolean;
   children?: ReactNode;
   onAddPage?: ((afterPageId?: string) => void) | undefined;
@@ -33,6 +34,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
   function ScrollingCanvasWorkspace(
     {
       activePageId,
+      activePageFocusKey,
       canTranslateCurrentSlide,
       children,
       onActivePageFromScroll,
@@ -89,7 +91,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
         programmaticScrollRef.current = false;
         programmaticScrollReleaseRef.current = undefined;
       }, 120);
-    }, [activePageId, project.pages.length]);
+    }, [activePageFocusKey, activePageId, project.pages.length]);
 
     useEffect(
       () => () => {

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1215,6 +1215,7 @@ export function EditorShell({ services }: EditorShellProps) {
           <ScrollingCanvasWorkspace
             project={vm.project}
             activePageId={vm.activePageId}
+            activePageFocusKey={vm.activePageFocusKey}
             selection={vm.selection}
             slideFrameRef={slideFrameRef}
             stageRef={stageRef}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -692,6 +692,7 @@ export function useEditorViewModel(services: AppServices) {
     shouldRestoreStoredProject,
   );
   const [activePageId, setActivePageId] = useState(initialProject.pages[0]?.id ?? '');
+  const [activePageFocusKey, setActivePageFocusKey] = useState(0);
   const activePageIdRef = useRef(activePageId);
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
   const selectedElementIdsRef = useRef(selectedElementIds);
@@ -847,6 +848,7 @@ export function useEditorViewModel(services: AppServices) {
   const languageDetectionSequenceRef = useRef(0);
   const skipNextProjectSaveRef = useRef(shouldRestoreStoredProject);
   const lastVersionProjectRef = useRef<ProjectDocument>(initialProject);
+  const needsFreshPersistenceTargetRef = useRef(false);
   const selection = useMemo<SelectionState>(
     () => ({ pageId: activePageId, elementIds: selectedElementIds, target: selectionTarget }),
     [activePageId, selectedElementIds, selectionTarget],
@@ -986,6 +988,7 @@ export function useEditorViewModel(services: AppServices) {
           setPageLanguageCodes({});
           setSelectedElementIds([]);
           lastVersionProjectRef.current = normalizedProject;
+          needsFreshPersistenceTargetRef.current = false;
           setLastEditedAt(normalizedProject.updatedAt);
           if (services.projectRepository.getVersionHistory) {
             void services.projectRepository
@@ -1824,8 +1827,15 @@ export function useEditorViewModel(services: AppServices) {
   async function reenablePersistence() {
     try {
       const projectToSave = projectRef.current;
-      await services.projectRepository.saveProject(projectToSave);
+      if (needsFreshPersistenceTargetRef.current && services.projectRepository.saveProjectAs) {
+        await services.projectRepository.saveProjectAs(projectToSave, {
+          projectDirectoryName: projectToSave.name,
+        });
+      } else {
+        await services.projectRepository.saveProject(projectToSave);
+      }
       lastVersionProjectRef.current = projectToSave;
+      needsFreshPersistenceTargetRef.current = false;
       setHasPersistedLocalProject(true);
       setLastEditedAt(projectToSave.updatedAt);
       setSaveAnimationKey((current) => current + 1);
@@ -1894,6 +1904,7 @@ export function useEditorViewModel(services: AppServices) {
         });
       }
       lastVersionProjectRef.current = projectToSave;
+      needsFreshPersistenceTargetRef.current = false;
       setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       setPersistenceAttention(false);
@@ -1927,9 +1938,16 @@ export function useEditorViewModel(services: AppServices) {
       updatedAt: new Date().toISOString(),
     };
     try {
-      await services.projectRepository.saveProject(nextProject, { projectDirectoryName: nextName });
+      if (needsFreshPersistenceTargetRef.current && services.projectRepository.saveProjectAs) {
+        await services.projectRepository.saveProjectAs(nextProject, {
+          projectDirectoryName: nextName,
+        });
+      } else {
+        await services.projectRepository.saveProject(nextProject, { projectDirectoryName: nextName });
+      }
       setProject(nextProject);
       lastVersionProjectRef.current = nextProject;
+      needsFreshPersistenceTargetRef.current = false;
       setLastEditedAt(nextProject.updatedAt);
       setSaveAnimationKey((current) => current + 1);
       skipNextProjectSaveRef.current = true;
@@ -1972,6 +1990,7 @@ export function useEditorViewModel(services: AppServices) {
       setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       lastVersionProjectRef.current = normalizedProject;
+      needsFreshPersistenceTargetRef.current = false;
       setLastEditedAt(normalizedProject.updatedAt);
       if (services.projectRepository.getVersionHistory) {
         void services.projectRepository
@@ -2094,6 +2113,7 @@ export function useEditorViewModel(services: AppServices) {
       setHasPersistedLocalProject(false);
       setPersistenceEnabled(false);
       lastVersionProjectRef.current = normalizedProject;
+      needsFreshPersistenceTargetRef.current = true;
       setLastEditedAt(normalizedProject.updatedAt);
       setVersionHistoryEntries([]);
       writeProjectNameToUrl(normalizedProject.name);
@@ -2414,6 +2434,7 @@ export function useEditorViewModel(services: AppServices) {
       setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       lastVersionProjectRef.current = normalizedProject;
+      needsFreshPersistenceTargetRef.current = false;
       setLastEditedAt(normalizedProject.updatedAt);
       if (services.projectRepository.getVersionHistory) {
         void services.projectRepository
@@ -2490,7 +2511,9 @@ export function useEditorViewModel(services: AppServices) {
     setSelectedVersionId(versionId);
     setPreviewProject(normalizedVersionProject);
     const nextPageId = entry?.firstChangedPageId ?? normalizedVersionProject.pages[0]?.id ?? '';
+    activePageIdRef.current = nextPageId;
     setActivePageId(nextPageId);
+    setActivePageFocusKey((current) => current + 1);
     setSelectedElementIds(entry?.firstChangedElementId ? [entry.firstChangedElementId] : []);
   }
 
@@ -4310,6 +4333,7 @@ export function useEditorViewModel(services: AppServices) {
     project: previewProject ?? project,
     automation,
     activePageId,
+    activePageFocusKey,
     zoomPercent,
     pagesPanelOpen,
     isFullscreen,

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -26,6 +26,7 @@ import type {
   StockMediaProviderState,
   StockMediaService,
   TranslatorService,
+  VersionHistoryEntry,
 } from '../../../../src/services/contracts/interfaces';
 import type { PptxImportInput } from '../../../../src/services/importing/pptx/pptxImportService';
 import type { MinioMirrorConfig } from '../../../../src/services/mirror/minioMirrorService';
@@ -226,6 +227,28 @@ class SavingProjectRepository implements ProjectRepository {
   saveProjectAs(project: ProjectDocument): Promise<void> {
     this.savedProjectsAs.push(project);
     return Promise.resolve();
+  }
+}
+
+class VersionHistoryProjectRepository extends SavingProjectRepository {
+  constructor(
+    private readonly project: ProjectDocument,
+    private readonly versionProject: ProjectDocument,
+    private readonly entries: VersionHistoryEntry[],
+  ) {
+    super();
+  }
+
+  override loadProject(): Promise<ProjectDocument | null> {
+    return Promise.resolve(this.project);
+  }
+
+  getVersionHistory(): Promise<VersionHistoryEntry[]> {
+    return Promise.resolve(this.entries);
+  }
+
+  loadVersion(): Promise<ProjectDocument | null> {
+    return Promise.resolve(this.versionProject);
   }
 }
 
@@ -1310,6 +1333,61 @@ describe('EditorShell', () => {
     ).toBeInTheDocument();
   });
 
+  it('chooses a fresh persistence target after importing PowerPoint over a saved project', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const repository = new SavingProjectRepository();
+    const importService = new PendingPresentationImportService();
+    services.projectRepository = repository;
+    services.presentationImportService = importService;
+    vi.stubGlobal(
+      'showOpenFilePicker',
+      vi.fn(() =>
+        Promise.resolve([
+          createPowerPointFileHandle(
+            new File(['pptx'], 'deck.pptx', {
+              type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            }),
+          ),
+        ] as FileSystemFileHandle[]),
+      ),
+    );
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+    expect(repository.savedProjects).toHaveLength(1);
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Import' }));
+    await user.click(screen.getByRole('menuitem', { name: 'PowerPoint (.pptx)' }));
+    await waitFor(() => {
+      expect(importService.importCalls).toHaveLength(1);
+    });
+
+    act(() => {
+      importService.resolveImport?.({
+        ...services.initialProject,
+        id: 'imported-powerpoint-project',
+        name: 'Imported PowerPoint Deck',
+      });
+    });
+
+    expect(
+      await screen.findByRole('button', { name: 'Edit project name Imported PowerPoint Deck' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Persistence disabled' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    expect(repository.savedProjectsAs).toHaveLength(1);
+    expect(repository.savedProjectsAs[0]).toMatchObject({
+      id: 'imported-powerpoint-project',
+      name: 'Imported PowerPoint Deck',
+    });
+  });
+
   it('downloads PPTX fonts during import without blocking the deck when fonts fail', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
@@ -1524,6 +1602,76 @@ describe('EditorShell', () => {
     render(<EditorShell services={secondServices} />);
 
     expect(await screen.findByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+  });
+
+  it('refocuses the changed slide when selecting a history version on the active page', async () => {
+    const user = userEvent.setup();
+    const scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollIntoView',
+    );
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    const project = sampleProject.createSampleProject();
+    const firstPageId = project.pages[0]!.id;
+    const titleElement = project.elements['text-title'];
+    if (titleElement?.type !== 'text') {
+      throw new Error('Expected sample project to include a text-title text element.');
+    }
+    const versionProject: ProjectDocument = {
+      ...project,
+      elements: {
+        ...project.elements,
+        'text-title': {
+          ...titleElement,
+          text: 'Changed title in history',
+        },
+      },
+    };
+    const versionEntry: VersionHistoryEntry = {
+      id: 'version-1',
+      authorName: 'Local user',
+      changeCount: 1,
+      createdAt: '2026-07-06T12:00:00.000Z',
+      fileName: 'version-1.json',
+      firstChangedElementId: 'text-title',
+      firstChangedPageId: firstPageId,
+      projectName: project.name,
+      summary: 'Version with title edit',
+    };
+    const services = createAppServices({ initialProject: project });
+    services.projectRepository = new VersionHistoryProjectRepository(project, versionProject, [
+      versionEntry,
+    ]);
+    window.localStorage.setItem('ew-canvas-ai.persistence-enabled', 'true');
+
+    try {
+      render(<EditorShell services={services} />);
+
+      expect(await screen.findByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Version history' }));
+      await screen.findByText('Version with title edit');
+      scrollIntoView.mockClear();
+
+      await user.click(screen.getByText('Version with title edit').closest('button')!);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+          'data-selected-elements',
+          'text-title',
+        );
+      });
+      expect(scrollIntoView).toHaveBeenCalled();
+    } finally {
+      if (scrollIntoViewDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', scrollIntoViewDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
+      }
+    }
   });
 
   it('loads the last project before autosaving on startup', async () => {


### PR DESCRIPTION
## Summary
- Track when a project needs a fresh persistence target and route the next save through `saveProjectAs` when available.
- Reset persistence state consistently after import, load, save, and restore flows so imported projects do not overwrite the previous folder.
- Refocus the active slide after selecting a version history entry by bumping a dedicated focus key and wiring it into the scrolling canvas.
- Add coverage for importing PowerPoint into an already saved project and for selecting version history on the active slide.

## Testing
- Added unit coverage for persistence target selection after PowerPoint import.
- Added UI coverage for version history selection refocusing the changed slide.
- Not run (not requested)