### PR TITLE
Persist mirror enablement across page reloads

### DIFF
--- a/apps/editor/src/ui/editor/persistence/editorPreferences.ts
+++ b/apps/editor/src/ui/editor/persistence/editorPreferences.ts
@@ -2,6 +2,7 @@ import { browserStorage } from '../../../services/browser/browserStorage';
 import { translationLanguageUtils } from '../translation/translationLanguageUtils';
 
 const PERSISTENCE_PREFERENCE_KEY = 'ew-canvas-ai.persistence-enabled';
+const MIRROR_PREFERENCE_KEY = 'ew-canvas-ai.mirror-enabled';
 const TRANSLATION_TARGET_LANGUAGE_KEY = 'localstudio.ai.translation-target-language';
 
 function readPersistencePreference() {
@@ -10,6 +11,17 @@ function readPersistencePreference() {
 
 function writePersistencePreference(enabled: boolean) {
   browserStorage.getBrowserLocalStorage()?.setItem(PERSISTENCE_PREFERENCE_KEY, enabled ? 'true' : 'false');
+}
+
+function readMirrorPreference() {
+  const storedValue = browserStorage.getBrowserLocalStorage()?.getItem(MIRROR_PREFERENCE_KEY);
+  if (storedValue === 'true') return true;
+  if (storedValue === 'false') return false;
+  return undefined;
+}
+
+function writeMirrorPreference(enabled: boolean) {
+  browserStorage.getBrowserLocalStorage()?.setItem(MIRROR_PREFERENCE_KEY, enabled ? 'true' : 'false');
 }
 
 function readTranslationTargetLanguage() {
@@ -26,7 +38,9 @@ function writeTranslationTargetLanguage(languageCode: string) {
 }
 
 export const editorPreferences = {
+  readMirrorPreference,
   readPersistencePreference,
+  writeMirrorPreference,
   writePersistencePreference,
   readTranslationTargetLanguage,
   writeTranslationTargetLanguage,

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -670,11 +670,14 @@ export function useEditorViewModel(services: AppServices) {
     () => services.mirrorService.loadConfig(),
     [services.mirrorService],
   );
+  const storedMirrorPreference = useMemo(() => editorPreferences.readMirrorPreference(), []);
+  const shouldEnableStoredMirror = storedMirrorPreference ?? Boolean(storedMirrorConfig);
   const shouldRestoreStoredProject = useMemo(
     () =>
       !services.skipStoredProjectLoad &&
-      (editorPreferences.readPersistencePreference() || Boolean(storedMirrorConfig)),
-    [services.skipStoredProjectLoad, storedMirrorConfig],
+      (editorPreferences.readPersistencePreference() ||
+        (Boolean(storedMirrorConfig) && shouldEnableStoredMirror)),
+    [services.skipStoredProjectLoad, shouldEnableStoredMirror, storedMirrorConfig],
   );
   const [project, setProject] = useState<ProjectDocument>(initialProject);
   const projectRef = useRef(project);
@@ -765,8 +768,8 @@ export function useEditorViewModel(services: AppServices) {
   const [lastEditedAt, setLastEditedAt] = useState<string | undefined>(initialProject.updatedAt);
   const [saveAnimationKey, setSaveAnimationKey] = useState(0);
   const [mirrorState, setMirrorState] = useState<MirrorState>(() => ({
-    enabled: Boolean(storedMirrorConfig),
-    status: storedMirrorConfig ? 'idle' : 'disabled',
+    enabled: Boolean(storedMirrorConfig) && shouldEnableStoredMirror,
+    status: storedMirrorConfig && shouldEnableStoredMirror ? 'idle' : 'disabled',
   }));
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [mirrorSettingsOpen, setMirrorSettingsOpen] = useState(false);
@@ -998,7 +1001,9 @@ export function useEditorViewModel(services: AppServices) {
           }
           writeProjectNameToUrl(normalizedProject.name);
           setHasPersistedLocalProject(true);
-          if (storedMirrorConfig) syncMirrorNowRef.current(normalizedProject);
+          if (storedMirrorConfig && shouldEnableStoredMirror) {
+            syncMirrorNowRef.current(normalizedProject);
+          }
         }
         setHasLoadedProject(true);
       })
@@ -1019,6 +1024,7 @@ export function useEditorViewModel(services: AppServices) {
     services.fontImportService,
     services.projectRepository,
     services.storedProjectName,
+    shouldEnableStoredMirror,
     storedMirrorConfig,
   ]);
 
@@ -2236,6 +2242,7 @@ export function useEditorViewModel(services: AppServices) {
 
   function saveMirrorConfig(config: MinioMirrorConfig) {
     services.mirrorService.saveConfig(config);
+    editorPreferences.writeMirrorPreference(true);
     setMirrorConfig(config);
     setHasMirrorConfig(true);
     setMirrorDisabledBySettings(false);
@@ -2272,11 +2279,13 @@ export function useEditorViewModel(services: AppServices) {
         openMirrorSettings();
         return;
       }
+      editorPreferences.writeMirrorPreference(true);
       setMirrorDisabledBySettings(false);
       setMirrorState({ enabled: true, status: 'idle' });
       void syncMirrorNow();
       return;
     }
+    editorPreferences.writeMirrorPreference(false);
     setMirrorDisabledBySettings(Boolean(options?.fromSettings));
     setMirrorState({ enabled: false, status: 'disabled' });
   }
@@ -2373,6 +2382,7 @@ export function useEditorViewModel(services: AppServices) {
       return;
     }
     if (!mirrorState.enabled) {
+      editorPreferences.writeMirrorPreference(true);
       setMirrorState({ enabled: true, status: 'idle' });
     }
     void syncMirrorNow();

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -139,6 +139,33 @@ describe('minioMirrorService.createMirrorFiles', () => {
 });
 
 describe('minioMirrorService.MinioMirrorService', () => {
+  it('persists MinIO mirror config in browser key-value storage', () => {
+    const records = new Map<string, string>();
+    const storage = {
+      getItem: vi.fn((key: string) => records.get(key) ?? null),
+      removeItem: vi.fn((key: string) => {
+        records.delete(key);
+      }),
+      setItem: vi.fn((key: string, value: string) => {
+        records.set(key, value);
+      }),
+    };
+    const service = new minioMirrorService.MinioMirrorService({ storage });
+
+    service.saveConfig(config);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'localstudio.minioMirror.config',
+      JSON.stringify(config),
+    );
+    expect(service.loadConfig()).toEqual(config);
+
+    service.clearConfig();
+
+    expect(storage.removeItem).toHaveBeenCalledWith('localstudio.minioMirror.config');
+    expect(service.loadConfig()).toBeNull();
+  });
+
   it('binds the browser fetch function when no fetch override is provided', async () => {
     const project = sampleProject.createSampleProject();
     const originalFetch = globalThis.fetch;

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -1220,6 +1220,51 @@ describe('EditorShell', () => {
     expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toBeInTheDocument();
   });
 
+  it('keeps saved mirror config disabled after refreshing the page', async () => {
+    const user = userEvent.setup();
+    const firstServices = createAppServices();
+    const firstRepository = new DeferredLoadingProjectRepository();
+    firstServices.projectRepository = firstRepository;
+    firstServices.mirrorService = new RecordingMirrorService();
+    const firstRender = render(<EditorShell services={firstServices} />);
+
+    act(() => {
+      firstRepository.resolveLoadedProject({
+        ...firstServices.initialProject,
+        name: 'Mirrored Folder',
+      });
+    });
+
+    expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Mirror settings' }));
+    await user.click(
+      within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+        name: 'Mirror settings',
+      }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Disable mirroring' }));
+
+    expect(window.localStorage.getItem('ew-canvas-ai.mirror-enabled')).toBe('false');
+    firstRender.unmount();
+
+    const secondServices = createAppServices();
+    const secondRepository = new DeferredLoadingProjectRepository();
+    const secondMirrorService = new RecordingMirrorService();
+    secondServices.projectRepository = secondRepository;
+    secondServices.mirrorService = secondMirrorService;
+    render(<EditorShell services={secondServices} />);
+
+    act(() => {
+      secondRepository.resolveLoadedProject({
+        ...secondServices.initialProject,
+        name: 'Mirrored Folder',
+      });
+    });
+
+    expect(await screen.findByRole('button', { name: 'Mirror disabled' })).toBeInTheDocument();
+    expect(secondMirrorService.syncProject).not.toHaveBeenCalled();
+  });
+
   it('opens mirror settings from the disabled mirror icon after mirroring is disabled in settings', async () => {
     const user = userEvent.setup();
     const services = createAppServices();


### PR DESCRIPTION
## Summary
- Persist the mirror enablement preference in browser storage alongside mirror config.
- Restore mirror state from the saved preference so disabled mirrors stay disabled after refresh.
- Avoid automatic sync on load when the user previously turned mirroring off.
- Add coverage for mirror config storage and refresh behavior in the editor shell.

## Testing
- Added unit coverage for MinIO mirror config persistence in browser storage.
- Added editor shell coverage for keeping mirroring disabled after a page refresh.
- Not run (not requested).