### PR TITLE
Add marquee selection for multi-select on the canvas

### DIFF
--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -152,6 +152,18 @@ interface ElementAnimationRenderState {
   progress: number;
 }
 
+interface MarqueeSelection {
+  anchor: { x: number; y: number };
+  current: { x: number; y: number };
+}
+
+interface StageRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 function clampAnimationProgress(value: number | undefined) {
   return Math.max(0, Math.min(1, value ?? 0));
 }
@@ -238,6 +250,24 @@ function getShapeLineDrawState(element: ShapeElement, state: ElementAnimationRen
 function getShapeEndpoint(element: ShapeElement, position: 'end' | 'start') {
   if (position === 'end' && element.shape === 'arrow') return element.endEndpoint ?? 'arrow';
   return (position === 'start' ? element.startEndpoint : element.endEndpoint) ?? 'none';
+}
+
+function getNormalizedStageRect(start: { x: number; y: number }, end: { x: number; y: number }) {
+  return {
+    height: Math.abs(end.y - start.y),
+    width: Math.abs(end.x - start.x),
+    x: Math.min(start.x, end.x),
+    y: Math.min(start.y, end.y),
+  };
+}
+
+function stageRectsIntersect(first: StageRect, second: StageRect) {
+  return (
+    first.x <= second.x + second.width &&
+    first.x + first.width >= second.x &&
+    first.y <= second.y + second.height &&
+    first.y + first.height >= second.y
+  );
 }
 
 function getEndpointStrokeWidth(element: ShapeElement) {
@@ -509,6 +539,7 @@ export function CanvasWorkspace({
     y: number;
   } | null>(null);
   const [dragGuide, setDragGuide] = useState<{ x: number; y: number } | null>(null);
+  const [marqueeSelection, setMarqueeSelection] = useState<MarqueeSelection | null>(null);
   const [cropModeElementId, setCropModeElementId] = useState<string | null>(null);
   const [cropDraft, setCropDraft] = useState<
     | {
@@ -687,6 +718,50 @@ export function CanvasWorkspace({
 
   function toDocumentY(value: number) {
     return value / scaleY;
+  }
+
+  function getStagePoint(event: MouseEvent) {
+    const artboard = artboardRef.current;
+    if (!artboard) return null;
+    const stageBounds = artboard.getBoundingClientRect();
+    return {
+      x: event.clientX - stageBounds.left,
+      y: event.clientY - stageBounds.top,
+    };
+  }
+
+  function getElementStageRect(element: DesignElement) {
+    const nodeRect = nodeRefs.current[element.id]?.getClientRect({
+      skipShadow: true,
+      skipStroke: true,
+    });
+    if (nodeRect) {
+      return {
+        height: nodeRect.height,
+        width: nodeRect.width,
+        x: nodeRect.x,
+        y: nodeRect.y,
+      };
+    }
+    return {
+      height: element.height * scaleY,
+      width: element.width * scaleX,
+      x: element.x * scaleX,
+      y: element.y * scaleY,
+    };
+  }
+
+  function selectElementsInMarquee(rect: StageRect) {
+    const selectedElementIds = visibleElements
+      .filter((element) => stageRectsIntersect(rect, getElementStageRect(element)))
+      .map((element) => element.id);
+    selectedElementIds.forEach((elementId, index) => {
+      if (index === 0) {
+        onSelectElement?.(elementId);
+        return;
+      }
+      onSelectElement?.(elementId, { additive: true });
+    });
   }
 
   function handleDragEnd(elementId: string, event: Konva.KonvaEventObject<DragEvent>) {
@@ -1065,7 +1140,35 @@ export function CanvasWorkspace({
       return;
     }
     onSelectSlide?.();
+    if (readOnly || !onSelectElement || !(event.evt instanceof MouseEvent)) return;
+    const startPoint = getStagePoint(event.evt);
+    if (!startPoint) return;
+    setMarqueeSelection({ anchor: startPoint, current: startPoint });
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const currentPoint = getStagePoint(moveEvent);
+      if (!currentPoint) return;
+      setMarqueeSelection({ anchor: startPoint, current: currentPoint });
+    };
+
+    const handleMouseUp = (upEvent: MouseEvent) => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+      setMarqueeSelection(null);
+      const endPoint = getStagePoint(upEvent);
+      if (!endPoint) return;
+      const marqueeRect = getNormalizedStageRect(startPoint, endPoint);
+      if (marqueeRect.width < 4 || marqueeRect.height < 4) return;
+      selectElementsInMarquee(marqueeRect);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
   }
+
+  const marqueeRect = marqueeSelection
+    ? getNormalizedStageRect(marqueeSelection.anchor, marqueeSelection.current)
+    : undefined;
 
   return (
     <div
@@ -1088,6 +1191,7 @@ export function CanvasWorkspace({
           : {})}
         data-selected-elements={selection.elementIds.join(',')}
         data-drag-guide={dragGuide ? 'active' : 'idle'}
+        data-marquee-selection={marqueeSelection ? 'active' : 'idle'}
         data-animation-preview={
           animationPreview?.playing && animationPreview.pageId === activePageId ? 'playing' : 'idle'
         }
@@ -1495,6 +1599,19 @@ export function CanvasWorkspace({
               element={selectedElement}
               scale={{ x: scaleX, y: scaleY }}
               onHandlePointerDown={beginCropDrag}
+            />
+          ) : null}
+          {showEditorOverlays && marqueeRect ? (
+            <div
+              aria-hidden="true"
+              className="marquee-selection-box"
+              data-testid="marquee-selection-box"
+              style={{
+                height: `${marqueeRect.height}px`,
+                left: `${marqueeRect.x}px`,
+                top: `${marqueeRect.y}px`,
+                width: `${marqueeRect.width}px`,
+              }}
             />
           ) : null}
           {showEditorOverlays

--- a/apps/editor/src/ui/styles/canvas-overlays.css
+++ b/apps/editor/src/ui/styles/canvas-overlays.css
@@ -67,6 +67,16 @@
   font-size: 18px;
 }
 
+.marquee-selection-box {
+  position: absolute;
+  z-index: 11;
+  box-sizing: border-box;
+  border: 1.5px solid #37fd76;
+  background: rgba(55, 253, 118, 0.14);
+  box-shadow: 0 0 12px rgba(55, 253, 118, 0.42);
+  pointer-events: none;
+}
+
 .background-selection-progress {
   width: 96px;
   height: 6px;

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -263,6 +263,71 @@ describe('CanvasWorkspace', () => {
     expect(onSelectPresentation).toHaveBeenCalledTimes(1);
   });
 
+  it('draws a green marquee and selects elements intersecting it', async () => {
+    const onSelectElement = vi.fn();
+    const stageRef = createRef<Konva.Stage>();
+    const { container } = render(
+      <CanvasWorkspace
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        stageRef={stageRef}
+        onSelectElement={onSelectElement}
+      />,
+    );
+
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeInTheDocument();
+
+    fireEvent.mouseDown(canvas!, { clientX: 450, clientY: 170 });
+    fireEvent.mouseMove(window, { clientX: 735, clientY: 315 });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('marquee-selection-box')).toHaveStyle({
+        height: '145px',
+        left: '450px',
+        top: '170px',
+        width: '285px',
+      });
+    });
+    expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+      'data-marquee-selection',
+      'active',
+    );
+
+    fireEvent.mouseUp(window, { clientX: 735, clientY: 315 });
+
+    expect(onSelectElement).toHaveBeenCalledTimes(2);
+    expect(onSelectElement).toHaveBeenNthCalledWith(1, 'text-subtitle');
+    expect(onSelectElement).toHaveBeenNthCalledWith(2, 'text-title', { additive: true });
+  });
+
+  it('keeps the marquee origin at the initial mouse position when dragging upward', async () => {
+    const { container } = render(
+      <CanvasWorkspace
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        onSelectElement={() => undefined}
+      />,
+    );
+
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeInTheDocument();
+
+    fireEvent.mouseDown(canvas!, { clientX: 735, clientY: 315 });
+    fireEvent.mouseMove(window, { clientX: 450, clientY: 170 });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('marquee-selection-box')).toHaveStyle({
+        height: '145px',
+        left: '450px',
+        top: '170px',
+        width: '285px',
+      });
+    });
+  });
+
   it('marks active animation preview state and advances click-triggered builds', () => {
     const onAnimationPreviewAdvance = vi.fn();
     const { container } = render(

--- a/tests/e2e/editor/canvas-direct-manipulation.spec.ts
+++ b/tests/e2e/editor/canvas-direct-manipulation.spec.ts
@@ -4,6 +4,71 @@ import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 const getServer = withIsolatedDevServer(test);
 
 test.describe('editor canvas direct manipulation journey', () => {
+  test('selects multiple slide elements with a marquee drag', async ({ page }) => {
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await editor.gotoNewProject();
+
+    const leftTextTool = page.getByLabel('Tool menu').getByRole('tab', { name: 'Text' });
+    await leftTextTool.click();
+    await expect(leftTextTool).toHaveAttribute('aria-expanded', 'true');
+    await page.getByRole('button', { name: 'Add a text box' }).click();
+    await editor.openTool('Design');
+    await page
+      .getByRole('tablist', { name: 'Movie inspector sections' })
+      .getByRole('tab', { name: 'Text' })
+      .click();
+    await page.getByRole('textbox', { name: 'Selected text content' }).fill('Marquee first');
+    await page.getByRole('tab', { name: 'Arrange' }).click();
+    await page.getByLabel('Selected element x position').fill('520');
+    await page.getByLabel('Selected element y position').fill('320');
+    await page.getByLabel('Selected element width').fill('320');
+    await page.getByLabel('Selected element height').fill('100');
+
+    await leftTextTool.click();
+    await expect(leftTextTool).toHaveAttribute('aria-expanded', 'true');
+    await page.getByRole('button', { name: 'Add a text box' }).click();
+    await editor.openTool('Design');
+    await page
+      .getByRole('tablist', { name: 'Movie inspector sections' })
+      .getByRole('tab', { name: 'Text' })
+      .click();
+    await page.getByRole('textbox', { name: 'Selected text content' }).fill('Marquee second');
+    await page.getByRole('tab', { name: 'Arrange' }).click();
+    await page.getByLabel('Selected element x position').fill('900');
+    await page.getByLabel('Selected element y position').fill('420');
+    await page.getByLabel('Selected element width').fill('320');
+    await page.getByLabel('Selected element height').fill('100');
+
+    const frame = page.getByTestId('slide-canvas-frame');
+    const canvas = frame.locator('canvas').first();
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+
+    const scaleX = canvasBox!.width / 1920;
+    const scaleY = canvasBox!.height / 1080;
+    const startClientX = canvasBox!.x + 1260 * scaleX;
+    const startClientY = canvasBox!.y + 560 * scaleY;
+    const endClientX = canvasBox!.x + 480 * scaleX;
+    const endClientY = canvasBox!.y + 280 * scaleY;
+
+    await page.mouse.move(startClientX, startClientY);
+    await page.mouse.down();
+    await page.mouse.move(endClientX, endClientY, { steps: 8 });
+    await expect(frame).toHaveAttribute('data-marquee-selection', 'active');
+    const marqueeBox = await page.getByTestId('marquee-selection-box').boundingBox();
+    expect(marqueeBox).not.toBeNull();
+    expect(Math.abs(marqueeBox!.x - endClientX)).toBeLessThan(3);
+    expect(Math.abs(marqueeBox!.y - endClientY)).toBeLessThan(3);
+    await page.mouse.up();
+
+    await expect
+      .poll(async () => {
+        const selectedElements = (await frame.getAttribute('data-selected-elements')) ?? '';
+        return selectedElements.split(',').filter(Boolean).length;
+      })
+      .toBe(2);
+  });
+
   test('drags a selected canvas element and verifies transform controls stay in sync', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Add drag-to-select marquee selection on the editor canvas with a green overlay indicator
- Select all visible elements intersecting the marquee, supporting additive selection order
- Cover the behavior with unit and end-to-end tests, including upward drag handling

## Testing
- Added unit coverage for marquee rendering, selection intersection, and reversed drag direction
- Added Playwright coverage for multi-element marquee selection in the editor journey
- Not run (not requested)