### PR TITLE
Preserve translated text position for slide captions

### DIFF
--- a/apps/editor/src/ui/editor/state/text-translation-layout.ts
+++ b/apps/editor/src/ui/editor/state/text-translation-layout.ts
@@ -13,6 +13,10 @@ function getMinimumTextHeight(text: string, fontSize: number) {
   return Math.ceil(lineCount * fontSize * 1.08 + Math.max(12, fontSize * 0.18));
 }
 
+function getTextHeightForLineCount(lineCount: number, fontSize: number) {
+  return Math.ceil(Math.max(1, lineCount) * fontSize * 1.08 + Math.max(12, fontSize * 0.18));
+}
+
 function getPageTextSample(project: ProjectDocument, pageId: string) {
   const page = project.pages.find((item) => item.id === pageId);
   if (!page) return '';
@@ -69,47 +73,58 @@ function estimateSingleLineTextWidth(text: string, fontSize: number) {
   }, 0);
 }
 
+function estimateWrappedLineCount(text: string, fontSize: number, availableWidth: number) {
+  return text.split('\n').reduce((lineCount, paragraph) => {
+    const words = paragraph.trim().split(/\s+/).filter(Boolean);
+    if (words.length === 0) return lineCount + 1;
+
+    let currentLineWidth = 0;
+    let paragraphLineCount = 1;
+    const spaceWidth = estimateSingleLineTextWidth(' ', fontSize);
+
+    for (const word of words) {
+      const wordWidth = estimateSingleLineTextWidth(word, fontSize);
+      if (currentLineWidth === 0) {
+        currentLineWidth = wordWidth;
+        paragraphLineCount += Math.max(0, Math.ceil(wordWidth / availableWidth) - 1);
+        continue;
+      }
+
+      const nextLineWidth = currentLineWidth + spaceWidth + wordWidth;
+      if (nextLineWidth <= availableWidth) {
+        currentLineWidth = nextLineWidth;
+        continue;
+      }
+
+      paragraphLineCount += 1;
+      currentLineWidth = wordWidth;
+      paragraphLineCount += Math.max(0, Math.ceil(wordWidth / availableWidth) - 1);
+    }
+
+    return lineCount + paragraphLineCount;
+  }, 0);
+}
+
 function fitTranslatedTextToOriginalFrame(
   element: Extract<ProjectDocument['elements'][string], { type: 'text' }>,
   translatedText: string,
   page?: Page,
 ): TranslationPatch {
+  void page;
   const normalizedText = normalizeTranslatedText(element.text, translatedText);
-  if (normalizedText.includes('\n')) return { text: normalizedText };
-
   const horizontalPadding = 12;
   const availableWidth = Math.max(1, element.width - horizontalPadding);
-  const estimatedWidth = estimateSingleLineTextWidth(normalizedText, element.fontSize);
-  if (estimatedWidth <= availableWidth) return { text: normalizedText };
-
-  const desiredWidth = Math.ceil(estimatedWidth + horizontalPadding);
-  const originalCenter = element.x + element.width / 2;
-  const pageWidth =
-    page?.width ?? Math.max(element.x + desiredWidth, originalCenter + desiredWidth / 2);
-  const maxWidthAroundCenter = Math.max(
-    1,
-    2 * Math.min(originalCenter, pageWidth - originalCenter),
+  const estimatedLineCount = estimateWrappedLineCount(
+    normalizedText,
+    element.fontSize,
+    availableWidth,
   );
-  const nextWidth = Math.max(element.width, Math.min(desiredWidth, maxWidthAroundCenter));
-  const nextX = Math.max(0, Math.min(pageWidth - nextWidth, originalCenter - nextWidth / 2));
+  const nextHeight = getTextHeightForLineCount(estimatedLineCount, element.fontSize);
+  if (nextHeight <= element.height) return { text: normalizedText };
 
-  if (nextWidth >= desiredWidth) {
-    return {
-      text: normalizedText,
-      width: nextWidth,
-      x: nextX,
-    };
-  }
-
-  const estimatedLineCount = Math.max(
-    1,
-    Math.ceil(estimatedWidth / Math.max(1, nextWidth - horizontalPadding)),
-  );
   return {
-    height: Math.max(element.height, Math.ceil(estimatedLineCount * element.fontSize * 1.08)),
+    height: nextHeight,
     text: normalizedText,
-    width: nextWidth,
-    x: nextX,
   };
 }
 

--- a/apps/editor/tests/unit/ui/editor/EditorShell.translation-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.translation-fixtures.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import type { ProjectDocument } from '../../../../src/domain/documents/model';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import type { TranslatorService } from '../../../../src/services/contracts/interfaces';
 
@@ -39,6 +40,68 @@ function createMultiTextProject(textCount: number) {
       name: `Slide ${index + 1}`,
       elementIds: [elementId],
     })),
+  };
+}
+
+function createThreeColumnCaptionProject(): ProjectDocument {
+  const now = new Date('2026-06-24T00:00:00.000Z').toISOString();
+  const captionElements = [
+    {
+      id: 'caption-left',
+      text: 'Exploring the future of artificial intelligence',
+      x: 120,
+    },
+    {
+      id: 'caption-center',
+      text: 'A look at the latest advancements and applications',
+      x: 680,
+    },
+    {
+      id: 'caption-right',
+      text: 'The impact of Web AI on society',
+      x: 1240,
+    },
+  ];
+
+  return {
+    id: 'project-caption-translation',
+    name: 'Caption Translation Deck',
+    assets: {},
+    createdAt: now,
+    updatedAt: now,
+    pages: [
+      {
+        id: 'page-1',
+        name: 'Hero split',
+        width: 1920,
+        height: 1080,
+        background: { type: 'color', color: '#050D10' },
+        elementIds: captionElements.map((element) => element.id),
+      },
+    ],
+    elements: Object.fromEntries(
+      captionElements.map((element) => [
+        element.id,
+        {
+          id: element.id,
+          type: 'text' as const,
+          text: element.text,
+          x: element.x,
+          y: 760,
+          width: 500,
+          height: 96,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          fontFamily: 'Open Sans',
+          fontSize: 38,
+          fontWeight: 500,
+          fill: '#ffffff',
+          align: 'center' as const,
+        },
+      ]),
+    ),
   };
 }
 
@@ -120,4 +183,5 @@ export const editorShellTranslationFixtures = {
   createDeferred,
   createMultiTextProject,
   createReadyPrepareTranslationMock,
+  createThreeColumnCaptionProject,
 };

--- a/apps/editor/tests/unit/ui/editor/EditorShell.translation.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.translation.test.tsx
@@ -12,6 +12,7 @@ const {
   createDeferred,
   createMultiTextProject,
   createReadyPrepareTranslationMock,
+  createThreeColumnCaptionProject,
   openLeftTab,
   selectTitleLayer,
 } = editorShellTestHarness;
@@ -144,8 +145,61 @@ describe('EditorShell translation workflows', () => {
       expect(title).toMatchObject({
         fontSize: 96,
         text: 'Revolucion de diseno impulsada por inteligencia artificial',
+        width: 600,
+        x: 1160,
       });
-      expect(title?.width).toBeGreaterThan(600);
+      expect(title?.height).toBeGreaterThan(240);
+    });
+  });
+
+  it('keeps translated slide captions anchored to their original columns', async () => {
+    const user = userEvent.setup();
+    const project = createThreeColumnCaptionProject();
+    const repository = new SavingProjectRepository();
+    const translations: Record<string, string> = {
+      'Exploring the future of artificial intelligence':
+        'Explorando o futuro da inteligencia artificial',
+      'A look at the latest advancements and applications':
+        'Veja os ultimos avancos e aplicacoes',
+      'The impact of Web AI on society': 'O impacto da Web AI na sociedade',
+    };
+    const translate = vi.fn((text: string) => Promise.resolve(translations[text] ?? text));
+    const services = createAppServices({ initialProject: project });
+    services.projectRepository = repository;
+    services.translatorService = {
+      detectLanguage: vi.fn().mockResolvedValue('en'),
+      prepareTranslation: createReadyPrepareTranslationMock(),
+      translate,
+    };
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'AI Tools');
+    await user.selectOptions(screen.getByLabelText('Translate to'), 'pt');
+    await user.click(screen.getByRole('button', { name: 'Translate Hero split' }));
+    await waitFor(() => {
+      expect(translate).toHaveBeenCalledTimes(3);
+    });
+    await user.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    await waitFor(() => {
+      const savedProject = repository.savedProjects.at(-1);
+      expect(savedProject?.elements['caption-left']).toMatchObject({
+        text: 'Explorando o futuro da inteligencia artificial',
+        x: 120,
+        width: 500,
+      });
+      expect(savedProject?.elements['caption-center']).toMatchObject({
+        text: 'Veja os ultimos avancos e aplicacoes',
+        x: 680,
+        width: 500,
+      });
+      expect(savedProject?.elements['caption-right']).toMatchObject({
+        text: 'O impacto da Web AI na sociedade',
+        x: 1240,
+        width: 500,
+      });
+      expect(savedProject?.elements['caption-left']?.height).toBeGreaterThanOrEqual(96);
     });
   });
 


### PR DESCRIPTION
## Summary
- Keep translated text anchored to its original x-position instead of resizing and drifting horizontally.
- Estimate wrapped line count and grow height only when the translated copy no longer fits the original frame.
- Add fixture coverage for a three-column caption layout to verify translated captions stay in place after translation.

## Testing
- Added unit coverage for the translated hero title and the three-caption layout.
- Verified saved project output preserves caption x positions and expands height only when needed.