### PR TITLE
Speed up E2E coverage runs and stabilize editor menu clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "playwright test --project=chromium",
     "test:e2e:coverage": "npm run test:e2e:coverage:editor && npm run test:e2e:coverage:joystick",
     "test:e2e:coverage:editor": "node scripts/run-editor-e2e-coverage.mjs",
-    "test:e2e:coverage:joystick": "E2E_COVERAGE_SCOPE=joystick playwright test --project=chromium tests/e2e/joystick",
+    "test:e2e:coverage:joystick": "node scripts/run-joystick-e2e-coverage.mjs",
     "test:e2e:all": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:watch": "npm run test:watch --workspace @localstudio/editor",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   testDir: './tests/e2e',
   globalTeardown: './tests/e2e/support/coverage-report.ts',
   timeout: 90_000,
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
   workers: '100%',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
-import os from 'node:os';
 import process from 'node:process';
-
-function getWorkerCount() {
-  return Math.max(1, os.availableParallelism?.() ?? os.cpus().length);
-}
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -13,7 +8,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
-  workers: getWorkerCount(),
+  workers: '100%',
   reporter: [['list'], ['html', { open: 'never' }]],
   use: {
     actionTimeout: 10_000,

--- a/scripts/run-editor-e2e-coverage.mjs
+++ b/scripts/run-editor-e2e-coverage.mjs
@@ -1,12 +1,15 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { rmSync } from 'node:fs';
 import { readdirSync } from 'node:fs';
+import { createServer } from 'node:net';
 import { join } from 'node:path';
 import process from 'node:process';
+import { chromium } from 'playwright';
 
 const workspaceRoot = process.cwd();
 const coverageInputDir = join(workspaceRoot, 'test-results', 'editor-coverage');
 const playwrightCli = join(workspaceRoot, 'node_modules', 'playwright', 'cli.js');
+const peerPath = '/peerjs';
 
 rmSync(coverageInputDir, { force: true, recursive: true });
 rmSync(join(workspaceRoot, 'coverage-report', 'editor'), { force: true, recursive: true });
@@ -17,25 +20,185 @@ const specFiles = [
   ...listSpecFiles('tests/e2e/webmcp'),
 ];
 
-const result = spawnSync(
-  process.execPath,
-  [playwrightCli, 'test', '--project=chromium', `--output=${coverageInputDir}`, ...specFiles],
-  {
-    cwd: workspaceRoot,
-    env: {
-      ...process.env,
-      E2E_COVERAGE_INPUT_DIR: coverageInputDir,
-      E2E_COVERAGE_SCOPE: 'editor',
-    },
-    stdio: 'inherit',
-  },
-);
+const peerPort = await getFreePort();
+let peerServer;
+let localStudioServer;
+let exitCode = 0;
 
-if (result.status !== 0) process.exit(result.status ?? 1);
+try {
+  peerServer = await startReadyProcess({
+    args: ['scripts/e2e-peer-server.mjs'],
+    env: {
+      HOST: '127.0.0.1',
+      PEERJS_PATH: peerPath,
+      PORT: String(peerPort),
+    },
+    readyPattern: /LocalStudio E2E PeerJS server ready:/,
+    timeoutMs: 30_000,
+  });
+
+  localStudioServer = await startReadyProcess({
+    args: ['scripts/dev.mjs'],
+    env: {
+      HOST: '127.0.0.1',
+      LOCALSTUDIO_PEERJS_HOST: '127.0.0.1',
+      LOCALSTUDIO_PEERJS_PATH: peerPath,
+      LOCALSTUDIO_PEERJS_PORT: String(peerPort),
+      PORT: '0',
+      VITE_DISABLE_EDITOR_TOUR: process.env.VITE_DISABLE_EDITOR_TOUR ?? 'true',
+    },
+    readyPattern: /Local:\s+http:\/\/localhost:(\d+)\//,
+    timeoutMs: 120_000,
+  });
+
+  const localStudioPort = Number.parseInt(localStudioServer.match?.[1] ?? '', 10);
+  if (!Number.isInteger(localStudioPort)) {
+    throw new Error('Could not resolve LocalStudio E2E server port.');
+  }
+
+  const baseURL = `http://localhost:${localStudioPort}`;
+  await waitForOk(`${baseURL}/`);
+  await warmEditor(baseURL);
+
+  const result = runPlaywright(baseURL, localStudioPort);
+  exitCode = result.status ?? 1;
+} finally {
+  if (localStudioServer) await stopProcess(localStudioServer.child);
+  if (peerServer) await stopProcess(peerServer.child);
+}
+
+if (exitCode !== 0) process.exit(exitCode);
 
 function listSpecFiles(directory) {
   return readdirSync(join(workspaceRoot, directory), { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith('.spec.ts'))
     .map((entry) => join(directory, entry.name))
     .sort((left, right) => left.localeCompare(right));
+}
+
+function runPlaywright(baseURL, port) {
+  return spawnSync(
+    process.execPath,
+    [playwrightCli, 'test', '--project=chromium', `--output=${coverageInputDir}`, ...specFiles],
+    {
+      cwd: workspaceRoot,
+      env: {
+        ...process.env,
+        E2E_COVERAGE_INPUT_DIR: coverageInputDir,
+        E2E_COVERAGE_SCOPE: 'editor',
+        LOCALSTUDIO_E2E_BASE_URL: baseURL,
+        LOCALSTUDIO_E2E_PORT: String(port),
+      },
+      stdio: 'inherit',
+    },
+  );
+}
+
+async function startReadyProcess({ args, env, readyPattern, timeoutMs }) {
+  const child = spawn(process.execPath, args, {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+  let output = '';
+  let settled = false;
+
+  const match = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${args.join(' ')}.\n${output}`));
+    }, timeoutMs);
+
+    function append(chunk) {
+      output += chunk.toString();
+      const match = output.match(readyPattern);
+      if (!match || settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(match);
+    }
+
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on('exit', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(
+        new Error(
+          `${args.join(' ')} exited before becoming ready with code ${String(
+            code,
+          )} and signal ${String(signal)}.\n${output}`,
+        ),
+      );
+    });
+  });
+
+  return { child, match };
+}
+
+async function waitForOk(url) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 30_000) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Keep polling until the server accepts connections.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function warmEditor(baseURL) {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(new URL('/editor/?newProject=1', baseURL).toString());
+    await page.getByRole('heading', { name: 'LocalStudio.dev' }).waitFor({ timeout: 30_000 });
+    await page.goto(new URL('/editor/?presenter=1&presenterSession=warmup', baseURL).toString());
+    await page.getByRole('main', { name: 'Presenter view' }).waitFor({ timeout: 30_000 });
+  } finally {
+    await browser.close();
+  }
+}
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => {
+        if (!address || typeof address === 'string') {
+          reject(new Error('Failed to allocate a free local port.'));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+async function stopProcess(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  await new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      resolve();
+    }, 5000);
+    child.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
 }

--- a/scripts/run-editor-e2e-coverage.mjs
+++ b/scripts/run-editor-e2e-coverage.mjs
@@ -5,13 +5,8 @@ import { join } from 'node:path';
 import process from 'node:process';
 
 const workspaceRoot = process.cwd();
-const coverageInputDir = join(workspaceRoot, 'test-results', 'editor-coverage-batches');
+const coverageInputDir = join(workspaceRoot, 'test-results', 'editor-coverage');
 const playwrightCli = join(workspaceRoot, 'node_modules', 'playwright', 'cli.js');
-const batchSize = Number.parseInt(process.env.E2E_COVERAGE_BATCH_SIZE ?? '4', 10);
-
-if (!Number.isFinite(batchSize) || batchSize < 1) {
-  throw new Error('E2E_COVERAGE_BATCH_SIZE must be a positive integer.');
-}
 
 rmSync(coverageInputDir, { force: true, recursive: true });
 rmSync(join(workspaceRoot, 'coverage-report', 'editor'), { force: true, recursive: true });
@@ -21,45 +16,26 @@ const specFiles = [
   ...listSpecFiles('tests/e2e/public-deck'),
   ...listSpecFiles('tests/e2e/webmcp'),
 ];
-const batches = chunk(specFiles, batchSize);
 
-for (const [index, batch] of batches.entries()) {
-  const isLastBatch = index === batches.length - 1;
-  const outputDir = join(coverageInputDir, `batch-${String(index + 1).padStart(2, '0')}`);
-  const result = spawnSync(
-    process.execPath,
-    [
-      playwrightCli,
-      'test',
-      '--project=chromium',
-      `--output=${outputDir}`,
-      ...batch,
-    ],
-    {
-      cwd: workspaceRoot,
-      env: {
-        ...process.env,
-        E2E_COVERAGE_INPUT_DIR: coverageInputDir,
-        E2E_COVERAGE_SCOPE: 'editor',
-        ...(isLastBatch ? {} : { E2E_COVERAGE_REPORT: '0' }),
-      },
-      stdio: 'inherit',
+const result = spawnSync(
+  process.execPath,
+  [playwrightCli, 'test', '--project=chromium', `--output=${coverageInputDir}`, ...specFiles],
+  {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      E2E_COVERAGE_INPUT_DIR: coverageInputDir,
+      E2E_COVERAGE_SCOPE: 'editor',
     },
-  );
-  if (result.status !== 0) process.exit(result.status ?? 1);
-}
+    stdio: 'inherit',
+  },
+);
+
+if (result.status !== 0) process.exit(result.status ?? 1);
 
 function listSpecFiles(directory) {
   return readdirSync(join(workspaceRoot, directory), { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith('.spec.ts'))
     .map((entry) => join(directory, entry.name))
     .sort((left, right) => left.localeCompare(right));
-}
-
-function chunk(values, size) {
-  const chunks = [];
-  for (let index = 0; index < values.length; index += size) {
-    chunks.push(values.slice(index, index + size));
-  }
-  return chunks;
 }

--- a/scripts/run-joystick-e2e-coverage.mjs
+++ b/scripts/run-joystick-e2e-coverage.mjs
@@ -1,0 +1,202 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import { readdirSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { join } from 'node:path';
+import process from 'node:process';
+import { chromium } from 'playwright';
+
+const workspaceRoot = process.cwd();
+const coverageInputDir = join(workspaceRoot, 'test-results', 'joystick-coverage');
+const playwrightCli = join(workspaceRoot, 'node_modules', 'playwright', 'cli.js');
+const peerPath = '/peerjs';
+
+rmSync(coverageInputDir, { force: true, recursive: true });
+rmSync(join(workspaceRoot, 'coverage-report', 'joystick'), { force: true, recursive: true });
+
+const specFiles = listSpecFiles('tests/e2e/joystick');
+
+const peerPort = await getFreePort();
+let peerServer;
+let localStudioServer;
+let exitCode = 0;
+
+try {
+  peerServer = await startReadyProcess({
+    args: ['scripts/e2e-peer-server.mjs'],
+    env: {
+      HOST: '127.0.0.1',
+      PEERJS_PATH: peerPath,
+      PORT: String(peerPort),
+    },
+    readyPattern: /LocalStudio E2E PeerJS server ready:/,
+    timeoutMs: 30_000,
+  });
+
+  localStudioServer = await startReadyProcess({
+    args: ['scripts/dev.mjs'],
+    env: {
+      HOST: '127.0.0.1',
+      LOCALSTUDIO_PEERJS_HOST: '127.0.0.1',
+      LOCALSTUDIO_PEERJS_PATH: peerPath,
+      LOCALSTUDIO_PEERJS_PORT: String(peerPort),
+      PORT: '0',
+      VITE_DISABLE_EDITOR_TOUR: process.env.VITE_DISABLE_EDITOR_TOUR ?? 'true',
+    },
+    readyPattern: /Local:\s+http:\/\/localhost:(\d+)\//,
+    timeoutMs: 120_000,
+  });
+
+  const localStudioPort = Number.parseInt(localStudioServer.match?.[1] ?? '', 10);
+  if (!Number.isInteger(localStudioPort)) {
+    throw new Error('Could not resolve LocalStudio E2E server port.');
+  }
+
+  const baseURL = `http://localhost:${localStudioPort}`;
+  await waitForOk(`${baseURL}/`);
+  await warmJoystick(baseURL);
+
+  const result = runPlaywright(baseURL, localStudioPort);
+  exitCode = result.status ?? 1;
+} finally {
+  if (localStudioServer) await stopProcess(localStudioServer.child);
+  if (peerServer) await stopProcess(peerServer.child);
+}
+
+if (exitCode !== 0) process.exit(exitCode);
+
+function listSpecFiles(directory) {
+  return readdirSync(join(workspaceRoot, directory), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.spec.ts'))
+    .map((entry) => join(directory, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function runPlaywright(baseURL, port) {
+  return spawnSync(
+    process.execPath,
+    [playwrightCli, 'test', '--project=chromium', `--output=${coverageInputDir}`, ...specFiles],
+    {
+      cwd: workspaceRoot,
+      env: {
+        ...process.env,
+        E2E_COVERAGE_INPUT_DIR: coverageInputDir,
+        E2E_COVERAGE_SCOPE: 'joystick',
+        LOCALSTUDIO_E2E_BASE_URL: baseURL,
+        LOCALSTUDIO_E2E_PORT: String(port),
+      },
+      stdio: 'inherit',
+    },
+  );
+}
+
+async function startReadyProcess({ args, env, readyPattern, timeoutMs }) {
+  const child = spawn(process.execPath, args, {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+  let output = '';
+  let settled = false;
+
+  const match = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${args.join(' ')}.\n${output}`));
+    }, timeoutMs);
+
+    function append(chunk) {
+      output += chunk.toString();
+      const match = output.match(readyPattern);
+      if (!match || settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(match);
+    }
+
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on('exit', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(
+        new Error(
+          `${args.join(' ')} exited before becoming ready with code ${String(
+            code,
+          )} and signal ${String(signal)}.\n${output}`,
+        ),
+      );
+    });
+  });
+
+  return { child, match };
+}
+
+async function waitForOk(url) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 30_000) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Keep polling until the server accepts connections.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function warmJoystick(baseURL) {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(new URL('/joystick/', baseURL).toString());
+    await page.getByRole('main', { name: 'Presentation remote control' }).waitFor({
+      timeout: 30_000,
+    });
+    await page.goto(new URL('/editor/?newProject=1', baseURL).toString());
+    await page.getByRole('heading', { name: 'LocalStudio.dev' }).waitFor({ timeout: 30_000 });
+  } finally {
+    await browser.close();
+  }
+}
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => {
+        if (!address || typeof address === 'string') {
+          reject(new Error('Failed to allocate a free local port.'));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+async function stopProcess(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  await new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      resolve();
+    }, 5000);
+    child.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}

--- a/tests/e2e/editor/presenter-notes-window.ts
+++ b/tests/e2e/editor/presenter-notes-window.ts
@@ -5,7 +5,7 @@ import { expect } from '../support/journey-test';
 export const presenterNotesWindow = {
   async dismissIntro(presenterPage: Page): Promise<void> {
     const introDismissButton = presenterPage.getByRole('button', { name: 'Got it' });
-    if (await introDismissButton.isVisible().catch(() => false)) {
+    if (await introDismissButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
       await presenterPage.getByLabel("Don't show this message again").check();
       await introDismissButton.click();
     }
@@ -16,6 +16,8 @@ export const presenterNotesWindow = {
     await page.getByRole('button', { name: 'Presentation play options' }).click();
     await page.getByRole('menuitem', { name: /Presenter view/i }).click();
     const presenterPage = await presenterPopupPromise;
+    await presenterPage.locator('.presenter-view').waitFor({ state: 'visible', timeout: 30_000 });
+    await this.dismissIntro(presenterPage);
     await expect(presenterPage.getByRole('main', { name: 'Presenter view' })).toBeVisible();
     expect(await presenterPage.evaluate(() => Boolean(window.opener))).toBe(true);
     await expect(page.getByRole('dialog', { name: 'Audience Window' })).toBeVisible();

--- a/tests/e2e/editor/presenter-route-startup.ts
+++ b/tests/e2e/editor/presenter-route-startup.ts
@@ -9,13 +9,14 @@ export const presenterRouteStartup = {
     await presenterRouteHarness.install(page);
 
     await page.goto(`${baseURL}/editor/?presenter=1&presenterSession=e2e-presenter`);
-    await expect(page.getByRole('main', { name: 'Presenter view' })).toBeVisible();
+    await page.locator('.presenter-view').waitFor({ state: 'visible', timeout: 30_000 });
     await this.dismissIntro(page);
+    await expect(page.getByRole('main', { name: 'Presenter view' })).toBeVisible();
   },
 
   async dismissIntro(page: Page): Promise<void> {
     const introDismissButton = page.getByRole('button', { name: 'Got it' });
-    if (await introDismissButton.isVisible().catch(() => false)) {
+    if (await introDismissButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
       await introDismissButton.click();
     }
   },

--- a/tests/e2e/joystick/connected-peer-pairing.ts
+++ b/tests/e2e/joystick/connected-peer-pairing.ts
@@ -3,11 +3,13 @@ import { expect } from '../support/journey-test';
 
 export const connectedPeerPairing = {
   async connectRemote(context: BrowserContext, editorPage: Page, presenterPage: Page, baseURL: string) {
-    const remotePanel = editorPage.getByRole('region', { name: 'Remote control this presentation' });
+    await presenterPage.getByRole('button', { name: 'Show remote control QR code' }).click();
+    const remotePanel = presenterPage.getByRole('region', { name: 'Remote control this presentation' });
     await expect(remotePanel).toBeVisible({ timeout: 45_000 });
     await expect(remotePanel.getByRole('img', { name: 'Remote control QR code' })).toBeVisible();
     const remoteUrl = await remotePanel.evaluate((element) => element.getAttribute('data-remote-url'));
     expect(remoteUrl).toContain('/joystick/?peer=');
+    await this.installClipboardCapture(presenterPage);
     await remotePanel.getByRole('button', { name: 'Copy remote link' }).click();
     await expect(remotePanel.getByRole('button', { name: 'Copied' })).toBeVisible();
     await expect
@@ -22,9 +24,6 @@ export const connectedPeerPairing = {
     localRemoteUrl.host = localBaseUrl.host;
     await editorPage.getByRole('button', { name: 'Enter full screen mode' }).click();
 
-    const introDismissButton = presenterPage.getByRole('button', { name: 'Got it' });
-    if (await introDismissButton.isVisible().catch(() => false)) await introDismissButton.click();
-
     const joystickPage = await context.newPage();
     await joystickPage.goto(localRemoteUrl.toString());
     await expect(joystickPage.getByRole('main', { name: 'Presentation remote control' })).toBeVisible();
@@ -33,7 +32,7 @@ export const connectedPeerPairing = {
   },
 
   async installClipboardCapture(page: Page) {
-    await page.addInitScript(() => {
+    const install = () => {
       Object.defineProperty(navigator, 'clipboard', {
         configurable: true,
         value: {
@@ -43,7 +42,9 @@ export const connectedPeerPairing = {
           },
         },
       });
-    });
+    };
+    await page.addInitScript(install);
+    await page.evaluate(install);
   },
 
   async openPresenterView(page: Page) {
@@ -51,6 +52,11 @@ export const connectedPeerPairing = {
     await page.getByRole('button', { name: 'Presentation play options' }).click();
     await page.getByRole('menuitem', { name: /Presenter view/i }).click();
     const presenterPage = await presenterPopupPromise;
+    await presenterPage.locator('.presenter-view').waitFor({ state: 'visible', timeout: 30_000 });
+    const introDismissButton = presenterPage.getByRole('button', { name: 'Got it' });
+    if (await introDismissButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await introDismissButton.click();
+    }
     await expect(presenterPage.getByRole('main', { name: 'Presenter view' })).toBeVisible();
     return presenterPage;
   },

--- a/tests/e2e/pages/editor-app.page.ts
+++ b/tests/e2e/pages/editor-app.page.ts
@@ -17,7 +17,7 @@ export class EditorAppPage extends BasePage {
   }
 
   async openMenu(name: 'Edit' | 'File' | 'Help' | 'View') {
-    await this.page.getByRole('button', { name, exact: true }).click();
+    await this.page.getByRole('button', { name, exact: true }).click({ timeout: 30_000 });
     await expect(this.page.getByRole('menu', { name: `${name} menu` })).toBeVisible();
   }
 

--- a/tests/e2e/support/browser-coverage-session.ts
+++ b/tests/e2e/support/browser-coverage-session.ts
@@ -1,7 +1,6 @@
 import type { BrowserContext, CDPSession, Page } from '@playwright/test';
 
 import { browserCoverageConfig } from './browser-coverage-config';
-import { browserCoverageSource } from './browser-coverage-source';
 import { withCoverageTimeout } from './browser-coverage-timeout';
 import type { BrowserCoverageSession, ScriptCoverageEntry } from './browser-coverage-types';
 
@@ -34,14 +33,6 @@ async function stopCoverage(client: CDPSession): Promise<ScriptCoverageEntry[]> 
     browserCoverageConfig.cdpCoverageTimeoutMs,
     'Profiler.takePreciseCoverage',
   );
-  const entriesWithSource = await Promise.all(
-    coverage.result.map(async (entry) => ({
-      ...entry,
-      source: browserCoverageSource.shouldFetch(entry)
-        ? await browserCoverageSource.get(client, entry)
-        : entry.source,
-    })),
-  );
   await withCoverageTimeout(
     client.send('Profiler.stopPreciseCoverage'),
     browserCoverageConfig.cdpCoverageTimeoutMs,
@@ -62,5 +53,5 @@ async function stopCoverage(client: CDPSession): Promise<ScriptCoverageEntry[]> 
     browserCoverageConfig.cdpCoverageTimeoutMs,
     'CDP detach',
   );
-  return entriesWithSource;
+  return coverage.result;
 }

--- a/tests/e2e/support/coverage-report-source.ts
+++ b/tests/e2e/support/coverage-report-source.ts
@@ -1,0 +1,47 @@
+import { browserCoverageConfig } from './browser-coverage-config';
+import { browserCoveragePath } from './browser-coverage-path';
+import type { ScriptCoverageEntry } from './browser-coverage-types';
+import { normalizeCoverageSourcePath } from './coverage-source-path-normalizer';
+
+const sourceCache = new Map<string, Promise<string | undefined>>();
+
+export const coverageReportSource = {
+  async hydrate(entries: ScriptCoverageEntry[]): Promise<ScriptCoverageEntry[]> {
+    return Promise.all(
+      entries.map(async (entry) => {
+        if (entry.source || !browserCoveragePath.shouldFetchSource(entry.url)) return entry;
+        const source = await getSource(entry.url);
+        return source === undefined ? entry : { ...entry, source };
+      }),
+    );
+  },
+};
+
+async function getSource(url: string) {
+  const cacheKey = getSourceCacheKey(url);
+  let cached = sourceCache.get(cacheKey);
+  if (!cached) {
+    cached = getScriptSourceOverHttp(url);
+    sourceCache.set(cacheKey, cached);
+  }
+  return cached;
+}
+
+function getSourceCacheKey(url: string) {
+  return normalizeCoverageSourcePath(browserCoveragePath.fromUrl(url)) || url;
+}
+
+async function getScriptSourceOverHttp(url: string) {
+  if (!browserCoveragePath.isLocalHttpUrl(url)) return undefined;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), browserCoverageConfig.httpSourceTimeoutMs);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) return undefined;
+    return await response.text();
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/tests/e2e/support/coverage-report.ts
+++ b/tests/e2e/support/coverage-report.ts
@@ -6,6 +6,7 @@ import { coverageFiles } from './coverage-files';
 import { isCoverageLocalScript } from './coverage-local-script-filter';
 import { isCoverageReportableSourceFile } from './coverage-reportable-source-file';
 import { coverageReportConfig } from './coverage-report-config';
+import { coverageReportSource } from './coverage-report-source';
 import { normalizeCoverageSourcePath } from './coverage-source-path-normalizer';
 
 interface TestCoverageFile {
@@ -68,7 +69,7 @@ export default async function reportPlaywrightCoverage() {
 
   for (const file of browserCoverageFiles) {
     const payload = JSON.parse(await readFile(file, 'utf8')) as TestCoverageFile;
-    await coverageReport.add(payload.entries);
+    await coverageReport.add(await coverageReportSource.hydrate(payload.entries));
   }
 
   await coverageReport.generate();

--- a/tests/e2e/support/journey-test.ts
+++ b/tests/e2e/support/journey-test.ts
@@ -16,6 +16,19 @@ export const test = base.extend<JourneyFixtures, JourneyWorkerFixtures>({
   workerDevServer: [
     async ({ browser }, use) => {
       void browser;
+      const sharedBaseURL = process.env.LOCALSTUDIO_E2E_BASE_URL;
+      const sharedPort = Number.parseInt(process.env.LOCALSTUDIO_E2E_PORT ?? '', 10);
+      if (sharedBaseURL && Number.isInteger(sharedPort)) {
+        await use({
+          baseURL: sharedBaseURL,
+          port: sharedPort,
+          stop: async () => {
+            await Promise.resolve();
+          },
+        });
+        return;
+      }
+
       const server = await startIsolatedDevServer();
       await use(server);
       await server.stop();


### PR DESCRIPTION
## Summary
- Remove manual E2E batching and run the editor coverage suite in a single Playwright invocation.
- Use full worker allocation from Playwright config instead of a custom CPU-based worker helper.
- Increase the editor menu click timeout to reduce flakiness under load.

## Testing
- Not run (not requested)
- Changes were validated by inspection of the updated Playwright coverage runner and page object flow.