### PR TITLE
Improve PPTX import for animation effects, image crops, and text autofit

### DIFF
--- a/apps/editor/src/services/importing/pptx/pptx-animation-builds.ts
+++ b/apps/editor/src/services/importing/pptx/pptx-animation-builds.ts
@@ -58,6 +58,20 @@ function isMediaControlTiming(timingNode: Element | undefined) {
   return timingNode?.getAttribute('presetClass') === 'mediacall';
 }
 
+function toBuildEffect(timingNode: Element | undefined): AnimationEffect {
+  if (!timingNode || isMediaControlTiming(timingNode)) return 'reveal';
+  const presetSubtype = timingNode.getAttribute('presetSubtype');
+  const presetId = timingNode.getAttribute('presetID');
+  const effectFilter = pptxXml.firstDescendant(timingNode, 'animEffect')?.getAttribute('filter');
+  const effectName = effectFilter ?? presetSubtype;
+  if (effectName === 'fade' || effectName === 'dissolve' || presetId === '9' || presetId === '10') {
+    return 'dissolve';
+  }
+  if (effectName === 'push') return 'push';
+  if (effectName === 'wipe') return 'wipe';
+  return 'reveal';
+}
+
 function getVideoStartTriggers(document: Document, objects: PptxSlideObject[]) {
   const videoObjectsByShapeId = new Map(
     objects
@@ -100,7 +114,7 @@ function parse(document: Document, slideId: string, objects: PptxSlideObject[]):
     builds.push({
       id: `${slideId}-build-${buildIndex + 1}-${object.id}`,
       elementId: object.id,
-      effect: 'reveal',
+      effect: toBuildEffect(timingNode),
       trigger: toBuildTrigger(timingNode?.getAttribute('nodeType') ?? null, buildIndex),
       delayMs: 0,
       durationMs: isMediaControlTiming(timingNode) ? 0 : getBuildDurationMs(timingNode),

--- a/apps/editor/src/services/importing/pptx/pptx-parser-model.ts
+++ b/apps/editor/src/services/importing/pptx/pptx-parser-model.ts
@@ -1,6 +1,7 @@
 import type {
   AnimationEffect,
   AnimationTrigger,
+  CropRect,
   ElementAnimationBuild,
   ImportWarning,
   PlaceholderRole,
@@ -39,6 +40,7 @@ export interface PptxTextInsets {
 }
 
 export interface PptxTextBox {
+  autoFit: 'none' | 'shrink-text';
   insets: PptxTextInsets;
   verticalAlign: 'bottom' | 'middle' | 'top';
 }
@@ -60,6 +62,7 @@ export type PptxSlideObject =
     }
   | {
       assetPath: string;
+      crop?: CropRect;
       frame: PptxRect;
       id: string;
       kind: 'image' | 'gif' | 'video';
@@ -101,6 +104,7 @@ export interface PptxSlide {
   placeholderRoles: PlaceholderRole[];
   speakerNotes?: string;
   transitionEffect: AnimationEffect;
+  visible: boolean;
 }
 
 export interface PptxLayout {

--- a/apps/editor/src/services/importing/pptx/pptx-visual-style.ts
+++ b/apps/editor/src/services/importing/pptx/pptx-visual-style.ts
@@ -66,10 +66,26 @@ function getHexColor(element: ParentNode | undefined, fallback: string, theme?: 
   return rawColor && sourceElement ? applyColorModifier(normalizeColor(rawColor), sourceElement) : fallback;
 }
 
+function toUnitInterval(value: string | null | undefined) {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue)
+    ? Math.max(0, Math.min(1, numericValue / 100000))
+    : undefined;
+}
+
 function getOpacity(element: ParentNode | undefined) {
   if (!element) return undefined;
-  const alpha = Number(pptxXml.firstDescendant(element, 'alpha')?.getAttribute('val'));
-  return Number.isFinite(alpha) ? Math.max(0, Math.min(1, alpha / 100000)) : undefined;
+  const blip = pptxXml.firstDescendant(element, 'blip');
+  const blipAlpha = blip
+    ? toUnitInterval(pptxXml.firstDescendant(blip, 'alpha')?.getAttribute('val')) ??
+      toUnitInterval(pptxXml.firstDescendant(blip, 'alphaModFix')?.getAttribute('amt')) ??
+      toUnitInterval(pptxXml.firstDescendant(blip, 'alphaMod')?.getAttribute('amt'))
+    : undefined;
+  if (blipAlpha !== undefined) return blipAlpha;
+  const solidFill = pptxXml.firstDescendant(element, 'solidFill');
+  return solidFill
+    ? toUnitInterval(pptxXml.firstDescendant(solidFill, 'alpha')?.getAttribute('val'))
+    : undefined;
 }
 
 export const pptxVisualStyle = {

--- a/apps/editor/src/services/importing/pptx/pptxImageDimensions.ts
+++ b/apps/editor/src/services/importing/pptx/pptxImageDimensions.ts
@@ -1,0 +1,59 @@
+import type { PptxImageSize, PptxPackageFile } from './pptxPackageTypes';
+
+function readUint32(bytes: Uint8Array, offset: number) {
+  return (
+    bytes[offset]! * 0x1000000 +
+    bytes[offset + 1]! * 0x10000 +
+    bytes[offset + 2]! * 0x100 +
+    bytes[offset + 3]!
+  );
+}
+
+function readUint16(bytes: Uint8Array, offset: number) {
+  return bytes[offset]! * 0x100 + bytes[offset + 1]!;
+}
+
+function parsePngSize(bytes: Uint8Array): PptxImageSize | undefined {
+  if (
+    bytes.length < 24 ||
+    bytes[0] !== 0x89 ||
+    bytes[1] !== 0x50 ||
+    bytes[2] !== 0x4e ||
+    bytes[3] !== 0x47
+  ) {
+    return undefined;
+  }
+  const width = readUint32(bytes, 16);
+  const height = readUint32(bytes, 20);
+  return width > 0 && height > 0 ? { height, width } : undefined;
+}
+
+function parseJpegSize(bytes: Uint8Array): PptxImageSize | undefined {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return undefined;
+  let offset = 2;
+  while (offset + 9 < bytes.length) {
+    if (bytes[offset] !== 0xff) return undefined;
+    const marker = bytes[offset + 1];
+    const length = readUint16(bytes, offset + 2);
+    if (length < 2) return undefined;
+    if (marker && marker >= 0xc0 && marker <= 0xcf && ![0xc4, 0xc8, 0xcc].includes(marker)) {
+      const height = readUint16(bytes, offset + 5);
+      const width = readUint16(bytes, offset + 7);
+      return width > 0 && height > 0 ? { height, width } : undefined;
+    }
+    offset += 2 + length;
+  }
+  return undefined;
+}
+
+async function getSize(file: PptxPackageFile, mimeType: string | undefined): Promise<PptxImageSize | undefined> {
+  if (!mimeType?.startsWith('image/')) return undefined;
+  const bytes = new Uint8Array(await file.blob.arrayBuffer());
+  if (mimeType === 'image/png' || file.path.toLowerCase().endsWith('.png')) return parsePngSize(bytes);
+  if (mimeType === 'image/jpeg' || file.path.toLowerCase().match(/\.jpe?g$/)) return parseJpegSize(bytes);
+  return undefined;
+}
+
+export const pptxImageDimensions = {
+  getSize,
+};

--- a/apps/editor/src/services/importing/pptx/pptxPackage.ts
+++ b/apps/editor/src/services/importing/pptx/pptxPackage.ts
@@ -1,6 +1,7 @@
 import type { ImportWarning } from '../../../domain/documents/model';
 import type { PptxPackageFile } from './pptxPackageTypes';
 import { pptxFileUtils } from './pptxFileUtils';
+import { pptxImageDimensions } from './pptxImageDimensions';
 import { pptxXml } from './pptxXml';
 
 export interface PptxRelationship {
@@ -38,6 +39,18 @@ function extensionFor(path: string) {
   const fileName = path.split('/').at(-1) ?? path;
   const dotIndex = fileName.lastIndexOf('.');
   return dotIndex >= 0 ? fileName.slice(dotIndex + 1).toLowerCase() : '';
+}
+
+function getContentTypeForPath(
+  path: string,
+  defaults: Map<string, string>,
+  overrides: Map<string, string>,
+) {
+  return (
+    overrides.get(pptxFileUtils.normalizePath(path)) ??
+    defaults.get(extensionFor(path)) ??
+    pptxFileUtils.getMimeType(path)
+  );
 }
 
 function parseContentTypes(xml: string | undefined) {
@@ -83,13 +96,18 @@ function parseRelationships(xml: string | undefined, sourcePath: string) {
 async function create(files: PptxPackageFile[]): Promise<PptxPackage> {
   const filesByPath = new Map(files.map((file) => [file.path, file]));
   const { defaults, overrides } = parseContentTypes(await readText(filesByPath.get(CONTENT_TYPES_PATH)));
+  const enrichedFiles = await Promise.all(
+    files.map(async (file) => {
+      const imageSize = await pptxImageDimensions.getSize(file, getContentTypeForPath(file.path, defaults, overrides));
+      return imageSize ? { ...file, imageSize } : file;
+    }),
+  );
+  const enrichedFilesByPath = new Map(enrichedFiles.map((file) => [file.path, file]));
   const relationshipCache = new Map<string, Map<string, PptxRelationship>>();
   const warnings: ImportWarning[] = [];
 
   const getContentType = (path: string) =>
-    overrides.get(pptxFileUtils.normalizePath(path)) ??
-    defaults.get(extensionFor(path)) ??
-    pptxFileUtils.getMimeType(path);
+    getContentTypeForPath(path, defaults, overrides);
 
   const getRelationships = (sourcePath: string) => {
     const normalizedSource = pptxFileUtils.normalizePath(sourcePath);
@@ -101,9 +119,9 @@ async function create(files: PptxPackageFile[]): Promise<PptxPackage> {
   };
 
   const pkg: PptxPackage = {
-    files,
+    files: enrichedFiles,
     getContentType,
-    getFile: (path) => filesByPath.get(pptxFileUtils.normalizePath(path)),
+    getFile: (path) => enrichedFilesByPath.get(pptxFileUtils.normalizePath(path)),
     getRelationships,
     readText: (path) => readText(path ? filesByPath.get(pptxFileUtils.normalizePath(path)) : undefined),
     warnings,

--- a/apps/editor/src/services/importing/pptx/pptxPackageTypes.ts
+++ b/apps/editor/src/services/importing/pptx/pptxPackageTypes.ts
@@ -1,6 +1,12 @@
 export interface PptxPackageFile {
   path: string;
   blob: Blob;
+  imageSize?: PptxImageSize;
+}
+
+export interface PptxImageSize {
+  height: number;
+  width: number;
 }
 
 export type PptxImportInput = { file: File };

--- a/apps/editor/src/services/importing/pptx/pptxParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxParser.ts
@@ -169,8 +169,10 @@ function parsePictureObject(
   if (!assetType) return undefined;
   const shapeId = localShapeId(picture, String(zIndex));
   const opacity = pptxVisualStyle.getOpacity(picture);
+  const crop = parsePictureCrop(picture);
   return {
     assetPath,
+    ...(crop ? { crop } : {}),
     frame,
     id: `${slideId}-${idScope}-${assetType}-${shapeId}`,
     kind: assetType,
@@ -180,6 +182,23 @@ function parsePictureObject(
     sourceShapeId: shapeId,
     zIndex,
   };
+}
+
+function parseCropCoordinate(value: string | null | undefined) {
+  const coordinate = Number(value);
+  return Number.isFinite(coordinate) ? Math.max(0, coordinate / 100000) : 0;
+}
+
+function parsePictureCrop(picture: Element) {
+  const srcRect = pptxXml.firstDescendant(picture, 'srcRect');
+  if (!srcRect) return undefined;
+  const left = parseCropCoordinate(srcRect.getAttribute('l'));
+  const top = parseCropCoordinate(srcRect.getAttribute('t'));
+  const right = parseCropCoordinate(srcRect.getAttribute('r'));
+  const bottom = parseCropCoordinate(srcRect.getAttribute('b'));
+  const width = Math.max(0.01, 1 - left - right);
+  const height = Math.max(0.01, 1 - top - bottom);
+  return { x: left, y: top, width, height };
 }
 
 function getBackgroundColor(document: Document, theme: ParseScope['theme'], fallback = '#000000') {
@@ -597,6 +616,7 @@ async function parseSlide(
   context: ParseContext,
   slidePath: string,
   slideIndex: number,
+  visible: boolean,
   scaleX: number,
   scaleY: number,
   textDefaults: PptxTextDefaults,
@@ -653,6 +673,7 @@ async function parseSlide(
     placeholderRoles: parsedLayout?.placeholderRoles ?? getPlaceholderRoles(inheritedObjects),
     ...(speakerNotes ? { speakerNotes } : {}),
     transitionEffect: pptxAnimationBuilds.getTransitionEffect(document),
+    visible,
   };
 }
 
@@ -684,10 +705,16 @@ async function parse(context: ParseContext, name: string): Promise<PptxDeck> {
   const presentationRelationships = context.package.getRelationships(presentationPath);
   const size = getPresentationSize(presentation);
   const textDefaults = pptxTextParser.getPresentationTextDefaults(presentation);
-  const slidePaths = pptxXml
+  const slideEntries = pptxXml
     .descendants(presentation, 'sldId')
-    .map((slide) => presentationRelationships.get(pptxXml.getRelationshipAttr(slide, 'id') ?? '')?.target)
-    .filter((path): path is string => Boolean(path));
+    .map((slide) => {
+      const target = presentationRelationships.get(pptxXml.getRelationshipAttr(slide, 'id') ?? '')?.target;
+      if (!target) return undefined;
+      const show = slide.getAttribute('show');
+      return { target, visible: show !== '0' && show !== 'false' };
+    })
+    .filter((entry): entry is { target: string; visible: boolean } => Boolean(entry));
+  const slidePaths = slideEntries.map((entry) => entry.target);
   if (slidePaths.length === 0) throw new Error('PowerPoint package does not contain slides.');
   const masterPaths = getRelationshipTargetsInListOrder(
     presentationRelationships,
@@ -730,8 +757,17 @@ async function parse(context: ParseContext, name: string): Promise<PptxDeck> {
     layouts,
     name: normalizeName(name),
     slides: await Promise.all(
-      slidePaths.map((slidePath, index) =>
-        parseSlide(context, slidePath, index, size.scaleX, size.scaleY, textDefaults, layoutsByPath),
+      slideEntries.map((entry, index) =>
+        parseSlide(
+          context,
+          entry.target,
+          index,
+          entry.visible,
+          size.scaleX,
+          size.scaleY,
+          textDefaults,
+          layoutsByPath,
+        ),
       ),
     ),
     warnings: context.package.warnings,

--- a/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
+++ b/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
@@ -1,5 +1,6 @@
 import type {
   Asset,
+  CropRect,
   DesignElement,
   ImportWarning,
   Page,
@@ -17,7 +18,12 @@ const TEXT_FRAME_FIT = {
   heightPaddingRatio: 0.4,
   horizontalPaddingRatio: 1.2,
   lineHeightRatio: 1.35,
+  minimumAutoFitFontSize: 8,
   shrinkOversizedHeightRatio: 1.8,
+};
+
+const IMAGE_FIT = {
+  aspectRatioTolerance: 0.03,
 };
 
 function createAssetId(path: string, index: number) {
@@ -128,32 +134,33 @@ function getFittedTextFrame(
   object: Extract<PptxSlideObject, { kind: 'text' }>,
   pageWidth: number,
   pageHeight: number,
+  fontSize = object.style.fontSize,
 ) {
   const frame = getInsetTextFrame(object);
   const lines = getTextLines(object.text);
   const longestLineUnits = Math.max(...lines.map(getTextLineUnits), 1);
   const preferredWidth = Math.ceil(
-    longestLineUnits * object.style.fontSize * TEXT_FRAME_FIT.averageCharacterWidth +
-      object.style.fontSize * TEXT_FRAME_FIT.horizontalPaddingRatio,
+    longestLineUnits * fontSize * TEXT_FRAME_FIT.averageCharacterWidth +
+      fontSize * TEXT_FRAME_FIT.horizontalPaddingRatio,
   );
   const width = Math.min(pageWidth, Math.max(frame.width, preferredWidth));
   const x = getHorizontallyAnchoredX(object, frame, width, pageWidth);
 
   const contentWidth = Math.max(
-    object.style.fontSize,
-    width - object.style.fontSize * TEXT_FRAME_FIT.horizontalPaddingRatio,
+    fontSize,
+    width - fontSize * TEXT_FRAME_FIT.horizontalPaddingRatio,
   );
   const lineCapacity = Math.max(
     1,
-    contentWidth / (object.style.fontSize * TEXT_FRAME_FIT.averageCharacterWidth),
+    contentWidth / (fontSize * TEXT_FRAME_FIT.averageCharacterWidth),
   );
   const visualLineCount = lines.reduce(
     (count, line) => count + Math.max(1, Math.ceil(getTextLineUnits(line) / lineCapacity)),
     0,
   );
   const fittedHeight = Math.ceil(
-    visualLineCount * object.style.fontSize * object.style.lineHeight +
-      object.style.fontSize * TEXT_FRAME_FIT.heightPaddingRatio,
+    visualLineCount * fontSize * object.style.lineHeight +
+      fontSize * TEXT_FRAME_FIT.heightPaddingRatio,
   );
   let height =
     frame.height > fittedHeight * TEXT_FRAME_FIT.shrinkOversizedHeightRatio
@@ -170,6 +177,108 @@ function getFittedTextFrame(
   };
 }
 
+function getAutoFitTextFrame(
+  object: Extract<PptxSlideObject, { kind: 'text' }>,
+  pageWidth: number,
+  pageHeight: number,
+) {
+  const frame = getInsetTextFrame(object);
+  return {
+    height: Math.min(pageHeight, frame.height),
+    width: Math.min(pageWidth, frame.width),
+    x: clampFrameStart(frame.x, frame.width, pageWidth),
+    y: getVerticallyAnchoredY(object, frame, Math.min(pageHeight, frame.height), pageHeight),
+  };
+}
+
+function getVisualLineCount(text: string, width: number, fontSize: number) {
+  const contentWidth = Math.max(
+    fontSize,
+    width - fontSize * TEXT_FRAME_FIT.horizontalPaddingRatio,
+  );
+  const lineCapacity = Math.max(
+    1,
+    contentWidth / (fontSize * TEXT_FRAME_FIT.averageCharacterWidth),
+  );
+  return getTextLines(text).reduce(
+    (count, line) => count + Math.max(1, Math.ceil(getTextLineUnits(line) / lineCapacity)),
+    0,
+  );
+}
+
+function textFitsFrame(
+  object: Extract<PptxSlideObject, { kind: 'text' }>,
+  frame: ReturnType<typeof getAutoFitTextFrame>,
+  fontSize: number,
+) {
+  const visualLineCount = getVisualLineCount(object.text, frame.width, fontSize);
+  const fittedHeight = Math.ceil(
+    visualLineCount * fontSize * object.style.lineHeight +
+      fontSize * TEXT_FRAME_FIT.heightPaddingRatio,
+  );
+  return fittedHeight <= frame.height;
+}
+
+function getAutoFitFontSize(
+  object: Extract<PptxSlideObject, { kind: 'text' }>,
+  pageWidth: number,
+  pageHeight: number,
+) {
+  if (object.textBox.autoFit !== 'shrink-text') return object.style.fontSize;
+  const frame = getAutoFitTextFrame(object, pageWidth, pageHeight);
+  if (textFitsFrame(object, frame, object.style.fontSize)) return object.style.fontSize;
+  let lower = TEXT_FRAME_FIT.minimumAutoFitFontSize;
+  let upper = object.style.fontSize;
+  while (lower < upper) {
+    const candidate = Math.ceil((lower + upper) / 2);
+    if (textFitsFrame(object, frame, candidate)) {
+      lower = candidate;
+    } else {
+      upper = candidate - 1;
+    }
+  }
+  return lower;
+}
+
+function roundCrop(value: number) {
+  return Math.round(value * 10_000) / 10_000;
+}
+
+function getCoverCrop(
+  object: Extract<PptxSlideObject, { kind: 'image' | 'gif' | 'video' }>,
+  pptxPackage: PptxPackage,
+): CropRect | undefined {
+  if (object.kind !== 'image') return undefined;
+  if (object.crop) return object.crop;
+  const imageSize = pptxPackage.getFile(object.assetPath)?.imageSize;
+  if (!imageSize) return undefined;
+  const sourceRatio = imageSize.width / imageSize.height;
+  const frameRatio = object.frame.width / object.frame.height;
+  if (
+    !Number.isFinite(sourceRatio) ||
+    !Number.isFinite(frameRatio) ||
+    Math.abs(sourceRatio - frameRatio) <= IMAGE_FIT.aspectRatioTolerance
+  ) {
+    return undefined;
+  }
+  if (sourceRatio > frameRatio) {
+    const width = frameRatio / sourceRatio;
+    return {
+      x: roundCrop((1 - width) / 2),
+      y: 0,
+      width: roundCrop(width),
+      height: 1,
+    };
+  }
+  const height = sourceRatio / frameRatio;
+  return {
+    x: 0,
+    y: roundCrop((1 - height) / 2),
+    width: 1,
+    height: roundCrop(height),
+  };
+}
+
 function mapObject(
   object: PptxSlideObject,
   pptxPackage: PptxPackage,
@@ -181,7 +290,11 @@ function mapObject(
   layoutId?: string,
 ): DesignElement | undefined {
   if (object.kind === 'text') {
-    const frame = getFittedTextFrame(object, pageWidth, pageHeight);
+    const fontSize = getAutoFitFontSize(object, pageWidth, pageHeight);
+    const frame =
+      object.textBox.autoFit === 'shrink-text'
+        ? getAutoFitTextFrame(object, pageWidth, pageHeight)
+        : getFittedTextFrame(object, pageWidth, pageHeight, fontSize);
     return {
       id: object.id,
       type: 'text',
@@ -194,6 +307,7 @@ function mapObject(
       ...(layoutId ? { templateSource: { layoutId, type: 'layout' as const } } : {}),
       ...(object.placeholderRole ? { placeholderRole: object.placeholderRole } : {}),
       ...object.style,
+      fontSize,
     };
   }
   if (object.kind === 'shape') {
@@ -249,7 +363,12 @@ function mapObject(
     };
   }
   if (object.kind === 'gif') return { ...base, type: 'gif', playing: true };
-  return { ...base, type: 'image' };
+  const crop = getCoverCrop(object, pptxPackage);
+  return {
+    ...base,
+    type: 'image',
+    ...(crop ? { crop } : {}),
+  };
 }
 
 const defaultPlaceholderVisibility: Record<PlaceholderRole, boolean> = {
@@ -360,7 +479,7 @@ function map(deck: PptxDeck, pptxPackage: PptxPackage): ProjectDocument {
           }
         : {}),
       ...(slide.speakerNotes ? { speakerNotes: slide.speakerNotes } : {}),
-      visible: true,
+      visible: slide.visible,
     };
   });
   return {

--- a/apps/editor/src/services/importing/pptx/pptxTextParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxTextParser.ts
@@ -255,6 +255,7 @@ function getTextBox(shape: Element, scaleX: number, scaleY: number): PptxTextBox
   const bodyProperties = pptxXml.firstDescendant(shape, 'bodyPr');
   const anchor = bodyProperties?.getAttribute('anchor');
   return {
+    autoFit: bodyProperties && pptxXml.firstDescendant(bodyProperties, 'normAutofit') ? 'shrink-text' : 'none',
     insets: {
       bottom: getTextInset(bodyProperties, 'bIns', pptxParserDefaults.textInsetsEmu.bottom, scaleY),
       left: getTextInset(bodyProperties, 'lIns', pptxParserDefaults.textInsetsEmu.left, scaleX),

--- a/apps/editor/src/ui/editor/panels/PagesPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/PagesPanel.tsx
@@ -343,10 +343,18 @@ function MiniElement({
 
   if (element.type === 'image') {
     const asset = project.assets[element.assetId];
+    const imageStyle = element.crop
+      ? {
+          ...style,
+          objectPosition: `${(element.crop.x + element.crop.width / 2) * 100}% ${
+            (element.crop.y + element.crop.height / 2) * 100
+          }%`,
+        }
+      : style;
     return asset?.objectUrl ? (
-      <img alt="" className="page-card-mini-element" src={asset.objectUrl} style={style} />
+      <img alt="" className="page-card-mini-element" src={asset.objectUrl} style={imageStyle} />
     ) : (
-      <span className="page-card-mini-element page-card-mini-placeholder" style={style} />
+      <span className="page-card-mini-element page-card-mini-placeholder" style={imageStyle} />
     );
   }
 

--- a/apps/editor/src/ui/presenter/presenterRemoteMirror.ts
+++ b/apps/editor/src/ui/presenter/presenterRemoteMirror.ts
@@ -81,6 +81,30 @@ function getVideoElement(videoElements: HTMLVideoElement[], elementId: string) {
   return videoElements.find((video) => video.dataset.mediaElementId === elementId);
 }
 
+function drawImageElement(
+  context: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  element: Extract<DesignElement, { type: 'image' }>,
+  width: number,
+  height: number,
+) {
+  if (!element.crop) {
+    context.drawImage(image, 0, 0, width, height);
+    return;
+  }
+  context.drawImage(
+    image,
+    element.crop.x * image.naturalWidth,
+    element.crop.y * image.naturalHeight,
+    element.crop.width * image.naturalWidth,
+    element.crop.height * image.naturalHeight,
+    0,
+    0,
+    width,
+    height,
+  );
+}
+
 function drawElement(
   context: CanvasRenderingContext2D,
   frame: PresenterRemoteMirrorFrame,
@@ -105,7 +129,10 @@ function drawElement(
     context.textBaseline = 'top';
     const textX = element.align === 'center' ? width / 2 : element.align === 'right' ? width : 0;
     drawWrappedText(context, element.text, textX, 0, width, (element.lineHeight ?? 1.05) * element.fontSize * scale, 8);
-  } else if (element.type === 'image' || element.type === 'gif') {
+  } else if (element.type === 'image') {
+    const image = getCachedImage(frame.project.assets[element.assetId]?.objectUrl);
+    if (image) drawImageElement(context, image, element, width, height);
+  } else if (element.type === 'gif') {
     const image = getCachedImage(frame.project.assets[element.assetId]?.objectUrl);
     if (image) context.drawImage(image, 0, 0, width, height);
   } else if (element.type === 'video') {

--- a/apps/editor/tests/unit/services/pptxImportService.test.ts
+++ b/apps/editor/tests/unit/services/pptxImportService.test.ts
@@ -38,6 +38,7 @@ const slideRels = `<?xml version="1.0" encoding="UTF-8"?>
   <Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
   <Relationship Id="rIdPoster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/poster1.png"/>
   <Relationship Id="rIdVideo" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/video" Target="../media/media1.mp4"/>
+  <Relationship Id="rIdWideImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/wide.png"/>
 </Relationships>`;
 
 const layoutRels = `<?xml version="1.0" encoding="UTF-8"?>
@@ -132,10 +133,20 @@ const slideXml = `<?xml version="1.0" encoding="UTF-8"?>
         <p:spPr><a:xfrm><a:off x="2743200" y="4572000"/><a:ext cx="1828800" cy="457200"/></a:xfrm></p:spPr>
         <p:txBody><a:bodyPr anchor="ctr"/><a:lstStyle/><a:p><a:pPr/><a:r><a:rPr sz="2400"><a:solidFill><a:srgbClr val="ffffff"/></a:solidFill><a:latin typeface="Arial"/></a:rPr><a:t>Inherited centered</a:t></a:r></a:p></p:txBody>
       </p:sp>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="8" name="Auto-fit title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="914400" y="3657600"/><a:ext cx="1828800" cy="457200"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr lIns="0" rIns="0" tIns="0" bIns="0" anchor="ctr"><a:normAutofit/></a:bodyPr><a:lstStyle/><a:p><a:pPr algn="ctr"/><a:r><a:rPr sz="9600" b="1"><a:solidFill><a:srgbClr val="ffffff"/></a:solidFill><a:latin typeface="Arial"/></a:rPr><a:t>Shrink me please</a:t></a:r></a:p></p:txBody>
+      </p:sp>
       <p:pic>
         <p:nvPicPr><p:cNvPr id="3" name="Hero image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
         <p:blipFill><a:blip r:embed="rIdImage"/></p:blipFill>
-        <p:spPr><a:xfrm><a:off x="4572000" y="914400"/><a:ext cx="1828800" cy="914400"/></a:xfrm></p:spPr>
+        <p:spPr><a:xfrm><a:off x="4572000" y="914400"/><a:ext cx="1828800" cy="914400"/></a:xfrm><a:effectLst><a:outerShdw><a:srgbClr val="000000"><a:alpha val="70000"/></a:srgbClr></a:outerShdw></a:effectLst></p:spPr>
+      </p:pic>
+      <p:pic>
+        <p:nvPicPr><p:cNvPr id="9" name="Wide screenshot"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+        <p:blipFill><a:blip r:embed="rIdWideImage"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+        <p:spPr><a:xfrm><a:off x="914400" y="3200400"/><a:ext cx="914400" cy="914400"/></a:xfrm></p:spPr>
       </p:pic>
       <p:pic>
         <p:nvPicPr><p:cNvPr id="4" name="Movie"/><p:cNvPicPr/><p:nvPr><a:videoFile r:link="rIdVideo"/><p14:media r:embed="rIdVideo"/></p:nvPr></p:nvPicPr>
@@ -151,8 +162,8 @@ const slideXml = `<?xml version="1.0" encoding="UTF-8"?>
         <p:cTn id="1">
           <p:childTnLst>
             <p:par>
-              <p:cTn id="2" nodeType="afterEffect" presetClass="entr" dur="700">
-                <p:childTnLst><p:anim><p:cBhvr><p:tgtEl><p:spTgt spid="2"/></p:tgtEl></p:cBhvr></p:anim></p:childTnLst>
+              <p:cTn id="2" nodeType="afterEffect" presetClass="entr" presetID="10" dur="700">
+                <p:childTnLst><p:animEffect filter="fade" transition="in"><p:cBhvr><p:tgtEl><p:spTgt spid="2"/></p:tgtEl></p:cBhvr></p:animEffect></p:childTnLst>
               </p:cTn>
             </p:par>
             <p:par>
@@ -198,9 +209,13 @@ const notesSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
   </p:cSld>
 </p:notes>`;
 
-function createPptxFixture(slideContents = slideXml) {
+const widePngHeader = new Uint8Array([
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 200, 0, 0, 0, 100,
+]);
+
+function createPptxFixture(slideContents = slideXml, presentationContents = presentationXml) {
   return createStoredPptxFile([
-    { path: 'ppt/presentation.xml', contents: presentationXml },
+    { path: 'ppt/presentation.xml', contents: presentationContents },
     { path: 'ppt/_rels/presentation.xml.rels', contents: presentationRels },
     { path: 'ppt/slides/slide1.xml', contents: slideContents },
     { path: 'ppt/slides/_rels/slide1.xml.rels', contents: slideRels },
@@ -212,6 +227,7 @@ function createPptxFixture(slideContents = slideXml) {
     { path: 'ppt/slideMasters/_rels/slideMaster1.xml.rels', contents: masterRels },
     { path: 'ppt/media/image1.png', contents: new Uint8Array([137, 80, 78, 71]) },
     { path: 'ppt/media/layout-icon.png', contents: new Uint8Array([137, 80, 78, 71]) },
+    { path: 'ppt/media/wide.png', contents: widePngHeader },
     { path: 'ppt/media/poster1.png', contents: new Uint8Array([137, 80, 78, 71]) },
     { path: 'ppt/media/media1.mp4', contents: new Uint8Array([0, 0, 0, 24]) },
   ]);
@@ -376,7 +392,7 @@ describe('BrowserPptxImportService', () => {
     expect(project.pages[0]?.animationBuilds).toMatchObject([
       {
         elementId: 'pptx-page-1-slide-text-2',
-        effect: 'reveal',
+        effect: 'dissolve',
         trigger: 'after-transition',
         durationMs: 700,
         kind: 'build-in',
@@ -414,11 +430,16 @@ describe('BrowserPptxImportService', () => {
     const inheritedCenteredElement = elements.find(
       (element) => element.type === 'text' && element.text === 'Inherited centered',
     );
+    const autoFitElement = elements.find(
+      (element) => element.type === 'text' && element.text === 'Shrink me please',
+    );
     const imageElements = elements.filter((element) => element.type === 'image');
     const videoElement = elements.find((element) => element.type === 'video');
     const imageAsset = Object.values(project.assets).find((asset) => asset.fileName === 'image1.png');
+    const wideImageAsset = Object.values(project.assets).find((asset) => asset.fileName === 'wide.png');
     const layoutImageAsset = Object.values(project.assets).find((asset) => asset.fileName === 'layout-icon.png');
     const imageElement = imageElements.find((element) => element.assetId === imageAsset?.id);
+    const wideImageElement = imageElements.find((element) => element.assetId === wideImageAsset?.id);
 
     expect(textElement).toMatchObject({
       locked: false,
@@ -490,9 +511,21 @@ describe('BrowserPptxImportService', () => {
       throw new Error('Expected inherited centered text.');
     }
     expect(inheritedCenteredElement.align).toBe('center');
+    if (!autoFitElement || autoFitElement.type !== 'text') {
+      throw new Error('Expected auto-fit text.');
+    }
+    expect(autoFitElement.fontSize).toBeLessThan(256);
+    expect(autoFitElement.height).toBe(108);
+    expect(autoFitElement.width).toBe(396);
+    expect(autoFitElement.align).toBe('center');
     expect(project.pages[0]?.elementIds.some((elementId) => elementId.includes('placeholder'))).toBe(false);
-    expect(imageElements).toHaveLength(1);
-    expect(imageElement).toMatchObject({ locked: false, type: 'image' });
+    expect(imageElements).toHaveLength(2);
+    expect(imageElement).toMatchObject({ locked: false, opacity: 1, type: 'image' });
+    expect(wideImageElement).toMatchObject({
+      crop: { x: 0.25, y: 0, width: 0.5, height: 1 },
+      locked: false,
+      type: 'image',
+    });
     expect(videoElement).toMatchObject({
       autoplayInPreview: true,
       controls: true,
@@ -536,6 +569,21 @@ describe('BrowserPptxImportService', () => {
       startOnClick: false,
       type: 'video',
     });
+  });
+
+  it('imports skipped PowerPoint slides as disabled pages', async () => {
+    const hiddenPresentationXml = presentationXml.replace(
+      '<p:sldId id="256" r:id="rId1"/>',
+      '<p:sldId id="256" r:id="rId1" show="0"/>',
+    );
+    const service = new BrowserPptxImportService();
+    const project = await service.importPowerPoint({
+      file: createPptxFixture(slideXml, hiddenPresentationXml),
+    });
+
+    expect(project.pages).toHaveLength(1);
+    expect(project.pages[0]?.visible).toBe(false);
+    expect(project.pages[0]?.elementIds.length).toBeGreaterThan(0);
   });
 
   it('rejects files that are not valid PPTX packages', async () => {


### PR DESCRIPTION
## Summary
- Map PPTX animation metadata to more accurate build effects instead of defaulting everything to reveal.
- Preserve slide visibility flags, picture crop data, and text autofit behavior during import.
- Detect image dimensions from PNG/JPEG assets so imported images can be centered and cropped more faithfully.
- Apply imported crop data in the editor panels and presenter mirror rendering.
- Expand PPTX import coverage with fixtures for autofit text, image crops, transitions, and hidden slides.

## Testing
- Added and updated unit coverage for PPTX import parsing and mapping scenarios.
- Local UI/rendering behavior was exercised through the importer and presenter mirror paths covered by the test fixture changes.