### PR TITLE
Disable persistence on the plain editor route unless a project is selected

### DIFF
--- a/apps/editor/src/App.tsx
+++ b/apps/editor/src/App.tsx
@@ -110,7 +110,9 @@ function stripBasePath(pathname: string) {
 function EditorApp() {
   const services = useMemo(() => {
     const url = new URL(window.location.href);
-    const shouldStartBlankProject = url.searchParams.get('newProject') === '1';
+    const storedProjectName = url.searchParams.get('project');
+    const shouldStartBlankProject =
+      url.searchParams.get('newProject') === '1' || !storedProjectName;
     if (shouldStartBlankProject) {
       url.searchParams.delete('newProject');
       url.searchParams.delete('project');
@@ -123,10 +125,7 @@ function EditorApp() {
             initialProject: sampleProject.createBlankProject(),
             skipStoredProjectLoad: true,
           }
-        : (() => {
-            const storedProjectName = url.searchParams.get('project');
-            return storedProjectName ? { storedProjectName } : {};
-          })(),
+        : { storedProjectName },
     );
   }, []);
 

--- a/apps/editor/tests/unit/app/App.test.tsx
+++ b/apps/editor/tests/unit/app/App.test.tsx
@@ -42,6 +42,18 @@ describe('App', () => {
     expect(screen.getByText('1 layers on current page')).toBeInTheDocument();
   });
 
+  it('starts with persistence disabled on the plain editor route', async () => {
+    window.history.replaceState({}, '', '/editor/');
+    window.localStorage.setItem('ew-canvas-ai.persistence-enabled', 'true');
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole('button', { name: 'Edit project name Untitled Project' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Persistence disabled' })).toBeInTheDocument();
+  });
+
   it('removes the new project query string after consuming it', async () => {
     window.history.replaceState({}, '', '/?newProject=1&theme=dark');
 

--- a/tests/e2e/editor/local-persistence.spec.ts
+++ b/tests/e2e/editor/local-persistence.spec.ts
@@ -5,7 +5,9 @@ import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 const getServer = withIsolatedDevServer(test);
 
 test.describe('editor local persistence journey', () => {
-  test('saves a browser-private project, reloads it, and opens version history', async ({ page }) => {
+  test('keeps the plain editor route fresh and restores a named browser-private project', async ({
+    page,
+  }) => {
     await installFakeOpfs(page);
 
     const editor = new EditorAppPage(page, getServer().baseURL);
@@ -18,7 +20,17 @@ test.describe('editor local persistence journey', () => {
     await expect(page.getByRole('button', { name: 'Version history' })).toBeEnabled();
 
     await page.goto(new URL('/editor/', getServer().baseURL).toString());
-    await expect(page.getByRole('button', { name: 'Edit project name E2E Persisted Deck' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Edit project name Untitled Project' }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Browser storage disabled' })).toBeVisible();
+
+    const restoredProjectUrl = new URL('/editor/', getServer().baseURL);
+    restoredProjectUrl.searchParams.set('project', 'E2E Persisted Deck');
+    await page.goto(restoredProjectUrl.toString());
+    await expect(
+      page.getByRole('button', { name: 'Edit project name E2E Persisted Deck' }),
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Browser storage enabled' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Version history' }).focus();


### PR DESCRIPTION
## Summary
- Treat the bare `/editor/` route as a blank, non-persistent session unless a `project` query param is present.
- Preserve stored-project loading when a named project is explicitly requested.
- Add coverage for the plain editor route in unit tests and update the persistence E2E flow to verify both the fresh default state and named-project restore.

## Testing
- Updated unit coverage for the editor app route behavior.
- Updated E2E coverage for plain-route freshness and named-project persistence restore.