### PR TITLE
Restore translation state on undo and redo

### DIFF
--- a/apps/editor/src/ui/editor/state/editorViewModelHistory.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelHistory.ts
@@ -1,8 +1,13 @@
 import type { ProjectDocument } from '../../../domain/documents/model';
 
+export interface EditorHistorySnapshot {
+  pageLanguageCodes: Record<string, string>;
+  project: ProjectDocument;
+}
+
 export interface EditorHistory {
-  past: ProjectDocument[];
-  future: ProjectDocument[];
+  past: EditorHistorySnapshot[];
+  future: EditorHistorySnapshot[];
 }
 
 function getActivePageIdForProject(project: ProjectDocument, currentPageId: string) {

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -1103,7 +1103,10 @@ export function useEditorViewModel(services: AppServices) {
       projectRef.current = nextProject;
 
       setHistory((currentHistory) => ({
-        past: [...currentHistory.past, currentProject].slice(-50),
+        past: [
+          ...currentHistory.past,
+          { pageLanguageCodes: { ...pageLanguageCodes }, project: currentProject },
+        ].slice(-50),
         future: [],
       }));
 
@@ -2781,14 +2784,16 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function undo() {
-    const previousProject = history.past.at(-1);
-    if (!previousProject) return;
+    const previousSnapshot = history.past.at(-1);
+    if (!previousSnapshot) return;
+    const previousProject = previousSnapshot.project;
 
     setHistory((currentHistory) => ({
       past: currentHistory.past.slice(0, -1),
-      future: [project, ...currentHistory.future],
+      future: [{ pageLanguageCodes: { ...pageLanguageCodes }, project }, ...currentHistory.future],
     }));
     setProject(previousProject);
+    setPageLanguageCodes(previousSnapshot.pageLanguageCodes);
     const nextActivePageId = editorViewModelHistory.getActivePageIdForProject(
       previousProject,
       activePageId,
@@ -2804,14 +2809,16 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function redo() {
-    const nextProject = history.future[0];
-    if (!nextProject) return;
+    const nextSnapshot = history.future[0];
+    if (!nextSnapshot) return;
+    const nextProject = nextSnapshot.project;
 
     setHistory((currentHistory) => ({
-      past: [...currentHistory.past, project],
+      past: [...currentHistory.past, { pageLanguageCodes: { ...pageLanguageCodes }, project }],
       future: currentHistory.future.slice(1),
     }));
     setProject(nextProject);
+    setPageLanguageCodes(nextSnapshot.pageLanguageCodes);
     const nextActivePageId = editorViewModelHistory.getActivePageIdForProject(
       nextProject,
       activePageId,

--- a/apps/editor/tests/unit/ui/editor/EditorShell.translation.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.translation.test.tsx
@@ -67,6 +67,32 @@ describe('EditorShell translation workflows', () => {
     expect(screen.getByText('Pair: pt → pt')).toBeInTheDocument();
   });
 
+  it('restores the toolbar source language after undoing a slide translation with Ctrl+Z', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const translator = new RecordingTranslatorService();
+    services.translatorService = translator;
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'AI Tools');
+    await user.selectOptions(screen.getByLabelText('Translate to'), 'pt');
+    await user.click(screen.getAllByRole('button', { name: 'Translate Slide 1' })[0]!);
+
+    expect(
+      await screen.findByRole('button', { name: 'Current slide language Portuguese' }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Translation path options' }));
+    expect(screen.getByLabelText<HTMLSelectElement>('Translate from').value).toBe('pt');
+
+    screen.getByRole('button', { name: 'Translate deck' }).focus();
+    await user.keyboard('{Control>}z{/Control}');
+
+    expect(
+      await screen.findByRole('button', { name: 'Current slide language English' }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText<HTMLSelectElement>('Translate from').value).toBe('en');
+  });
+
   it('ignores repeated translate clicks while a translation is running', async () => {
     const user = userEvent.setup();
     const services = createAppServices();


### PR DESCRIPTION
## Summary
- Capture page language codes alongside editor history snapshots so undo/redo can restore translation state, not just the project document
- Restore the active page language and translation controls when stepping backward or forward through history
- Add a regression test covering Ctrl+Z after translating a slide

## Testing
- Added unit coverage for undoing a slide translation and verifying the toolbar source language resets correctly
- Not run (not requested)