### PR TITLE
Preserve versioned image assets when pruning storage

### DIFF
--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -42,6 +42,10 @@ const PROJECT_CONFIG_FILE_NAME = 'localstudio.json';
 const VERSION_HISTORY_FILE_NAME = 'manifest.json';
 const VERSION_HISTORY_LIMIT = 100;
 
+function addRetainedFileName(fileNames: Set<string>, fileName: string | undefined) {
+  if (fileName) fileNames.add(fileName);
+}
+
 async function createFileBackedProjectSnapshot(
   project: ProjectDocument,
   assetsDirectory: FileSystemDirectoryHandle,
@@ -215,16 +219,14 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
         .map((asset) => asset.fileName)
         .filter((fileName): fileName is string => Boolean(fileName)),
     );
-
+    await this.addVersionAssetFileNames(directoryHandle, retainedAssetFileNames);
     await this.removeUnretainedAssetFiles(assetsDirectory, retainedAssetFileNames);
-    await this.removeUnretainedAssetFiles(
-      fontsDirectory,
-      new Set(
-        Object.values(projectForDisk.fonts ?? {})
-          .map((font) => font.fileName)
-          .filter((fileName): fileName is string => Boolean(fileName)),
-      ),
-    );
+    const retainedFontFileNames = new Set<string>();
+    for (const font of Object.values(projectForDisk.fonts ?? {})) {
+      addRetainedFileName(retainedFontFileNames, font.fileName);
+    }
+    await this.addVersionFontFileNames(directoryHandle, retainedFontFileNames);
+    await this.removeUnretainedAssetFiles(fontsDirectory, retainedFontFileNames);
     await this.writeJsonFile(directoryHandle, PROJECT_FILE_NAME, projectForDisk);
     const configDirectory = await directoryHandle.getDirectoryHandle('config', { create: true });
     await this.writeJsonFile(configDirectory, PROJECT_CONFIG_FILE_NAME, {
@@ -432,6 +434,58 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       removals.push(directoryHandle.removeEntry(name).catch(() => undefined));
     }
     await Promise.all(removals);
+  }
+
+  private async addVersionAssetFileNames(
+    directoryHandle: FileSystemDirectoryHandle,
+    retainedAssetFileNames: Set<string>,
+  ) {
+    await this.addVersionFileNames(directoryHandle, (versionProject) => {
+      for (const asset of Object.values(versionProject.assets)) {
+        addRetainedFileName(retainedAssetFileNames, asset.fileName);
+      }
+    });
+  }
+
+  private async addVersionFontFileNames(
+    directoryHandle: FileSystemDirectoryHandle,
+    retainedFontFileNames: Set<string>,
+  ) {
+    await this.addVersionFileNames(directoryHandle, (versionProject) => {
+      for (const font of Object.values(versionProject.fonts ?? {})) {
+        addRetainedFileName(retainedFontFileNames, font.fileName);
+      }
+    });
+  }
+
+  private async addVersionFileNames(
+    directoryHandle: FileSystemDirectoryHandle,
+    addProjectFileNames: (versionProject: ProjectDocument) => void,
+  ) {
+    let manifest: VersionHistoryManifest;
+    let versionsDirectory: FileSystemDirectoryHandle;
+    try {
+      const historyDirectory = await directoryHandle.getDirectoryHandle('history');
+      const manifestHandle = await historyDirectory.getFileHandle(VERSION_HISTORY_FILE_NAME);
+      const manifestFile = await manifestHandle.getFile();
+      manifest = JSON.parse(await manifestFile.text()) as VersionHistoryManifest;
+      versionsDirectory = await historyDirectory.getDirectoryHandle('versions');
+    } catch (error) {
+      if (isNotFoundError(error)) return;
+      throw error;
+    }
+    if (manifest.versions.length === 0) return;
+    await Promise.all(
+      manifest.versions.map(async (entry) => {
+        try {
+          const fileHandle = await versionsDirectory.getFileHandle(entry.fileName);
+          const file = await fileHandle.getFile();
+          addProjectFileNames(JSON.parse(await file.text()) as ProjectDocument);
+        } catch (error) {
+          if (!isNotFoundError(error)) throw error;
+        }
+      }),
+    );
   }
 
   private async writeMirrorFile(directoryHandle: FileSystemDirectoryHandle, file: MirrorFile) {

--- a/apps/editor/src/services/storage/opfsProjectRepository.ts
+++ b/apps/editor/src/services/storage/opfsProjectRepository.ts
@@ -32,6 +32,10 @@ const VERSION_HISTORY_FILE_NAME = 'manifest.json';
 const VERSION_HISTORY_LIMIT = 100;
 const LAST_PROJECT_NAME_KEY = 'localstudio.ai.opfs.last-project-name';
 
+function addRetainedFileName(fileNames: Set<string>, fileName: string | undefined) {
+  if (fileName) fileNames.add(fileName);
+}
+
 async function createFileBackedProjectSnapshot(
   project: ProjectDocument,
   assetsDirectory: FileSystemDirectoryHandle,
@@ -188,16 +192,14 @@ export class OpfsProjectRepository implements ProjectRepository {
         .map((asset) => asset.fileName)
         .filter((fileName): fileName is string => Boolean(fileName)),
     );
-
+    await this.addVersionAssetFileNames(directoryHandle, retainedAssetFileNames);
     await this.removeUnretainedAssetFiles(assetsDirectory, retainedAssetFileNames);
-    await this.removeUnretainedAssetFiles(
-      fontsDirectory,
-      new Set(
-        Object.values(projectForDisk.fonts ?? {})
-          .map((font) => font.fileName)
-          .filter((fileName): fileName is string => Boolean(fileName)),
-      ),
-    );
+    const retainedFontFileNames = new Set<string>();
+    for (const font of Object.values(projectForDisk.fonts ?? {})) {
+      addRetainedFileName(retainedFontFileNames, font.fileName);
+    }
+    await this.addVersionFontFileNames(directoryHandle, retainedFontFileNames);
+    await this.removeUnretainedAssetFiles(fontsDirectory, retainedFontFileNames);
     await this.writeJsonFile(directoryHandle, PROJECT_FILE_NAME, projectForDisk);
     const configDirectory = await directoryHandle.getDirectoryHandle('config', { create: true });
     await this.writeJsonFile(configDirectory, PROJECT_CONFIG_FILE_NAME, {
@@ -373,6 +375,58 @@ export class OpfsProjectRepository implements ProjectRepository {
       removals.push(directoryHandle.removeEntry(name).catch(() => undefined));
     }
     await Promise.all(removals);
+  }
+
+  private async addVersionAssetFileNames(
+    directoryHandle: FileSystemDirectoryHandle,
+    retainedAssetFileNames: Set<string>,
+  ) {
+    await this.addVersionFileNames(directoryHandle, (versionProject) => {
+      for (const asset of Object.values(versionProject.assets)) {
+        addRetainedFileName(retainedAssetFileNames, asset.fileName);
+      }
+    });
+  }
+
+  private async addVersionFontFileNames(
+    directoryHandle: FileSystemDirectoryHandle,
+    retainedFontFileNames: Set<string>,
+  ) {
+    await this.addVersionFileNames(directoryHandle, (versionProject) => {
+      for (const font of Object.values(versionProject.fonts ?? {})) {
+        addRetainedFileName(retainedFontFileNames, font.fileName);
+      }
+    });
+  }
+
+  private async addVersionFileNames(
+    directoryHandle: FileSystemDirectoryHandle,
+    addProjectFileNames: (versionProject: ProjectDocument) => void,
+  ) {
+    let manifest: VersionHistoryManifest;
+    let versionsDirectory: FileSystemDirectoryHandle;
+    try {
+      const historyDirectory = await directoryHandle.getDirectoryHandle('history');
+      const manifestHandle = await historyDirectory.getFileHandle(VERSION_HISTORY_FILE_NAME);
+      const manifestFile = await manifestHandle.getFile();
+      manifest = JSON.parse(await manifestFile.text()) as VersionHistoryManifest;
+      versionsDirectory = await historyDirectory.getDirectoryHandle('versions');
+    } catch (error) {
+      if (isNotFoundError(error)) return;
+      throw error;
+    }
+    if (manifest.versions.length === 0) return;
+    await Promise.all(
+      manifest.versions.map(async (entry) => {
+        try {
+          const fileHandle = await versionsDirectory.getFileHandle(entry.fileName);
+          const file = await fileHandle.getFile();
+          addProjectFileNames(JSON.parse(await file.text()) as ProjectDocument);
+        } catch (error) {
+          if (!isNotFoundError(error)) throw error;
+        }
+      }),
+    );
   }
 
   private async writeMirrorFile(directoryHandle: FileSystemDirectoryHandle, file: MirrorFile) {

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
@@ -386,4 +386,52 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
 
     expect(assetsDirectory.files.has('asset-removed.png')).toBe(false);
   });
+
+  it('keeps image asset files that are still referenced by version history', async () => {
+    const directory = new MockDirectoryHandle();
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory: () => Promise.resolve(directory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:history-image');
+    const projectWithImage = sampleProject.createBlankProject();
+    projectWithImage.assets['asset-history-image'] = {
+      id: 'asset-history-image',
+      type: 'image',
+      name: 'History image',
+      mimeType: 'image/png',
+      objectUrl: 'data:image/png;base64,aGlzdG9yeQ==',
+    };
+    projectWithImage.elements['image-history'] = {
+      id: 'image-history',
+      type: 'image',
+      assetId: 'asset-history-image',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+    };
+    projectWithImage.pages[0]?.elementIds.push('image-history');
+
+    await repository.saveProject(projectWithImage);
+    const version = await repository.saveVersion(projectWithImage, {
+      previousProject: sampleProject.createBlankProject(),
+    });
+    await repository.saveProject({
+      ...projectWithImage,
+      assets: {},
+      elements: {},
+      pages: projectWithImage.pages.map((page) => ({ ...page, elementIds: [] })),
+    });
+
+    const assetsDirectory = directory.directories.get('assets')!;
+    expect(assetsDirectory.files.has('asset-history-image.png')).toBe(true);
+    const loadedVersion = await repository.loadVersion(version.id);
+    expect(loadedVersion?.assets['asset-history-image']?.objectUrl).toBe('blob:history-image');
+    expect(createObjectUrl).toHaveBeenCalled();
+  });
 });

--- a/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
@@ -272,6 +272,55 @@ describe('OpfsProjectRepository', () => {
     expect(loadedVersion?.name).toBe('Versioned Deck');
   });
 
+  it('keeps image asset files that are still referenced by OPFS version history', async () => {
+    const root = new MockDirectoryHandle();
+    const repository = new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage: new MemoryStorage(),
+    });
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:history-image');
+    const projectWithImage = sampleProject.createBlankProject();
+    projectWithImage.assets['asset-history-image'] = {
+      id: 'asset-history-image',
+      type: 'image',
+      name: 'History image',
+      mimeType: 'image/png',
+      objectUrl: 'data:image/png;base64,aGlzdG9yeQ==',
+    };
+    projectWithImage.elements['image-history'] = {
+      id: 'image-history',
+      type: 'image',
+      assetId: 'asset-history-image',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      rotation: 0,
+      locked: false,
+      visible: true,
+      opacity: 1,
+    };
+    projectWithImage.pages[0]?.elementIds.push('image-history');
+
+    await repository.saveProject(projectWithImage);
+    const version = await repository.saveVersion(projectWithImage, {
+      previousProject: sampleProject.createBlankProject(),
+    });
+    await repository.saveProject({
+      ...projectWithImage,
+      assets: {},
+      elements: {},
+      pages: projectWithImage.pages.map((page) => ({ ...page, elementIds: [] })),
+    });
+
+    const projectDirectory = await getProjectDirectory(root, projectWithImage.name);
+    const assetsDirectory = projectDirectory.directories.get('assets')!;
+    expect(assetsDirectory.files.has('asset-history-image.png')).toBe(true);
+    const loadedVersion = await repository.loadVersion(version.id);
+    expect(loadedVersion?.assets['asset-history-image']?.objectUrl).toBe('blob:history-image');
+    expect(createObjectUrl).toHaveBeenCalled();
+  });
+
   it('surfaces unavailable OPFS errors without creating fallback state', async () => {
     const repository = new OpfsProjectRepository({
       getRootDirectory: () => Promise.reject(new DOMException('Private browsing', 'SecurityError')),


### PR DESCRIPTION
## Summary
- Keep asset files that are still referenced by saved version history before pruning project storage
- Apply the same retention logic to browser file-system and OPFS repositories
- Add regression tests covering image assets surviving after the live project stops referencing them

## Testing
- Added unit tests for both storage backends to verify versioned images remain available after cleanup
- Confirmed restored version assets still resolve to object URLs in the loaded version