### PR TITLE
Prevent text boxes from overflowing while editing and resizing

### DIFF
--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -52,6 +52,7 @@ import type { CommonElementProps, ElementAnimationRenderState } from './canvas-e
 import { shapeLineDraw } from './shape-line-draw';
 
 const TEXT_FRAME_PADDING = 6;
+const TEXT_EDITOR_HEIGHT_BUFFER = 4;
 
 interface CanvasWorkspaceProps {
   project: ProjectDocument;
@@ -215,6 +216,7 @@ export function CanvasWorkspace({
   const [stageSize, setStageSize] = useState({ width: 768, height: 432 });
   const [editingTextId, setEditingTextId] = useState<string | null>(null);
   const [editingTextValue, setEditingTextValue] = useState('');
+  const [editingTextHeight, setEditingTextHeight] = useState<number | undefined>(undefined);
   const [fontRenderVersion, setFontRenderVersion] = useState(0);
   const [processingBlinkOn, setProcessingBlinkOn] = useState(false);
   const [backgroundPreviewPoint, setBackgroundPreviewPoint] = useState<{
@@ -573,17 +575,34 @@ export function CanvasWorkspace({
     onSelectElement?.(element.id);
     setEditingTextId(element.id);
     setEditingTextValue(element.text);
+    setEditingTextHeight(element.height);
   }
 
   function commitTextEditing() {
     if (!editingTextId) return;
     onUpdateTextContent?.(editingTextId, editingTextValue);
     setEditingTextId(null);
+    setEditingTextHeight(undefined);
   }
 
   function cancelTextEditing() {
     setEditingTextId(null);
     setEditingTextValue('');
+    setEditingTextHeight(undefined);
+  }
+
+  function updateTextEditing(element: Extract<DesignElement, { type: 'text' }>, input: HTMLTextAreaElement) {
+    const nextValue = input.value;
+    setEditingTextValue(nextValue);
+    onUpdateTextContent?.(element.id, nextValue);
+
+    const nextHeight = Math.ceil(
+      Math.max(8, toDocumentY(input.scrollHeight + TEXT_EDITOR_HEIGHT_BUFFER)),
+    );
+    setEditingTextHeight(nextHeight);
+    if (nextHeight !== element.height) {
+      onUpdateElementFrame?.(element.id, { height: nextHeight });
+    }
   }
 
   function pickBackgroundSubject(
@@ -1136,7 +1155,7 @@ export function CanvasWorkspace({
                       fontFamily: element.fontFamily,
                       fontSize: `${element.fontSize * scaleY}px`,
                       fontWeight: element.fontWeight,
-                      height: `${element.height * scaleY}px`,
+                      height: `${Math.max(element.height, editingTextHeight ?? element.height) * scaleY}px`,
                       left: `${element.x * scaleX}px`,
                       lineHeight: element.lineHeight ?? 1.05,
                       padding: `${TEXT_FRAME_PADDING * scaleY}px`,
@@ -1147,7 +1166,7 @@ export function CanvasWorkspace({
                     }}
                     onBlur={commitTextEditing}
                     onChange={(event) => {
-                      setEditingTextValue(event.target.value);
+                      updateTextEditing(element, event.currentTarget);
                     }}
                     onKeyDown={(event) => {
                       if (event.key === 'Escape') {

--- a/apps/editor/src/ui/editor/state/editorViewModelText.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelText.ts
@@ -11,11 +11,12 @@ function getFramePatchWithTextMinimum(
   if (patch.height === undefined) return patch;
   const element = project.elements[elementId];
   if (!element || element.type !== 'text') return patch;
+  const nextElement = { ...element, ...patch };
   return {
     ...patch,
     height: Math.max(
       patch.height,
-      textTranslationLayout.getMinimumTextHeight(element.text, element.fontSize),
+      textTranslationLayout.getMinimumTextFrameHeight(nextElement),
     ),
   };
 }
@@ -23,7 +24,7 @@ function getFramePatchWithTextMinimum(
 function ensureTextElementMinimumHeight(project: ProjectDocument, elementId: string) {
   const element = project.elements[elementId];
   if (!element || element.type !== 'text') return project;
-  const minimumHeight = textTranslationLayout.getMinimumTextHeight(element.text, element.fontSize);
+  const minimumHeight = textTranslationLayout.getMinimumTextFrameHeight(element);
   if (element.height >= minimumHeight) return project;
   return new basicCommands.UpdateElementFrameCommand(elementId, {
     height: minimumHeight,

--- a/apps/editor/src/ui/editor/state/text-translation-layout.ts
+++ b/apps/editor/src/ui/editor/state/text-translation-layout.ts
@@ -1,4 +1,4 @@
-import type { Page, ProjectDocument } from '../../../domain/documents/model';
+import type { Page, ProjectDocument, TextElement } from '../../../domain/documents/model';
 
 export type TranslationPatch = {
   fontSize?: number;
@@ -8,13 +8,20 @@ export type TranslationPatch = {
   x?: number;
 };
 
+const TEXT_FRAME_HORIZONTAL_PADDING = 12;
+const TEXT_FRAME_VERTICAL_PADDING_RATIO = 0.18;
+const TEXT_FRAME_LINE_HEIGHT = 1.08;
+
 function getMinimumTextHeight(text: string, fontSize: number) {
   const lineCount = Math.max(1, text.split('\n').length);
-  return Math.ceil(lineCount * fontSize * 1.08 + Math.max(12, fontSize * 0.18));
+  return getTextHeightForLineCount(lineCount, fontSize);
 }
 
 function getTextHeightForLineCount(lineCount: number, fontSize: number) {
-  return Math.ceil(Math.max(1, lineCount) * fontSize * 1.08 + Math.max(12, fontSize * 0.18));
+  return Math.ceil(
+    Math.max(1, lineCount) * fontSize * TEXT_FRAME_LINE_HEIGHT +
+      Math.max(12, fontSize * TEXT_FRAME_VERTICAL_PADDING_RATIO),
+  );
 }
 
 function getPageTextSample(project: ProjectDocument, pageId: string) {
@@ -74,6 +81,7 @@ function estimateSingleLineTextWidth(text: string, fontSize: number) {
 }
 
 function estimateWrappedLineCount(text: string, fontSize: number, availableWidth: number) {
+  const safeAvailableWidth = Math.max(1, availableWidth);
   return text.split('\n').reduce((lineCount, paragraph) => {
     const words = paragraph.trim().split(/\s+/).filter(Boolean);
     if (words.length === 0) return lineCount + 1;
@@ -86,23 +94,29 @@ function estimateWrappedLineCount(text: string, fontSize: number, availableWidth
       const wordWidth = estimateSingleLineTextWidth(word, fontSize);
       if (currentLineWidth === 0) {
         currentLineWidth = wordWidth;
-        paragraphLineCount += Math.max(0, Math.ceil(wordWidth / availableWidth) - 1);
+        paragraphLineCount += Math.max(0, Math.ceil(wordWidth / safeAvailableWidth) - 1);
         continue;
       }
 
       const nextLineWidth = currentLineWidth + spaceWidth + wordWidth;
-      if (nextLineWidth <= availableWidth) {
+      if (nextLineWidth <= safeAvailableWidth) {
         currentLineWidth = nextLineWidth;
         continue;
       }
 
       paragraphLineCount += 1;
       currentLineWidth = wordWidth;
-      paragraphLineCount += Math.max(0, Math.ceil(wordWidth / availableWidth) - 1);
+      paragraphLineCount += Math.max(0, Math.ceil(wordWidth / safeAvailableWidth) - 1);
     }
 
     return lineCount + paragraphLineCount;
   }, 0);
+}
+
+function getMinimumTextFrameHeight(element: TextElement) {
+  const availableWidth = element.width - TEXT_FRAME_HORIZONTAL_PADDING;
+  const lineCount = estimateWrappedLineCount(element.text, element.fontSize, availableWidth);
+  return getTextHeightForLineCount(lineCount, element.fontSize);
 }
 
 function fitTranslatedTextToOriginalFrame(
@@ -112,8 +126,7 @@ function fitTranslatedTextToOriginalFrame(
 ): TranslationPatch {
   void page;
   const normalizedText = normalizeTranslatedText(element.text, translatedText);
-  const horizontalPadding = 12;
-  const availableWidth = Math.max(1, element.width - horizontalPadding);
+  const availableWidth = Math.max(1, element.width - TEXT_FRAME_HORIZONTAL_PADDING);
   const estimatedLineCount = estimateWrappedLineCount(
     normalizedText,
     element.fontSize,
@@ -130,6 +143,7 @@ function fitTranslatedTextToOriginalFrame(
 
 export const textTranslationLayout = {
   fitTranslatedTextToOriginalFrame,
+  getMinimumTextFrameHeight,
   getMinimumTextHeight,
   getPageTextSample,
   mapWithConcurrency,

--- a/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
+++ b/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
@@ -45,6 +45,45 @@ describe('editor view model text helpers', () => {
     expect(nextProject.elements['text-title']?.height).toBeGreaterThan(1);
   });
 
+  it('expands a text element after long pasted content wraps inside the frame', () => {
+    const project = sampleProject.createSampleProject();
+    const element = project.elements['text-title']!;
+
+    const nextProject = editorViewModelText.updateTextContent(
+      project,
+      'text-title',
+      '55 Horas, 770M Tokens e Uma Alternativa ao Canva Rodando no Browser',
+    );
+
+    expect(nextProject.elements['text-title']).toMatchObject({
+      text: '55 Horas, 770M Tokens e Uma Alternativa ao Canva Rodando no Browser',
+      width: element.width,
+    });
+    expect(nextProject.elements['text-title']?.height).toBeGreaterThan(element.height);
+  });
+
+  it('keeps wrapped text readable when a frame is resized narrower', () => {
+    const baseProject = sampleProject.createSampleProject();
+    const project = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'text-title': {
+          ...baseProject.elements['text-title']!,
+          text: '55 Horas, 770M Tokens e Uma Alternativa ao Canva Rodando no Browser',
+        },
+      },
+    };
+
+    const patch = editorViewModelText.getFramePatchWithTextMinimum(project, 'text-title', {
+      height: 1,
+      width: 240,
+    });
+
+    expect(patch.width).toBe(240);
+    expect(patch.height).toBeGreaterThan(1);
+  });
+
   it('expands a text element after style updates increase font size', () => {
     const project = createProjectWithShortTitleFrame();
 

--- a/tests/e2e/editor/canvas-resize-text-journey.ts
+++ b/tests/e2e/editor/canvas-resize-text-journey.ts
@@ -36,13 +36,28 @@ export async function resizeTextAndUseArrangeControls(page: Page, baseURL: strin
   await expect.poll(async () => Number(await widthInput.inputValue())).toBeGreaterThan(360);
   await expect.poll(async () => Number(await heightInput.inputValue())).toBeGreaterThan(200);
 
-  await editor.openTool('Layout');
-  await page.getByRole('button', { name: 'Add a little bit of body text', exact: true }).click();
+  await editor.openTool('Text');
+  await page.getByRole('button', { name: 'Add a text box' }).click();
   await editor.openTool('Design');
   await page
     .getByRole('tablist', { name: 'Movie inspector sections' })
     .getByRole('tab', { name: 'Arrange' })
     .click();
+  await xInput.fill('560');
+  await yInput.fill('280');
+  await widthInput.fill('320');
+  await heightInput.fill('120');
+
+  const editPoint = await getCanvasPoint(page, { x: 720, y: 340 });
+  await page.mouse.dblclick(editPoint.x, editPoint.y);
+  const canvasTextEditor = page.getByRole('textbox', { name: 'Edit text' });
+  await expect(canvasTextEditor).toBeVisible();
+  await canvasTextEditor.fill(
+    '55 Horas, 770M Tokens e Uma Alternativa ao Canva Rodando no Browser',
+  );
+  await expect.poll(async () => Number(await heightInput.inputValue())).toBeGreaterThan(120);
+  await expect(canvasTextEditor).toBeFocused();
+  await page.keyboard.press('Enter');
 
   await rotationInput.fill('18');
   await expect(rotationInput).toHaveValue('18');


### PR DESCRIPTION
## Summary
- Keep text frames in sync with the textarea while editing so pasted or wrapped content expands instead of overflowing.
- Compute minimum text-frame height from wrapped line estimates, including during translation and resize flows.
- Add coverage for long pasted text, narrow frame resizing, and the canvas edit journey.

## Testing
- Added unit tests for wrapped text growth and minimum-height behavior.
- Extended the end-to-end journey to verify a text box expands correctly after inline editing.