### PR TITLE
Gate presenter remote info logs behind a localStorage flag

### DIFF
--- a/packages/presenter-remote/src/debug-log.ts
+++ b/packages/presenter-remote/src/debug-log.ts
@@ -1,6 +1,17 @@
 type DebugLogLevel = 'error' | 'info' | 'warn';
 
+const presenterRemoteDebugStorageKey = 'localstudio.presenterRemoteDebug';
+
+function isPresenterRemoteInfoLoggingEnabled() {
+  try {
+    return globalThis.localStorage?.getItem(presenterRemoteDebugStorageKey) === 'true';
+  } catch {
+    return false;
+  }
+}
+
 function write(level: DebugLogLevel, message: string, detail?: unknown) {
+  if (level === 'info' && !isPresenterRemoteInfoLoggingEnabled()) return;
   const prefix = '[LocalStudio presenter remote]';
   if (detail === undefined) {
     globalThis.console[level](prefix, message);

--- a/tests/e2e/editor/presenter-logging-contract-browser.ts
+++ b/tests/e2e/editor/presenter-logging-contract-browser.ts
@@ -18,10 +18,13 @@ export async function evaluatePresenterLoggingContract({
   const originalWarn = console.warn;
   const originalError = console.error;
   try {
+    localStorage.removeItem('localstudio.presenterRemoteDebug');
     console.info = (...values: unknown[]) => logs.push(`info:${values.join('|')}`);
     console.warn = (...values: unknown[]) => logs.push(`warn:${values.join('|')}`);
     console.error = (...values: unknown[]) => logs.push(`error:${values.join('|')}`);
     presenterRemoteDebugLog.info('ready');
+    localStorage.setItem('localstudio.presenterRemoteDebug', 'true');
+    presenterRemoteDebugLog.info('enabled');
     presenterRemoteDebugLog.warn('object', { ok: true });
     presenterRemoteDebugLog.error('failure', new TypeError('bad stream'));
     const circular: { self?: unknown } = {};
@@ -31,6 +34,7 @@ export async function evaluatePresenterLoggingContract({
     console.info = originalInfo;
     console.warn = originalWarn;
     console.error = originalError;
+    localStorage.removeItem('localstudio.presenterRemoteDebug');
   }
 
   return { logs };

--- a/tests/e2e/editor/service-contracts-presenter-logging.spec.ts
+++ b/tests/e2e/editor/service-contracts-presenter-logging.spec.ts
@@ -13,10 +13,13 @@ test('executes presenter debug logging contracts in the browser runtime', async 
 
   expect(result.logs).toEqual(
     expect.arrayContaining([
-      expect.stringContaining('info:[LocalStudio presenter remote]|ready'),
+      expect.stringContaining('info:[LocalStudio presenter remote]|enabled'),
       expect.stringContaining('warn:[LocalStudio presenter remote]|object|{"ok":true}'),
       expect.stringContaining('error:[LocalStudio presenter remote]|failure|TypeError: bad stream'),
       expect.stringContaining('warn:[LocalStudio presenter remote]|circular|[object Object]'),
     ]),
+  );
+  expect(result.logs).not.toEqual(
+    expect.arrayContaining([expect.stringContaining('info:[LocalStudio presenter remote]|ready')]),
   );
 });


### PR DESCRIPTION
## Summary
- Add a `localStorage` feature flag to suppress presenter remote `info` logs unless explicitly enabled.
- Keep `warn` and `error` logging behavior unchanged.
- Update the browser contract test to verify the disabled-by-default and enabled states.

## Testing
- Updated E2E contract coverage for presenter logging behavior.
- Not run (not requested)