### PR TITLE
Refine header menus and add bug report guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,12 @@ LocalStudio.dev uses browser-local AI features. Some paths need Chrome experimen
 
 When changing AI flows, document which browser and device you tested. When changing UI, include a screenshot or short recording in the pull request.
 
+## Issues
+
+Bug reports should include a reproducible video demo whenever possible. We recommend recording with
+[Loom](https://chromewebstore.google.com/detail/loom-%E2%80%93-screen-recorder-sc/liecbddmkiiihnedobmlmillhodjkdmb?utm_source=localstudio.dev)
+so maintainers can see the browser, steps, and failure state clearly.
+
 ## Pull Requests
 
 Keep PRs focused. Describe the user-visible change, list the checks you ran, and call out browser-specific behavior.

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1072,10 +1072,6 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         onNewProject={openBlankProjectInNewTab}
         onOpenKeyboardShortcuts={() => setKeyboardShortcutsOpen(true)}
         onStartAiSetupTour={startAiWorkflowTour}
-        onSelectLayers={() => {
-          vm.setActiveTab('layout');
-          openLeftPanel();
-        }}
         onShare={() => {
           setSharePanelOpen(true);
         }}

--- a/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
@@ -18,7 +18,6 @@ interface EditorToolbarSurfaceProps {
   onNewProject: () => void;
   onOpenKeyboardShortcuts: () => void;
   onOpenPresenterView: () => void;
-  onSelectLayers: () => void;
   onShare: () => void;
   onStartAiSetupTour: () => void;
   onStartPresenterMode: (options?: { fromBeginning?: boolean }) => void;
@@ -37,7 +36,6 @@ export function EditorToolbarSurface({
   onNewProject,
   onOpenKeyboardShortcuts,
   onOpenPresenterView,
-  onSelectLayers,
   onShare,
   onStartAiSetupTour,
   onStartPresenterMode,
@@ -115,7 +113,6 @@ export function EditorToolbarSurface({
       onProjectNameChange={isHistoryReadOnly ? undefined : vm.setProjectName}
       onRedo={isHistoryReadOnly ? undefined : vm.redo}
       onResetZoom={vm.resetZoom}
-      onSelectLayers={onSelectLayers}
       onShare={onShare}
       onOpenPresenterView={onOpenPresenterView}
       onStartPresenterMode={onStartPresenterMode}

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -57,7 +57,6 @@ interface TopToolbarProps {
   onOpenPresenterView?: (() => void) | undefined;
   onRedo?: (() => void) | undefined;
   onResetZoom?: (() => void) | undefined;
-  onSelectLayers?: (() => void) | undefined;
   onShare?: (() => void) | undefined;
   onStartPresenterMode?: ((options?: { fromBeginning?: boolean }) => void) | undefined;
   onTranslationSourceLanguageChange?: ((languageCode: string) => void) | undefined;
@@ -91,6 +90,7 @@ interface HeaderMenuSubmenu {
 type HeaderMenuAction = HeaderMenuActionItem | HeaderMenuSeparator | HeaderMenuSubmenu;
 
 const menuLabels: HeaderMenu[] = ['File', 'Edit', 'View', 'Help'];
+const githubIssuesUrl = 'https://github.com/ErickWendel/localstudio/issues/new/choose';
 
 export function TopToolbar({
   project,
@@ -137,7 +137,6 @@ export function TopToolbar({
   onOpenPresenterView,
   onRedo,
   onResetZoom,
-  onSelectLayers,
   onShare,
   onStartPresenterMode,
   onSaveLocal,
@@ -262,19 +261,17 @@ export function TopToolbar({
       { label: 'Redo', disabled: !canRedo, onSelect: onRedo },
       { label: 'Duplicate', disabled: !hasSelection, onSelect: onDuplicate },
       { label: 'Delete', disabled: !hasSelection, onSelect: onDelete },
-      {
-        label: 'Translate Deck',
-        disabled: !canTranslateDeck || !onTranslateDeck,
-        onSelect: onTranslateDeck,
-      },
     ],
     View: [
-      { label: 'Zoom Out', disabled: !onZoomOut, onSelect: onZoomOut },
-      { label: '100%', disabled: !onResetZoom, onSelect: onResetZoom },
-      { label: 'Zoom In', disabled: !onZoomIn, onSelect: onZoomIn },
-      onSelectLayers
-        ? { label: 'Toggle Layers Panel', onSelect: onSelectLayers }
-        : { label: 'Toggle Layers Panel', disabled: true },
+      {
+        kind: 'submenu',
+        label: 'Zoom',
+        items: [
+          { label: 'Zoom Out', disabled: !onZoomOut, onSelect: onZoomOut },
+          { label: '100%', disabled: !onResetZoom, onSelect: onResetZoom },
+          { label: 'Zoom In', disabled: !onZoomIn, onSelect: onZoomIn },
+        ],
+      },
     ],
     Help: [
       { label: 'AI Setup Tour', disabled: !onStartAiSetupTour, onSelect: onStartAiSetupTour },
@@ -283,7 +280,12 @@ export function TopToolbar({
         disabled: !onOpenKeyboardShortcuts,
         onSelect: onOpenKeyboardShortcuts,
       },
-      { label: 'Local AI Setup', disabled: true },
+      {
+        label: 'Found a bug?',
+        onSelect: () => {
+          window.open(githubIssuesUrl, '_blank', 'noopener,noreferrer');
+        },
+      },
     ],
   };
 

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -15,8 +15,9 @@ describe('TopToolbar', () => {
     const onNewProject = vi.fn();
     const onSaveLocalAs = vi.fn();
     const onSaveLocal = vi.fn();
-    const onSelectLayers = vi.fn();
-    const onTranslateDeck = vi.fn();
+    const onResetZoom = vi.fn();
+    const onZoomIn = vi.fn();
+    const onZoomOut = vi.fn();
 
     render(
       <TopToolbar
@@ -30,9 +31,9 @@ describe('TopToolbar', () => {
         onNewProject={onNewProject}
         onSaveLocal={onSaveLocal}
         onSaveLocalAs={onSaveLocalAs}
-        onSelectLayers={onSelectLayers}
-        onTranslateDeck={onTranslateDeck}
-        canTranslateDeck
+        onResetZoom={onResetZoom}
+        onZoomIn={onZoomIn}
+        onZoomOut={onZoomOut}
       />,
     );
 
@@ -73,12 +74,21 @@ describe('TopToolbar', () => {
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'View' }));
-    await user.click(screen.getByRole('menuitem', { name: 'Toggle Layers Panel' }));
-    expect(onSelectLayers).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menuitem', { name: 'Toggle Layers Panel' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('menuitem', { name: 'Zoom' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Zoom Out' }));
+    expect(onZoomOut).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'View' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Zoom' }));
+    await user.click(screen.getByRole('menuitem', { name: '100%' }));
+    expect(onResetZoom).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'View' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Zoom' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Zoom In' }));
+    expect(onZoomIn).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByRole('button', { name: 'Edit' }));
-    await user.click(screen.getByRole('menuitem', { name: 'Translate Deck' }));
-    expect(onTranslateDeck).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menuitem', { name: 'Translate Deck' })).not.toBeInTheDocument();
   });
 
   it('opens the PowerPoint export action from the File menu', async () => {
@@ -218,6 +228,24 @@ describe('TopToolbar', () => {
     await user.click(screen.getByRole('menuitem', { name: 'AI Setup Tour' }));
 
     expect(onStartAiSetupTour).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens GitHub issues from the Help menu bug report action', async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<TopToolbar project={sampleProject.createSampleProject()} language="PT-BR" />);
+
+    await user.click(screen.getByRole('button', { name: 'Help' }));
+    expect(screen.queryByRole('menuitem', { name: 'Local AI Setup' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('menuitem', { name: 'Found a bug?' }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://github.com/ErickWendel/localstudio/issues/new/choose',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    openSpy.mockRestore();
   });
 
   it('closes header menus when clicking outside them', async () => {

--- a/tests/e2e/editor/create-and-edit-deck.spec.ts
+++ b/tests/e2e/editor/create-and-edit-deck.spec.ts
@@ -37,13 +37,25 @@ test.describe('editor create and edit deck journey', () => {
     await expect(page.getByRole('button', { name: 'Background Shape', exact: true })).toBeHidden();
 
     await editor.openMenu('Edit');
+    await expect(page.getByRole('menuitem', { name: 'Translate Deck' })).toBeHidden();
     await page.getByRole('menuitem', { name: 'Undo' }).click();
     await expect(page.getByRole('button', { name: 'Background Shape', exact: true })).toBeVisible();
     await editor.openMenu('Edit');
     await page.getByRole('menuitem', { name: 'Redo' }).click();
     await expect(page.getByRole('button', { name: 'Background Shape', exact: true })).toBeHidden();
 
+    await editor.openMenu('View');
+    await expect(page.getByRole('menuitem', { name: 'Toggle Layers Panel' })).toBeHidden();
+    await page.getByRole('menuitem', { name: 'Zoom' }).click();
+    const zoomMenu = page.getByRole('menu', { name: 'Zoom' });
+    await expect(zoomMenu).toBeVisible();
+    await expect(zoomMenu.getByRole('menuitem', { name: 'Zoom Out' })).toBeVisible();
+    await expect(zoomMenu.getByRole('menuitem', { name: '100%' })).toBeVisible();
+    await expect(zoomMenu.getByRole('menuitem', { name: 'Zoom In' })).toBeVisible();
+
     await editor.openMenu('Help');
+    await expect(page.getByRole('menuitem', { name: 'Local AI Setup' })).toBeHidden();
+    await expect(page.getByRole('menuitem', { name: 'Found a bug?' })).toBeVisible();
     await page.getByRole('menuitem', { name: 'Keyboard Shortcuts' }).click();
     await expect(page.getByRole('dialog', { name: 'Keyboard shortcuts' })).toBeVisible();
     await page.getByRole('button', { name: 'Close keyboard shortcuts' }).click();


### PR DESCRIPTION
## Summary
- Removed the Layers panel shortcut from the editor toolbar wiring and simplified the View menu into a Zoom submenu.
- Replaced the old Help menu placeholder with a direct "Found a bug?" link to GitHub issues.
- Updated contributing docs to ask for reproducible Loom videos on bug reports when possible.
- Adjusted unit and e2e coverage to match the new menu structure and bug-report action.

## Testing
- Updated unit tests for `TopToolbar` to verify the new Zoom submenu and GitHub issues link behavior.
- Updated editor e2e coverage to validate the revised View and Help menu contents.
- Not run (not requested)