### PR TITLE
Fix live canvas resizing for text and image elements

### DIFF
--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -312,6 +312,26 @@ export function CanvasWorkspace({
     page?.background.type === 'color'
       ? page.background.color
       : (page?.background.colorFallback ?? '#050D10');
+  const transformAnchors =
+    selectedElement?.type === 'text'
+      ? ([
+          'top-left',
+          'top-right',
+          'middle-left',
+          'middle-right',
+          'bottom-left',
+          'bottom-right',
+        ] as const)
+      : ([
+          'top-left',
+          'top-center',
+          'top-right',
+          'middle-left',
+          'middle-right',
+          'bottom-left',
+          'bottom-center',
+          'bottom-right',
+        ] as const);
   const setElementNodeRef = useCallback((elementId: string, node: Konva.Node | null) => {
     nodeRefs.current[elementId] = node;
   }, []);
@@ -495,26 +515,61 @@ export function CanvasWorkspace({
     });
   }
 
-  function handleTransformEnd(elementId: string, event: Konva.KonvaEventObject<Event>) {
-    const node = event.target;
+  function getTransformFramePatch(elementId: string, node: Konva.Node): ElementFramePatch | undefined {
     const element = project.elements[elementId];
-    const scaleX = Math.abs(node.scaleX());
-    const scaleY = node.scaleY();
-    const nextWidth = toDocumentX(Math.max(8, node.width() * scaleX));
-
-    node.scaleX(1);
-    node.scaleY(1);
-
-    onUpdateElementFrame?.(elementId, {
+    if (!element) return undefined;
+    const scaleXValue = Math.abs(node.scaleX());
+    const scaleYValue = Math.abs(node.scaleY());
+    const nextWidth = toDocumentX(Math.max(8, node.width() * scaleXValue));
+    const nextHeight = toDocumentY(Math.max(8, node.height() * scaleYValue));
+    return {
       x:
-        element?.type === 'image' && element.flipX
+        element.type === 'image' && element.flipX
           ? toDocumentX(node.x()) - nextWidth
           : toDocumentX(node.x()),
       y: toDocumentY(node.y()),
       width: nextWidth,
-      height: toDocumentY(Math.max(8, node.height() * scaleY)),
+      height: nextHeight,
       rotation: node.rotation(),
-    });
+    };
+  }
+
+  function applyTransformPatchToNode(
+    elementId: string,
+    node: Konva.Node,
+    patch: ElementFramePatch,
+  ) {
+    const element = project.elements[elementId];
+    if (!element) return;
+    const width = patch.width ?? element.width;
+    const height = patch.height ?? element.height;
+    const x = patch.x ?? element.x;
+    const y = patch.y ?? element.y;
+
+    node.width(width * scaleX);
+    node.height(height * scaleY);
+    node.x(element.type === 'image' && element.flipX ? (x + width) * scaleX : x * scaleX);
+    node.y(y * scaleY);
+    node.rotation(patch.rotation ?? element.rotation);
+    node.scaleX(element.type === 'image' && element.flipX ? -1 : 1);
+    node.scaleY(1);
+  }
+
+  function handleTransform(elementId: string, event: Konva.KonvaEventObject<Event>) {
+    const node = event.target;
+    const frame = getTransformFramePatch(elementId, node);
+    if (!frame) return;
+
+    applyTransformPatchToNode(elementId, node, frame);
+  }
+
+  function handleTransformEnd(elementId: string, event: Konva.KonvaEventObject<Event>) {
+    const node = event.target;
+    const draft = getTransformFramePatch(elementId, node);
+    if (!draft) return;
+
+    applyTransformPatchToNode(elementId, node, draft);
+    onUpdateElementFrame?.(elementId, draft);
   }
 
   function toggleCropMode() {
@@ -736,6 +791,9 @@ export function CanvasWorkspace({
       onTap: () => {
         if (isProcessing) return;
         onSelectElement?.(element.id);
+      },
+      onTransform: (event: Konva.KonvaEventObject<Event>) => {
+        handleTransform(element.id, event);
       },
       onTransformEnd: (event: Konva.KonvaEventObject<Event>) => {
         handleTransformEnd(element.id, event);
@@ -1077,16 +1135,7 @@ export function CanvasWorkspace({
                   ignoreStroke
                   resizeEnabled={!selectedElement?.locked}
                   rotateEnabled={!selectedElement?.locked}
-                  enabledAnchors={[
-                    'top-left',
-                    'top-center',
-                    'top-right',
-                    'middle-left',
-                    'middle-right',
-                    'bottom-left',
-                    'bottom-center',
-                    'bottom-right',
-                  ]}
+                  enabledAnchors={[...transformAnchors]}
                   boundBoxFunc={(oldBox, newBox) =>
                     newBox.width < 8 || newBox.height < 8 ? oldBox : newBox
                   }
@@ -1204,7 +1253,6 @@ export function CanvasWorkspace({
               ))}
             </div>
           ) : null}
-          <span className="canvas-fallback-label">Selected Image</span>
         </div>
         {showEditorOverlays &&
         animationPreview?.pageId === activePageId &&

--- a/apps/editor/src/ui/editor/canvas/canvas-element-props.ts
+++ b/apps/editor/src/ui/editor/canvas/canvas-element-props.ts
@@ -27,6 +27,7 @@ export interface CommonElementProps {
   onMouseLeave: (event: Konva.KonvaEventObject<MouseEvent>) => void;
   onMouseMove: (event: Konva.KonvaEventObject<MouseEvent>) => void;
   onTap: () => void;
+  onTransform: (event: Konva.KonvaEventObject<Event>) => void;
   onTransformEnd: (event: Konva.KonvaEventObject<Event>) => void;
 }
 

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import type Konva from 'konva';
 import { vi } from 'vitest';
+import type { ElementFramePatch } from '../../../../src/domain/commands/elements/basicCommands';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import type { ProjectDocument } from '../../../../src/domain/documents/model';
 import { CanvasWorkspace } from '../../../../src/ui/editor/canvas/CanvasWorkspace';
@@ -28,6 +29,18 @@ describe('CanvasWorkspace', () => {
     expect(screen.getByRole('button', { name: 'Flip' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Crop' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Animate' })).toBeInTheDocument();
+  });
+
+  it('does not leak the selected image label into the canvas DOM', () => {
+    render(
+      <CanvasWorkspace
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['image-hero'] }}
+      />,
+    );
+
+    expect(screen.queryByText('Selected Image')).not.toBeInTheDocument();
   });
 
   it('uses layout sizing instead of transform scaling for zoom', () => {
@@ -148,6 +161,124 @@ describe('CanvasWorkspace', () => {
     );
 
     expect(container.querySelector('.canvas-accessible-text')).not.toBeInTheDocument();
+  });
+
+  it('resizes selected text live instead of stretching it until transform end', () => {
+    const onUpdateElementFrame = vi.fn<(elementId: string, patch: ElementFramePatch) => void>();
+    const stageRef = createRef<Konva.Stage>();
+    const project = sampleProject.createSampleProject();
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-title'] }}
+        stageRef={stageRef}
+        onUpdateElementFrame={onUpdateElementFrame}
+      />,
+    );
+
+    const textNode = stageRef.current
+      ?.find('Text')
+      .find((node) => (node as Konva.Text).text() === 'AI Design Revolution') as
+      | Konva.Text
+      | undefined;
+    expect(textNode).toBeDefined();
+
+    const originalWidth = textNode!.width();
+    const originalHeight = textNode!.height();
+
+    act(() => {
+      textNode!.scaleX(1.5);
+      textNode!.scaleY(1.25);
+      textNode!.fire('transform', { target: textNode });
+    });
+
+    expect(textNode!.scaleX()).toBe(1);
+    expect(textNode!.scaleY()).toBe(1);
+    expect(textNode!.width()).toBeCloseTo(originalWidth * 1.5);
+    expect(textNode!.height()).toBeCloseTo(originalHeight * 1.25);
+    expect(onUpdateElementFrame).not.toHaveBeenCalled();
+
+    act(() => {
+      textNode!.fire('transformend', { target: textNode });
+    });
+
+    expect(onUpdateElementFrame).toHaveBeenCalledWith(
+      'text-title',
+      expect.objectContaining({
+        height: 300,
+        width: 900,
+      }),
+    );
+  });
+
+  it('hides vertical transform handles for selected text', () => {
+    const stageRef = createRef<Konva.Stage>();
+    const project = sampleProject.createSampleProject();
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-title'] }}
+        stageRef={stageRef}
+      />,
+    );
+
+    expect(stageRef.current?.findOne('.top-center')?.visible()).toBe(false);
+    expect(stageRef.current?.findOne('.bottom-center')?.visible()).toBe(false);
+    expect(stageRef.current?.findOne('.top-left')?.visible()).toBe(true);
+    expect(stageRef.current?.findOne('.bottom-right')?.visible()).toBe(true);
+  });
+
+  it('resizes selected images live instead of stretching the bitmap until transform end', async () => {
+    const onUpdateElementFrame = vi.fn<(elementId: string, patch: ElementFramePatch) => void>();
+    const stageRef = createRef<Konva.Stage>();
+
+    render(
+      <CanvasWorkspace
+        project={sampleProject.createSampleProject()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['image-hero'] }}
+        stageRef={stageRef}
+        onUpdateElementFrame={onUpdateElementFrame}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(stageRef.current?.findOne('Image')).toBeDefined();
+    });
+
+    const imageNode = stageRef.current?.findOne('Image');
+    expect(imageNode).toBeDefined();
+
+    const originalWidth = imageNode!.width();
+    const originalHeight = imageNode!.height();
+
+    act(() => {
+      imageNode!.scaleX(0.8);
+      imageNode!.scaleY(1.2);
+      imageNode!.fire('transform', { target: imageNode });
+    });
+
+    expect(imageNode!.scaleX()).toBe(1);
+    expect(imageNode!.scaleY()).toBe(1);
+    expect(imageNode!.width()).toBeCloseTo(originalWidth * 0.8);
+    expect(imageNode!.height()).toBeCloseTo(originalHeight * 1.2);
+    expect(onUpdateElementFrame).not.toHaveBeenCalled();
+
+    act(() => {
+      imageNode!.fire('transformend', { target: imageNode });
+    });
+
+    expect(onUpdateElementFrame).toHaveBeenCalledWith(
+      'image-hero',
+      expect.objectContaining({
+        height: 882,
+        width: 784,
+      }),
+    );
   });
 
   it('selects slide and presentation surfaces from canvas clicks', () => {

--- a/tests/e2e/editor/canvas-resize-text-journey.ts
+++ b/tests/e2e/editor/canvas-resize-text-journey.ts
@@ -21,20 +21,39 @@ export async function resizeTextAndUseArrangeControls(page: Page, baseURL: strin
   const heightInput = page.getByLabel('Selected element height');
   const xInput = page.getByLabel('Selected element x position');
   const yInput = page.getByLabel('Selected element y position');
+  const textFontSizeInput = page.getByRole('spinbutton', { name: 'Text font size' });
   const rotationInput = page.getByRole('spinbutton', { name: 'Selected element rotation' });
   await xInput.fill('560');
   await yInput.fill('280');
   await widthInput.fill('320');
   await heightInput.fill('180');
 
-  const resizeStart = await getCanvasPoint(page, { x: 880, y: 460 });
+  const initialTextFontSize = Number(await textFontSizeInput.inputValue());
+  const verticalHandleProbe = await getCanvasPoint(page, { x: 720, y: 460 });
+  await page.mouse.move(verticalHandleProbe.x, verticalHandleProbe.y);
+  await page.mouse.down();
+  await page.mouse.move(verticalHandleProbe.x, verticalHandleProbe.y + 45, { steps: 10 });
+  await page.mouse.up();
+
+  await expect(textFontSizeInput).toHaveValue(String(initialTextFontSize));
+  await expect(widthInput).toHaveValue('320');
+  await expect(heightInput).toHaveValue('180');
+
+  const frameX = Number(await xInput.inputValue());
+  const frameY = Number(await yInput.inputValue());
+  const frameWidth = Number(await widthInput.inputValue());
+  const frameHeight = Number(await heightInput.inputValue());
+  const resizeStart = await getCanvasPoint(page, {
+    x: frameX + frameWidth,
+    y: frameY + frameHeight,
+  });
   await page.mouse.move(resizeStart.x, resizeStart.y);
   await page.mouse.down();
   await page.mouse.move(resizeStart.x + 90, resizeStart.y + 50, { steps: 10 });
   await page.mouse.up();
 
-  await expect.poll(async () => Number(await widthInput.inputValue())).toBeGreaterThan(360);
-  await expect.poll(async () => Number(await heightInput.inputValue())).toBeGreaterThan(200);
+  await expect.poll(async () => Number(await widthInput.inputValue())).toBeGreaterThan(frameWidth);
+  await expect.poll(async () => Number(await heightInput.inputValue())).toBeGreaterThan(frameHeight);
 
   await editor.openTool('Text');
   await page.getByRole('button', { name: 'Add a text box' }).click();


### PR DESCRIPTION
## Summary
- Update canvas transforms to apply live frame changes during drag, instead of waiting for transform end.
- Use text-specific transform handles so vertical anchors are hidden for text elements.
- Remove the stray selected-image fallback label from the canvas DOM.
- Expand unit and e2e coverage for live resize behavior and handle visibility.

## Testing
- Added unit tests for live text resizing, live image resizing, and text handle visibility.
- Updated the e2e canvas resize journey to verify resize interactions and preserve text font size during vertical drags.
- Not run (not requested).