### PR TITLE
Fix PPTX placeholder layout and inherited frame handling

### DIFF
--- a/apps/editor/src/services/importing/pptx/pptx-parser-model.ts
+++ b/apps/editor/src/services/importing/pptx/pptx-parser-model.ts
@@ -18,12 +18,17 @@ export interface PptxRect {
 }
 
 export interface PptxTransform extends PptxRect {
+  childOffsetX?: number;
+  childOffsetY?: number;
   flipX?: boolean;
   rotation: number;
+  scaleX?: number;
+  scaleY?: number;
 }
 
 export interface PptxTextStyle {
   align: 'left' | 'center' | 'right';
+  capitalization?: 'all';
   fill: string;
   fontFamily: string;
   fontSize: number;
@@ -48,9 +53,11 @@ export interface PptxTextBox {
 export type PptxSlideObject =
   | {
       frame: PptxRect;
+      frameSource?: 'inherited' | 'self';
       id: string;
       kind: 'text';
       opacity?: number;
+      placeholderIndex?: string;
       placeholderRole?: PlaceholderRole;
       rotation?: number;
       source: 'layout' | 'master' | 'slide';
@@ -64,9 +71,12 @@ export type PptxSlideObject =
       assetPath: string;
       crop?: CropRect;
       frame: PptxRect;
+      frameSource?: 'inherited' | 'self';
       id: string;
       kind: 'image' | 'gif' | 'video';
       opacity?: number;
+      placeholderIndex?: string;
+      placeholderOnly?: boolean;
       placeholderRole?: PlaceholderRole;
       rotation?: number;
       source: 'layout' | 'master' | 'slide';
@@ -81,6 +91,7 @@ export type PptxSlideObject =
       id: string;
       kind: 'shape';
       opacity?: number;
+      placeholderIndex?: string;
       placeholderRole?: PlaceholderRole;
       rotation?: number;
       shape: ShapeKind;
@@ -126,10 +137,14 @@ export interface PptxDeck {
 }
 
 export interface PptxTextDefaults {
+  bodyParagraphProperties: Element | undefined;
+  bodyRunProperties: Element | undefined;
   defaultParagraphProperties: Element | undefined;
   defaultRunProperties: Element | undefined;
   listParagraphProperties: Element | undefined;
   listRunProperties: Element | undefined;
+  titleParagraphProperties: Element | undefined;
+  titleRunProperties: Element | undefined;
 }
 
 export interface PptxTheme {

--- a/apps/editor/src/services/importing/pptx/pptxFileUtils.ts
+++ b/apps/editor/src/services/importing/pptx/pptxFileUtils.ts
@@ -22,6 +22,7 @@ function getMimeType(path: string, fallback = 'application/octet-stream') {
   const lowerPath = path.toLowerCase();
   if (lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')) return 'image/jpeg';
   if (lowerPath.endsWith('.png')) return 'image/png';
+  if (lowerPath.endsWith('.svg')) return 'image/svg+xml';
   if (lowerPath.endsWith('.gif')) return 'image/gif';
   if (lowerPath.endsWith('.mp4')) return 'video/mp4';
   if (lowerPath.endsWith('.mov')) return 'video/quicktime';

--- a/apps/editor/src/services/importing/pptx/pptxParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxParser.ts
@@ -64,12 +64,16 @@ function parseFrame(element: Element, scaleX: number, scaleY: number, groupTrans
       height: Math.round(localFrame.height),
     };
   }
+  const childOffsetX = groupTransform.childOffsetX ?? 0;
+  const childOffsetY = groupTransform.childOffsetY ?? 0;
+  const childScaleX = groupTransform.scaleX ?? 1;
+  const childScaleY = groupTransform.scaleY ?? 1;
   return {
     ...localFrame,
-    x: Math.round(groupTransform.x + localFrame.x),
-    y: Math.round(groupTransform.y + localFrame.y),
-    width: Math.round(localFrame.width),
-    height: Math.round(localFrame.height),
+    x: Math.round(groupTransform.x + (localFrame.x - childOffsetX) * childScaleX),
+    y: Math.round(groupTransform.y + (localFrame.y - childOffsetY) * childScaleY),
+    width: Math.round(localFrame.width * childScaleX),
+    height: Math.round(localFrame.height * childScaleY),
     rotation: groupTransform.rotation + localFrame.rotation,
   };
 }
@@ -90,24 +94,30 @@ function parseTextObject(
   idScope: 'layout' | 'master' | 'slide' = 'slide',
 ): PptxSlideObject | undefined {
   const placeholderRole = pptxTextParser.getPlaceholderRole(shape);
-  const text =
+  const rawText =
     pptxTextParser.getTextParagraphs(shape) ||
     (idScope === 'slide' ? '' : pptxTextParser.getPlaceholderFallbackText(placeholderRole));
+  if (!rawText) return undefined;
+  const style = pptxTextParser.getTextStyle(shape, scaleY, textDefaults, scope.theme, placeholderRole);
+  const text = pptxTextParser.applyTextStyle(rawText, style);
   if (!text) return undefined;
   const frame = parseFrame(shape, scaleX, scaleY, scope.groupTransform);
-  if (!frame) return undefined;
+  if (!frame && !placeholderRole) return undefined;
+  const resolvedFrame = frame ?? { height: 1, width: 1, x: 0, y: 0, rotation: 0 };
   const shapeId = localShapeId(shape, String(zIndex));
   const opacity = pptxVisualStyle.getOpacity(shape);
   return {
-    frame,
+    frame: resolvedFrame,
+    frameSource: frame ? 'self' : 'inherited',
     id: `${slideId}-${idScope}-text-${shapeId}`,
     kind: 'text',
     ...(opacity !== undefined ? { opacity } : {}),
+    ...(pptxTextParser.getPlaceholderIndex(shape) ? { placeholderIndex: pptxTextParser.getPlaceholderIndex(shape)! } : {}),
     ...(placeholderRole ? { placeholderRole } : {}),
-    rotation: frame.rotation,
+    rotation: resolvedFrame.rotation,
     source: idScope,
     sourceShapeId: shapeId,
-    style: pptxTextParser.getTextStyle(shape, scaleY, textDefaults, scope.theme),
+    style,
     text,
     textBox: pptxTextParser.getTextBox(shape, scaleX, scaleY),
     zIndex,
@@ -147,14 +157,33 @@ function parsePictureObject(
   idScope: 'layout' | 'master' | 'slide' = 'slide',
 ): PptxSlideObject | undefined {
   const frame = parseFrame(picture, scaleX, scaleY, scope.groupTransform);
-  if (!frame) return undefined;
+  const placeholderIndex = pptxTextParser.getPlaceholderIndex(picture);
+  if (!frame && !placeholderIndex) return undefined;
   const videoRelId =
     pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'videoFile'), 'link') ??
     pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'media'), 'embed');
-  const imageRelId = pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'blip'), 'embed');
+  const imageRelId =
+    pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'blip'), 'embed') ??
+    pptxXml.getRelationshipAttr(pptxXml.firstDescendant(picture, 'svgBlip'), 'embed');
   const assetPath =
     getRelationshipTarget(context, relationships, videoRelId, slideId) ??
     getRelationshipTarget(context, relationships, imageRelId, slideId);
+  if (!assetPath && idScope !== 'slide' && placeholderIndex) {
+    const shapeId = localShapeId(picture, String(zIndex));
+    return {
+      assetPath: '',
+      frame: frame ?? { height: 1, width: 1, x: 0, y: 0, rotation: 0 },
+      frameSource: frame ? 'self' : 'inherited',
+      id: `${slideId}-${idScope}-image-placeholder-${shapeId}`,
+      kind: 'image',
+      placeholderIndex,
+      placeholderOnly: true,
+      rotation: frame?.rotation ?? 0,
+      source: idScope,
+      sourceShapeId: shapeId,
+      zIndex,
+    };
+  }
   if (!assetPath) return undefined;
   const mimeType = context.package.getContentType(assetPath) ?? pptxFileUtils.getMimeType(assetPath);
   const assetType = pptxFileUtils.getAssetType(assetPath, mimeType);
@@ -170,14 +199,17 @@ function parsePictureObject(
   const shapeId = localShapeId(picture, String(zIndex));
   const opacity = pptxVisualStyle.getOpacity(picture);
   const crop = parsePictureCrop(picture);
+  const resolvedFrame = frame ?? { height: 1, width: 1, x: 0, y: 0, rotation: 0 };
   return {
     assetPath,
     ...(crop ? { crop } : {}),
-    frame,
+    frame: resolvedFrame,
+    frameSource: frame ? 'self' : 'inherited',
     id: `${slideId}-${idScope}-${assetType}-${shapeId}`,
     kind: assetType,
     ...(opacity !== undefined ? { opacity } : {}),
-    rotation: frame.rotation,
+    ...(placeholderIndex ? { placeholderIndex } : {}),
+    rotation: resolvedFrame.rotation,
     source: idScope,
     sourceShapeId: shapeId,
     zIndex,
@@ -275,6 +307,7 @@ function parseShapeObject(
     ...(startEndpoint ? { startEndpoint } : {}),
     ...(endEndpoint ? { endEndpoint } : {}),
     ...(opacity !== undefined ? { opacity } : {}),
+    ...(pptxTextParser.getPlaceholderIndex(shape) ? { placeholderIndex: pptxTextParser.getPlaceholderIndex(shape)! } : {}),
     ...(placeholderRole ? { placeholderRole } : {}),
     rotation: frame.rotation,
     shape: shapeKind,
@@ -284,9 +317,56 @@ function parseShapeObject(
   };
 }
 
+function parsePicturePlaceholderObject(
+  shape: Element,
+  slideId: string,
+  zIndex: number,
+  scaleX: number,
+  scaleY: number,
+  scope: ParseScope,
+  idScope: 'layout' | 'master' | 'slide' = 'slide',
+): PptxSlideObject | undefined {
+  if (pptxTextParser.getPlaceholderType(shape) !== 'pic') return undefined;
+  const placeholderIndex = pptxTextParser.getPlaceholderIndex(shape);
+  if (!placeholderIndex) return undefined;
+  const frame = parseFrame(shape, scaleX, scaleY, scope.groupTransform);
+  if (!frame) return undefined;
+  const shapeId = localShapeId(shape, String(zIndex));
+  return {
+    assetPath: '',
+    frame,
+    frameSource: 'self',
+    id: `${slideId}-${idScope}-image-placeholder-${shapeId}`,
+    kind: 'image',
+    placeholderIndex,
+    placeholderOnly: true,
+    rotation: frame.rotation,
+    source: idScope,
+    sourceShapeId: shapeId,
+    zIndex,
+  };
+}
+
+function getPositiveNumber(value: string | null | undefined) {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : undefined;
+}
+
 function parseGroupTransform(group: Element, scaleX: number, scaleY: number, parent?: PptxTransform) {
   const frame = parseFrame(group, scaleX, scaleY, parent);
-  return frame;
+  if (!frame) return undefined;
+  const transform = pptxXml.firstDescendant(group, 'xfrm');
+  const childOffset = transform ? pptxXml.firstDescendant(transform, 'chOff') : undefined;
+  const childExtent = transform ? pptxXml.firstDescendant(transform, 'chExt') : undefined;
+  const childWidth = getPositiveNumber(childExtent?.getAttribute('cx'));
+  const childHeight = getPositiveNumber(childExtent?.getAttribute('cy'));
+  return {
+    ...frame,
+    childOffsetX: Number(childOffset?.getAttribute('x') ?? 0) * scaleX,
+    childOffsetY: Number(childOffset?.getAttribute('y') ?? 0) * scaleY,
+    scaleX: childWidth ? frame.width / (childWidth * scaleX) : 1,
+    scaleY: childHeight ? frame.height / (childHeight * scaleY) : 1,
+  };
 }
 
 function getTableColumnWidths(table: Element) {
@@ -399,6 +479,19 @@ function parseSlideTreeObjects(
   for (const child of pptxXml.childElements(tree)) {
     const zIndex = zIndexStart + objects.length;
     if (child.localName === 'sp') {
+      const picturePlaceholderObject = parsePicturePlaceholderObject(
+        child,
+        slideId,
+        zIndex,
+        scaleX,
+        scaleY,
+        scope,
+        idScope,
+      );
+      if (picturePlaceholderObject) {
+        objects.push(picturePlaceholderObject);
+        continue;
+      }
       const textObject = parseTextObject(child, slideId, zIndex, scaleX, scaleY, textDefaults, scope, idScope);
       if (textObject) objects.push(textObject);
       if (!textObject || !pptxTextParser.getTextParagraphs(child)) {
@@ -411,6 +504,7 @@ function parseSlideTreeObjects(
       if (object) objects.push(object);
     }
     if (child.localName === 'grpSp') {
+      const groupTransform = parseGroupTransform(child, scaleX, scaleY, scope.groupTransform);
       objects.push(
         ...parseSlideTreeObjects(
           context,
@@ -423,9 +517,7 @@ function parseSlideTreeObjects(
           relationships,
           {
             ...scope,
-            ...(parseGroupTransform(child, scaleX, scaleY, scope.groupTransform)
-              ? { groupTransform: parseGroupTransform(child, scaleX, scaleY, scope.groupTransform)! }
-              : {}),
+            ...(groupTransform ? { groupTransform } : {}),
           },
           idScope,
         ),
@@ -463,6 +555,17 @@ async function loadTheme(context: ParseContext, masterPath: string | undefined) 
   const theme = { colors };
   context.themeCache.set(masterPath, theme);
   return theme;
+}
+
+async function loadMasterTextDefaults(
+  context: ParseContext,
+  masterPath: string | undefined,
+  textDefaults: PptxTextDefaults,
+) {
+  if (!masterPath) return textDefaults;
+  const xml = await context.package.readText(masterPath);
+  if (!xml) return textDefaults;
+  return pptxTextParser.getMasterTextDefaults(pptxXml.parseXml(xml), textDefaults);
 }
 
 async function parseInheritedObjects(
@@ -525,6 +628,82 @@ function getPlaceholderRoles(objects: PptxSlideObject[]) {
   );
 }
 
+function findInheritedPlaceholder(
+  object: PptxSlideObject,
+  inheritedObjects: PptxSlideObject[],
+) {
+  if (!object.placeholderRole && !object.placeholderIndex) return undefined;
+  const candidates = inheritedObjects.filter(
+    (inheritedObject) =>
+      inheritedObject.kind === object.kind &&
+      (object.placeholderRole
+        ? inheritedObject.placeholderRole === object.placeholderRole
+        : inheritedObject.placeholderIndex === object.placeholderIndex),
+  );
+  const exactMatch = object.placeholderIndex
+    ? candidates.find((candidate) => candidate.placeholderIndex === object.placeholderIndex)
+    : undefined;
+  return exactMatch ?? candidates.at(-1);
+}
+
+function textBoxMatchesDefaults(object: Extract<PptxSlideObject, { kind: 'text' }>) {
+  return object.textBox.autoFit === 'none' && object.textBox.verticalAlign === 'top';
+}
+
+function inheritPlaceholderTextObject(
+  object: Extract<PptxSlideObject, { kind: 'text' }>,
+  inheritedObject: Extract<PptxSlideObject, { kind: 'text' }>,
+) : Extract<PptxSlideObject, { kind: 'text' }> {
+  const inheritedStyle = inheritedObject.style;
+  const inheritsFrame = object.frameSource === 'inherited';
+  const textBox = textBoxMatchesDefaults(object) ? inheritedObject.textBox : object.textBox;
+  const style = {
+    ...inheritedStyle,
+    align: object.style.align,
+    fontWeight:
+      object.style.fontWeight === pptxParserDefaults.textStyle.fontWeight
+        ? inheritedStyle.fontWeight
+        : object.style.fontWeight,
+    ...(object.style.capitalization ? { capitalization: object.style.capitalization } : {}),
+  };
+  return {
+    ...object,
+    frame: inheritsFrame ? inheritedObject.frame : object.frame,
+    ...(inheritsFrame ? { frameSource: 'self' as const } : {}),
+    style,
+    text: pptxTextParser.applyTextStyle(object.text, style),
+    textBox,
+  };
+}
+
+function inheritPlaceholderFrame(
+  object: Extract<PptxSlideObject, { kind: 'image' | 'gif' | 'video' }>,
+  inheritedObject: PptxSlideObject,
+) : Extract<PptxSlideObject, { kind: 'image' | 'gif' | 'video' }> {
+  if (object.frameSource !== 'inherited') return object;
+  return {
+    ...object,
+    frame: inheritedObject.frame,
+    frameSource: 'self' as const,
+    rotation: inheritedObject.rotation ?? 0,
+  };
+}
+
+function inheritSlidePlaceholderObjects(
+  objects: PptxSlideObject[],
+  inheritedObjects: PptxSlideObject[],
+) {
+  return objects.map((object) => {
+    const inheritedObject = findInheritedPlaceholder(object, inheritedObjects);
+    if (!inheritedObject) return object;
+    if (object.kind === 'text' && inheritedObject.kind === 'text') {
+      return inheritPlaceholderTextObject(object, inheritedObject);
+    }
+    if (object.kind !== 'image' && object.kind !== 'gif' && object.kind !== 'video') return object;
+    return inheritPlaceholderFrame(object, inheritedObject);
+  });
+}
+
 function getRelationshipTargetsInListOrder(
   relationships: Map<string, PptxRelationship>,
   listItems: Element[],
@@ -574,6 +753,7 @@ async function parseLayout(
   const resolvedMasterPath =
     masterPath ?? findRelationshipByType(relationships, '/slideMaster')?.target;
   const theme = await loadTheme(context, resolvedMasterPath);
+  const scopedTextDefaults = await loadMasterTextDefaults(context, resolvedMasterPath, textDefaults);
   const scope = { theme };
   const masterObjects = await parseInheritedObjects(
     context,
@@ -581,7 +761,7 @@ async function parseLayout(
     layoutId,
     scaleX,
     scaleY,
-    textDefaults,
+    scopedTextDefaults,
     scope,
     'master',
   );
@@ -593,7 +773,7 @@ async function parseLayout(
     masterObjects.length,
     scaleX,
     scaleY,
-    textDefaults,
+    scopedTextDefaults,
     relationships,
     scope,
     'layout',
@@ -633,6 +813,7 @@ async function parseSlide(
   const layoutRels = layoutPath ? context.package.getRelationships(layoutPath) : new Map<string, PptxRelationship>();
   const masterPath = findRelationshipByType(layoutRels, '/slideMaster')?.target;
   const theme = await loadTheme(context, masterPath);
+  const scopedTextDefaults = await loadMasterTextDefaults(context, masterPath, textDefaults);
   const scope = { theme };
   const speakerNotes = await pptxTextParser.parseSpeakerNotes(context, notesPath);
   const parsedLayout = layoutPath ? layoutsByPath.get(layoutPath) : undefined;
@@ -641,20 +822,18 @@ async function parseSlide(
     ...object,
     zIndex: index,
   }));
-  const objects: PptxSlideObject[] = [];
-  objects.push(
-    ...parseSlideTreeObjects(
-      context,
-      tree,
-      slideId,
-      objects.length,
-      scaleX,
-      scaleY,
-      textDefaults,
-      rels,
-      scope,
-    ),
+  const parsedObjects = parseSlideTreeObjects(
+    context,
+    tree,
+    slideId,
+    0,
+    scaleX,
+    scaleY,
+    scopedTextDefaults,
+    rels,
+    scope,
   );
+  const objects = inheritSlidePlaceholderObjects(parsedObjects, inheritedObjects);
   const videoStartTriggers = pptxAnimationBuilds.getVideoStartTriggers(document, objects);
   for (const object of objects) {
     const startTrigger = videoStartTriggers.get(object.sourceShapeId);
@@ -662,7 +841,7 @@ async function parseSlide(
   }
   const resolvedLayoutId = parsedLayout?.id ?? layoutId;
   return {
-    backgroundColor: getBackgroundColor(document, theme),
+    backgroundColor: getBackgroundColor(document, theme, parsedLayout?.backgroundColor ?? '#000000'),
     id: slideId,
     ...(resolvedLayoutId ? { layoutId: resolvedLayoutId } : {}),
     ...(parsedLayout?.name ? { layoutName: parsedLayout.name } : {}),

--- a/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
+++ b/apps/editor/src/services/importing/pptx/pptxProjectMapper.ts
@@ -191,6 +191,22 @@ function getAutoFitTextFrame(
   };
 }
 
+function getFixedTextFrame(
+  object: Extract<PptxSlideObject, { kind: 'text' }>,
+  pageWidth: number,
+  pageHeight: number,
+) {
+  const frame = getInsetTextFrame(object);
+  const width = Math.min(pageWidth, frame.width);
+  const height = Math.min(pageHeight, frame.height);
+  return {
+    height,
+    width,
+    x: clampFrameStart(frame.x, width, pageWidth),
+    y: clampFrameStart(frame.y, height, pageHeight),
+  };
+}
+
 function getVisualLineCount(text: string, width: number, fontSize: number) {
   const contentWidth = Math.max(
     fontSize,
@@ -290,10 +306,14 @@ function mapObject(
   layoutId?: string,
 ): DesignElement | undefined {
   if (object.kind === 'text') {
+    const { capitalization, ...style } = object.style;
+    void capitalization;
     const fontSize = getAutoFitFontSize(object, pageWidth, pageHeight);
     const frame =
       object.textBox.autoFit === 'shrink-text'
         ? getAutoFitTextFrame(object, pageWidth, pageHeight)
+        : object.placeholderRole
+          ? getFixedTextFrame(object, pageWidth, pageHeight)
         : getFittedTextFrame(object, pageWidth, pageHeight, fontSize);
     return {
       id: object.id,
@@ -306,7 +326,7 @@ function mapObject(
       opacity: object.opacity ?? 1,
       ...(layoutId ? { templateSource: { layoutId, type: 'layout' as const } } : {}),
       ...(object.placeholderRole ? { placeholderRole: object.placeholderRole } : {}),
-      ...object.style,
+      ...style,
       fontSize,
     };
   }
@@ -329,6 +349,7 @@ function mapObject(
       ...(object.endEndpoint ? { endEndpoint: object.endEndpoint } : {}),
     };
   }
+  if (object.placeholderOnly) return undefined;
   const asset = getOrCreateAsset(object.assetPath, pptxPackage, assets);
   if (!asset) {
     warnings.push({

--- a/apps/editor/src/services/importing/pptx/pptxTextParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxTextParser.ts
@@ -21,10 +21,28 @@ function getPresentationTextDefaults(document: Document): PptxTextDefaults {
     ? pptxXml.firstDescendant(defaultTextStyle, 'lvl1pPr')
     : undefined;
   return {
+    bodyParagraphProperties: undefined,
+    bodyRunProperties: undefined,
     defaultParagraphProperties,
     defaultRunProperties: getParagraphDefaultRunProperties(defaultParagraphProperties),
     listParagraphProperties,
     listRunProperties: getParagraphDefaultRunProperties(listParagraphProperties),
+    titleParagraphProperties: undefined,
+    titleRunProperties: undefined,
+  };
+}
+
+function getMasterTextDefaults(document: Document, baseDefaults: PptxTextDefaults): PptxTextDefaults {
+  const titleStyle = pptxXml.firstDescendant(document, 'titleStyle');
+  const bodyStyle = pptxXml.firstDescendant(document, 'bodyStyle');
+  const titleParagraphProperties = titleStyle ? pptxXml.firstDescendant(titleStyle, 'lvl1pPr') : undefined;
+  const bodyParagraphProperties = bodyStyle ? pptxXml.firstDescendant(bodyStyle, 'lvl1pPr') : undefined;
+  return {
+    ...baseDefaults,
+    bodyParagraphProperties: bodyParagraphProperties ?? baseDefaults.bodyParagraphProperties,
+    bodyRunProperties: getParagraphDefaultRunProperties(bodyParagraphProperties) ?? baseDefaults.bodyRunProperties,
+    titleParagraphProperties: titleParagraphProperties ?? baseDefaults.titleParagraphProperties,
+    titleRunProperties: getParagraphDefaultRunProperties(titleParagraphProperties) ?? baseDefaults.titleRunProperties,
   };
 }
 
@@ -32,12 +50,19 @@ function getPlaceholderType(shape: Element) {
   return pptxXml.firstDescendant(shape, 'ph')?.getAttribute('type');
 }
 
+function getPlaceholderIndex(shape: Element) {
+  return pptxXml.firstDescendant(shape, 'ph')?.getAttribute('idx') ?? undefined;
+}
+
 function getPlaceholderRole(shape: Element): PlaceholderRole | undefined {
+  const placeholder = pptxXml.firstDescendant(shape, 'ph');
+  if (!placeholder) return undefined;
   const type = getPlaceholderType(shape);
   if (type === 'title' || type === 'ctrTitle') return 'title';
   if (type === 'body' || type === 'obj' || type === 'subTitle') return 'body';
   if (type === 'ftr') return 'footer';
   if (type === 'sldNum') return 'slideNumber';
+  if (!type) return 'body';
   return undefined;
 }
 
@@ -100,6 +125,21 @@ function hasEnabledBold(...elements: Array<Element | undefined>) {
   return false;
 }
 
+function getRoleParagraphProperties(
+  role: PlaceholderRole | undefined,
+  textDefaults: PptxTextDefaults,
+) {
+  if (role === 'title') return textDefaults.titleParagraphProperties;
+  if (role === 'body') return textDefaults.bodyParagraphProperties;
+  return undefined;
+}
+
+function getRoleRunProperties(role: PlaceholderRole | undefined, textDefaults: PptxTextDefaults) {
+  if (role === 'title') return textDefaults.titleRunProperties;
+  if (role === 'body') return textDefaults.bodyRunProperties;
+  return undefined;
+}
+
 function getFontSize(rawSize: number, scaleY: number) {
   return Number.isFinite(rawSize) && rawSize > 0
     ? Math.max(8, Math.round((rawSize / 100) * EMUS_PER_POINT * scaleY))
@@ -157,6 +197,7 @@ function getTextStyle(
   scaleY: number,
   textDefaults: PptxTextDefaults,
   theme: PptxTheme | undefined,
+  placeholderRole?: PlaceholderRole,
 ): PptxTextStyle {
   const paragraph = getFirstParagraph(shape);
   const paragraphProperties = paragraph ? pptxXml.firstDescendant(paragraph, 'pPr') : undefined;
@@ -165,6 +206,8 @@ function getTextStyle(
   const listParagraphProperties = getListParagraphProperties(shape);
   const listDefaultRunProperties = getListDefaultRunProperties(shape);
   const verticalAlign = getVerticalAlign(shape);
+  const roleParagraphProperties = getRoleParagraphProperties(placeholderRole, textDefaults);
+  const roleRunProperties = getRoleRunProperties(placeholderRole, textDefaults);
   const inheritedRunProperties =
     verticalAlign === 'middle' ? textDefaults.listRunProperties : textDefaults.defaultRunProperties;
   const inheritedParagraphProperties =
@@ -177,6 +220,7 @@ function getTextStyle(
       runProperties,
       paragraphDefaultRunProperties,
       listDefaultRunProperties,
+      roleRunProperties,
       inheritedRunProperties,
       textDefaults.defaultRunProperties,
     ),
@@ -185,6 +229,7 @@ function getTextStyle(
     runProperties,
     paragraphDefaultRunProperties,
     listDefaultRunProperties,
+    roleRunProperties,
     inheritedRunProperties,
     textDefaults.defaultRunProperties,
   );
@@ -192,36 +237,82 @@ function getTextStyle(
     runProperties,
     paragraphDefaultRunProperties,
     listDefaultRunProperties,
+    roleRunProperties,
+    inheritedRunProperties,
+    textDefaults.defaultRunProperties,
+  );
+  const capitalization = getFirstAttribute(
+    'cap',
+    runProperties,
+    paragraphDefaultRunProperties,
+    listDefaultRunProperties,
+    roleRunProperties,
     inheritedRunProperties,
     textDefaults.defaultRunProperties,
   );
   const fontSize = getFontSize(size, scaleY);
   return {
     align: getTextAlign(paragraphProperties, listParagraphProperties, textDefaults, fontSize, verticalAlign),
-    fill: pptxVisualStyle.getHexColor(
-      runProperties ??
-        paragraphDefaultRunProperties ??
-        listDefaultRunProperties ??
-        inheritedRunProperties ??
-        shape,
-      pptxParserDefaults.textStyle.fill,
+    ...(capitalization === 'all' ? { capitalization: 'all' as const } : {}),
+    fill: getTextFill(
       theme,
+      runProperties,
+      paragraphDefaultRunProperties,
+      listDefaultRunProperties,
+      roleRunProperties,
+      inheritedRunProperties,
+      shape,
     ),
     fontFamily: font && !font.startsWith('+') ? font : pptxParserDefaults.textStyle.fontFamily,
     fontSize,
     fontWeight: bold ? 700 : pptxParserDefaults.textStyle.fontWeight,
-    lineHeight: getLineHeight(paragraphProperties, listParagraphProperties, inheritedParagraphProperties),
+    lineHeight: getLineHeight(
+      paragraphProperties,
+      listParagraphProperties,
+      roleParagraphProperties,
+      inheritedParagraphProperties,
+    ),
     verticalAlign,
   };
+}
+
+function getTextFill(theme: PptxTheme | undefined, ...elements: Array<Element | undefined>) {
+  for (const element of elements) {
+    const color = pptxVisualStyle.getHexColor(element, '', theme);
+    if (color) return color;
+  }
+  return pptxParserDefaults.textStyle.fill;
+}
+
+function applyRunCapitalization(text: string, runProperties: Element | undefined) {
+  const capitalization = runProperties?.getAttribute('cap');
+  if (capitalization === 'all') return text.toLocaleUpperCase();
+  return text;
+}
+
+function getParagraphText(paragraph: Element) {
+  const runs = pptxXml.descendants(paragraph, 'r');
+  if (runs.length === 0) return pptxXml.textContent(paragraph, 't');
+  return runs
+    .map((run) => {
+      const runProperties = pptxXml.firstDescendant(run, 'rPr');
+      return applyRunCapitalization(pptxXml.textContent(run, 't'), runProperties);
+    })
+    .join('');
 }
 
 function getTextParagraphs(shape: Element) {
   const body = pptxXml.firstDescendant(shape, 'txBody');
   const paragraphs = body ? pptxXml.descendants(body, 'p') : [];
   return paragraphs
-    .map((paragraph) => pptxXml.textContent(paragraph, 't').replace(/[ \t\r\f\v]+/g, ' ').trim())
+    .map((paragraph) => getParagraphText(paragraph).replace(/[ \t\r\f\v]+/g, ' ').trim())
     .filter(Boolean)
     .join('\n');
+}
+
+function applyTextStyle(text: string, style: PptxTextStyle) {
+  if (style.capitalization === 'all') return text.toLocaleUpperCase();
+  return text;
 }
 
 async function parseSpeakerNotes(context: ParseContext, notesPath: string | undefined) {
@@ -267,7 +358,10 @@ function getTextBox(shape: Element, scaleX: number, scaleY: number): PptxTextBox
 }
 
 export const pptxTextParser = {
+  applyTextStyle,
+  getMasterTextDefaults,
   getPlaceholderFallbackText,
+  getPlaceholderIndex,
   getPlaceholderRole,
   getPlaceholderType,
   getPresentationTextDefaults,

--- a/apps/editor/tests/unit/services/pptxImportService.test.ts
+++ b/apps/editor/tests/unit/services/pptxImportService.test.ts
@@ -68,6 +68,10 @@ const layoutXml = `<?xml version="1.0" encoding="UTF-8"?>
         <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm></p:spPr>
         <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Title Text</a:t></a:r></a:p></p:txBody>
       </p:sp>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="23" name="Photo placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="pic" idx="13"/></p:nvPr></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="914400" y="3200400"/><a:ext cx="1828800" cy="914400"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+      </p:sp>
     </p:spTree>
   </p:cSld>
 </p:sldLayout>`;
@@ -237,6 +241,7 @@ const contentTypesXml = `<?xml version="1.0" encoding="UTF-8"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
   <Default Extension="xml" ContentType="application/xml"/>
   <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="svg" ContentType="image/svg+xml"/>
   <Override PartName="/deck/main.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
   <Override PartName="/deck/media/photo.dat" ContentType="image/png"/>
 </Types>`;
@@ -263,6 +268,7 @@ const standardSlideRels = `<?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
   <Relationship Id="rIdLayout" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../layouts/layoutA.xml"/>
   <Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/photo.dat"/>
+  <Relationship Id="rIdSvg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/decor.svg"/>
   <Relationship Id="rIdExternal" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="https://example.com/external.png" TargetMode="External"/>
   <Relationship Id="rIdChart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
 </Relationships>`;
@@ -285,6 +291,9 @@ const standardLayoutXml = `<?xml version="1.0" encoding="UTF-8"?>
 const standardMasterXml = `<?xml version="1.0" encoding="UTF-8"?>
 <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
   <p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+  <p:txStyles>
+    <p:titleStyle><a:lvl1pPr><a:defRPr sz="4000" cap="all"><a:solidFill><a:srgbClr val="ffffff"/></a:solidFill></a:defRPr></a:lvl1pPr></p:titleStyle>
+  </p:txStyles>
 </p:sldMaster>`;
 
 const standardThemeXml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -314,6 +323,16 @@ const standardSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
           <a:ln w="25400"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill></a:ln>
         </p:spPr>
       </p:sp>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="11" name="All caps text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="914400" y="1600200"/><a:ext cx="1828800" cy="457200"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr sz="2400" cap="all"><a:solidFill><a:srgbClr val="ffffff"/></a:solidFill></a:rPr><a:t>Mixed case</a:t></a:r></a:p></p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="12" name="Inherited title"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="914400" y="5029200"/><a:ext cx="3657600" cy="457200"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr/><a:t>Inherited style</a:t></a:r></a:p></p:txBody>
+      </p:sp>
       <p:grpSp>
         <p:nvGrpSpPr><p:cNvPr id="20" name="Group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
         <p:grpSpPr><a:xfrm><a:off x="1828800" y="914400"/><a:ext cx="1828800" cy="914400"/><a:chOff x="0" y="0"/><a:chExt cx="1828800" cy="914400"/></a:xfrm></p:grpSpPr>
@@ -323,6 +342,18 @@ const standardSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
             <a:xfrm><a:off x="0" y="0"/><a:ext cx="457200" cy="457200"/></a:xfrm>
             <a:prstGeom prst="diamond"><a:avLst/></a:prstGeom>
             <a:solidFill><a:srgbClr val="00aa66"/></a:solidFill>
+          </p:spPr>
+        </p:sp>
+      </p:grpSp>
+      <p:grpSp>
+        <p:nvGrpSpPr><p:cNvPr id="22" name="Scaled group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+        <p:grpSpPr><a:xfrm><a:off x="2743200" y="914400"/><a:ext cx="1828800" cy="914400"/><a:chOff x="914400" y="457200"/><a:chExt cx="914400" cy="457200"/></a:xfrm></p:grpSpPr>
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="23" name="Scaled grouped rectangle"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="1371600" y="685800"/><a:ext cx="228600" cy="228600"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+            <a:solidFill><a:srgbClr val="0066aa"/></a:solidFill>
           </p:spPr>
         </p:sp>
       </p:grpSp>
@@ -350,6 +381,11 @@ const standardSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
         <p:spPr><a:xfrm><a:off x="4572000" y="2286000"/><a:ext cx="914400" cy="457200"/></a:xfrm></p:spPr>
       </p:pic>
       <p:pic>
+        <p:nvPicPr><p:cNvPr id="52" name="SVG image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+        <p:blipFill><a:blip><a:extLst><a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="rIdSvg"/></a:ext></a:extLst></a:blip></p:blipFill>
+        <p:spPr><a:xfrm><a:off x="5486400" y="2286000"/><a:ext cx="914400" cy="457200"/></a:xfrm></p:spPr>
+      </p:pic>
+      <p:pic>
         <p:nvPicPr><p:cNvPr id="51" name="External image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
         <p:blipFill><a:blip r:embed="rIdExternal"/></p:blipFill>
         <p:spPr><a:xfrm><a:off x="4572000" y="3200400"/><a:ext cx="914400" cy="457200"/></a:xfrm></p:spPr>
@@ -372,6 +408,7 @@ function createStandardsFixture() {
     { path: 'deck/masters/_rels/masterA.xml.rels', contents: standardMasterRels },
     { path: 'deck/theme/themeA.xml', contents: standardThemeXml },
     { path: 'deck/media/photo.dat', contents: new Uint8Array([137, 80, 78, 71]) },
+    { path: 'deck/media/decor.svg', contents: '<svg xmlns="http://www.w3.org/2000/svg"/>' },
     { path: 'deck/charts/chart1.xml', contents: '<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>' },
   ], 'standards.pptx');
 }
@@ -586,6 +623,84 @@ describe('BrowserPptxImportService', () => {
     expect(project.pages[0]?.elementIds.length).toBeGreaterThan(0);
   });
 
+  it('keeps long placeholder text inside its authored PowerPoint frame', async () => {
+    const placeholderSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="30" name="Body placeholder"/><p:cNvSpPr/><p:nvPr><p:ph type="body" idx="15"/></p:nvPr></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="4572000" y="914400"/><a:ext cx="1828800" cy="914400"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr sz="1800"/><a:t>This placeholder has a long sentence that should wrap inside the body column instead of expanding across the whole slide.</a:t></a:r></a:p></p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+    const service = new BrowserPptxImportService();
+    const project = await service.importPowerPoint({ file: createPptxFixture(placeholderSlideXml) });
+    const placeholderElement = Object.values(project.elements).find(
+      (element) => element.type === 'text' && element.placeholderRole === 'body',
+    );
+
+    expect(placeholderElement).toMatchObject({
+      type: 'text',
+      placeholderRole: 'body',
+      x: 973,
+      y: 196,
+      width: 358,
+      height: 184,
+    });
+  });
+
+  it('inherits placeholder frames when slide text and pictures omit direct transforms', async () => {
+    const inheritedFrameSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="30" name="Title"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+        <p:spPr/>
+        <p:txBody><a:bodyPr><a:normAutofit/></a:bodyPr><a:lstStyle/><a:p><a:r><a:rPr sz="2400"/><a:t>Inherited frame title</a:t></a:r></a:p></p:txBody>
+      </p:sp>
+      <p:pic>
+        <p:nvPicPr><p:cNvPr id="31" name="Photo"/><p:cNvPicPr/><p:nvPr><p:ph type="pic" idx="13"/></p:nvPr></p:nvPicPr>
+        <p:blipFill><a:blip r:embed="rIdImage"/></p:blipFill>
+        <p:spPr/>
+      </p:pic>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+    const service = new BrowserPptxImportService();
+    const project = await service.importPowerPoint({ file: createPptxFixture(inheritedFrameSlideXml) });
+    const titleElement = Object.values(project.elements).find(
+      (element) => element.type === 'text' && element.text === 'Inherited frame title',
+    );
+    const imageAsset = Object.values(project.assets).find((asset) => asset.fileName === 'image1.png');
+    const imageElement = Object.values(project.elements).find(
+      (element) => element.type === 'image' && element.assetId === imageAsset?.id,
+    );
+
+    expect(titleElement).toMatchObject({
+      type: 'text',
+      placeholderRole: 'title',
+      x: 13,
+      y: 4,
+      width: 166,
+      height: 88,
+    });
+    expect(imageElement).toMatchObject({
+      type: 'image',
+      x: 192,
+      y: 672,
+      width: 384,
+      height: 192,
+    });
+  });
+
   it('rejects files that are not valid PPTX packages', async () => {
     const service = new BrowserPptxImportService();
 
@@ -607,8 +722,12 @@ describe('BrowserPptxImportService', () => {
 
     const elements = Object.values(project.elements);
     const themeShape = elements.find((element) => element.type === 'shape' && element.id.includes('shape-10'));
+    const allCapsText = elements.find((element) => element.type === 'text' && element.id.includes('text-11'));
+    const inheritedTitle = elements.find((element) => element.type === 'text' && element.id.includes('text-12'));
     const groupedShape = elements.find((element) => element.type === 'shape' && element.id.includes('shape-21'));
+    const scaledGroupedShape = elements.find((element) => element.type === 'shape' && element.id.includes('shape-23'));
     const imageAsset = Object.values(project.assets).find((asset) => asset.fileName === 'photo.dat');
+    const svgAsset = Object.values(project.assets).find((asset) => asset.fileName === 'decor.svg');
     const tableTexts = elements
       .filter((element) => element.type === 'text')
       .filter((element) => ['Cell A', 'Cell B'].includes(element.text))
@@ -623,6 +742,16 @@ describe('BrowserPptxImportService', () => {
       strokeWidth: 5,
       rotation: 90,
     });
+    expect(allCapsText).toMatchObject({
+      type: 'text',
+      text: 'MIXED CASE',
+    });
+    expect(inheritedTitle).toMatchObject({
+      type: 'text',
+      fill: '#FFFFFF',
+      fontSize: 107,
+      text: 'INHERITED STYLE',
+    });
     expect(groupedShape).toMatchObject({
       type: 'shape',
       shape: 'diamond',
@@ -630,8 +759,17 @@ describe('BrowserPptxImportService', () => {
       x: 384,
       y: 192,
     });
+    expect(scaledGroupedShape).toMatchObject({
+      type: 'shape',
+      shape: 'rect',
+      width: 96,
+      height: 96,
+      x: 768,
+      y: 288,
+    });
     expect(tableTexts).toEqual(['Cell A', 'Cell B']);
     expect(imageAsset).toMatchObject({ fileName: 'photo.dat', mimeType: 'image/png', type: 'image' });
+    expect(svgAsset).toMatchObject({ fileName: 'decor.svg', mimeType: 'image/svg+xml', type: 'image' });
     expect(project.importWarnings).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ code: 'pptx-external-relationship', severity: 'warning' }),


### PR DESCRIPTION
## Summary
- Improve PPTX import so placeholder text, images, and shapes inherit layout/master positioning and styling more accurately
- Add support for placeholder indices, picture placeholders, SVG assets, and master text defaults
- Preserve placeholder-driven sizing in the project mapper while skipping placeholder-only assets

## Testing
- Updated unit coverage for PPTX import parsing and mapping behavior
- Not run (not requested)