### PR TITLE
Hide disabled slides from presenter and editor navigation

### DIFF
--- a/apps/editor/src/domain/documents/pageVisibility.ts
+++ b/apps/editor/src/domain/documents/pageVisibility.ts
@@ -1,0 +1,55 @@
+import type { Page, ProjectDocument } from './model';
+
+function isVisible(page: Page) {
+  return page.visible !== false;
+}
+
+function getVisiblePages(project: ProjectDocument) {
+  return project.pages.filter(isVisible);
+}
+
+function getVisiblePage(project: ProjectDocument, pageId: string) {
+  return project.pages.find((page) => page.id === pageId && isVisible(page));
+}
+
+function getFirstVisiblePage(project: ProjectDocument) {
+  return getVisiblePages(project)[0];
+}
+
+function getVisiblePageIndex(project: ProjectDocument, pageId: string) {
+  return getVisiblePages(project).findIndex((page) => page.id === pageId);
+}
+
+function getNearestVisiblePage(project: ProjectDocument, pageId: string, direction: -1 | 1 = 1) {
+  const page = getVisiblePage(project, pageId);
+  if (page) return page;
+
+  const sourceIndex = project.pages.findIndex((item) => item.id === pageId);
+  const startIndex = sourceIndex < 0 ? 0 : sourceIndex + direction;
+  for (
+    let index = startIndex;
+    index >= 0 && index < project.pages.length;
+    index += direction
+  ) {
+    const candidate = project.pages[index];
+    if (candidate && isVisible(candidate)) return candidate;
+  }
+
+  return getFirstVisiblePage(project);
+}
+
+function getRelativeVisiblePage(project: ProjectDocument, pageId: string, offset: -1 | 1) {
+  const visiblePages = getVisiblePages(project);
+  const visibleIndex = visiblePages.findIndex((page) => page.id === pageId);
+  if (visibleIndex >= 0) return visiblePages[visibleIndex + offset];
+  return getNearestVisiblePage(project, pageId, offset);
+}
+
+export const pageVisibility = {
+  getFirstVisiblePage,
+  getNearestVisiblePage,
+  getRelativeVisiblePage,
+  getVisiblePageIndex,
+  getVisiblePages,
+  isVisible,
+};

--- a/apps/editor/src/services/presenter/presenterRemoteStateFactory.ts
+++ b/apps/editor/src/services/presenter/presenterRemoteStateFactory.ts
@@ -1,4 +1,5 @@
 import type { DesignElement, Page, ProjectDocument } from '../../domain/documents/model';
+import { pageVisibility } from '../../domain/documents/pageVisibility';
 import { presenterRemoteDebugLog } from '@localstudio/presenter-remote/debug-log';
 import type {
   PresenterRemotePreviewBatch,
@@ -30,12 +31,14 @@ function createRemoteStateSkeleton(
   connectedControllerCount: number,
   timer: PresenterRemoteTimerState,
 ): PresenterRemoteState {
-  const activePageIndex = Math.max(
-    0,
-    payload.project.pages.findIndex((page) => page.id === payload.activePageId),
-  );
-  const activePage = payload.project.pages[activePageIndex] ?? payload.project.pages[0];
-  const nextPage = payload.project.pages[activePageIndex + 1];
+  const visiblePages = pageVisibility.getVisiblePages(payload.project);
+  const activePage =
+    pageVisibility.getNearestVisiblePage(payload.project, payload.activePageId) ??
+    payload.project.pages[0];
+  const activePageIndex = activePage
+    ? Math.max(0, visiblePages.findIndex((page) => page.id === activePage.id))
+    : 0;
+  const nextPage = visiblePages[activePageIndex + 1];
   const activePageBuilds = activePage ? getRemoteBuildInfo(payload, activePage) : undefined;
   return {
     activePageId: activePage?.id ?? payload.activePageId,
@@ -47,8 +50,8 @@ function createRemoteStateSkeleton(
     deckName: payload.project.name,
     nextPageName: nextPage?.name,
     notes: activePage?.speakerNotes ?? '',
-    pageCount: payload.project.pages.length,
-    pages: payload.project.pages.map((page) => ({
+    pageCount: visiblePages.length,
+    pages: visiblePages.map((page) => ({
       id: page.id,
       name: page.name,
     })),
@@ -83,18 +86,20 @@ function createRemoteState(
   connectedControllerCount: number,
   timer: PresenterRemoteTimerState,
 ): Promise<PresenterRemoteState> {
-  const activePageIndex = Math.max(
-    0,
-    payload.project.pages.findIndex((page) => page.id === payload.activePageId),
-  );
-  const activePage = payload.project.pages[activePageIndex] ?? payload.project.pages[0];
-  const nextPage = payload.project.pages[activePageIndex + 1];
+  const visiblePages = pageVisibility.getVisiblePages(payload.project);
+  const activePage =
+    pageVisibility.getNearestVisiblePage(payload.project, payload.activePageId) ??
+    payload.project.pages[0];
+  const activePageIndex = activePage
+    ? Math.max(0, visiblePages.findIndex((page) => page.id === activePage.id))
+    : 0;
+  const nextPage = visiblePages[activePageIndex + 1];
   const hiddenElementIds =
     activePage && payload.animationPreview?.pageId === activePage.id
       ? new Set(payload.animationPreview.hiddenElementIds)
       : undefined;
   const activePageBuilds = activePage ? getRemoteBuildInfo(payload, activePage) : undefined;
-  const pages = payload.project.pages.map((page) => ({
+  const pages = visiblePages.map((page) => ({
     id: page.id,
     name: page.name,
   }));
@@ -104,7 +109,7 @@ function createRemoteState(
       : Promise.resolve(undefined),
     createUpcomingSlidePreviews(
       payload.project,
-      payload.project.pages.slice(activePageIndex + 1, activePageIndex + 4),
+      visiblePages.slice(activePageIndex + 1, activePageIndex + 4),
     ),
   ]).then(([slidePreview, upcomingSlidePreviews]) => ({
     activePageId: activePage?.id ?? payload.activePageId,
@@ -117,7 +122,7 @@ function createRemoteState(
     nextPageName: nextPage?.name,
     nextSlidePreview: upcomingSlidePreviews[0]?.preview,
     notes: activePage?.speakerNotes ?? '',
-    pageCount: payload.project.pages.length,
+    pageCount: visiblePages.length,
     pages,
     presenterMode: payload.presenterMode ?? 'presenting',
     commandAvailability: [
@@ -198,7 +203,7 @@ async function createRemotePreviewBatches(
       : undefined;
   const previews = await Promise.all(
     payload.project.pages
-      .filter((page) => pageIds.has(page.id))
+      .filter((page) => pageVisibility.isVisible(page) && pageIds.has(page.id))
       .map(async (page) => ({
         id: page.id,
         name: page.name,

--- a/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
+++ b/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type MutableRefObject } from 'react';
 import type { ElementAnimationBuild, ProjectDocument } from '../../../domain/documents/model';
+import { pageVisibility } from '../../../domain/documents/pageVisibility';
 
 export interface AnimationPreviewState {
   activeBuild: ElementAnimationBuild | undefined;
@@ -219,10 +220,11 @@ export function useAnimationPreviewController({
   }
 
   function goToPresentationPage(offset: -1 | 1) {
-    const pages = projectRef.current.pages;
-    const currentIndex = pages.findIndex((page) => page.id === activePageIdRef.current);
-    if (currentIndex < 0) return false;
-    const nextPage = pages[currentIndex + offset];
+    const nextPage = pageVisibility.getRelativeVisiblePage(
+      projectRef.current,
+      activePageIdRef.current,
+      offset,
+    );
     if (!nextPage) return false;
     activePageIdRef.current = nextPage.id;
     setActivePageId(nextPage.id);
@@ -232,10 +234,12 @@ export function useAnimationPreviewController({
   }
 
   function playPresentationPreview(pageId = activePageIdRef.current) {
-    activePageIdRef.current = pageId;
-    setActivePageId(pageId);
+    const page = pageVisibility.getNearestVisiblePage(projectRef.current, pageId);
+    if (!page) return;
+    activePageIdRef.current = page.id;
+    setActivePageId(page.id);
     setSelectedElementIds([]);
-    playAnimationPreview(pageId, 'presenter');
+    playAnimationPreview(page.id, 'presenter');
   }
 
   function advancePresentationPreview() {

--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -30,6 +30,10 @@ interface ScrollingCanvasWorkspaceProps extends CanvasWorkspaceProps {
   translatingPageIds?: string[] | undefined;
 }
 
+function getPageDisplayName(name: string, visible: boolean) {
+  return visible ? name : `${name} (skipped)`;
+}
+
 export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanvasWorkspaceProps>(
   function ScrollingCanvasWorkspace(
     {
@@ -153,6 +157,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
           const isTranslatingPage = translatingPageIds.includes(page.id);
           const shouldRenderCanvas = isActive || index === preloadedPageIndex;
           const visible = page.visible ?? true;
+          const pageDisplayName = getPageDisplayName(page.name, visible);
           const pageClassName = [
             'scroll-page',
             isActive ? 'scroll-page-active' : '',
@@ -179,8 +184,9 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
                 canMoveUp={index > 0}
                 canTranslate={Boolean(canTranslateCurrentSlide)}
                 index={index}
-                name={page.name}
+                name={pageDisplayName}
                 pageId={page.id}
+                rawName={page.name}
                 visible={visible}
                 {...(onAddPage ? { onAddPage } : {})}
                 {...(onDeletePage ? { onDeletePage } : {})}
@@ -219,7 +225,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
                     onActivePageFromScroll?.(page.id);
                   }}
                 >
-                  <span>{visible ? page.name : `${page.name} hidden`}</span>
+                  <span>{pageDisplayName}</span>
                 </button>
               )}
               {showPageControls && onAddPage ? (
@@ -251,6 +257,7 @@ interface PageHeaderProps {
   index: number;
   name: string;
   pageId: string;
+  rawName: string;
   visible: boolean;
   onAddPage?: (afterPageId?: string) => void;
   onDeletePage?: (pageId: string) => void;
@@ -269,6 +276,7 @@ function PageHeader({
   index,
   name,
   pageId,
+  rawName,
   visible,
   onAddPage,
   onDeletePage,
@@ -285,7 +293,7 @@ function PageHeader({
         type="button"
         aria-label={`Rename ${name}`}
         onClick={() => {
-          const nextName = window.prompt('Page title', name);
+          const nextName = window.prompt('Page title', rawName);
           if (nextName) onRenamePage?.(pageId, nextName);
         }}
       >

--- a/apps/editor/src/ui/editor/panels/PagesPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/PagesPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type DragEvent } from 'react';
 import type { DesignElement, Page, ProjectDocument } from '../../../domain/documents/model';
+import { pageVisibility } from '../../../domain/documents/pageVisibility';
 
 type DropPosition = 'before' | 'after';
 
@@ -16,6 +17,14 @@ interface PagesPanelProps {
   onSelectPage?: ((pageId: string) => void) | undefined;
   onSetPageVisibility?: ((pageId: string, visible: boolean) => void) | undefined;
   onTranslatePage?: ((pageId: string) => void) | undefined;
+}
+
+function getPageDisplayName(page: Page) {
+  return page.visible === false ? `${page.name} (skipped)` : page.name;
+}
+
+function formatActivePageCount(count: number) {
+  return `${count} active ${count === 1 ? 'page' : 'pages'}`;
 }
 
 export function PagesPanel({
@@ -94,12 +103,14 @@ export function PagesPanel({
     onReorderPage?.(pageId, position === 'after' ? targetIndex + 1 : targetIndex);
   }
 
+  const activePageCount = pageVisibility.getVisiblePages(project).length;
+
   return (
     <aside className="pages-panel" aria-label="Pages">
       <div className="pages-panel-header">
         <div>
           <h2 className="panel-heading">Pages</h2>
-          <p className="panel-muted">{project.pages.length} pages</p>
+          <p className="panel-muted">{formatActivePageCount(activePageCount)}</p>
         </div>
         <div className="pages-panel-header-actions ew-inline-row">
           <button className="icon-button" type="button" aria-label="Add page" title="Add page" onClick={onAddPage}>
@@ -117,6 +128,7 @@ export function PagesPanel({
       <div className="pages-list">
         {project.pages.map((page, index) => {
           const visible = page.visible ?? true;
+          const pageDisplayName = getPageDisplayName(page);
           const isActive = page.id === activePageId;
           const dropPosition = dropIndicator?.pageId === page.id ? dropIndicator.position : undefined;
           const className = [
@@ -129,7 +141,7 @@ export function PagesPanel({
             .join(' ');
           return (
             <article
-              aria-label={`Page ${index + 1}: ${page.name}`}
+              aria-label={`Page ${index + 1}: ${pageDisplayName}`}
               className={className}
               data-drop-position={dropPosition}
               draggable
@@ -163,12 +175,19 @@ export function PagesPanel({
                 className="page-card-preview"
                 style={{ aspectRatio: `${page.width} / ${page.height}` }}
                 type="button"
-                aria-label={`Select ${page.name}`}
+                aria-label={`Select ${pageDisplayName}`}
                 onClick={() => {
                   onSelectPage?.(page.id);
                 }}
               >
                 <MiniPagePreview page={page} project={project} visible={visible} />
+                {visible ? null : (
+                  <span className="page-card-skip-badge" aria-label="Skipped slide">
+                    <span className="material-symbols-outlined" aria-hidden="true">
+                      visibility_off
+                    </span>
+                  </span>
+                )}
               </button>
               <div className="page-card-body">
                 {editingPageId === page.id ? (
@@ -190,12 +209,12 @@ export function PagesPanel({
                   <button
                     className="page-title-button"
                     type="button"
-                    aria-label={`Rename ${page.name}`}
+                    aria-label={`Rename ${pageDisplayName}`}
                     onClick={() => {
                       startRename(page.id, page.name);
                     }}
                   >
-                    {page.name}
+                    {pageDisplayName}
                   </button>
                 )}
                 <div

--- a/apps/editor/src/ui/editor/shell/EditorFooter.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorFooter.tsx
@@ -25,6 +25,8 @@ export function EditorFooter({
   onZoomIn,
   onZoomOut,
 }: EditorFooterProps) {
+  const activePageNumber = pageCount === 0 ? 0 : activePageIndex + 1;
+
   return (
     <footer className="editor-footer" aria-label="Editor footer controls">
       <div className="editor-footer-left">
@@ -100,7 +102,7 @@ export function EditorFooter({
           Pages
         </button>
         <span className="footer-page-count">
-          {activePageIndex + 1} / {pageCount}
+          {activePageNumber} / {pageCount}
         </span>
       </div>
     </footer>

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type Konva from 'konva';
 import type { AppServices } from '../../../app/composition';
+import { pageVisibility } from '../../../domain/documents/pageVisibility';
 import type { ShareMetadata } from '../../../services/contracts/interfaces';
 import { editorAutomationController } from '../../../services/automation/editorAutomationController';
 import type { EditorAutomationDelegate } from '../../../services/automation/editorAutomationController';
@@ -130,6 +131,12 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     vm.project.pages.findIndex((page) => page.id === vm.activePageId),
   );
   const activePage = vm.project.pages[activePageIndex];
+  const visiblePages = pageVisibility.getVisiblePages(vm.project);
+  const visiblePageCount = visiblePages.length;
+  const activeVisiblePageIndex = Math.max(
+    0,
+    visiblePages.findIndex((page) => page.id === vm.activePageId),
+  );
   const deckTranslationStatus = vm.deckTranslationProgress
     ? `Translating ${vm.deckTranslationProgress.currentPageName} · ${vm.deckTranslationProgress.completedPages}/${vm.deckTranslationProgress.totalPages}`
     : undefined;
@@ -818,7 +825,10 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     if (!presenterRemoteSession && !presenterSessionId) return undefined;
     return getPresenterSessionService().subscribeToCommands((message) => {
       if (message.command === 'start-presenting') {
-        const firstPageId = vm.project.pages[0]?.id ?? vm.activePageId;
+        const firstPageId =
+          pageVisibility.getFirstVisiblePage(vm.project)?.id ??
+          vm.project.pages[0]?.id ??
+          vm.activePageId;
         setRemotePresenterActive(true);
         if (firstPageId) {
           vm.playPresentationPreview(firstPageId);
@@ -1134,7 +1144,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           ) : null}
           {slideNumberVisible ? (
             <div className="presentation-slide-number" aria-live="polite">
-              Slide {activePageIndex + 1} of {vm.project.pages.length}
+              Slide {activeVisiblePageIndex + 1} of {visiblePageCount}
             </div>
           ) : null}
           <ScrollingCanvasWorkspace
@@ -1435,9 +1445,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       ) : null}
       <ProjectVideoPreloader project={vm.project} />
       <EditorFooter
-        activePageIndex={activePageIndex}
+        activePageIndex={activeVisiblePageIndex}
         notesOpen={speakerNotesOpen}
-        pageCount={vm.project.pages.length}
+        pageCount={visiblePageCount}
         pagesPanelOpen={vm.pagesPanelOpen}
         zoomPercent={vm.zoomPercent}
         onResetZoom={vm.resetZoom}

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 import type { Page, ProjectDocument, SelectionState } from '../../domain/documents/model';
+import { pageVisibility } from '../../domain/documents/pageVisibility';
 import type {
   PresenterCommandMessage,
   PresenterStateMessage,
@@ -122,14 +123,7 @@ function isEditablePresenterTarget(target: EventTarget | null) {
 }
 
 function getActivePage(project: ProjectDocument, activePageId: string) {
-  return project.pages.find((page) => page.id === activePageId) ?? project.pages[0];
-}
-
-function getPageIndex(project: ProjectDocument, activePageId: string) {
-  return Math.max(
-    0,
-    project.pages.findIndex((page) => page.id === activePageId),
-  );
+  return pageVisibility.getNearestVisiblePage(project, activePageId) ?? project.pages[0];
 }
 
 function getBuildsRemaining(payload: PresenterStatePayload, page: Page) {
@@ -337,9 +331,15 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     };
   }, [remotePanelOpen]);
 
+  const visiblePages = useMemo(
+    () => (snapshot ? pageVisibility.getVisiblePages(snapshot.project) : []),
+    [snapshot],
+  );
   const activePage = snapshot ? getActivePage(snapshot.project, snapshot.activePageId) : undefined;
-  const activePageIndex = snapshot ? getPageIndex(snapshot.project, snapshot.activePageId) : 0;
-  const upcomingPages = snapshot ? snapshot.project.pages.slice(activePageIndex + 1, activePageIndex + 3) : [];
+  const activePageIndex = activePage
+    ? Math.max(0, visiblePages.findIndex((page) => page.id === activePage.id))
+    : 0;
+  const upcomingPages = visiblePages.slice(activePageIndex + 1, activePageIndex + 3);
   const buildsRemaining = snapshot && activePage ? getBuildsRemaining(snapshot, activePage) : 0;
   const speakerNotes = activePage?.speakerNotes ?? '';
   const currentTimeLabel = currentTime.toLocaleTimeString([], {
@@ -403,12 +403,12 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
   }, []);
 
   const goToPage = useCallback((index: number) => {
-    const page = snapshot?.project.pages[index];
+    const page = visiblePages[index];
     if (!page) return false;
     setSlideNavigatorIndex(index);
     postCommand({ command: 'go-to-page', pageId: page.id });
     return true;
-  }, [postCommand, snapshot]);
+  }, [postCommand, visiblePages]);
 
   const executePresenterShortcut = useCallback((action: KeyboardShortcutAction) => {
     if (action === 'shortcut-toggle') {
@@ -426,7 +426,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     }
     if (action === 'next-navigator-slide') {
       setSlideNavigatorIndex((current) =>
-        Math.min((snapshot?.project.pages.length ?? 1) - 1, current + 1),
+        Math.min(Math.max(0, visiblePages.length - 1), current + 1),
       );
       return;
     }
@@ -444,7 +444,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       return;
     }
     if (action === 'last-slide') {
-      goToPage((snapshot?.project.pages.length ?? 1) - 1);
+      goToPage(visiblePages.length - 1);
       return;
     }
     if (action === 'next-slide') {
@@ -493,7 +493,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     postCommand,
     resetTimer,
     slideNavigatorIndex,
-    snapshot,
+    visiblePages,
   ]);
 
   function dismissIntro() {
@@ -519,7 +519,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
         if (event.key === '+' || event.key === '=') {
           event.preventDefault();
           setSlideNavigatorIndex((current) =>
-            Math.min((snapshot?.project.pages.length ?? 1) - 1, current + 1),
+            Math.min(Math.max(0, visiblePages.length - 1), current + 1),
           );
           return;
         }
@@ -648,6 +648,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     snapshot,
     startPresenterMovieHold,
     stopPresenterMovieHold,
+    visiblePages.length,
   ]);
 
   useEffect(() => {
@@ -817,7 +818,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
         </header>
         <div className="presenter-status-row" aria-label="Presenter status">
           <span className="presenter-status-item ew-ellipsis">
-            Current: Slide {activePageIndex + 1} of {snapshot.project.pages.length}
+            Current: Slide {activePageIndex + 1} of {visiblePages.length}
           </span>
           <span className="presenter-status-item ew-ellipsis">
             Builds remaining: {buildsRemaining}
@@ -922,7 +923,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
           onActivateSlide={goToPage}
           onClose={() => setSlideNavigatorOpen(false)}
           onSelectSlide={setSlideNavigatorIndex}
-          pages={snapshot.project.pages}
+          pages={visiblePages}
           selectedIndex={slideNavigatorIndex}
         />
       ) : null}

--- a/apps/editor/src/ui/styles/pages-panel.css
+++ b/apps/editor/src/ui/styles/pages-panel.css
@@ -66,6 +66,7 @@
 }
 
 .page-card-preview {
+  position: relative;
   grid-area: preview;
   width: 100%;
   border: 1px solid rgba(255, 255, 255, 0.16);
@@ -74,6 +75,25 @@
   cursor: pointer;
   padding: 0;
   overflow: hidden;
+}
+
+.page-card-skip-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  border-radius: 999px;
+  background: rgba(5, 13, 16, 0.72);
+  color: #ffffff;
+  pointer-events: none;
+}
+
+.page-card-skip-badge .material-symbols-outlined {
+  font-size: 15px;
 }
 
 .page-card-canvas {

--- a/apps/editor/tests/unit/services/presenterRemoteSessionService.previews.test.ts
+++ b/apps/editor/tests/unit/services/presenterRemoteSessionService.previews.test.ts
@@ -122,6 +122,61 @@ describe('BrowserPresenterSessionService remote previews', () => {
     });
   });
 
+  it('omits hidden slides from published remote state and previews', async () => {
+    const popup = {
+      location: { href: '' },
+      postMessage: vi.fn(),
+      closed: false,
+    } as unknown as Window;
+    const signalingService = new InMemoryPresenterRemoteSignalingService({
+      randomCode: () => 'ABCD-1234',
+      randomId: () => 'remote-session-1',
+    });
+    const service = new BrowserPresenterSessionService({
+      href: 'https://localstudio.test/editor/?project=Demo',
+      openWindow: vi.fn(() => popup),
+      randomId: () => 'session-1',
+      remoteSignalingService: signalingService,
+    });
+    service.openPresenterWindow();
+    await service.openRemoteControlSession({ presenterLabel: 'MacBook Pro', ttlMs: 60_000 });
+    const project = sampleProject.createSampleProject();
+    project.pages.push(
+      {
+        ...project.pages[0]!,
+        id: 'page-hidden',
+        name: 'Hidden slide',
+        visible: false,
+      },
+      {
+        ...project.pages[0]!,
+        id: 'page-enabled',
+        name: 'Enabled slide',
+        visible: true,
+      },
+    );
+
+    service.publishState({
+      activePageId: project.pages[0]!.id,
+      animationPreview: undefined,
+      project,
+    });
+
+    await vi.waitFor(() => {
+      expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
+    });
+    const publishedState = signalingService.getPublishedState('ABCD-1234');
+
+    expect(publishedState?.pageCount).toBe(2);
+    expect(publishedState?.pages).toEqual([
+      { id: project.pages[0]!.id, name: project.pages[0]!.name },
+      { id: 'page-enabled', name: 'Enabled slide' },
+    ]);
+    expect(publishedState?.nextPageName).toBe('Enabled slide');
+    expect(publishedState?.upcomingSlidePreviews).toHaveLength(1);
+    expect(publishedState?.upcomingSlidePreviews?.[0]?.pageId).toBe('page-enabled');
+  });
+
   it('publishes requested PeerJS slide previews in bounded batches', async () => {
     const popup = {
       location: { href: '' },

--- a/apps/editor/tests/unit/ui/editor/PagesPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/PagesPanel.test.tsx
@@ -146,4 +146,25 @@ describe('PagesPanel', () => {
 
     expect(screen.getByRole('button', { name: 'Move Slide 1 up' })).toBeDisabled();
   });
+
+  it('marks skipped pages and counts only active pages', () => {
+    const project = sampleProject.createSampleProject();
+    project.pages.push({
+      ...project.pages[0]!,
+      id: 'page-2',
+      name: 'Skipped Slide',
+      elementIds: [],
+      visible: false,
+    });
+
+    render(<PagesPanel activePageId="page-1" project={project} />);
+
+    expect(screen.getByText('1 active page')).toBeInTheDocument();
+    expect(screen.getByRole('article', { name: 'Page 2: Skipped Slide (skipped)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select Skipped Slide (skipped)' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rename Skipped Slide (skipped)' })).toHaveTextContent(
+      'Skipped Slide (skipped)',
+    );
+    expect(screen.getByLabelText('Skipped slide')).toBeInTheDocument();
+  });
 });

--- a/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
@@ -39,6 +39,37 @@ describe('ScrollingCanvasWorkspace', () => {
     expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'auto' });
   });
 
+  it('does not scroll when the active slide visibility changes', () => {
+    const project = sampleProject.createSampleProject();
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    const { rerender } = render(
+      <ScrollingCanvasWorkspace
+        activePageId="page-1"
+        project={project}
+        selection={{ pageId: 'page-1', elementIds: [] }}
+      />,
+    );
+
+    scrollIntoView.mockClear();
+    rerender(
+      <ScrollingCanvasWorkspace
+        activePageId="page-1"
+        project={{
+          ...project,
+          pages: [{ ...project.pages[0]!, visible: false }],
+        }}
+        selection={{ pageId: 'page-1', elementIds: [] }}
+      />,
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
   it('activates placeholder pages and exposes page header actions', async () => {
     const user = userEvent.setup();
     const project = sampleProject.createSampleProject();

--- a/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
@@ -230,6 +230,52 @@ describe('useAnimationPreviewController', () => {
     expect(activePageIdRef.current).toBe('page-2');
   });
 
+  it('skips hidden slides during presenter navigation', () => {
+    const project = createProject();
+    project.pages[1] = { ...project.pages[1]!, visible: false };
+    project.pages.push({
+      id: 'page-3',
+      name: 'Slide 3',
+      width: 1280,
+      height: 720,
+      background: { type: 'color', color: '#ffffff' },
+      elementIds: [],
+      animationBuilds: [],
+      visible: true,
+    });
+    const projectRef = { current: project };
+    const activePageIdRef = { current: 'page-1' };
+    const setActivePageId = vi.fn();
+    const setSelectedElementIds = vi.fn();
+    const { result } = renderHook(() =>
+      useAnimationPreviewController({
+        activePageIdRef,
+        projectRef,
+        setActivePageId,
+        setSelectedElementIds,
+      }),
+    );
+
+    act(() => {
+      result.current.playPresentationPreview('page-1');
+    });
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    act(() => {
+      result.current.advanceAnimationPreview();
+    });
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    act(() => {
+      result.current.advancePresentationPreview();
+    });
+
+    expect(activePageIdRef.current).toBe('page-3');
+    expect(setActivePageId).toHaveBeenLastCalledWith('page-3');
+  });
+
   it('rewinds through the current slide build pipeline before moving to the previous slide', () => {
     const projectRef = { current: createProject() };
     const activePageIdRef = { current: 'page-1' };

--- a/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
+++ b/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
@@ -574,6 +574,72 @@ describe('PresenterView', () => {
     expect(screen.queryByRole('dialog', { name: 'Slide navigator' })).not.toBeInTheDocument();
   });
 
+  it('omits hidden slides from presenter counts, previews, and navigation', () => {
+    const opener = { postMessage: vi.fn() };
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: opener,
+    });
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+    render(<PresenterView sessionId="session-1" />);
+    const project = sampleProject.createSampleProject();
+    project.pages.push(
+      {
+        background: { type: 'color', color: '#111111' },
+        elementIds: [],
+        height: 1080,
+        id: 'page-2',
+        name: 'Hidden slide',
+        visible: false,
+        width: 1920,
+      },
+      {
+        background: { type: 'color', color: '#222222' },
+        elementIds: [],
+        height: 1080,
+        id: 'page-3',
+        name: 'Enabled slide',
+        visible: true,
+        width: 1920,
+      },
+    );
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            payload: {
+              activePageId: 'page-1',
+              animationPreview: undefined,
+              project,
+            },
+            sessionId: 'session-1',
+            source: 'localstudio-presenter-main',
+            type: 'state',
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByText('Current: Slide 1 of 2')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Hidden slide' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Enabled slide' })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'End' });
+
+    expect(opener.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'go-to-page',
+        pageId: 'page-3',
+      }),
+      window.location.origin,
+    );
+
+    fireEvent.keyDown(window, { key: '#' });
+    expect(screen.queryByRole('option', { name: /Hidden slide/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Enabled slide/ })).toBeInTheDocument();
+  });
+
   it('opens the remote control QR panel from the presenter toolbar', async () => {
     window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
     render(<PresenterView sessionId="session-1" />);

--- a/tests/e2e/editor/manage-slides.spec.ts
+++ b/tests/e2e/editor/manage-slides.spec.ts
@@ -11,7 +11,7 @@ test.describe('editor manage slides journey', () => {
     const pagesPanel = page.getByRole('complementary', { name: 'Pages' });
 
     await pagesPanel.getByLabel('Add page').click();
-    await expect(page.getByText('2 pages')).toBeVisible();
+    await expect(page.getByText('2 active pages')).toBeVisible();
     await expect(page.getByText('2 / 2')).toBeVisible();
 
     await pagesPanel.getByRole('button', { name: 'Rename Slide 2' }).click();
@@ -20,17 +20,21 @@ test.describe('editor manage slides journey', () => {
     await expect(page.getByRole('article', { name: 'Page 2: Agenda' })).toBeVisible();
 
     await pagesPanel.getByRole('button', { name: 'Duplicate Agenda' }).click();
-    await expect(page.getByText('3 pages')).toBeVisible();
+    await expect(page.getByText('3 active pages')).toBeVisible();
 
     await pagesPanel.getByRole('button', { name: 'Hide Agenda', exact: true }).click();
+    await expect(page.getByRole('article', { name: 'Page 2: Agenda (skipped)' })).toBeVisible();
+    await expect(page.getByText('2 active pages')).toBeVisible();
+    await expect(page.getByText('2 / 2')).toBeVisible();
     await expect(pagesPanel.getByRole('button', { name: 'Show Agenda', exact: true })).toBeVisible();
     await pagesPanel.getByRole('button', { name: 'Show Agenda', exact: true }).click();
+    await expect(page.getByText('3 active pages')).toBeVisible();
 
     await pagesPanel.getByRole('button', { name: 'Move Agenda up', exact: true }).click();
     await pagesPanel.getByRole('button', { name: 'Select Slide 1' }).click();
     await expect(page.getByText(/1 \/ 3|2 \/ 3/)).toBeVisible();
 
     await pagesPanel.getByRole('button', { name: 'Delete Agenda', exact: true }).click();
-    await expect(page.getByText('2 pages')).toBeVisible();
+    await expect(page.getByText('2 active pages')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Added shared page-visibility helpers to centralize visible-slide lookup and navigation.
- Updated presenter, animation preview, editor shell, and presenter view flows to skip hidden slides in counts, next/previous navigation, and remote state.
- Improved editor page labeling with explicit skipped-slide indicators and clearer naming in the pages panel and canvas workspace.
- Added tests covering hidden-slide handling in presenter remote previews and editor page rendering.

## Testing
- Added unit coverage for skipped-slide labeling, visible-page counts, and remote preview filtering.
- Not run (not requested)