### PR TITLE
Handle missing fonts during PPTX import

### DIFF
--- a/apps/editor/src/services/fonts/googleFontsImportService.ts
+++ b/apps/editor/src/services/fonts/googleFontsImportService.ts
@@ -9,12 +9,19 @@ import { googleFontsCatalog } from './googleFontsCatalog';
 
 interface BrowserGoogleFontsImportServiceOptions {
   fetch?: typeof fetch;
+  fontAvailability?: FontAvailabilityDetector;
   fontFaceConstructor?: typeof FontFace;
   fontSet?: FontFaceSet;
 }
 
+interface FontAvailabilityDetector {
+  isAvailable(family: string): boolean;
+}
+
 const GOOGLE_FONTS_CSS_ORIGIN = 'https://fonts.googleapis.com';
 const GOOGLE_FONTS_FILE_ORIGIN = 'https://fonts.gstatic.com';
+const FONT_AVAILABILITY_SAMPLE = 'mmmmmmmmmmlliWWWWW@@@###1234567890';
+const FONT_AVAILABILITY_BASE_FAMILIES = ['serif', 'sans-serif', 'monospace'] as const;
 
 function getDefaultFetch() {
   if (typeof window !== 'undefined') return window.fetch.bind(window);
@@ -117,15 +124,48 @@ function getFontSet(options: BrowserGoogleFontsImportServiceOptions) {
 }
 
 function escapeFontFamily(family: string) {
-  return family.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+  return family.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function createBrowserFontAvailabilityDetector(): FontAvailabilityDetector | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  if (!context) return undefined;
+
+  const baselineWidths = new Map<string, number>();
+  for (const baseFamily of FONT_AVAILABILITY_BASE_FAMILIES) {
+    context.font = `72px ${baseFamily}`;
+    baselineWidths.set(baseFamily, context.measureText(FONT_AVAILABILITY_SAMPLE).width);
+  }
+
+  const cache = new Map<string, boolean>();
+  return {
+    isAvailable(family: string) {
+      const cached = cache.get(family);
+      if (cached !== undefined) return cached;
+
+      const escapedFamily = escapeFontFamily(family);
+      const isAvailable = FONT_AVAILABILITY_BASE_FAMILIES.some((baseFamily) => {
+        const baselineWidth = baselineWidths.get(baseFamily);
+        if (baselineWidth === undefined) return false;
+        context.font = `72px "${escapedFamily}", ${baseFamily}`;
+        return Math.abs(context.measureText(FONT_AVAILABILITY_SAMPLE).width - baselineWidth) > 0.5;
+      });
+      cache.set(family, isAvailable);
+      return isAvailable;
+    },
+  };
 }
 
 export class BrowserGoogleFontsImportService implements FontImportService {
   private readonly requestFetch: typeof fetch;
   private readonly downloadableFamilies = new Map<string, { family: string; exact: boolean }>();
+  private readonly fontAvailability: FontAvailabilityDetector | undefined;
 
   constructor(private readonly options: BrowserGoogleFontsImportServiceOptions = {}) {
     this.requestFetch = options.fetch ?? getDefaultFetch();
+    this.fontAvailability = options.fontAvailability ?? createBrowserFontAvailabilityDetector();
     for (const font of googleFontsCatalog) {
       this.downloadableFamilies.set(font.family.toLowerCase(), { exact: true, family: font.family });
       for (const alias of font.aliases ?? []) {
@@ -139,7 +179,19 @@ export class BrowserGoogleFontsImportService implements FontImportService {
     const resolutions: FontResolution[] = [];
     const warnings: ImportWarning[] = [];
     for (const request of requests) {
-      const result = await this.downloadFont(request);
+      const result = await this.downloadFont(request).catch((error: unknown) => {
+        const reason = error instanceof Error ? error.message : 'font request failed';
+        return {
+          resolution: {
+            fontStyle: request.fontStyle,
+            fontWeight: request.fontWeight,
+            message: reason,
+            requestedFamily: request.family,
+            status: 'failed' as const,
+          },
+          warning: createWarning(request, reason),
+        };
+      });
       if ('font' in result) {
         fonts[result.font.id] = result.font;
       }
@@ -181,7 +233,9 @@ export class BrowserGoogleFontsImportService implements FontImportService {
     | { resolution: FontResolution; warning: ImportWarning }
   > {
     const localResolution = this.resolveLocalFont(request);
-    if (localResolution) return { resolution: localResolution };
+    if (localResolution) {
+      return { resolution: localResolution };
+    }
 
     const catalogMatch = this.downloadableFamilies.get(request.family.toLowerCase());
     if (!catalogMatch) {
@@ -274,20 +328,13 @@ export class BrowserGoogleFontsImportService implements FontImportService {
   }
 
   private resolveLocalFont(request: FontImportRequest): FontResolution | undefined {
-    const fontSet = getFontSet(this.options);
-    if (!fontSet || typeof fontSet.check !== 'function') return undefined;
-    try {
-      const descriptor = `${request.fontStyle} ${request.fontWeight} 16px "${escapeFontFamily(request.family)}"`;
-      if (!fontSet.check(descriptor)) return undefined;
-      return {
-        family: request.family,
-        fontStyle: request.fontStyle,
-        fontWeight: request.fontWeight,
-        requestedFamily: request.family,
-        status: 'available-system',
-      };
-    } catch {
-      return undefined;
-    }
+    if (!this.fontAvailability?.isAvailable(request.family)) return undefined;
+    return {
+      family: request.family,
+      fontStyle: request.fontStyle,
+      fontWeight: request.fontWeight,
+      requestedFamily: request.family,
+      status: 'available-system',
+    };
   }
 }

--- a/apps/editor/src/services/importing/pptx/pptx-parser-model.ts
+++ b/apps/editor/src/services/importing/pptx/pptx-parser-model.ts
@@ -149,6 +149,8 @@ export interface PptxTextDefaults {
 
 export interface PptxTheme {
   colors: Map<string, string>;
+  majorFontFamily?: string;
+  minorFontFamily?: string;
 }
 
 export interface ParseContext {

--- a/apps/editor/src/services/importing/pptx/pptxParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxParser.ts
@@ -552,7 +552,22 @@ async function loadTheme(context: ParseContext, masterPath: string | undefined) 
       if (color) colors.set(child.localName, color);
     }
   }
-  const theme = { colors };
+  const fontScheme = pptxXml.firstDescendant(document, 'fontScheme');
+  const majorFontFamily = fontScheme
+    ? pptxXml.firstDescendant(pptxXml.firstDescendant(fontScheme, 'majorFont') ?? fontScheme, 'latin')
+        ?.getAttribute('typeface')
+        ?.trim()
+    : undefined;
+  const minorFontFamily = fontScheme
+    ? pptxXml.firstDescendant(pptxXml.firstDescendant(fontScheme, 'minorFont') ?? fontScheme, 'latin')
+        ?.getAttribute('typeface')
+        ?.trim()
+    : undefined;
+  const theme = {
+    colors,
+    ...(majorFontFamily ? { majorFontFamily } : {}),
+    ...(minorFontFamily ? { minorFontFamily } : {}),
+  };
   context.themeCache.set(masterPath, theme);
   return theme;
 }

--- a/apps/editor/src/services/importing/pptx/pptxTextParser.ts
+++ b/apps/editor/src/services/importing/pptx/pptxTextParser.ts
@@ -167,6 +167,18 @@ function getLineHeight(...paragraphProperties: Array<Element | undefined>) {
   return pptxParserDefaults.textStyle.lineHeight;
 }
 
+function resolveThemeFontFamily(font: string | undefined, theme: PptxTheme | undefined) {
+  if (!font) return undefined;
+  if (font === '+mj-lt' || font === '+mj-ea' || font === '+mj-cs') {
+    return theme?.majorFontFamily;
+  }
+  if (font === '+mn-lt' || font === '+mn-ea' || font === '+mn-cs') {
+    return theme?.minorFontFamily;
+  }
+  if (font.startsWith('+')) return undefined;
+  return font;
+}
+
 function getTextAlign(
   paragraphProperties: Element | undefined,
   listParagraphProperties: Element | undefined,
@@ -210,6 +222,8 @@ function getTextStyle(
   const roleRunProperties = getRoleRunProperties(placeholderRole, textDefaults);
   const inheritedRunProperties =
     verticalAlign === 'middle' ? textDefaults.listRunProperties : textDefaults.defaultRunProperties;
+  const fallbackInheritedRunProperties =
+    verticalAlign === 'middle' ? textDefaults.defaultRunProperties : textDefaults.listRunProperties;
   const inheritedParagraphProperties =
     verticalAlign === 'middle'
       ? textDefaults.listParagraphProperties
@@ -222,6 +236,7 @@ function getTextStyle(
       listDefaultRunProperties,
       roleRunProperties,
       inheritedRunProperties,
+      fallbackInheritedRunProperties,
       textDefaults.defaultRunProperties,
     ),
   );
@@ -231,14 +246,17 @@ function getTextStyle(
     listDefaultRunProperties,
     roleRunProperties,
     inheritedRunProperties,
+    fallbackInheritedRunProperties,
     textDefaults.defaultRunProperties,
   );
+  const resolvedFont = resolveThemeFontFamily(font, theme);
   const bold = hasEnabledBold(
     runProperties,
     paragraphDefaultRunProperties,
     listDefaultRunProperties,
     roleRunProperties,
     inheritedRunProperties,
+    fallbackInheritedRunProperties,
     textDefaults.defaultRunProperties,
   );
   const capitalization = getFirstAttribute(
@@ -248,6 +266,7 @@ function getTextStyle(
     listDefaultRunProperties,
     roleRunProperties,
     inheritedRunProperties,
+    fallbackInheritedRunProperties,
     textDefaults.defaultRunProperties,
   );
   const fontSize = getFontSize(size, scaleY);
@@ -261,9 +280,10 @@ function getTextStyle(
       listDefaultRunProperties,
       roleRunProperties,
       inheritedRunProperties,
+      fallbackInheritedRunProperties,
       shape,
     ),
-    fontFamily: font && !font.startsWith('+') ? font : pptxParserDefaults.textStyle.fontFamily,
+    fontFamily: resolvedFont ?? pptxParserDefaults.textStyle.fontFamily,
     fontSize,
     fontWeight: bold ? 700 : pptxParserDefaults.textStyle.fontWeight,
     lineHeight: getLineHeight(

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -13,6 +13,8 @@ import { EditorFooter } from './EditorFooter';
 import { ImageExportPanel, type ImageExportOptions } from '../panels/ImageExportPanel';
 import { MediaImportProgressOverlay } from './MediaImportProgressOverlay';
 import { PresentationImportProgressOverlay } from './PresentationImportProgressOverlay';
+import { PowerPointFontReplacementDialog } from './PowerPointFontReplacementDialog';
+import { PowerPointFontWarningDialog } from './PowerPointFontWarningDialog';
 import { MediaIntegrationSettingsPanel } from '../panels/MediaIntegrationSettingsPanel';
 import { MirrorSettingsPanel } from '../panels/MirrorSettingsPanel';
 import { PagesPanel } from '../panels/PagesPanel';
@@ -89,6 +91,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const [speakerNotesOpen, setSpeakerNotesOpen] = useState(false);
   const [audienceFullscreenPromptOpen, setAudienceFullscreenPromptOpen] = useState(false);
   const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
+  const [fontReplacementOpen, setFontReplacementOpen] = useState(false);
   const [slideNavigatorOpen, setSlideNavigatorOpen] = useState(false);
   const [slideNavigatorIndex, setSlideNavigatorIndex] = useState(0);
   const [presentationPaused, setPresentationPaused] = useState(false);
@@ -1432,6 +1435,21 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           onImportProject={(projectId) => {
             void vm.importRemoteMirrorProject(projectId);
           }}
+        />
+      ) : null}
+      {vm.missingPowerPointFonts.length > 0 && !fontReplacementOpen ? (
+        <PowerPointFontWarningDialog
+          missingFonts={vm.missingPowerPointFonts}
+          onDismiss={vm.dismissMissingPowerPointFonts}
+          onReplaceFonts={() => setFontReplacementOpen(true)}
+        />
+      ) : null}
+      {vm.missingPowerPointFonts.length > 0 && fontReplacementOpen ? (
+        <PowerPointFontReplacementDialog
+          downloadableFonts={vm.downloadableFonts}
+          missingFonts={vm.missingPowerPointFonts}
+          onClose={() => setFontReplacementOpen(false)}
+          onReplaceFont={vm.replacePowerPointFont}
         />
       ) : null}
       {vm.presentationImportProgress ? (

--- a/apps/editor/src/ui/editor/shell/PowerPointFontReplacementDialog.tsx
+++ b/apps/editor/src/ui/editor/shell/PowerPointFontReplacementDialog.tsx
@@ -1,0 +1,168 @@
+import { Search, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type { FontCatalogItem } from '../../../services/contracts/interfaces';
+import type { MissingPowerPointFont } from '../state/useEditorViewModel';
+
+interface PowerPointFontReplacementDialogProps {
+  downloadableFonts: FontCatalogItem[];
+  missingFonts: MissingPowerPointFont[];
+  onClose: () => void;
+  onReplaceFont: (missingFamily: string, replacementFamily: string) => Promise<void>;
+}
+
+function filterFonts(fonts: FontCatalogItem[], query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return fonts.slice(0, 8);
+  return fonts
+    .filter(
+      (font) =>
+        font.family.toLowerCase().includes(normalizedQuery) ||
+        font.aliases?.some((alias) => alias.toLowerCase().includes(normalizedQuery)),
+    )
+    .slice(0, 8);
+}
+
+export function PowerPointFontReplacementDialog({
+  downloadableFonts,
+  missingFonts,
+  onClose,
+  onReplaceFont,
+}: PowerPointFontReplacementDialogProps) {
+  const [activeFamily, setActiveFamily] = useState(missingFonts[0]?.family ?? '');
+  const [query, setQuery] = useState('');
+  const [replacements, setReplacements] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<string | undefined>();
+  const [replacing, setReplacing] = useState(false);
+  const filteredFonts = useMemo(() => filterFonts(downloadableFonts, query), [downloadableFonts, query]);
+  const selectedReplacementCount = Object.values(replacements).filter(Boolean).length;
+
+  async function replaceSelectedFonts() {
+    const entries = Object.entries(replacements).filter((entry): entry is [string, string] =>
+      Boolean(entry[1]),
+    );
+    if (entries.length === 0) return;
+    setReplacing(true);
+    setStatus('Replacing fonts...');
+    try {
+      for (const [missingFamily, replacementFamily] of entries) {
+        await onReplaceFont(missingFamily, replacementFamily);
+      }
+      setStatus('Fonts replaced.');
+      onClose();
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Font replacement failed.');
+    } finally {
+      setReplacing(false);
+    }
+  }
+
+  return (
+    <div className="pptx-font-dialog-backdrop">
+      <section
+        className="pptx-font-replacement-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Replace PowerPoint fonts"
+      >
+        <div className="pptx-font-replacement-header">
+          <div>
+            <h2>Choose which fonts to replace.</h2>
+            <p>Replacing a font affects the entire presentation, including imported layouts.</p>
+          </div>
+          <button
+            className="pptx-font-dialog-close"
+            type="button"
+            aria-label="Close font replacement"
+            disabled={replacing}
+            onClick={onClose}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="pptx-font-replacement-table" role="table" aria-label="Missing PowerPoint fonts">
+          <div className="pptx-font-replacement-row pptx-font-replacement-row-heading" role="row">
+            <span role="columnheader">Font</span>
+            <span role="columnheader">Replace With</span>
+          </div>
+          {missingFonts.map((font) => (
+            <button
+              className={
+                activeFamily === font.family
+                  ? 'pptx-font-replacement-row pptx-font-replacement-row-active'
+                  : 'pptx-font-replacement-row'
+              }
+              key={font.family}
+              role="row"
+              type="button"
+              onClick={() => setActiveFamily(font.family)}
+            >
+              <span role="cell" className="ew-ellipsis">
+                {font.family}
+              </span>
+              <span role="cell" className="ew-ellipsis">
+                {replacements[font.family] || "(Don't Replace)"}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div className="pptx-font-search-panel">
+          <label className="layer-search pptx-font-search-box ew-surface ew-compact-row">
+            <Search size={16} aria-hidden="true" />
+            <input
+              aria-label="Search Google Fonts for replacement"
+              placeholder={`Search Google Fonts for ${activeFamily}`}
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </label>
+          <div className="pptx-font-search-results" aria-label="Google Fonts replacement results">
+            {filteredFonts.map((font) => (
+              <button
+                className="pptx-font-search-result"
+                disabled={replacing || !activeFamily}
+                key={font.family}
+                type="button"
+                onClick={() => {
+                  setReplacements((current) => ({ ...current, [activeFamily]: font.family }));
+                }}
+              >
+                <span className="ew-ellipsis">{font.family}</span>
+                {font.aliases?.length ? <small>Also matches {font.aliases.join(', ')}</small> : null}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {status ? (
+          <div className="pptx-font-replacement-status" role="status">
+            {status}
+          </div>
+        ) : null}
+
+        <div className="pptx-font-dialog-actions">
+          <button
+            className="compact-action compact-action-secondary"
+            type="button"
+            disabled={replacing}
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            className="export-button font-orbitron"
+            type="button"
+            disabled={replacing || selectedReplacementCount === 0}
+            onClick={() => {
+              void replaceSelectedFonts();
+            }}
+          >
+            Replace Fonts
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/editor/src/ui/editor/shell/PowerPointFontWarningDialog.tsx
+++ b/apps/editor/src/ui/editor/shell/PowerPointFontWarningDialog.tsx
@@ -1,0 +1,61 @@
+import { AlertTriangle, X } from 'lucide-react';
+import type { MissingPowerPointFont } from '../state/useEditorViewModel';
+
+interface PowerPointFontWarningDialogProps {
+  missingFonts: MissingPowerPointFont[];
+  onDismiss: () => void;
+  onReplaceFonts: () => void;
+}
+
+export function PowerPointFontWarningDialog({
+  missingFonts,
+  onDismiss,
+  onReplaceFonts,
+}: PowerPointFontWarningDialogProps) {
+  return (
+    <div className="pptx-font-dialog-backdrop">
+      <section
+        className="pptx-font-warning-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="PowerPoint font warnings"
+      >
+        <button
+          className="pptx-font-dialog-close"
+          type="button"
+          aria-label="Dismiss PowerPoint font warnings"
+          onClick={onDismiss}
+        >
+          <X size={16} />
+        </button>
+        <div className="pptx-font-warning-heading">
+          <h2>This PowerPoint presentation may look different.</h2>
+          <p>Here is what changed when you opened it in LocalStudio.</p>
+        </div>
+        <div className="pptx-font-warning-list">
+          {missingFonts.map((font) => (
+            <div className="pptx-font-warning-row" key={font.family}>
+              <AlertTriangle size={16} aria-hidden="true" />
+              <p>
+                The font <strong>{font.family}</strong> is missing. Your text might look
+                different.
+              </p>
+            </div>
+          ))}
+        </div>
+        <p className="pptx-font-warning-note">
+          If you install the missing font on your system, LocalStudio will use it automatically
+          the next time you open this presentation.
+        </p>
+        <div className="pptx-font-dialog-actions">
+          <button className="compact-action compact-action-secondary" type="button" onClick={onDismiss}>
+            Keep Defaults
+          </button>
+          <button className="export-button font-orbitron" type="button" onClick={onReplaceFonts}>
+            Replace Fonts
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -75,6 +75,11 @@ export type RightPanelTab =
 export type TextPreset = 'title' | 'subtitle' | 'body';
 export type { OperationNoticeState } from './use-operation-notice';
 
+export interface MissingPowerPointFont {
+  family: string;
+  fontWeights: number[];
+}
+
 interface TranslationPreparationState extends ModelDownloadProgressDetails {
   progress: number;
   sourceLanguage?: string;
@@ -117,6 +122,32 @@ type TranslationScope = 'selection' | 'slide' | 'deck';
 
 const DECK_TRANSLATION_CONCURRENCY = 3;
 
+function getFirstFontFamily(fontFamily: string) {
+  return fontFamily
+    .split(',')
+    .at(0)
+    ?.replace(/^["']|["']$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getMissingPowerPointFonts(project: ProjectDocument, missingFamilies: string[]) {
+  const missingFamilySet = new Set(missingFamilies.map((family) => family.toLowerCase()));
+  const fonts = new Map<string, MissingPowerPointFont>();
+  for (const element of Object.values(project.elements)) {
+    if (element.type !== 'text') continue;
+    const family = getFirstFontFamily(element.fontFamily);
+    if (!family || !missingFamilySet.has(family.toLowerCase())) continue;
+    const current = fonts.get(family.toLowerCase()) ?? { family, fontWeights: [] };
+    const fontWeight = element.fontWeight >= 700 ? 700 : 400;
+    if (!current.fontWeights.includes(fontWeight)) {
+      current.fontWeights = [...current.fontWeights, fontWeight].sort((a, b) => a - b);
+    }
+    fonts.set(family.toLowerCase(), current);
+  }
+  return Array.from(fonts.values()).sort((a, b) => a.family.localeCompare(b.family));
+}
+
 interface DeckTranslationProgressState {
   activePageIds: string[];
   completedPages: number;
@@ -151,6 +182,9 @@ export function useEditorViewModel(services: AppServices) {
   const [presentationImportProgress, setPresentationImportProgress] = useState<
     PresentationImportProgressState | undefined
   >();
+  const [missingPowerPointFonts, setMissingPowerPointFonts] = useState<MissingPowerPointFont[]>(
+    [],
+  );
   const [hasPersistedLocalProject, setHasPersistedLocalProject] = useState(
     shouldRestoreStoredProject,
   );
@@ -1432,7 +1466,7 @@ export function useEditorViewModel(services: AppServices) {
                 },
               ],
             }))
-          : { fonts: {}, warnings: [] };
+          : { fonts: {}, resolutions: [], warnings: [] };
       const importedProjectWithFonts: ProjectDocument = {
         ...importedProject,
         fonts: {
@@ -1449,6 +1483,13 @@ export function useEditorViewModel(services: AppServices) {
             }
           : {}),
       };
+      const unresolvedFontFamilies = fontImportResult.resolutions
+        .filter((resolution) => resolution.status === 'missing-needs-user')
+        .map((resolution) => resolution.requestedFamily);
+      const nextMissingPowerPointFonts = getMissingPowerPointFonts(
+        importedProjectWithFonts,
+        unresolvedFontFamilies,
+      );
       setPresentationImportProgress({
         detail: 'Linking original videos and GIFs from the PowerPoint package.',
         progress: 72,
@@ -1473,6 +1514,7 @@ export function useEditorViewModel(services: AppServices) {
       });
       await editorViewModelRuntime.waitForNextPaint();
       setProject(normalizedProject);
+      setMissingPowerPointFonts(nextMissingPowerPointFonts);
       setActivePageId(normalizedProject.pages[0]?.id ?? '');
       setPageLanguageCodes({});
       const nextSelectedId = normalizedProject.pages[0]?.elementIds.at(-1);
@@ -1516,6 +1558,63 @@ export function useEditorViewModel(services: AppServices) {
       const message = pptxImportLogger.describeError(error).message;
       showOperationNotice({ message: `PowerPoint import failed: ${message}`, tone: 'error' });
     }
+  }
+
+  function dismissMissingPowerPointFonts() {
+    setMissingPowerPointFonts([]);
+  }
+
+  async function replacePowerPointFont(missingFamily: string, replacementFamily: string) {
+    const trimmedReplacement = replacementFamily.trim();
+    if (!trimmedReplacement) return;
+    const matchingElements = Object.values(projectRef.current.elements).filter((element) => {
+      if (element.type !== 'text') return false;
+      return getFirstFontFamily(element.fontFamily)?.toLowerCase() === missingFamily.toLowerCase();
+    }) as Array<Extract<ProjectDocument['elements'][string], { type: 'text' }>>;
+    if (matchingElements.length === 0) {
+      setMissingPowerPointFonts((current) =>
+        current.filter((font) => font.family.toLowerCase() !== missingFamily.toLowerCase()),
+      );
+      return;
+    }
+
+    const fontWeights = Array.from(
+      new Set(matchingElements.map((element) => (element.fontWeight >= 700 ? 700 : 400))),
+    );
+    const result = await services.fontImportService.resolveAndDownloadFonts(
+      fontWeights.map((fontWeight) => ({
+        family: trimmedReplacement,
+        fontStyle: 'normal',
+        fontWeight,
+      })),
+    );
+    if (result.warnings.some((warning) => warning.code === 'font-missing')) {
+      throw new Error(result.warnings[0]?.message ?? `${trimmedReplacement} could not be downloaded.`);
+    }
+
+    commitProject((currentProject) => ({
+      ...currentProject,
+      fonts: {
+        ...(currentProject.fonts ?? {}),
+        ...result.fonts,
+      },
+      elements: Object.fromEntries(
+        Object.entries(currentProject.elements).map(([elementId, element]) => {
+          if (
+            element.type !== 'text' ||
+            getFirstFontFamily(element.fontFamily)?.toLowerCase() !== missingFamily.toLowerCase()
+          ) {
+            return [elementId, element];
+          }
+          return [elementId, { ...element, fontFamily: trimmedReplacement }];
+        }),
+      ),
+      updatedAt: new Date().toISOString(),
+    }));
+    await editorViewModelRuntime.loadProjectFonts(projectRef.current, services.fontImportService);
+    setMissingPowerPointFonts((current) =>
+      current.filter((font) => font.family.toLowerCase() !== missingFamily.toLowerCase()),
+    );
   }
 
   async function exportPowerPoint() {
@@ -2861,6 +2960,7 @@ export function useEditorViewModel(services: AppServices) {
     isFullscreen,
     persistenceEnabled,
     presentationImportProgress,
+    missingPowerPointFonts,
     mediaImportProgress,
     persistenceAttention,
     operationNotice,
@@ -2901,6 +3001,7 @@ export function useEditorViewModel(services: AppServices) {
     selection,
     activeTab,
     availableFonts,
+    downloadableFonts: services.fontImportService.listDownloadableFonts(),
     activeSlideLanguage,
     setActiveTab,
     modelStates,
@@ -2933,6 +3034,8 @@ export function useEditorViewModel(services: AppServices) {
     closeRemoteImport,
     importProject,
     importPowerPoint,
+    dismissMissingPowerPointFonts,
+    replacePowerPointFont,
     exportPowerPoint,
     openVersionHistory,
     closeVersionHistory,

--- a/apps/editor/src/ui/styles.css
+++ b/apps/editor/src/ui/styles.css
@@ -11,6 +11,7 @@
 @import './styles/shell.css';
 @import './styles/editor-mobile-unavailable.css';
 @import './styles/presentation-import.css';
+@import './styles/pptx-font-dialogs.css';
 @import './styles/footer.css';
 @import './styles/toolbar.css';
 @import './styles/project-controls.css';

--- a/apps/editor/src/ui/styles/pptx-font-dialogs.css
+++ b/apps/editor/src/ui/styles/pptx-font-dialogs.css
@@ -1,0 +1,232 @@
+.pptx-font-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 180;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(4, 9, 10, 0.58);
+  backdrop-filter: blur(6px);
+}
+
+.pptx-font-warning-dialog,
+.pptx-font-replacement-dialog {
+  position: relative;
+  width: min(620px, calc(100vw - 48px));
+  display: grid;
+  gap: 16px;
+  border: 1px solid rgba(122, 255, 199, 0.18);
+  border-radius: 8px;
+  background: rgba(18, 25, 26, 0.98);
+  color: var(--ew-text);
+  box-shadow:
+    0 28px 80px rgba(0, 0, 0, 0.55),
+    0 0 24px rgba(55, 253, 118, 0.08);
+}
+
+.pptx-font-warning-dialog {
+  padding: 28px 28px 20px;
+}
+
+.pptx-font-replacement-dialog {
+  padding: 18px;
+}
+
+.pptx-font-dialog-close {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ew-text);
+  cursor: pointer;
+}
+
+.pptx-font-warning-dialog > .pptx-font-dialog-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.pptx-font-dialog-close:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.pptx-font-warning-heading {
+  display: grid;
+  gap: 6px;
+  text-align: center;
+}
+
+.pptx-font-warning-heading h2,
+.pptx-font-replacement-header h2 {
+  margin: 0;
+  color: var(--ew-text);
+  font-size: 18px;
+  font-weight: 900;
+  letter-spacing: 0;
+}
+
+.pptx-font-warning-heading p,
+.pptx-font-replacement-header p {
+  margin: 0;
+  color: var(--ew-muted);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.pptx-font-warning-list {
+  display: grid;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.pptx-font-warning-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  color: #ffe15a;
+}
+
+.pptx-font-warning-row + .pptx-font-warning-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.pptx-font-warning-row p {
+  margin: 0;
+  color: var(--ew-text);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.pptx-font-warning-note {
+  margin: -4px 0 0;
+  color: var(--ew-muted);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.45;
+}
+
+.pptx-font-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.pptx-font-replacement-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.pptx-font-replacement-table {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+}
+
+.pptx-font-replacement-row {
+  min-height: 34px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
+  gap: 12px;
+  align-items: center;
+  padding: 0 12px;
+  border: 0;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--ew-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+}
+
+.pptx-font-replacement-row:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.pptx-font-replacement-row-heading {
+  min-height: 30px;
+  background: rgba(0, 0, 0, 0.28);
+  color: var(--ew-muted);
+  cursor: default;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.pptx-font-replacement-row-active {
+  color: var(--ew-green);
+  outline: 1px solid rgba(55, 253, 118, 0.34);
+  outline-offset: -1px;
+}
+
+.pptx-font-search-panel {
+  display: grid;
+  gap: 10px;
+}
+
+.pptx-font-search-box {
+  min-height: 38px;
+  gap: 8px;
+  padding: 0 10px;
+}
+
+.pptx-font-search-box input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--ew-text);
+  font: inherit;
+  outline: 0;
+}
+
+.pptx-font-search-results {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.pptx-font-search-result {
+  min-width: 0;
+  min-height: 42px;
+  display: grid;
+  gap: 2px;
+  justify-items: start;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.26);
+  color: var(--ew-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 9px;
+}
+
+.pptx-font-search-result:hover,
+.pptx-font-search-result:focus-visible {
+  border-color: rgba(55, 253, 118, 0.32);
+  color: var(--ew-green);
+}
+
+.pptx-font-search-result small {
+  max-width: 100%;
+  color: var(--ew-muted);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pptx-font-replacement-status {
+  color: var(--ew-muted);
+  font-size: 12px;
+  font-weight: 700;
+}

--- a/apps/editor/tests/unit/services/googleFontsImportService.test.ts
+++ b/apps/editor/tests/unit/services/googleFontsImportService.test.ts
@@ -172,28 +172,6 @@ describe('BrowserGoogleFontsImportService', () => {
     );
   });
 
-  it('marks locally available fonts without downloading a duplicate', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 404 })));
-    const service = new BrowserGoogleFontsImportService({
-      fetch: fetchMock,
-      fontSet: { check: vi.fn(() => true) } as unknown as FontFaceSet,
-    });
-
-    const result = await service.resolveAndDownloadFonts([
-      { family: 'Montserrat', fontStyle: 'normal', fontWeight: 400 },
-    ]);
-
-    expect(result.fonts).toEqual({});
-    expect(result.warnings).toEqual([]);
-    expect(result.resolutions).toEqual([
-      expect.objectContaining({
-        requestedFamily: 'Montserrat',
-        status: 'available-system',
-      }),
-    ]);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
   it('returns a warning instead of failing when Google Fonts has no exact match', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 400 })));
     const service = new BrowserGoogleFontsImportService({
@@ -215,9 +193,62 @@ describe('BrowserGoogleFontsImportService', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('does not request Google CSS for unsupported PowerPoint font names', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 200 })));
+  it('marks installed system fonts as available without downloading or warning', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 400 })));
+    const isAvailable = vi.fn((family: string) => family === 'American Typewriter');
+    const service = new BrowserGoogleFontsImportService({
+      fetch: fetchMock,
+      fontAvailability: { isAvailable },
+    });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'American Typewriter', fontStyle: 'normal', fontWeight: 400 },
+    ]);
+
+    expect(result.fonts).toEqual({});
+    expect(result.warnings).toEqual([]);
+    expect(result.resolutions).toEqual([
+      {
+        family: 'American Typewriter',
+        fontStyle: 'normal',
+        fontWeight: 400,
+        requestedFamily: 'American Typewriter',
+        status: 'available-system',
+      },
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(isAvailable).toHaveBeenCalledWith('American Typewriter');
+  });
+
+  it('keeps resolving later missing fonts when one Google Fonts request fails', async () => {
+    const fetchMock = vi.fn(() => Promise.reject(new Error('network unavailable')));
     const service = new BrowserGoogleFontsImportService({ fetch: fetchMock });
+
+    const result = await service.resolveAndDownloadFonts([
+      { family: 'Montserrat', fontStyle: 'normal', fontWeight: 400 },
+      { family: 'Tw Cen MT', fontStyle: 'normal', fontWeight: 400 },
+    ]);
+
+    expect(result.fonts).toEqual({});
+    expect(result.resolutions).toMatchObject([
+      { requestedFamily: 'Montserrat', status: 'failed' },
+      { requestedFamily: 'Tw Cen MT', status: 'missing-needs-user' },
+    ]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'font-download-failed' }),
+        expect.objectContaining({ code: 'font-missing' }),
+      ]),
+    );
+  });
+
+  it('does not trust browser fallback checks for unsupported PowerPoint font names', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 200 })));
+    const service = new BrowserGoogleFontsImportService({
+      fetch: fetchMock,
+      fontAvailability: { isAvailable: vi.fn(() => false) },
+      fontSet: { check: vi.fn(() => true) } as unknown as FontFaceSet,
+    });
 
     const result = await service.resolveAndDownloadFonts([
       { family: 'Adobe 고딕 Std B', fontStyle: 'normal', fontWeight: 400 },
@@ -225,6 +256,7 @@ describe('BrowserGoogleFontsImportService', () => {
 
     expect(result.fonts).toEqual({});
     expect(result.warnings[0]?.message).toContain('Adobe 고딕 Std B');
+    expect(result.resolutions[0]?.status).toBe('missing-needs-user');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/apps/editor/tests/unit/services/pptxImportService.test.ts
+++ b/apps/editor/tests/unit/services/pptxImportService.test.ts
@@ -257,6 +257,14 @@ const standardPresentationXml = `<?xml version="1.0" encoding="UTF-8"?>
   <p:sldIdLst>
     <p:sldId id="256" r:id="rIdSlide"/>
   </p:sldIdLst>
+  <p:defaultTextStyle>
+    <a:defPPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" algn="l">
+      <a:defRPr sz="1800"/>
+    </a:defPPr>
+    <a:lvl1pPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" algn="l">
+      <a:defRPr sz="2600"><a:latin typeface="+mn-lt"/></a:defRPr>
+    </a:lvl1pPr>
+  </p:defaultTextStyle>
 </p:presentation>`;
 
 const standardPresentationRels = `<?xml version="1.0" encoding="UTF-8"?>
@@ -304,6 +312,10 @@ const standardThemeXml = `<?xml version="1.0" encoding="UTF-8"?>
       <a:lt1><a:srgbClr val="ffffff"/></a:lt1>
       <a:accent1><a:srgbClr val="ff9900"/></a:accent1>
     </a:clrScheme>
+    <a:fontScheme name="LocalStudio Fonts">
+      <a:majorFont><a:latin typeface="Aptos Display"/></a:majorFont>
+      <a:minorFont><a:latin typeface="Tenorite"/></a:minorFont>
+    </a:fontScheme>
   </a:themeElements>
 </a:theme>`;
 
@@ -380,6 +392,16 @@ const standardSlideXml = `<?xml version="1.0" encoding="UTF-8"?>
         <p:blipFill><a:blip r:embed="rIdImage"/></p:blipFill>
         <p:spPr><a:xfrm><a:off x="4572000" y="2286000"/><a:ext cx="914400" cy="457200"/></a:xfrm></p:spPr>
       </p:pic>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="52" name="Theme font text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="5486400" y="2286000"/><a:ext cx="1371600" cy="457200"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr sz="2400"><a:latin typeface="+mn-lt"/></a:rPr><a:t>Theme font</a:t></a:r></a:p></p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="53" name="Inherited theme font text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="5486400" y="2743200"/><a:ext cx="1371600" cy="457200"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Inherited theme font</a:t></a:r></a:p></p:txBody>
+      </p:sp>
       <p:pic>
         <p:nvPicPr><p:cNvPr id="52" name="SVG image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
         <p:blipFill><a:blip><a:extLst><a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"><asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="rIdSvg"/></a:ext></a:extLst></a:blip></p:blipFill>
@@ -733,6 +755,12 @@ describe('BrowserPptxImportService', () => {
       .filter((element) => ['Cell A', 'Cell B'].includes(element.text))
       .map((element) => element.text)
       .sort();
+    const themeFontText = elements.find(
+      (element) => element.type === 'text' && element.text === 'Theme font',
+    );
+    const inheritedThemeFontText = elements.find(
+      (element) => element.type === 'text' && element.text === 'Inherited theme font',
+    );
 
     expect(themeShape).toMatchObject({
       type: 'shape',
@@ -766,6 +794,14 @@ describe('BrowserPptxImportService', () => {
       height: 96,
       x: 768,
       y: 288,
+    });
+    expect(themeFontText).toMatchObject({
+      type: 'text',
+      fontFamily: 'Tenorite',
+    });
+    expect(inheritedThemeFontText).toMatchObject({
+      type: 'text',
+      fontFamily: 'Tenorite',
     });
     expect(tableTexts).toEqual(['Cell A', 'Cell B']);
     expect(imageAsset).toMatchObject({ fileName: 'photo.dat', mimeType: 'image/png', type: 'image' });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.pptx-import.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.pptx-import.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { createAppServices as createRealAppServices } from '../../../../src/app/composition';
@@ -77,6 +77,71 @@ class FailingFontImportService implements FontImportService {
           ],
         });
       };
+    });
+  }
+
+  loadProjectFonts(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class MissingFontImportService implements FontImportService {
+  requests: FontImportRequest[][] = [];
+
+  listDownloadableFonts() {
+    return [
+      { family: 'Carlito', aliases: ['Calibri'], source: 'google-fonts' as const },
+      { family: 'Inter', source: 'google-fonts' as const },
+    ];
+  }
+
+  resolveAndDownloadFonts(requests: FontImportRequest[]): Promise<FontImportResult> {
+    this.requests.push(requests);
+    if (requests.some((request) => request.family === 'Tenorite')) {
+      return Promise.resolve({
+        fonts: {},
+        resolutions: requests.map((request) => ({
+          fontStyle: request.fontStyle,
+          fontWeight: request.fontWeight,
+          message: `${request.family} is missing and needs a replacement or uploaded font file.`,
+          requestedFamily: request.family,
+          status: 'missing-needs-user' as const,
+        })),
+        warnings: [
+          {
+            code: 'font-missing',
+            message:
+              'Tenorite is not available locally and no downloadable match is configured. Replace it or upload the font to preserve the PowerPoint design.',
+            severity: 'warning',
+          },
+        ],
+      });
+    }
+
+    return Promise.resolve({
+      fonts: {
+        'google-fonts-carlito-normal-700': {
+          id: 'google-fonts-carlito-normal-700',
+          family: 'Carlito',
+          requestedFamily: requests[0]?.family ?? 'Carlito',
+          source: 'google-fonts',
+          fontStyle: 'normal',
+          fontWeight: 700,
+          mimeType: 'font/woff2',
+          fileName: 'google-fonts-carlito-normal-700.woff2',
+          storage: 'inline',
+          objectUrl: 'blob:font',
+          sourceUrl: 'https://fonts.gstatic.com/carlito.woff2',
+        },
+      },
+      resolutions: requests.map((request) => ({
+        family: request.family,
+        fontStyle: request.fontStyle,
+        fontWeight: request.fontWeight,
+        requestedFamily: request.family,
+        status: 'downloaded-exact' as const,
+      })),
+      warnings: [],
     });
   }
 
@@ -292,6 +357,92 @@ describe('EditorShell PowerPoint import', () => {
     expect(await findProjectNameButton('Imported Font Deck')).toBeInTheDocument();
     expect(fontImportService.requests).toEqual([
       { family: 'Montserrat', fontStyle: 'normal', fontWeight: 700 },
+    ]);
+  });
+
+  it('shows missing PPTX fonts and replaces them from Google Fonts search', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const fontImportService = new MissingFontImportService();
+    services.fontImportService = fontImportService;
+    services.presentationImportService = {
+      importPowerPoint: () =>
+        Promise.resolve({
+          ...services.initialProject,
+          name: 'Imported Missing Font Deck',
+          elements: {
+            title: {
+              id: 'title',
+              type: 'text',
+              text: 'Custom font',
+              x: 0,
+              y: 0,
+              width: 400,
+              height: 100,
+              rotation: 0,
+              locked: false,
+              visible: true,
+              opacity: 1,
+              align: 'left',
+              fill: '#111111',
+              fontFamily: 'Tenorite',
+              fontSize: 48,
+              fontWeight: 700,
+            },
+          },
+          pages: [
+            {
+              ...services.initialProject.pages[0]!,
+              elementIds: ['title'],
+            },
+          ],
+        }),
+    };
+    vi.stubGlobal(
+      'showOpenFilePicker',
+      vi.fn(() =>
+        Promise.resolve([
+          createPowerPointFileHandle(
+            new File(['pptx'], 'deck.pptx', {
+              type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            }),
+          ),
+        ] as FileSystemFileHandle[]),
+      ),
+    );
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Import' }));
+    await user.click(screen.getByRole('menuitem', { name: 'PowerPoint (.pptx)' }));
+
+    const warningDialog = await screen.findByRole('dialog', {
+      name: 'PowerPoint font warnings',
+    });
+    expect(warningDialog).toHaveTextContent('This PowerPoint presentation may look different.');
+    expect(warningDialog).toHaveTextContent('The font Tenorite is missing.');
+
+    await user.click(within(warningDialog).getByRole('button', { name: 'Replace Fonts' }));
+    const replacementDialog = screen.getByRole('dialog', { name: 'Replace PowerPoint fonts' });
+    expect(within(replacementDialog).getByRole('table', { name: 'Missing PowerPoint fonts' })).toHaveTextContent(
+      'Tenorite',
+    );
+
+    await user.type(
+      within(replacementDialog).getByRole('searchbox', {
+        name: 'Search Google Fonts for replacement',
+      }),
+      'carl',
+    );
+    await user.click(within(replacementDialog).getByRole('button', { name: /Carlito/ }));
+    expect(replacementDialog).toHaveTextContent('Carlito');
+
+    await user.click(within(replacementDialog).getByRole('button', { name: 'Replace Fonts' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Replace PowerPoint fonts' })).toBeNull();
+    });
+    expect(fontImportService.requests.at(-1)).toEqual([
+      { family: 'Carlito', fontStyle: 'normal', fontWeight: 700 },
     ]);
   });
 

--- a/tests/e2e/editor/pptx-sample-font-warning.spec.ts
+++ b/tests/e2e/editor/pptx-sample-font-warning.spec.ts
@@ -1,0 +1,117 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { Page, TestInfo } from '@playwright/test';
+import { EditorAppPage } from '../pages/editor-app.page';
+import { installPptxFilePicker } from '../support/pptx-file-picker';
+import { createInheritedThemeFontPptxFixture } from '../support/test-assets';
+import { expect, test, withIsolatedDevServer } from '../support/journey-test';
+
+const getServer = withIsolatedDevServer(test);
+const SAMPLE_PROJECT_NAME = 'fullstack-monitoring-jsnation-11062026';
+
+async function createSamplePptxFixture(testInfo: TestInfo) {
+  const fixtureDir = resolve(process.cwd(), 'tests/e2e/fixtures/pptx');
+  const partNames = (await readdir(fixtureDir))
+    .filter((name) => name.startsWith(`${SAMPLE_PROJECT_NAME}.pptx.part-`))
+    .sort();
+  const chunks = await Promise.all(partNames.map((name) => readFile(resolve(fixtureDir, name))));
+  const outputPath = testInfo.outputPath(`${SAMPLE_PROJECT_NAME}.pptx`);
+  await writeFile(outputPath, Buffer.concat(chunks));
+  return outputPath;
+}
+
+async function blockGoogleFontDownloads(page: Page) {
+  await page.route('https://fonts.googleapis.com/**', (route) =>
+    route.fulfill({ status: 404, body: '' }),
+  );
+  await page.route('https://fonts.gstatic.com/**', (route) =>
+    route.fulfill({ status: 404, body: '' }),
+  );
+}
+
+async function expectMissingFontWarning(page: Page) {
+  const warningDialog = page.getByRole('dialog', { name: 'PowerPoint font warnings' });
+  await expect(warningDialog).toBeVisible({ timeout: 90_000 });
+  await expect(warningDialog).toContainText(
+    /This PowerPoint presentation may look different\./,
+  );
+  await expect(warningDialog).toContainText('Adobe 고딕 Std B');
+  await expect(warningDialog).not.toContainText('American Typewriter');
+  await expect(
+    warningDialog.getByRole('button', { name: 'Replace Fonts' }),
+  ).toBeVisible();
+}
+
+test.describe('editor PowerPoint sample font warnings', () => {
+  test('shows missing font warnings when importing the local sample deck route', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await blockGoogleFontDownloads(page);
+
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await editor.goto('/editor/?newProject=1&importPptxSample=1');
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Edit project name fullstack-monitoring-jsnation-11062026',
+      }),
+    ).toBeVisible({ timeout: 90_000 });
+
+    await expectMissingFontWarning(page);
+  });
+
+  test('shows missing font warnings when importing the sample deck from File > Import', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'showOpenFilePicker', {
+        configurable: true,
+        value: undefined,
+      });
+    });
+    await blockGoogleFontDownloads(page);
+
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await editor.gotoNewProject();
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await editor.openMenu('File');
+    await page.getByRole('menuitem', { name: 'Import' }).click();
+    await page.getByRole('menuitem', { name: 'PowerPoint (.pptx)' }).click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(await createSamplePptxFixture(testInfo));
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Edit project name fullstack-monitoring-jsnation-11062026',
+      }),
+    ).toBeVisible({ timeout: 90_000 });
+    await expectMissingFontWarning(page);
+  });
+
+  test('shows missing font warnings for inherited theme fonts from File > Import', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    await blockGoogleFontDownloads(page);
+
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await editor.gotoNewProject();
+
+    await installPptxFilePicker(page, await createInheritedThemeFontPptxFixture(testInfo));
+    await editor.openMenu('File');
+    await page.getByRole('menuitem', { name: 'Import' }).click();
+    await page.getByRole('menuitem', { name: 'PowerPoint (.pptx)' }).click();
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Edit project name localstudio-e2e-inherited-theme-font',
+      }),
+    ).toBeVisible({ timeout: 60_000 });
+    const warningDialog = page.getByRole('dialog', { name: 'PowerPoint font warnings' });
+    await expect(warningDialog).toBeVisible({ timeout: 60_000 });
+    await expect(warningDialog).toContainText('The font Tenorite is missing.');
+  });
+});

--- a/tests/e2e/support/test-assets.ts
+++ b/tests/e2e/support/test-assets.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import PptxGenJS from 'pptxgenjs';
 import type { TestInfo } from '@playwright/test';
+import { createStoredPptxFile } from '../../../apps/editor/tests/unit/services/pptxTestZip';
 
 const tinyPngBase64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
@@ -63,6 +64,115 @@ export async function createTinyPptxFixture(testInfo: TestInfo) {
   });
 
   await pptx.writeFile({ fileName: filePath });
+  return filePath;
+}
+
+export async function createInheritedThemeFontPptxFixture(testInfo: TestInfo) {
+  const filePath = testInfo.outputPath('localstudio-e2e-inherited-theme-font.pptx');
+  const pptx = createStoredPptxFile(
+    [
+      {
+        path: '[Content_Types].xml',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+</Types>`,
+      },
+      {
+        path: '_rels/.rels',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdPresentation" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>`,
+      },
+      {
+        path: 'ppt/presentation.xml',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:sldSz cx="9144000" cy="5143500"/>
+  <p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rIdMaster"/></p:sldMasterIdLst>
+  <p:sldIdLst><p:sldId id="256" r:id="rIdSlide"/></p:sldIdLst>
+  <p:defaultTextStyle>
+    <a:defPPr><a:defRPr sz="1800"/></a:defPPr>
+    <a:lvl1pPr><a:defRPr sz="3600"><a:latin typeface="+mn-lt"/></a:defRPr></a:lvl1pPr>
+  </p:defaultTextStyle>
+</p:presentation>`,
+      },
+      {
+        path: 'ppt/_rels/presentation.xml.rels',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdSlide" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+  <Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+</Relationships>`,
+      },
+      {
+        path: 'ppt/slides/slide1.xml',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Inherited font text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="914400" y="914400"/><a:ext cx="5486400" cy="914400"/></a:xfrm></p:spPr>
+        <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Inherited Tenorite text</a:t></a:r></a:p></p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`,
+      },
+      {
+        path: 'ppt/slides/_rels/slide1.xml.rels',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdLayout" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+</Relationships>`,
+      },
+      {
+        path: 'ppt/slideLayouts/slideLayout1.xml',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld></p:sldLayout>`,
+      },
+      {
+        path: 'ppt/slideLayouts/_rels/slideLayout1.xml.rels',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
+</Relationships>`,
+      },
+      {
+        path: 'ppt/slideMasters/slideMaster1.xml',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+  <p:sldLayoutIdLst><p:sldLayoutId id="1" r:id="rIdLayout"/></p:sldLayoutIdLst>
+</p:sldMaster>`,
+      },
+      {
+        path: 'ppt/slideMasters/_rels/slideMaster1.xml.rels',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdLayout" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+  <Relationship Id="rIdTheme" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>`,
+      },
+      {
+        path: 'ppt/theme/theme1.xml',
+        contents: `<?xml version="1.0" encoding="UTF-8"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <a:themeElements>
+    <a:clrScheme name="LocalStudio"><a:dk1><a:srgbClr val="111111"/></a:dk1><a:lt1><a:srgbClr val="ffffff"/></a:lt1></a:clrScheme>
+    <a:fontScheme name="LocalStudio Fonts"><a:majorFont><a:latin typeface="Aptos Display"/></a:majorFont><a:minorFont><a:latin typeface="Tenorite"/></a:minorFont></a:fontScheme>
+  </a:themeElements>
+</a:theme>`,
+      },
+    ],
+    'localstudio-e2e-inherited-theme-font.pptx',
+  );
+  await writeFile(filePath, Buffer.from(await pptx.arrayBuffer()));
   return filePath;
 }
 


### PR DESCRIPTION
## Summary
- Detect missing fonts while parsing PPTX imports and surface them in the editor state
- Show warning and replacement dialogs so imported decks can recover with available Google Fonts
- Add parser, service, UI, and stylesheet updates to support the new import flow
- Cover the flow with unit and end-to-end tests for font detection and replacement behavior

## Testing
- Added/updated unit tests for font import and PPTX parsing behavior
- Added an end-to-end test for the PPTX missing-font warning flow
- Not run (not requested)