### PR TITLE
Fix top toolbar overflow at medium widths

### DIFF
--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -479,7 +479,7 @@ export function TopToolbar({
                 setIsEditingProjectName(true);
               }}
             >
-              {project.name}
+              <span className="project-title-text">{project.name}</span>
             </button>
           )}
           <ProjectPlayControl

--- a/apps/editor/src/ui/styles/project-controls.css
+++ b/apps/editor/src/ui/styles/project-controls.css
@@ -1,7 +1,7 @@
 .project-group {
   gap: 8px;
   min-width: 0;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
 }
 
 .project-play-shell {
@@ -13,8 +13,9 @@
 }
 
 .project-title {
+  width: clamp(48px, calc(100vw - 1305px), 150px);
   min-width: 0;
-  max-width: 150px;
+  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   border: 0;
@@ -31,6 +32,13 @@
 .project-title-button {
   cursor: text;
   padding: 0;
+}
+
+.project-title-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .project-title-button:hover {
@@ -98,7 +106,9 @@
 }
 
 .project-title-input {
-  width: min(220px, 24vw);
+  width: clamp(80px, calc(100vw - 1260px), 220px);
+  min-width: 0;
+  flex: 0 0 auto;
   height: 26px;
   border: 1px solid var(--ew-green);
   border-radius: 4px;
@@ -115,6 +125,7 @@
 .local-only-badge {
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   height: 22px;
   padding: 0 8px;
   border: 1px solid var(--ew-border);
@@ -137,4 +148,10 @@
 
 .toolbar-icon-group {
   position: relative;
+}
+
+@media (max-width: 1280px) {
+  .project-group {
+    gap: 4px;
+  }
 }

--- a/apps/editor/src/ui/styles/responsive-tablet.css
+++ b/apps/editor/src/ui/styles/responsive-tablet.css
@@ -1,3 +1,21 @@
+@media (max-width: 1500px) {
+  .local-only-badge {
+    display: none;
+  }
+}
+
+@media (max-width: 1280px) {
+  .language-chip,
+  .github-toolbar-link,
+  .profile-avatar {
+    display: none;
+  }
+
+  .toolbar-right {
+    gap: 8px;
+  }
+}
+
 @media (max-width: 1023px) {
   .app-shell {
     width: 100vw;

--- a/apps/editor/src/ui/styles/toolbar.css
+++ b/apps/editor/src/ui/styles/toolbar.css
@@ -2,6 +2,7 @@
   gap: 24px;
   height: 100%;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .toolbar-product-title {

--- a/tests/e2e/editor/top-toolbar-responsive.spec.ts
+++ b/tests/e2e/editor/top-toolbar-responsive.spec.ts
@@ -1,0 +1,63 @@
+import type { Page } from '@playwright/test';
+import { EditorAppPage } from '../pages/editor-app.page';
+import { expect, test, withIsolatedDevServer } from '../support/journey-test';
+
+const getServer = withIsolatedDevServer(test);
+
+async function expectToolbarItemsDoNotOverlap(page: Page) {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const title = document.querySelector('.project-title')?.getBoundingClientRect();
+          const play = document.querySelector('.project-play-shell')?.getBoundingClientRect();
+          const localStatus = document.querySelector('.local-only-badge');
+          const localStatusBox = localStatus?.getBoundingClientRect();
+          const localStatusVisible = localStatus
+            ? getComputedStyle(localStatus).display !== 'none'
+            : false;
+          const editingActions = document
+            .querySelector('.toolbar-icon-group')
+            ?.getBoundingClientRect();
+          if (!title || !play || !editingActions) return false;
+
+          return (
+            title.right <= play.left &&
+            (!localStatusVisible ||
+              (localStatusBox !== undefined &&
+                play.right <= localStatusBox.left &&
+                localStatusBox.right <= editingActions.left)) &&
+            play.right <= editingActions.left &&
+            document.documentElement.scrollWidth <= document.documentElement.clientWidth
+          );
+        }),
+      { timeout: 5_000 },
+    )
+    .toBe(true);
+}
+
+test.describe('editor top toolbar responsive layout', () => {
+  test('truncates the project title before it collides with toolbar actions', async ({ page }) => {
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await page.setViewportSize({ width: 1365, height: 768 });
+    await editor.gotoNewProject();
+    await editor.renameProject('web-ai-beyond-chat-collaboration-control-room');
+
+    await page.setViewportSize({ width: 1440, height: 768 });
+
+    await expectToolbarItemsDoNotOverlap(page);
+    await expect(page.locator('.local-only-badge')).toBeHidden();
+
+    await page.setViewportSize({ width: 1365, height: 768 });
+
+    await expectToolbarItemsDoNotOverlap(page);
+    await expect(page.locator('.local-only-badge')).toBeHidden();
+
+    await page.setViewportSize({ width: 1120, height: 768 });
+
+    await expectToolbarItemsDoNotOverlap(page);
+    await expect(page.locator('.language-chip')).toBeHidden();
+    await expect(page.locator('.github-toolbar-link')).toBeHidden();
+    await expect(page.locator('.profile-avatar')).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- Constrain the project name control so it truncates cleanly instead of colliding with adjacent toolbar actions.
- Adjust toolbar flex behavior and responsive breakpoints to preserve layout density on narrower screens.
- Add an end-to-end regression test that checks toolbar items do not overlap across common viewport widths.

## Testing
- Added Playwright coverage for the responsive top toolbar layout.
- Not run (not requested).