### PR TITLE
Fix header and submenu hover behavior in the editor toolbar

### DIFF
--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -211,6 +211,14 @@ export function TopToolbar({
     setOpenSubmenu(null);
   }
 
+  function switchOpenHeaderMenu(menu: HeaderMenu) {
+    if (!openMenu || openMenu === menu) return;
+    setTranslationMenuOpen(false);
+    setPlayMenuOpen(false);
+    setOpenSubmenu(null);
+    setOpenMenu(menu);
+  }
+
   function commitProjectName() {
     const nextName = projectNameDraft.trim();
     if (nextName && nextName !== project.name) {
@@ -293,7 +301,7 @@ export function TopToolbar({
   function handleMenuAction(action: HeaderMenuAction) {
     if (action.kind === 'separator') return;
     if (action.kind === 'submenu') {
-      setOpenSubmenu((current) => (current === action.label ? null : action.label));
+      setOpenSubmenu(action.label);
       return;
     }
     if (action.disabled) return;
@@ -364,7 +372,10 @@ export function TopToolbar({
                   setTranslationMenuOpen(false);
                   setPlayMenuOpen(false);
                   setOpenSubmenu(null);
-                  setOpenMenu((current) => (current === item ? null : item));
+                  setOpenMenu(item);
+                }}
+                onPointerEnter={() => {
+                  switchOpenHeaderMenu(item);
                 }}
               >
                 {item}
@@ -377,6 +388,9 @@ export function TopToolbar({
                         aria-label={action.label}
                         className="toolbar-dropdown-separator"
                         key={action.label}
+                        onPointerEnter={() => {
+                          setOpenSubmenu(null);
+                        }}
                         role="separator"
                       />
                     ) : action.kind === 'submenu' ? (
@@ -391,6 +405,9 @@ export function TopToolbar({
                           type="button"
                           onClick={() => {
                             handleMenuAction(action);
+                          }}
+                          onPointerEnter={() => {
+                            setOpenSubmenu(action.label);
                           }}
                         >
                           <span>{action.label}</span>
@@ -433,6 +450,9 @@ export function TopToolbar({
                         type="button"
                         onClick={() => {
                           handleMenuAction(action);
+                        }}
+                        onPointerEnter={() => {
+                          setOpenSubmenu(null);
                         }}
                       >
                         {action.label}

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -108,6 +108,44 @@ describe('TopToolbar', () => {
     expect(onExportPowerPoint).toHaveBeenCalledTimes(1);
   });
 
+  it('opens file submenus when users hover their triggers', () => {
+    render(<TopToolbar project={sampleProject.createSampleProject()} language="PT-BR" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'File' }));
+    fireEvent.pointerEnter(screen.getByRole('menuitem', { name: 'Import' }));
+
+    expect(screen.getByRole('menu', { name: 'Import' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'PowerPoint (.pptx)' })).toBeInTheDocument();
+
+    fireEvent.pointerEnter(screen.getByRole('menuitem', { name: 'Export to' }));
+
+    expect(screen.queryByRole('menu', { name: 'Import' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menu', { name: 'Export to' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Images (.zip)' })).toBeInTheDocument();
+  });
+
+  it('switches open header menus when users hover another header item', () => {
+    render(<TopToolbar project={sampleProject.createSampleProject()} language="PT-BR" />);
+
+    fireEvent.pointerEnter(screen.getByRole('button', { name: 'View' }));
+    expect(screen.queryByRole('menu', { name: 'View menu' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'File' }));
+    fireEvent.pointerEnter(screen.getByRole('menuitem', { name: 'Import' }));
+    expect(screen.getByRole('menu', { name: 'File menu' })).toBeInTheDocument();
+    expect(screen.getByRole('menu', { name: 'Import' })).toBeInTheDocument();
+
+    fireEvent.pointerEnter(screen.getByRole('button', { name: 'View' }));
+
+    expect(screen.queryByRole('menu', { name: 'File menu' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menu', { name: 'Import' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menu', { name: 'View menu' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Zoom' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+    expect(screen.getByRole('menu', { name: 'View menu' })).toBeInTheDocument();
+  });
+
   it('opens the image archive export action from the File menu', () => {
     const onExportImages = vi.fn();
 

--- a/tests/e2e/editor/create-and-edit-deck.spec.ts
+++ b/tests/e2e/editor/create-and-edit-deck.spec.ts
@@ -46,7 +46,7 @@ test.describe('editor create and edit deck journey', () => {
 
     await editor.openMenu('View');
     await expect(page.getByRole('menuitem', { name: 'Toggle Layers Panel' })).toBeHidden();
-    await page.getByRole('menuitem', { name: 'Zoom' }).click();
+    await page.getByRole('menuitem', { name: 'Zoom' }).hover();
     const zoomMenu = page.getByRole('menu', { name: 'Zoom' });
     await expect(zoomMenu).toBeVisible();
     await expect(zoomMenu.getByRole('menuitem', { name: 'Zoom Out' })).toBeVisible();


### PR DESCRIPTION
## Summary
- Keep the current submenu open when hovering its trigger, and close conflicting menus when switching between header menus.
- Open submenu items on pointer hover for a smoother menu navigation flow.
- Update unit coverage for hover-driven header and submenu transitions.
- Adjust the editor e2e flow to hover into the Zoom submenu instead of clicking directly.

## Testing
- Added unit tests covering hover behavior for file submenus and header menu switching.
- Updated the editor e2e journey to validate submenu opening via hover.
- Not run (not requested).