### PR TITLE
Use text translation layout for live editor frame sizing

### DIFF
--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -50,9 +50,9 @@ import { CanvasDragGuide } from './CanvasDragGuide';
 import { CropFrameOverlay } from './CropFrameOverlay';
 import type { CommonElementProps, ElementAnimationRenderState } from './canvas-element-props';
 import { shapeLineDraw } from './shape-line-draw';
+import { textTranslationLayout } from '../state/text-translation-layout';
 
 const TEXT_FRAME_PADDING = 6;
-const TEXT_EDITOR_HEIGHT_BUFFER = 4;
 
 interface CanvasWorkspaceProps {
   project: ProjectDocument;
@@ -648,12 +648,13 @@ export function CanvasWorkspace({
 
   function updateTextEditing(element: Extract<DesignElement, { type: 'text' }>, input: HTMLTextAreaElement) {
     const nextValue = input.value;
+    const nextHeight = textTranslationLayout.getMinimumTextFrameHeight({
+      ...element,
+      text: nextValue,
+    });
+
     setEditingTextValue(nextValue);
     onUpdateTextContent?.(element.id, nextValue);
-
-    const nextHeight = Math.ceil(
-      Math.max(8, toDocumentY(input.scrollHeight + TEXT_EDITOR_HEIGHT_BUFFER)),
-    );
     setEditingTextHeight(nextHeight);
     if (nextHeight !== element.height) {
       onUpdateElementFrame?.(element.id, { height: nextHeight });

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -213,6 +213,46 @@ describe('CanvasWorkspace', () => {
     );
   });
 
+  it('shrinks the live text editor frame to the typed text height', () => {
+    const onSelectElement = vi.fn();
+    const onUpdateElementFrame = vi.fn<(elementId: string, patch: ElementFramePatch) => void>();
+    const onUpdateTextContent = vi.fn();
+    const stageRef = createRef<Konva.Stage>();
+    const project = sampleProject.createSampleProject();
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-title'] }}
+        stageRef={stageRef}
+        onSelectElement={onSelectElement}
+        onUpdateElementFrame={onUpdateElementFrame}
+        onUpdateTextContent={onUpdateTextContent}
+      />,
+    );
+
+    const textNode = stageRef.current
+      ?.find('Text')
+      .find((node) => (node as Konva.Text).text() === 'AI Design Revolution') as
+      | Konva.Text
+      | undefined;
+    expect(textNode).toBeDefined();
+
+    act(() => {
+      textNode!.fire('dblclick', { target: textNode });
+    });
+
+    const editor = screen.getByLabelText('Edit text');
+    fireEvent.change(editor, { target: { value: 'Hello dear' } });
+
+    expect(onUpdateTextContent).toHaveBeenCalledWith('text-title', 'Hello dear');
+    const lastFrameUpdate = onUpdateElementFrame.mock.calls.at(-1);
+    expect(lastFrameUpdate?.[0]).toBe('text-title');
+    expect(typeof lastFrameUpdate?.[1].height).toBe('number');
+    expect(lastFrameUpdate?.[1].height).toBeLessThan(project.elements['text-title']!.height);
+  });
+
   it('hides vertical transform handles for selected text', () => {
     const stageRef = createRef<Konva.Stage>();
     const project = sampleProject.createSampleProject();

--- a/tests/e2e/editor/canvas-resize-text-journey.ts
+++ b/tests/e2e/editor/canvas-resize-text-journey.ts
@@ -71,6 +71,8 @@ export async function resizeTextAndUseArrangeControls(page: Page, baseURL: strin
   await page.mouse.dblclick(editPoint.x, editPoint.y);
   const canvasTextEditor = page.getByRole('textbox', { name: 'Edit text' });
   await expect(canvasTextEditor).toBeVisible();
+  await canvasTextEditor.fill('Hello dear');
+  await expect.poll(async () => Number(await heightInput.inputValue())).toBeLessThan(120);
   await canvasTextEditor.fill(
     '55 Horas, 770M Tokens e Uma Alternativa ao Canva Rodando no Browser',
   );


### PR DESCRIPTION
## Summary
- Update the live text editor frame to use `textTranslationLayout.getMinimumTextFrameHeight` instead of measuring textarea scroll height directly.
- Keep the editor frame aligned with the typed content so it can shrink as well as grow.
- Add unit coverage for the live resize path and extend the e2e journey to verify the frame contracts after editing shorter text.

## Testing
- Added a unit test covering live text editor height updates.
- Extended the e2e resize journey to validate the text frame shrinks after shorter input.
- Not run (not requested).