### PR TITLE
Add local font upload mirroring and share-safe font routes

### DIFF
--- a/apps/editor/src/app/composition.ts
+++ b/apps/editor/src/app/composition.ts
@@ -5,6 +5,7 @@ import type {
   ExportService,
   FontImportService,
   ImageGenerationService,
+  LocalFontMirrorService,
   MagicEraserService,
   MirrorService,
   ModelSetupService,
@@ -34,6 +35,7 @@ import { BrowserPptxImportService } from '../services/importing/pptx/pptxImportS
 import { BrowserPptxExportService } from '../services/exporting/pptxExportService';
 import { BrowserStockMediaService } from '../services/stock-media/stockMediaService';
 import { BrowserGoogleFontsImportService } from '../services/fonts/googleFontsImportService';
+import { BrowserLocalFontMirrorService } from '../services/fonts/localFontMirrorService';
 import { webGpuLanguageDetectionRuntime } from '../services/translation/webGpuLanguageDetectionRuntime';
 import { webGpuTextGenerationRuntime } from '../services/prompting/webGpuTextGenerationRuntime';
 import { minioMirrorService } from '../services/mirror/minioMirrorService';
@@ -48,6 +50,7 @@ export interface AppServices {
   projectRepository: ProjectRepository;
   exportService: ExportService;
   fontImportService: FontImportService;
+  localFontMirrorService: LocalFontMirrorService;
   presentationImportService: PresentationImportService;
   presentationExportService: PresentationExportService;
   shareService: ShareService;
@@ -92,6 +95,7 @@ export function createAppServices(options: CreateAppServicesOptions = {}): AppSe
     projectRepository: createProjectRepository(persistenceMode),
     exportService: new BrowserExportService(),
     fontImportService: new BrowserGoogleFontsImportService(),
+    localFontMirrorService: new BrowserLocalFontMirrorService(),
     presentationImportService: new BrowserPptxImportService(),
     presentationExportService: new BrowserPptxExportService(),
     shareService: new BrowserShareService({ mirrorService }),

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -136,11 +136,11 @@ export interface Asset {
 export interface ProjectFont {
   id: string;
   family: string;
-  source: 'google-fonts';
+  source: 'google-fonts' | 'uploaded';
   requestedFamily: string;
   fontStyle: 'normal' | 'italic';
   fontWeight: number;
-  mimeType: 'font/woff2';
+  mimeType: 'font/woff2' | 'font/woff' | 'font/ttf' | 'font/otf';
   fileName: string;
   storage: 'inline' | 'file' | 'remote';
   objectUrl?: string;

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -98,6 +98,8 @@ export interface MirrorService<TConfig = unknown> {
   listProjects(config: TConfig): Promise<MirrorProjectSummary[]>;
   downloadProject(projectId: string, config: TConfig): Promise<MirrorFile[]>;
   deleteProject?(projectId: string, config: TConfig): Promise<void>;
+  getPublicObjectUrl?(key: string, config: TConfig): string;
+  uploadPublicObject?(key: string, blob: Blob, config: TConfig): Promise<void>;
 }
 
 export interface VersionHistoryEntry {
@@ -216,13 +218,65 @@ export interface FontImportResult {
 export interface FontCatalogItem {
   aliases?: string[];
   family: string;
-  source: 'google-fonts';
+  source: 'google-fonts' | 'local-font-folder';
 }
 
 export interface FontImportService {
   listDownloadableFonts(): FontCatalogItem[];
   resolveAndDownloadFonts(requests: FontImportRequest[]): Promise<FontImportResult>;
   loadProjectFonts(project: ProjectDocument): Promise<void>;
+}
+
+export interface LocalFontMirrorSettings {
+  enabled: boolean;
+  folderLabel?: string | undefined;
+  supported: boolean;
+  systemHint: string;
+}
+
+export interface LocalFontMirrorProgress {
+  label: string;
+  stage:
+    | 'adding-project-fonts'
+    | 'checking-local-fonts'
+    | 'requesting-font-folder'
+    | 'scanning-font-folder'
+    | 'uploading-test-fonts'
+    | 'verifying-mirrored-fonts';
+}
+
+export interface LocalFontMirrorResult {
+  project: ProjectDocument;
+  addedFonts: ProjectFont[];
+  unresolvedFamilies: string[];
+  warnings: ImportWarning[];
+}
+
+export interface LocalFontMirrorTestResult {
+  warning?: string | undefined;
+}
+
+export interface LocalFontMirrorService {
+  getSettings(): LocalFontMirrorSettings;
+  setEnabled(enabled: boolean): LocalFontMirrorSettings;
+  chooseFontFolder(): Promise<LocalFontMirrorSettings>;
+  listAvailableFonts(): Promise<FontCatalogItem[]>;
+  importFontFamily(
+    project: ProjectDocument,
+    request: FontImportRequest,
+    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+  ): Promise<LocalFontMirrorResult>;
+  importProjectFonts(
+    project: ProjectDocument,
+    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+  ): Promise<LocalFontMirrorResult>;
+  getTestFontFiles(
+    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+  ): Promise<File[]>;
+  validateTestFontFiles(
+    files: File[],
+    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+  ): Promise<LocalFontMirrorTestResult>;
 }
 
 export type ShareStatus = 'published' | 'copied' | 'syncing' | 'sync-failed';

--- a/apps/editor/src/services/fonts/localFontFolderHandleStore.ts
+++ b/apps/editor/src/services/fonts/localFontFolderHandleStore.ts
@@ -1,0 +1,66 @@
+interface LocalFontFolderHandleStoreOptions {
+  indexedDB?: IDBFactory | undefined;
+}
+
+const DATABASE_NAME = 'localstudio-local-font-mirror';
+const DATABASE_VERSION = 1;
+const STORE_NAME = 'handles';
+const FONT_DIRECTORY_HANDLE_KEY = 'font-directory';
+
+function getIndexedDB(options: LocalFontFolderHandleStoreOptions) {
+  if (options.indexedDB) return options.indexedDB;
+  if (typeof indexedDB === 'undefined') return undefined;
+  return indexedDB;
+}
+
+function openDatabase(factory: IDBFactory): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = factory.open(DATABASE_NAME, DATABASE_VERSION);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onerror = () => reject(request.error ?? new Error('Could not open font folder store.'));
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+function transactionComplete(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error('Font folder store failed.'));
+    transaction.onabort = () => reject(transaction.error ?? new Error('Font folder store was aborted.'));
+  });
+}
+
+export const localFontFolderHandleStore = {
+  async load(options: LocalFontFolderHandleStoreOptions = {}) {
+    const factory = getIndexedDB(options);
+    if (!factory) return undefined;
+    const database = await openDatabase(factory);
+    try {
+      const transaction = database.transaction(STORE_NAME, 'readonly');
+      const request = transaction.objectStore(STORE_NAME).get(FONT_DIRECTORY_HANDLE_KEY);
+      const handle = await new Promise<FileSystemDirectoryHandle | undefined>((resolve, reject) => {
+        request.onerror = () => reject(request.error ?? new Error('Could not read font folder handle.'));
+        request.onsuccess = () => resolve(request.result as FileSystemDirectoryHandle | undefined);
+      });
+      await transactionComplete(transaction);
+      return handle;
+    } finally {
+      database.close();
+    }
+  },
+
+  async save(handle: FileSystemDirectoryHandle, options: LocalFontFolderHandleStoreOptions = {}) {
+    const factory = getIndexedDB(options);
+    if (!factory) throw new Error('This browser cannot remember a font folder.');
+    const database = await openDatabase(factory);
+    try {
+      const transaction = database.transaction(STORE_NAME, 'readwrite');
+      transaction.objectStore(STORE_NAME).put(handle, FONT_DIRECTORY_HANDLE_KEY);
+      await transactionComplete(transaction);
+    } finally {
+      database.close();
+    }
+  },
+};

--- a/apps/editor/src/services/fonts/localFontMirrorPreferences.ts
+++ b/apps/editor/src/services/fonts/localFontMirrorPreferences.ts
@@ -1,0 +1,38 @@
+import type { BrowserKeyValueStorage } from '../browser/browserStorage';
+import { browserStorage } from '../browser/browserStorage';
+
+export interface LocalFontMirrorPreference {
+  enabled: boolean;
+  folderLabel?: string | undefined;
+}
+
+interface LocalFontMirrorPreferencesOptions {
+  storage?: BrowserKeyValueStorage;
+}
+
+const LOCAL_FONT_MIRROR_ENABLED_KEY = 'localstudio.ai.local-font-mirror.enabled';
+const LOCAL_FONT_MIRROR_FOLDER_LABEL_KEY = 'localstudio.ai.local-font-mirror.folder-label';
+
+function getStorage(options: LocalFontMirrorPreferencesOptions) {
+  return options.storage ?? browserStorage.getBrowserLocalStorage();
+}
+
+export const localFontMirrorPreferences = {
+  read(options: LocalFontMirrorPreferencesOptions = {}): LocalFontMirrorPreference {
+    const storage = getStorage(options);
+    return {
+      enabled: storage?.getItem(LOCAL_FONT_MIRROR_ENABLED_KEY) === 'true',
+      folderLabel: storage?.getItem(LOCAL_FONT_MIRROR_FOLDER_LABEL_KEY) ?? undefined,
+    };
+  },
+
+  write(preference: LocalFontMirrorPreference, options: LocalFontMirrorPreferencesOptions = {}) {
+    const storage = getStorage(options);
+    storage?.setItem(LOCAL_FONT_MIRROR_ENABLED_KEY, preference.enabled ? 'true' : 'false');
+    if (preference.folderLabel) {
+      storage?.setItem(LOCAL_FONT_MIRROR_FOLDER_LABEL_KEY, preference.folderLabel);
+      return;
+    }
+    storage?.removeItem?.(LOCAL_FONT_MIRROR_FOLDER_LABEL_KEY);
+  },
+};

--- a/apps/editor/src/services/fonts/localFontMirrorService.ts
+++ b/apps/editor/src/services/fonts/localFontMirrorService.ts
@@ -1,0 +1,435 @@
+import type { ImportWarning, ProjectDocument, ProjectFont, TextElement } from '../../domain/documents/model';
+import type {
+  FontCatalogItem,
+  FontImportRequest,
+  LocalFontMirrorProgress,
+  LocalFontMirrorResult,
+  LocalFontMirrorService,
+  LocalFontMirrorSettings,
+  LocalFontMirrorTestResult,
+} from '../contracts/interfaces';
+import { localFontFolderHandleStore } from './localFontFolderHandleStore';
+import { localFontMirrorPreferences } from './localFontMirrorPreferences';
+
+interface BrowserLocalFontMirrorServiceOptions {
+  createObjectURL?: typeof URL.createObjectURL;
+  fontDirectoryHandle?: FileSystemDirectoryHandle | undefined;
+  fontFaceConstructor?: typeof FontFace | undefined;
+  now?: () => Date;
+  showDirectoryPicker?: (() => Promise<FileSystemDirectoryHandle>) | undefined;
+}
+
+type PermissionMode = 'read' | 'readwrite';
+
+type DirectoryHandleWithPermissions = FileSystemDirectoryHandle & {
+  queryPermission?: (descriptor?: { mode?: PermissionMode }) => Promise<PermissionState>;
+  requestPermission?: (descriptor?: { mode?: PermissionMode }) => Promise<PermissionState>;
+};
+
+const FONT_EXTENSIONS = ['woff2', 'woff', 'ttf', 'otf'] as const;
+const FONT_MIME_TYPES: Record<(typeof FONT_EXTENSIONS)[number], ProjectFont['mimeType']> = {
+  otf: 'font/otf',
+  ttf: 'font/ttf',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+};
+const MAX_SCAN_DEPTH = 3;
+const MAX_TEST_FONT_FILES = 2;
+
+function getDefaultShowDirectoryPicker() {
+  if (typeof window === 'undefined') return undefined;
+  const runtimeWindow = window as Window & { showDirectoryPicker?: () => Promise<FileSystemDirectoryHandle> };
+  return runtimeWindow.showDirectoryPicker?.bind(runtimeWindow);
+}
+
+function getSystemHint() {
+  const runtimeNavigator =
+    typeof navigator === 'undefined'
+      ? undefined
+      : (navigator as Navigator & { userAgentData?: { platform?: string } });
+  const platform =
+    !runtimeNavigator
+      ? ''
+      : `${runtimeNavigator.userAgentData?.platform ?? runtimeNavigator.platform ?? ''}`.toLowerCase();
+  if (platform.includes('mac')) return '~/Library/Fonts or /Library/Fonts';
+  if (platform.includes('win')) {
+    return 'C:\\Windows\\Fonts or %LOCALAPPDATA%\\Microsoft\\Windows\\Fonts';
+  }
+  return '~/.local/share/fonts, /usr/share/fonts, or ~/.fonts';
+}
+
+function normalizeFamily(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function getFirstFontFamily(fontFamily: string) {
+  return fontFamily
+    .split(',')
+    .map((family) => family.trim().replace(/^["']|["']$/g, ''))
+    .find(Boolean);
+}
+
+function collectTextFontFamilies(project: ProjectDocument) {
+  const families = new Map<string, string>();
+  const addFamily = (fontFamily: string | undefined) => {
+    const family = fontFamily ? getFirstFontFamily(fontFamily) : undefined;
+    if (!family) return;
+    families.set(normalizeFamily(family), family);
+  };
+
+  for (const element of Object.values(project.elements)) {
+    if (element.type === 'text') addFamily(element.fontFamily);
+  }
+  for (const theme of Object.values(project.themes ?? {})) {
+    addFamily(theme.typography.bodyFontFamily);
+    addFamily(theme.typography.headingFontFamily);
+  }
+  for (const layout of Object.values(project.slideLayouts ?? {})) {
+    for (const element of Object.values(layout.elements)) {
+      if (element.type === 'text') addFamily(element.fontFamily);
+    }
+  }
+
+  return Array.from(families.values()).sort((left, right) => left.localeCompare(right));
+}
+
+function collectFontWeights(project: ProjectDocument, family: string) {
+  const normalizedFamily = normalizeFamily(family);
+  const weights = new Set<number>();
+  const addWeight = (element: TextElement) => {
+    if (normalizeFamily(getFirstFontFamily(element.fontFamily) ?? '') !== normalizedFamily) return;
+    weights.add(element.fontWeight >= 700 ? 700 : 400);
+  };
+  for (const element of Object.values(project.elements)) {
+    if (element.type === 'text') addWeight(element);
+  }
+  for (const layout of Object.values(project.slideLayouts ?? {})) {
+    for (const element of Object.values(layout.elements)) {
+      if (element.type === 'text') addWeight(element);
+    }
+  }
+  return weights.size > 0 ? Array.from(weights).sort((left, right) => left - right) : [400];
+}
+
+function getEmbeddedFontFamilies(project: ProjectDocument) {
+  return new Set(Object.values(project.fonts ?? {}).map((font) => normalizeFamily(font.family)));
+}
+
+function getFontExtension(fileName: string) {
+  const extension = fileName.split('.').at(-1)?.toLowerCase();
+  return FONT_EXTENSIONS.find((item) => item === extension);
+}
+
+function fontFileMatchesFamily(file: File, family: string) {
+  const stem = file.name.replace(/\.[^.]+$/g, '');
+  return normalizeFamily(stem).includes(normalizeFamily(family));
+}
+
+function inferFamilyFromFileName(fileName: string) {
+  const stem = fileName
+    .replace(/\.[^.]+$/g, '')
+    .replace(
+      /\b(black|bold|book|condensed|display|extra|extrabold|hairline|heavy|italic|light|medium|regular|semibold|thin|variable|vf)\b/gi,
+      ' ',
+    )
+    .replace(/[-_.]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return stem || fileName.replace(/\.[^.]+$/g, '');
+}
+
+function createFontId(family: string, fontWeight: number, fileName: string) {
+  const familySlug = family
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48);
+  const fileSlug = fileName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 32);
+  return `font-${familySlug || 'font'}-${fontWeight}-${fileSlug || 'file'}`;
+}
+
+async function scanFontFiles(directory: FileSystemDirectoryHandle, depth = 0): Promise<File[]> {
+  const entries = (directory as unknown as {
+    entries?: () => AsyncIterable<[string, FileSystemDirectoryHandle | FileSystemFileHandle]>;
+  }).entries;
+  if (!entries) return [];
+
+  const files: File[] = [];
+  for await (const [, handle] of entries.call(directory)) {
+    if (handle.kind === 'file') {
+      const file = await handle.getFile();
+      if (getFontExtension(file.name)) files.push(file);
+      continue;
+    }
+    if (handle.kind === 'directory' && depth < MAX_SCAN_DEPTH) {
+      files.push(...(await scanFontFiles(handle, depth + 1)));
+    }
+  }
+  return files.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function ensureReadPermission(directory: FileSystemDirectoryHandle) {
+  const handle = directory as DirectoryHandleWithPermissions;
+  if (!handle.queryPermission || !handle.requestPermission) return true;
+  const currentPermission = await handle.queryPermission({ mode: 'read' });
+  if (currentPermission === 'granted') return true;
+  return (await handle.requestPermission({ mode: 'read' })) === 'granted';
+}
+
+export class BrowserLocalFontMirrorService implements LocalFontMirrorService {
+  private readonly createObjectURL: typeof URL.createObjectURL;
+  private fontDirectoryHandle: FileSystemDirectoryHandle | undefined;
+  private readonly fontFaceConstructor: typeof FontFace | undefined;
+  private readonly now: () => Date;
+  private readonly showDirectoryPicker: (() => Promise<FileSystemDirectoryHandle>) | undefined;
+
+  constructor(options: BrowserLocalFontMirrorServiceOptions = {}) {
+    this.createObjectURL = options.createObjectURL ?? URL.createObjectURL.bind(URL);
+    this.fontDirectoryHandle = options.fontDirectoryHandle;
+    this.fontFaceConstructor = options.fontFaceConstructor ?? (typeof FontFace !== 'undefined' ? FontFace : undefined);
+    this.now = options.now ?? (() => new Date());
+    this.showDirectoryPicker = options.showDirectoryPicker ?? getDefaultShowDirectoryPicker();
+  }
+
+  getSettings(): LocalFontMirrorSettings {
+    const preference = localFontMirrorPreferences.read();
+    return {
+      ...preference,
+      supported: Boolean(this.showDirectoryPicker),
+      systemHint: getSystemHint(),
+    };
+  }
+
+  setEnabled(enabled: boolean): LocalFontMirrorSettings {
+    const current = localFontMirrorPreferences.read();
+    localFontMirrorPreferences.write({ ...current, enabled });
+    return this.getSettings();
+  }
+
+  async chooseFontFolder(): Promise<LocalFontMirrorSettings> {
+    if (!this.showDirectoryPicker) throw new Error('This browser cannot choose a font folder.');
+    const handle = await this.showDirectoryPicker();
+    this.fontDirectoryHandle = handle;
+    await localFontFolderHandleStore.save(handle);
+    localFontMirrorPreferences.write({ enabled: true, folderLabel: handle.name });
+    return this.getSettings();
+  }
+
+  async listAvailableFonts(): Promise<FontCatalogItem[]> {
+    if (!this.getSettings().enabled) return [];
+    const files = await this.loadAvailableFontFiles();
+    const fonts = new Map<string, FontCatalogItem>();
+    for (const file of files) {
+      const family = inferFamilyFromFileName(file.name);
+      const key = normalizeFamily(family);
+      if (!key || fonts.has(key)) continue;
+      fonts.set(key, { family, source: 'local-font-folder' });
+    }
+    return Array.from(fonts.values()).sort((left, right) =>
+      left.family.localeCompare(right.family),
+    );
+  }
+
+  async importFontFamily(
+    project: ProjectDocument,
+    request: FontImportRequest,
+    options: { onProgress?: (progress: LocalFontMirrorProgress) => void } = {},
+  ): Promise<LocalFontMirrorResult> {
+    const settings = this.getSettings();
+    const warnings: ImportWarning[] = [];
+    if (!settings.enabled) {
+      return {
+        project,
+        addedFonts: [],
+        unresolvedFamilies: [request.family],
+        warnings: [
+          this.createWarning(
+            'local-font-mirroring-disabled',
+            'Local font mirroring is not enabled.',
+          ),
+        ],
+      };
+    }
+
+    options.onProgress?.({ label: 'Scanning font folder', stage: 'scanning-font-folder' });
+    const files = await this.loadAvailableFontFiles();
+    const matchingFile = files.find((file) => fontFileMatchesFamily(file, request.family));
+    const extension = matchingFile ? getFontExtension(matchingFile.name) : undefined;
+    if (!matchingFile || !extension) {
+      return {
+        project,
+        addedFonts: [],
+        unresolvedFamilies: [request.family],
+        warnings: [
+          this.createWarning(
+            'local-font-not-found',
+            `${request.family} was not found in the selected font folder.`,
+          ),
+        ],
+      };
+    }
+
+    options.onProgress?.({ label: 'Adding project fonts', stage: 'adding-project-fonts' });
+    const fontWeight = request.fontWeight >= 700 ? 700 : 400;
+    const id = createFontId(request.family, fontWeight, matchingFile.name);
+    const font: ProjectFont = {
+      id,
+      family: request.family,
+      requestedFamily: request.family,
+      source: 'uploaded',
+      fontStyle: request.fontStyle,
+      fontWeight,
+      mimeType: FONT_MIME_TYPES[extension],
+      fileName: `${id}.${extension}`,
+      storage: 'inline',
+      objectUrl: this.createObjectURL(matchingFile),
+      sourceUrl: `local-font-folder://${matchingFile.name}`,
+    };
+
+    return {
+      project: {
+        ...project,
+        fonts: { ...(project.fonts ?? {}), [id]: font },
+        updatedAt: this.now().toISOString(),
+      },
+      addedFonts: [font],
+      unresolvedFamilies: [],
+      warnings,
+    };
+  }
+
+  async importProjectFonts(
+    project: ProjectDocument,
+    options: { onProgress?: (progress: LocalFontMirrorProgress) => void } = {},
+  ): Promise<LocalFontMirrorResult> {
+    const settings = this.getSettings();
+    const warnings: ImportWarning[] = [];
+    if (!settings.enabled) return { project, addedFonts: [], unresolvedFamilies: [], warnings };
+
+    const usedFamilies = collectTextFontFamilies(project);
+    const embeddedFamilies = getEmbeddedFontFamilies(project);
+    const unresolvedFamilies = usedFamilies.filter((family) => !embeddedFamilies.has(normalizeFamily(family)));
+    if (unresolvedFamilies.length === 0) return { project, addedFonts: [], unresolvedFamilies: [], warnings };
+
+    options.onProgress?.({ label: 'Checking local fonts', stage: 'checking-local-fonts' });
+    const files = await this.loadAvailableFontFiles();
+    if (files.length === 0) {
+      return {
+        project,
+        addedFonts: [],
+        unresolvedFamilies,
+        warnings: [this.createWarning('local-font-folder-missing', 'Local font mirroring is enabled, but the font folder is not available.')],
+      };
+    }
+
+    options.onProgress?.({ label: 'Scanning font folder', stage: 'scanning-font-folder' });
+    const addedFonts: ProjectFont[] = [];
+    const nextFonts = { ...(project.fonts ?? {}) };
+    const stillUnresolved: string[] = [];
+
+    options.onProgress?.({ label: 'Adding project fonts', stage: 'adding-project-fonts' });
+    for (const family of unresolvedFamilies) {
+      const matchingFile = files.find((file) => fontFileMatchesFamily(file, family));
+      const extension = matchingFile ? getFontExtension(matchingFile.name) : undefined;
+      if (!matchingFile || !extension) {
+        stillUnresolved.push(family);
+        continue;
+      }
+      for (const fontWeight of collectFontWeights(project, family)) {
+        const id = createFontId(family, fontWeight, matchingFile.name);
+        const font: ProjectFont = {
+          id,
+          family,
+          requestedFamily: family,
+          source: 'uploaded',
+          fontStyle: 'normal',
+          fontWeight,
+          mimeType: FONT_MIME_TYPES[extension],
+          fileName: `${id}.${extension}`,
+          storage: 'inline',
+          objectUrl: this.createObjectURL(matchingFile),
+          sourceUrl: `local-font-folder://${matchingFile.name}`,
+        };
+        nextFonts[id] = font;
+        addedFonts.push(font);
+      }
+    }
+
+    for (const family of stillUnresolved) {
+      warnings.push(this.createWarning('local-font-not-found', `${family} was not found in the selected font folder.`));
+    }
+
+    return {
+      project: addedFonts.length > 0 ? { ...project, fonts: nextFonts, updatedAt: this.now().toISOString() } : project,
+      addedFonts,
+      unresolvedFamilies: stillUnresolved,
+      warnings,
+    };
+  }
+
+  async getTestFontFiles(
+    options: { onProgress?: (progress: LocalFontMirrorProgress) => void } = {},
+  ): Promise<File[]> {
+    if (!this.getSettings().enabled) return [];
+    options.onProgress?.({ label: 'Scanning font folder', stage: 'scanning-font-folder' });
+    const directory = await this.loadReadableFontDirectory();
+    if (!directory) return [];
+    return (await scanFontFiles(directory)).slice(0, MAX_TEST_FONT_FILES);
+  }
+
+  async validateTestFontFiles(
+    files: File[],
+    options: { onProgress?: (progress: LocalFontMirrorProgress) => void } = {},
+  ): Promise<LocalFontMirrorTestResult> {
+    if (files.length === 0) {
+      return { warning: 'Storage is ready, but no readable font files were found in the selected folder.' };
+    }
+    if (!this.fontFaceConstructor) return {};
+
+    options.onProgress?.({ label: 'Verifying mirrored fonts', stage: 'verifying-mirrored-fonts' });
+    const failures: string[] = [];
+    for (const file of files) {
+      const objectUrl = this.createObjectURL(file);
+      try {
+        const fontFace = new this.fontFaceConstructor(`LocalStudio Test ${file.name}`, `url(${objectUrl})`);
+        await fontFace.load();
+      } catch {
+        failures.push(file.name);
+      }
+    }
+    if (failures.length === files.length) {
+      return {
+        warning:
+          'Storage is ready, but the selected folder does not look like a usable system fonts folder.',
+      };
+    }
+    if (failures.length > 0) {
+      return {
+        warning: `Storage is ready, but ${failures.join(', ')} could not be loaded as a font.`,
+      };
+    }
+    return {};
+  }
+
+  private async loadAvailableFontFiles() {
+    const directory = await this.loadReadableFontDirectory();
+    return directory ? scanFontFiles(directory) : [];
+  }
+
+  private async loadReadableFontDirectory() {
+    const directory = this.fontDirectoryHandle ?? (await localFontFolderHandleStore.load());
+    if (!directory) return undefined;
+    if (!(await ensureReadPermission(directory))) return undefined;
+    return directory;
+  }
+
+  private createWarning(code: string, message: string): ImportWarning {
+    return { code, message, severity: 'warning' };
+  }
+}

--- a/apps/editor/src/services/sharing/shareService.ts
+++ b/apps/editor/src/services/sharing/shareService.ts
@@ -174,6 +174,21 @@ export class BrowserShareService implements ShareService {
       }),
     );
 
+    await Promise.all(
+      Object.entries(projectForShare.fonts ?? {}).map(async ([fontId, font]) => {
+        const blob = await assetFileUtils.objectUrlToBlobIfReadable(font.objectUrl, this.fetchImpl);
+        if (!blob) return;
+
+        const key = storageObjectUtils.joinObjectKey(getShareRootKey(config, shareId), 'fonts', font.fileName);
+        await this.mirrorService.uploadPublicObject(key, blob, config);
+        projectForShare.fonts![fontId] = {
+          ...font,
+          objectUrl: this.mirrorService.getPublicObjectUrl(key, config),
+          storage: 'remote',
+        };
+      }),
+    );
+
     return projectForShare;
   }
 

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -32,8 +32,10 @@ interface DesignPanelProps {
   activePageId: string;
   selection: SelectionState;
   availableFonts?: FontCatalogItem[];
+  localFonts?: FontCatalogItem[];
   focusFontControlKey?: number | undefined;
   onDownloadFont?: (family: string) => Promise<void>;
+  onImportLocalFont?: (family: string) => Promise<void>;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
   onUpdateElementFrame?: (elementId: string, patch: ElementFramePatch) => void;
   onUpdateTextContent?: (elementId: string, text: string) => void;
@@ -101,12 +103,14 @@ export function DesignPanel({
   onSetElementLock,
   onSetSelectedElementZOrder,
   availableFonts = [],
+  localFonts = [],
   focusFontControlKey,
   onDownloadFont,
+  onImportLocalFont,
   onReplaceVideoAsset,
   onSetElementAnimationBuilds,
 }: DesignPanelProps) {
-  const fontSelectRef = useRef<HTMLSelectElement>(null);
+  const fontSelectRef = useRef<HTMLButtonElement>(null);
   const [fontDownloadOpen, setFontDownloadOpen] = useState(false);
   const [fontSearchInput, setFontSearchInput] = useState('');
   const [fontSearchQuery, setFontSearchQuery] = useState('');
@@ -133,6 +137,13 @@ export function DesignPanel({
       ).sort((left, right) => left.localeCompare(right)),
     [projectFontFamilies],
   );
+  const localFontFamilyOptions = useMemo(() => {
+    const existingFamilies = new Set(fontFamilyOptions.map((font) => font.toLowerCase()));
+    return localFonts
+      .map((font) => font.family)
+      .filter((family) => !existingFamilies.has(family.toLowerCase()))
+      .sort((left, right) => left.localeCompare(right));
+  }, [fontFamilyOptions, localFonts]);
   const filteredDownloadableFonts = useMemo(() => {
     const query = fontSearchQuery.trim();
     return availableFonts
@@ -171,11 +182,33 @@ export function DesignPanel({
     try {
       await onDownloadFont(family);
       setFontDownloadStatus(`${family} downloaded and applied`);
+      setFontDownloadOpen(false);
     } catch (error) {
       setFontDownloadStatus(error instanceof Error ? error.message : 'Font download failed.');
     } finally {
       setDownloadingFontFamily(undefined);
     }
+  }
+
+  async function applyFontFamily(family: string) {
+    if (!family) return;
+    const isLocalFont = localFontFamilyOptions.some((localFamily) => localFamily === family);
+    if (isLocalFont && onImportLocalFont) {
+      setDownloadingFontFamily(family);
+      setFontDownloadStatus(`Adding ${family} from local fonts...`);
+      try {
+        await onImportLocalFont(family);
+        setFontDownloadStatus(`${family} added to mirrored fonts`);
+        setFontDownloadOpen(false);
+      } catch (error) {
+        setFontDownloadStatus(error instanceof Error ? error.message : 'Local font import failed.');
+      } finally {
+        setDownloadingFontFamily(undefined);
+      }
+      return;
+    }
+    updateSelectedStyle({ fontFamily: family });
+    setFontDownloadOpen(false);
   }
 
   function submitFontSearch(event: FormEvent<HTMLFormElement>) {
@@ -271,10 +304,12 @@ export function DesignPanel({
                   fontDownloadOpen,
                   fontDownloadStatus,
                   fontFamilyOptions,
+                  localFontFamilyOptions,
                   fontSearchInput,
                   fontSearchQuery,
                   fontSelectRef,
                   hasFontDownload: Boolean(onDownloadFont),
+                  onApplyFontFamily: applyFontFamily,
                   onDownloadFontFamily: downloadFont,
                   onFontSearchInputChange: (value) => {
                     setFontSearchInput(value);

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -62,6 +62,7 @@ interface LeftToolPanelProps {
   languageDetectionProviderStates?: AiProviderState[];
   translationLanguageOptions?: Array<{ code: string; flag: string; label: string }>;
   availableFonts?: FontCatalogItem[];
+  localFonts?: FontCatalogItem[];
   languageDetectionPreparation?: {
     progress: number;
     sourceLanguage?: string;
@@ -83,6 +84,7 @@ interface LeftToolPanelProps {
   };
   onDownloadModel?: ((id: string) => Promise<void>) | undefined;
   onDownloadFont?: ((family: string) => Promise<void>) | undefined;
+  onImportLocalFont?: ((family: string) => Promise<void>) | undefined;
   onRemoveModel?: ((id: string) => Promise<void>) | undefined;
   onCreateImageOptionsChange?: ((options: CreateImagePromptOptions) => void) | undefined;
   stockGifResults?: StockMediaItem[];
@@ -174,6 +176,7 @@ export function LeftToolPanel({
   languageDetectionProviderStates,
   translationLanguageOptions,
   availableFonts,
+  localFonts,
   languageDetectionPreparation,
   translationPreparation,
   translationTargetAttention,
@@ -183,6 +186,7 @@ export function LeftToolPanel({
   promptPreparation,
   onDownloadModel,
   onDownloadFont,
+  onImportLocalFont,
   onRemoveModel,
   onCreateImageOptionsChange,
   stockGifResults,
@@ -341,8 +345,10 @@ export function LeftToolPanel({
             activePageId={activePageId}
             selection={selection}
             {...(availableFonts ? { availableFonts } : {})}
+            {...(localFonts ? { localFonts } : {})}
             {...(focusFontControlKey ? { focusFontControlKey } : {})}
             {...(onDownloadFont ? { onDownloadFont } : {})}
+            {...(onImportLocalFont ? { onImportLocalFont } : {})}
             {...(onAlignSelectedElement ? { onAlignSelectedElement } : {})}
             {...(onSetElementLock ? { onSetElementLock } : {})}
             {...(onSetSelectedElementZOrder ? { onSetSelectedElementZOrder } : {})}

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -1,25 +1,38 @@
 import { useEffect, useRef, useState } from 'react';
-import type { MirrorState } from '../../../services/contracts/interfaces';
+import type {
+  LocalFontMirrorProgress,
+  LocalFontMirrorSettings,
+  MirrorState,
+} from '../../../services/contracts/interfaces';
 import type { MinioMirrorConfig } from '../../../services/mirror/minioMirrorService';
 
 interface MirrorSettingsPanelProps {
   config: MinioMirrorConfig;
+  localFontMirrorSettings: LocalFontMirrorSettings;
   mirrorState: MirrorState;
   mirrorDisabledBySettings?: boolean;
   onBack?: () => void;
+  onChooseLocalFontFolder: () => Promise<void>;
   onClose: () => void;
   onEnabledChange: (enabled: boolean) => void;
+  onLocalFontMirrorEnabledChange: (enabled: boolean) => void;
   onSave: (config: MinioMirrorConfig) => void;
-  onTestConnection: (config: MinioMirrorConfig) => void | Promise<void>;
+  onTestConnection: (
+    config: MinioMirrorConfig,
+    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+  ) => void | Promise<string | void>;
 }
 
 export function MirrorSettingsPanel({
   config,
+  localFontMirrorSettings,
   mirrorState,
   mirrorDisabledBySettings = false,
   onBack,
+  onChooseLocalFontFolder,
   onClose,
   onEnabledChange,
+  onLocalFontMirrorEnabledChange,
   onSave,
   onTestConnection,
 }: MirrorSettingsPanelProps) {
@@ -30,6 +43,9 @@ export function MirrorSettingsPanel({
     'idle',
   );
   const [connectionError, setConnectionError] = useState<string | undefined>();
+  const [connectionDetail, setConnectionDetail] = useState<string | undefined>();
+  const [folderStatus, setFolderStatus] = useState<'idle' | 'choosing' | 'failed'>('idle');
+  const [folderError, setFolderError] = useState<string | undefined>();
 
   function updateDraft(patch: Partial<MinioMirrorConfig>) {
     setDraft((current) => ({ ...current, ...patch }));
@@ -50,15 +66,41 @@ export function MirrorSettingsPanel({
   async function testConnection() {
     setConnectionStatus('testing');
     setConnectionError(undefined);
+    setConnectionDetail('Checking storage');
     try {
-      await onTestConnection(normalizedDraft());
+      const warning = await onTestConnection(normalizedDraft(), {
+        onProgress: (progress) => setConnectionDetail(progress.label),
+      });
       setConnectionStatus('ready');
+      setConnectionDetail(warning ?? undefined);
     } catch (error) {
       setConnectionStatus('failed');
       setConnectionError(
         error instanceof Error ? error.message : 'S3-compatible connection failed.',
       );
+      setConnectionDetail(undefined);
     }
+  }
+
+  async function chooseFontFolder() {
+    setFolderStatus('choosing');
+    setFolderError(undefined);
+    try {
+      await onChooseLocalFontFolder();
+    } catch (error) {
+      setFolderStatus('failed');
+      setFolderError(error instanceof Error ? error.message : 'Could not choose font folder.');
+      return;
+    }
+    setFolderStatus('idle');
+  }
+
+  async function setLocalFontMirroringEnabled(enabled: boolean) {
+    if (!enabled) {
+      onLocalFontMirrorEnabledChange(false);
+      return;
+    }
+    await chooseFontFolder();
   }
 
   const publicBucketUrl = `${draft.endpoint.replace(/\/+$/g, '')}/${draft.bucket.trim()}`;
@@ -116,120 +158,188 @@ export function MirrorSettingsPanel({
         </button>
       </div>
 
-      <div className="mirror-settings-grid ew-field-scope" data-tour-id="mirror-settings-fields">
-        <label>
-          <span>Endpoint</span>
-          <input
-            value={draft.endpoint}
-            onChange={(event) => updateDraft({ endpoint: event.target.value })}
-          />
-        </label>
-        <label>
-          <span>Bucket</span>
-          <input
-            value={draft.bucket}
-            onChange={(event) => updateDraft({ bucket: event.target.value })}
-          />
-        </label>
-        <label>
-          <span>Region</span>
-          <input
-            value={draft.region}
-            onChange={(event) => updateDraft({ region: event.target.value })}
-          />
-        </label>
-        <label>
-          <span>Access key</span>
-          <input
-            value={draft.accessKey}
-            onChange={(event) => updateDraft({ accessKey: event.target.value })}
-          />
-        </label>
-        <label>
-          <span>Secret key</span>
-          <span className="mirror-secret-control">
-            <input
-              aria-label="Secret key"
-              type={secretVisible ? 'text' : 'password'}
-              value={draft.secretKey}
-              onChange={(event) => updateDraft({ secretKey: event.target.value })}
-            />
-            <button
-              className="stitch-icon-button mirror-secret-toggle"
-              type="button"
-              aria-label={secretVisible ? 'Hide secret key' : 'Show secret key'}
-              onClick={() => setSecretVisible((current) => !current)}
-            >
-              <span className="material-symbols-outlined" aria-hidden="true">
-                {secretVisible ? 'visibility_off' : 'visibility'}
-              </span>
-            </button>
-          </span>
-        </label>
-        <label>
-          <span>Public base URL</span>
-          <input
-            value={draft.publicBaseUrl}
-            onChange={(event) => updateDraft({ publicBaseUrl: event.target.value })}
-          />
-        </label>
-        <label>
-          <span>Prefix</span>
-          <input
-            value={draft.prefix}
-            onChange={(event) => updateDraft({ prefix: event.target.value })}
-          />
-        </label>
-        <label className="mirror-checkbox-row">
-          <input
-            checked={draft.pathStyle}
-            type="checkbox"
-            onChange={(event) => updateDraft({ pathStyle: event.target.checked })}
-          />
-          <span>Path-style URLs</span>
-        </label>
-      </div>
-
-      <p
-        className={
-          mirrorState.status === 'failed' || connectionStatus === 'failed'
-            ? 'mirror-settings-status mirror-settings-status-error'
-            : 'mirror-settings-status'
-        }
-      >
-        {connectionStatus === 'ready' ? (
-          <>
-            <span className="material-symbols-outlined" aria-hidden="true">
-              check_circle
-            </span>
-            S3-compatible connection is ready.
-          </>
-        ) : connectionStatus === 'failed' ? (
-          connectionError
-        ) : mirrorState.status === 'failed' ? (
-          (mirrorState.error ?? 'S3-compatible connection failed.')
-        ) : mirrorState.status === 'syncing' || connectionStatus === 'testing' ? (
-          'Checking S3-compatible connection...'
-        ) : mirrorState.status === 'synced' ? (
-          'S3-compatible connection is ready.'
-        ) : (
-          'Keys are stored in this browser profile.'
-        )}
-      </p>
-
-      <div className="mirror-settings-help">
-        <p>Local S3-compatible default login: localstudio / localstudio123</p>
-        {connectionStatus === 'ready' ? (
-          <div className="mirror-settings-links">
-            <a href={publicBucketUrl} target="_blank" rel="noreferrer">
-              Open public bucket
-            </a>
-            <a href={consoleUrl} target="_blank" rel="noreferrer">
-              Open storage console
-            </a>
+      <section className="mirror-settings-section" aria-label="Mirror project storage">
+        <div className="mirror-settings-section-heading">
+          <div>
+            <h3>Mirror project storage</h3>
+            <p>Store public deck assets in an S3-compatible bucket.</p>
           </div>
-        ) : null}
-      </div>
+        </div>
+
+        <div className="mirror-settings-grid ew-field-scope" data-tour-id="mirror-settings-fields">
+          <label>
+            <span>Endpoint</span>
+            <input
+              value={draft.endpoint}
+              onChange={(event) => updateDraft({ endpoint: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Bucket</span>
+            <input
+              value={draft.bucket}
+              onChange={(event) => updateDraft({ bucket: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Region</span>
+            <input
+              value={draft.region}
+              onChange={(event) => updateDraft({ region: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Access key</span>
+            <input
+              value={draft.accessKey}
+              onChange={(event) => updateDraft({ accessKey: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Secret key</span>
+            <span className="mirror-secret-control">
+              <input
+                aria-label="Secret key"
+                type={secretVisible ? 'text' : 'password'}
+                value={draft.secretKey}
+                onChange={(event) => updateDraft({ secretKey: event.target.value })}
+              />
+              <button
+                className="stitch-icon-button mirror-secret-toggle"
+                type="button"
+                aria-label={secretVisible ? 'Hide secret key' : 'Show secret key'}
+                onClick={() => setSecretVisible((current) => !current)}
+              >
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  {secretVisible ? 'visibility_off' : 'visibility'}
+                </span>
+              </button>
+            </span>
+          </label>
+          <label>
+            <span>Public base URL</span>
+            <input
+              value={draft.publicBaseUrl}
+              onChange={(event) => updateDraft({ publicBaseUrl: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Prefix</span>
+            <input
+              value={draft.prefix}
+              onChange={(event) => updateDraft({ prefix: event.target.value })}
+            />
+          </label>
+          <label className="mirror-checkbox-row">
+            <input
+              checked={draft.pathStyle}
+              type="checkbox"
+              onChange={(event) => updateDraft({ pathStyle: event.target.checked })}
+            />
+            <span>Path-style URLs</span>
+          </label>
+        </div>
+
+        <p
+          className={
+            mirrorState.status === 'failed' || connectionStatus === 'failed'
+              ? 'mirror-settings-status mirror-settings-status-error'
+              : 'mirror-settings-status'
+          }
+        >
+          {connectionStatus === 'ready' ? (
+            <>
+              <span className="material-symbols-outlined" aria-hidden="true">
+                check_circle
+              </span>
+              S3-compatible connection is ready.
+            </>
+          ) : connectionStatus === 'failed' ? (
+            connectionError
+          ) : mirrorState.status === 'failed' ? (
+            (mirrorState.error ?? 'S3-compatible connection failed.')
+          ) : mirrorState.status === 'syncing' || connectionStatus === 'testing' ? (
+            'Checking S3-compatible connection...'
+          ) : mirrorState.status === 'synced' ? (
+            'S3-compatible connection is ready.'
+          ) : (
+            'Keys are stored in this browser profile.'
+          )}
+        </p>
+
+        <div className="mirror-settings-help">
+          <p>Local S3-compatible default login: localstudio / localstudio123</p>
+          {connectionStatus === 'ready' ? (
+            <div className="mirror-settings-links">
+              <a href={publicBucketUrl} target="_blank" rel="noreferrer">
+                Open public bucket
+              </a>
+              <a href={consoleUrl} target="_blank" rel="noreferrer">
+                Open storage console
+              </a>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section
+        className="mirror-settings-section mirror-settings-fonts"
+        aria-label="Local font mirroring"
+      >
+        <div className="mirror-settings-section-heading">
+          <div>
+            <h3>Mirror my local fonts</h3>
+            <p>
+              LocalStudio can use fonts installed on this machine while editing. Public viewers need
+              those font files mirrored to storage before they can see the same typography.
+            </p>
+          </div>
+          <label className="mirror-settings-font-toggle">
+            <input
+              checked={localFontMirrorSettings.enabled}
+              type="checkbox"
+              onChange={(event) => void setLocalFontMirroringEnabled(event.target.checked)}
+            />
+            <span aria-hidden="true" className="mirror-settings-font-toggle-track">
+              <span className="mirror-settings-font-toggle-thumb" />
+            </span>
+            <span>{localFontMirrorSettings.enabled ? 'Enabled' : 'Off'}</span>
+          </label>
+        </div>
+        <div className="mirror-settings-font-hint">
+          <span className="material-symbols-outlined" aria-hidden="true">
+            travel_explore
+          </span>
+          <span>
+            Usual font folder for this system: <strong>{localFontMirrorSettings.systemHint}</strong>
+          </span>
+        </div>
+        <div className="mirror-settings-font-actions">
+          <button
+            className="mirror-settings-font-action"
+            type="button"
+            disabled={!localFontMirrorSettings.supported || folderStatus === 'choosing'}
+            onClick={() => void chooseFontFolder()}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              folder_open
+            </span>
+            <span>
+              {folderStatus === 'choosing'
+                ? 'Choosing font folder...'
+                : localFontMirrorSettings.folderLabel
+                  ? `Folder: ${localFontMirrorSettings.folderLabel}`
+                  : 'Choose font folder'}
+            </span>
+          </button>
+          {!localFontMirrorSettings.supported ? (
+            <span className="mirror-settings-font-warning">
+              This browser cannot remember a local font folder.
+            </span>
+          ) : null}
+          {folderError ? <span className="mirror-settings-font-warning">{folderError}</span> : null}
+        </div>
+      </section>
 
       <div className="mirror-settings-actions" data-tour-id="mirror-settings-actions">
         <button
@@ -249,7 +359,7 @@ export function MirrorSettingsPanel({
         </button>
         <button className="footer-toggle" type="button" onClick={() => void testConnection()}>
           {connectionStatus === 'testing'
-            ? 'Checking S3-compatible connection...'
+            ? (connectionDetail ?? 'Checking S3-compatible connection...')
             : 'Test connection'}
         </button>
         <button
@@ -261,6 +371,9 @@ export function MirrorSettingsPanel({
           Save settings
         </button>
       </div>
+      {connectionStatus === 'ready' && connectionDetail ? (
+        <p className="mirror-settings-status">{connectionDetail}</p>
+      ) : null}
     </aside>
   );
 }

--- a/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
+++ b/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
@@ -3,8 +3,8 @@ import {
   AlignLeft,
   AlignRight,
   Bold,
+  ChevronDown,
   Download,
-  Plus,
   Search,
 } from 'lucide-react';
 import type { FormEvent, RefObject } from 'react';
@@ -19,10 +19,12 @@ export interface TextStyleControls {
   fontDownloadOpen: boolean;
   fontDownloadStatus?: string | undefined;
   fontFamilyOptions: string[];
+  localFontFamilyOptions: string[];
   fontSearchInput: string;
   fontSearchQuery: string;
-  fontSelectRef: RefObject<HTMLSelectElement | null>;
+  fontSelectRef: RefObject<HTMLButtonElement | null>;
   hasFontDownload: boolean;
+  onApplyFontFamily: (family: string) => Promise<void>;
   onDownloadFontFamily: (family: string) => Promise<void>;
   onFontSearchInputChange: (value: string) => void;
   onFontSearchSubmit: (event: FormEvent<HTMLFormElement>) => void;
@@ -32,6 +34,11 @@ export interface TextStyleControls {
 const regularTextWeight = 400;
 const boldTextWeight = 800;
 
+function fontMatchesQuery(fontFamily: string, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  return !normalizedQuery || fontFamily.toLowerCase().includes(normalizedQuery);
+}
+
 export function TextStyleInspector({
   downloadingFontFamily,
   element,
@@ -39,10 +46,12 @@ export function TextStyleInspector({
   fontDownloadOpen,
   fontDownloadStatus,
   fontFamilyOptions,
+  localFontFamilyOptions,
   fontSearchInput,
   fontSearchQuery,
   fontSelectRef,
   hasFontDownload,
+  onApplyFontFamily,
   onDownloadFontFamily,
   onFontSearchInputChange,
   onFontSearchSubmit,
@@ -53,39 +62,30 @@ export function TextStyleInspector({
   onUpdateStyle: (patch: ElementStylePatch) => void;
 }) {
   const selectedTextIsBold = element.fontWeight >= boldTextWeight;
+  const fontQuery = fontSearchQuery.trim();
+  const matchingProjectFonts = fontFamilyOptions.filter((fontFamily) => fontMatchesQuery(fontFamily, fontQuery));
+  const matchingLocalFonts = localFontFamilyOptions.filter((fontFamily) => fontMatchesQuery(fontFamily, fontQuery));
 
   return (
     <section className="movie-panel-section" aria-label="Selected text controls">
       <h3>Typography</h3>
       <div className="text-inspector-stack">
         <div className="font-control-row">
-          <label className="text-inspector-field ew-field-scope ew-grid-compact text-inspector-field-full">
+          <div className="text-inspector-field ew-field-scope ew-grid-compact text-inspector-field-full">
             <span className="text-inspector-label ew-strong-label">Font</span>
-            <select
+            <button
               aria-label="Selected text font"
+              aria-expanded={fontDownloadOpen}
+              className="font-picker-trigger"
               ref={fontSelectRef}
-              value={element.fontFamily}
-              onChange={(event) => {
-                onUpdateStyle({ fontFamily: event.target.value });
-              }}
+              style={{ fontFamily: element.fontFamily }}
+              type="button"
+              onClick={onToggleFontDownload}
             >
-              {fontFamilyOptions.map((fontFamily) => (
-                <option key={fontFamily} value={fontFamily}>
-                  {fontFamily}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button
-            aria-expanded={fontDownloadOpen}
-            aria-label="Download additional font"
-            className="font-add-button"
-            title="Download additional font"
-            type="button"
-            onClick={onToggleFontDownload}
-          >
-            <Plus size={16} />
-          </button>
+              <span className="ew-ellipsis">{element.fontFamily}</span>
+              <ChevronDown size={15} aria-hidden="true" />
+            </button>
+          </div>
         </div>
         {fontDownloadOpen ? (
           <div className="font-download-panel">
@@ -94,7 +94,7 @@ export function TextStyleInspector({
                 <Search size={16} aria-hidden="true" />
                 <input
                   aria-label="Search downloadable fonts"
-                  placeholder="Search Google Fonts"
+                  placeholder="Search project, local, or Google fonts"
                   type="search"
                   value={fontSearchInput}
                   onChange={(event) => {
@@ -102,38 +102,90 @@ export function TextStyleInspector({
                   }}
                 />
               </label>
-              <button className="font-search-submit" type="submit" aria-label="Search fonts">
-                <Search size={16} />
-              </button>
             </form>
-            {fontSearchQuery ? (
-              <div className="font-download-results" aria-label="Downloadable font results">
-                {filteredDownloadableFonts.length > 0 ? (
-                  filteredDownloadableFonts.map((font) => (
+            <div className="font-download-results" aria-label="Downloadable font results">
+              {matchingProjectFonts.length > 0 ? (
+                <section className="font-result-group" aria-label="Project font results">
+                  <h4>Project fonts</h4>
+                  {matchingProjectFonts.map((fontFamily) => (
                     <button
-                      aria-label={`Download ${font.family}`}
-                      className="font-download-result"
-                      disabled={!hasFontDownload || downloadingFontFamily === font.family}
-                      key={font.family}
+                      aria-label={`Apply ${fontFamily}`}
+                      className="font-download-result font-preview-result"
+                      key={fontFamily}
                       type="button"
                       onClick={() => {
-                        void onDownloadFontFamily(font.family);
+                        void onApplyFontFamily(fontFamily);
                       }}
                     >
-                      <span className="ew-ellipsis">{font.family}</span>
+                      <span className="ew-ellipsis" style={{ fontFamily }}>
+                        {fontFamily}
+                      </span>
+                      {element.fontFamily === fontFamily ? (
+                        <span className="material-symbols-outlined font-result-check" aria-hidden="true">
+                          check
+                        </span>
+                      ) : null}
+                    </button>
+                  ))}
+                </section>
+              ) : null}
+              {matchingLocalFonts.length > 0 ? (
+                <section className="font-result-group" aria-label="Local font folder results">
+                  <h4>Local font folder</h4>
+                  {matchingLocalFonts.map((fontFamily) => (
+                    <button
+                      aria-label={`Add ${fontFamily} from local fonts`}
+                      className="font-download-result font-preview-result"
+                      disabled={downloadingFontFamily === fontFamily}
+                      key={fontFamily}
+                      type="button"
+                      onClick={() => {
+                        void onApplyFontFamily(fontFamily);
+                      }}
+                    >
+                      <span className="ew-ellipsis" style={{ fontFamily }}>
+                        {fontFamily}
+                      </span>
                       <Download size={15} />
                     </button>
-                  ))
-                ) : (
-                  <p className="panel-muted">No Google Fonts match that search.</p>
-                )}
-              </div>
-            ) : null}
-            {fontDownloadStatus ? (
-              <div className="panel-muted" role="status">
-                {fontDownloadStatus}
-              </div>
-            ) : null}
+                  ))}
+                </section>
+              ) : null}
+              {fontSearchQuery ? (
+                <section className="font-result-group" aria-label="Google font results">
+                  <h4>Google Fonts</h4>
+                  {filteredDownloadableFonts.length > 0 ? (
+                    filteredDownloadableFonts.map((font) => (
+                      <button
+                        aria-label={`Download ${font.family}`}
+                        className="font-download-result"
+                        disabled={!hasFontDownload || downloadingFontFamily === font.family}
+                        key={font.family}
+                        type="button"
+                        onClick={() => {
+                          void onDownloadFontFamily(font.family);
+                        }}
+                      >
+                        <span className="ew-ellipsis">{font.family}</span>
+                        <Download size={15} />
+                      </button>
+                    ))
+                  ) : (
+                    <p className="panel-muted">No Google Fonts match that search.</p>
+                  )}
+                </section>
+              ) : null}
+              {matchingProjectFonts.length === 0 &&
+              matchingLocalFonts.length === 0 &&
+              (!fontSearchQuery || filteredDownloadableFonts.length === 0) ? (
+                <p className="panel-muted">No fonts match that search.</p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+        {fontDownloadStatus ? (
+          <div className="panel-muted" role="status">
+            {fontDownloadStatus}
           </div>
         ) : null}
         <div className="text-inspector-pair">

--- a/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
@@ -36,7 +36,9 @@ export function EditorLeftPanelSurface({
       activePageId={vm.activePageId}
       selection={vm.selection}
       availableFonts={vm.availableFonts}
+      localFonts={vm.localFontOptions}
       onDownloadFont={isHistoryReadOnly ? undefined : vm.downloadFontForSelection}
+      onImportLocalFont={isHistoryReadOnly ? undefined : vm.importLocalFontForSelection}
       onSelectElement={isHistoryReadOnly ? undefined : onSelectElement}
       onSetElementVisibility={isHistoryReadOnly ? undefined : vm.setElementVisibility}
       onSetElementLock={isHistoryReadOnly ? undefined : vm.setElementLock}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -87,6 +87,7 @@ export function EditorShell({ services }: EditorShellProps) {
 function EditorDesktopShell({ services }: EditorShellProps) {
   const vm = useEditorViewModel(services);
   const automationDelegateRef = useRef(vm.automation);
+  const prepareProjectFontsForPublicShareRef = useRef(vm.prepareProjectFontsForPublicShare);
   const movieHoldStateRef = useRef<MovieHoldState | undefined>(undefined);
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);
   const [designFontFocusKey, setDesignFontFocusKey] = useState(0);
@@ -119,6 +120,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const [isExportingImages, setIsExportingImages] = useState(false);
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
   const [shareMetadata, setShareMetadata] = useState<ShareMetadata | undefined>();
+  const [shareProgressLabel, setShareProgressLabel] = useState<string | undefined>();
   const stageRef = useRef<Konva.Stage>(null);
   const imageExportStageRef = useRef<Konva.Stage>(null);
   const workspaceRef = useRef<HTMLElement>(null);
@@ -128,6 +130,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const aiWorkflowTourRef = useRef<EditorAiWorkflowTourHandle>(null);
   const imageExportNoticeTimeoutRef = useRef<number | undefined>(undefined);
   const presenterFullscreenEnteredRef = useRef(false);
+  const pendingShareAfterLocalSaveRef = useRef(false);
   const toolbarImageInputRef = useRef<HTMLInputElement>(null);
   const hasSelection = vm.selection.elementIds.length > 0;
   const isHistoryReadOnly = vm.versionHistoryOpen;
@@ -251,13 +254,55 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   }
 
   async function copyPublicShareLink() {
-    const nextShare = shareMetadata
-      ? await services.shareService.updateShare(shareMetadata.shareId, vm.project)
-      : await services.shareService.createShare(vm.project);
-    const copiedShare: ShareMetadata = { ...nextShare, status: 'copied' };
-    setShareMetadata(copiedShare);
-    await navigator.clipboard?.writeText(copiedShare.publicUrl);
-    return copiedShare;
+    setShareProgressLabel('Checking local fonts');
+    try {
+      const fontResult = await vm.prepareProjectFontsForPublicShare({
+        onProgress: (progress) => setShareProgressLabel(progress.label),
+      });
+      if (fontResult.unresolvedFamilies.length > 0) {
+        setShareProgressLabel(
+          `Publishing with fallback risk for ${fontResult.unresolvedFamilies.join(', ')}`,
+        );
+      } else {
+        setShareProgressLabel('Publishing public link');
+      }
+      const projectToShare = fontResult.project;
+      const nextShare = shareMetadata
+        ? await services.shareService.updateShare(shareMetadata.shareId, projectToShare)
+        : await services.shareService.createShare(projectToShare);
+      const copiedShare: ShareMetadata = { ...nextShare, status: 'copied' };
+      setShareMetadata(copiedShare);
+      await navigator.clipboard?.writeText(copiedShare.publicUrl);
+      return copiedShare;
+    } finally {
+      setShareProgressLabel(undefined);
+    }
+  }
+
+  function continueShareAfterLocalSave() {
+    if (!pendingShareAfterLocalSaveRef.current) return;
+    pendingShareAfterLocalSaveRef.current = false;
+    if (!vm.hasMirrorConfig) {
+      setSharePanelOpen(false);
+      vm.openMirrorSettings();
+      return;
+    }
+    setSharePanelOpen(true);
+  }
+
+  async function openShareWorkflow() {
+    setSharePanelOpen(false);
+    if (!vm.persistenceEnabled) {
+      pendingShareAfterLocalSaveRef.current = true;
+      const saved = await vm.setPersistence(true);
+      if (saved) continueShareAfterLocalSave();
+      return;
+    }
+    if (!vm.hasMirrorConfig) {
+      vm.openMirrorSettings();
+      return;
+    }
+    setSharePanelOpen(true);
   }
 
   function presentFromSharePanel() {
@@ -787,6 +832,10 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   }, [vm.automation]);
 
   useEffect(() => {
+    prepareProjectFontsForPublicShareRef.current = vm.prepareProjectFontsForPublicShare;
+  });
+
+  useEffect(() => {
     const pageId = vm.activePageId;
     if (!pageId) return undefined;
     if (presenterRemoteUnavailable) return undefined;
@@ -1046,8 +1095,10 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     }
     const timeoutId = window.setTimeout(() => {
       setShareMetadata((current) => (current ? { ...current, status: 'syncing' } : current));
-      void services.shareService
-        .updateShare(shareId, vm.project)
+      void (async () => {
+        const fontResult = await prepareProjectFontsForPublicShareRef.current();
+        return services.shareService.updateShare(shareId, fontResult.project);
+      })()
         .then((nextShare) => {
           setShareMetadata(nextShare);
         })
@@ -1087,8 +1138,12 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         onNewProject={openBlankProjectInNewTab}
         onOpenKeyboardShortcuts={() => setKeyboardShortcutsOpen(true)}
         onStartAiSetupTour={startAiWorkflowTour}
+        onLocalProjectSetupCancel={() => {
+          pendingShareAfterLocalSaveRef.current = false;
+        }}
+        onLocalProjectSetupConfirm={continueShareAfterLocalSave}
         onShare={() => {
-          setSharePanelOpen(true);
+          void openShareWorkflow();
         }}
         onOpenPresenterView={openPresenterView}
         onStartPresenterMode={startPresenterMode}
@@ -1368,8 +1423,13 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         <SharePanel
           projectName={vm.project.name}
           share={shareMetadata}
+          shareProgressLabel={shareProgressLabel}
           onClose={() => {
             setSharePanelOpen(false);
+          }}
+          onConfigurePublicLink={() => {
+            setSharePanelOpen(false);
+            vm.openMirrorSettings();
           }}
           onCopyLink={copyPublicShareLink}
           publicLinkUnavailableReason={
@@ -1413,14 +1473,17 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       {vm.mirrorSettingsOpen ? (
         <MirrorSettingsPanel
           config={vm.mirrorConfig}
+          localFontMirrorSettings={vm.localFontMirrorSettings}
           mirrorState={vm.mirrorState}
           mirrorDisabledBySettings={vm.mirrorDisabledBySettings}
           onBack={() => {
             vm.closeMirrorSettings();
             vm.openSettings();
           }}
+          onChooseLocalFontFolder={vm.chooseLocalFontMirrorFolder}
           onClose={vm.closeMirrorSettings}
           onEnabledChange={vm.setMirrorEnabledFromSettings}
+          onLocalFontMirrorEnabledChange={vm.setLocalFontMirrorEnabled}
           onSave={vm.saveMirrorConfig}
           onTestConnection={vm.testMirrorConnection}
         />

--- a/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
@@ -18,6 +18,8 @@ interface EditorToolbarSurfaceProps {
   onNewProject: () => void;
   onOpenKeyboardShortcuts: () => void;
   onOpenPresenterView: () => void;
+  onLocalProjectSetupCancel?: () => void;
+  onLocalProjectSetupConfirm?: () => void;
   onShare: () => void;
   onStartAiSetupTour: () => void;
   onStartPresenterMode: (options?: { fromBeginning?: boolean }) => void;
@@ -36,6 +38,8 @@ export function EditorToolbarSurface({
   onNewProject,
   onOpenKeyboardShortcuts,
   onOpenPresenterView,
+  onLocalProjectSetupCancel,
+  onLocalProjectSetupConfirm,
   onShare,
   onStartAiSetupTour,
   onStartPresenterMode,
@@ -58,9 +62,14 @@ export function EditorToolbarSurface({
         vm.localProjectSetupOpen ? (
           <LocalProjectSetupPanel
             initialName={vm.project.name}
-            onCancel={vm.closeLocalProjectSetup}
+            onCancel={() => {
+              vm.closeLocalProjectSetup();
+              onLocalProjectSetupCancel?.();
+            }}
             onConfirm={(projectName) => {
-              void vm.confirmLocalProjectSetup(projectName);
+              void vm.confirmLocalProjectSetup(projectName).then((saved) => {
+                if (saved) onLocalProjectSetupConfirm?.();
+              });
             }}
           />
         ) : null

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -24,6 +24,8 @@ import { sampleProject } from '../../../domain/projects/sampleProject';
 import type { EditorAutomationDelegate } from '../../../services/automation/editorAutomationController';
 import type {
   AiProviderState,
+  FontCatalogItem,
+  LocalFontMirrorProgress,
   MirrorProjectSummary,
   MirrorState,
   ModelDownloadProgressDetails,
@@ -36,6 +38,7 @@ import { pptxFontRequests } from '../../../services/importing/pptx/pptxFontReque
 import { pptxImportLogger } from '../../../services/importing/pptx/pptxImportLogger';
 import { minioMirrorService } from '../../../services/mirror/minioMirrorService';
 import type { MinioMirrorConfig } from '../../../services/mirror/minioMirrorService';
+import { storageObjectUtils } from '../../../services/storage/storageObjectUtils';
 import { aiModelCatalog } from '../../../services/model-setup/aiModelCatalog';
 import { imageGenerationModel } from '../../../services/image-generation/imageGenerationModel';
 import { createPrefixedId } from '../../../services/ids/idUtils';
@@ -261,6 +264,10 @@ export function useEditorViewModel(services: AppServices) {
   }));
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [mirrorSettingsOpen, setMirrorSettingsOpen] = useState(false);
+  const [localFontMirrorSettings, setLocalFontMirrorSettings] = useState(() =>
+    services.localFontMirrorService.getSettings(),
+  );
+  const [localFontOptions, setLocalFontOptions] = useState<FontCatalogItem[]>([]);
   const [mediaSettingsOpen, setMediaSettingsOpen] = useState(false);
   const [mirrorDisabledBySettings, setMirrorDisabledBySettings] = useState(false);
   const [remoteImportOpen, setRemoteImportOpen] = useState(false);
@@ -359,6 +366,24 @@ export function useEditorViewModel(services: AppServices) {
     () => services.fontImportService.listDownloadableFonts(),
     [services.fontImportService],
   );
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadLocalFontOptions = async () => {
+      const fonts = localFontMirrorSettings.enabled
+        ? await services.localFontMirrorService.listAvailableFonts().catch(() => [])
+        : [];
+      if (!cancelled) setLocalFontOptions(fonts);
+    };
+    void loadLocalFontOptions();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    localFontMirrorSettings.enabled,
+    localFontMirrorSettings.folderLabel,
+    services.localFontMirrorService,
+  ]);
   const activeSlideLanguage = useMemo(() => {
     const option = translationLanguageUtils.getLanguageOption(pageLanguageCodes[activePageId]);
     return {
@@ -1220,20 +1245,19 @@ export function useEditorViewModel(services: AppServices) {
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
-      return;
+      return true;
     }
 
     if (hasPersistedLocalProject) {
-      void reenablePersistence();
-      return;
+      return reenablePersistence();
     }
 
     if (services.persistenceMode === 'opfs') {
-      void reenablePersistence();
-      return;
+      return reenablePersistence();
     }
 
     setLocalProjectSetupOpen(true);
+    return false;
   }
 
   async function reenablePersistence() {
@@ -1260,11 +1284,13 @@ export function useEditorViewModel(services: AppServices) {
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(true);
       }
+      return true;
     } catch {
       setPersistenceEnabled(false);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
+      return false;
     }
   }
 
@@ -1289,7 +1315,7 @@ export function useEditorViewModel(services: AppServices) {
 
   async function saveLocalNow() {
     if (!persistenceEnabled) {
-      setPersistence(true);
+      void setPersistence(true);
       return;
     }
     try {
@@ -1343,7 +1369,7 @@ export function useEditorViewModel(services: AppServices) {
 
   async function confirmLocalProjectSetup(projectName: string) {
     const nextName = projectName.trim();
-    if (!nextName) return;
+    if (!nextName) return false;
     const nextProject = {
       ...projectRef.current,
       name: nextName,
@@ -1372,11 +1398,13 @@ export function useEditorViewModel(services: AppServices) {
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(true);
       }
+      return true;
     } catch {
       setPersistenceEnabled(false);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
+      return false;
     }
   }
 
@@ -1699,6 +1727,14 @@ export function useEditorViewModel(services: AppServices) {
     setMirrorSettingsOpen(false);
   }
 
+  function setLocalFontMirrorEnabled(enabled: boolean) {
+    setLocalFontMirrorSettings(services.localFontMirrorService.setEnabled(enabled));
+  }
+
+  async function chooseLocalFontMirrorFolder() {
+    setLocalFontMirrorSettings(await services.localFontMirrorService.chooseFontFolder());
+  }
+
   function closeRemoteImport() {
     setRemoteImportOpen(false);
   }
@@ -1736,11 +1772,42 @@ export function useEditorViewModel(services: AppServices) {
     setMirrorEnabled(enabled, { fromSettings: true });
   }
 
-  async function testMirrorConnection(config: MinioMirrorConfig) {
+  async function testMirrorConnection(
+    config: MinioMirrorConfig,
+    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+  ) {
     setMirrorState({ enabled: true, status: 'syncing' });
     try {
+      options?.onProgress?.({ label: 'Checking storage', stage: 'checking-local-fonts' });
       await services.mirrorService.listProjects(config);
+      const testFontFiles = localFontMirrorSettings.enabled
+        ? await services.localFontMirrorService.getTestFontFiles({
+            ...(options?.onProgress ? { onProgress: options.onProgress } : {}),
+          })
+        : [];
+      if (localFontMirrorSettings.enabled && testFontFiles.length > 0) {
+        if (!services.mirrorService.uploadPublicObject) {
+          throw new Error('Mirror storage does not support public font uploads.');
+        }
+        options?.onProgress?.({ label: 'Uploading test fonts', stage: 'uploading-test-fonts' });
+        await Promise.all(
+          testFontFiles.map((file, index) => {
+            const key = storageObjectUtils.joinObjectKey(
+              storageObjectUtils.normalizeObjectKeyPart(config.prefix),
+              'font-mirror-test',
+              `${Date.now().toString(36)}-${index + 1}-${file.name}`,
+            );
+            return services.mirrorService.uploadPublicObject?.(key, file, config) ?? Promise.resolve();
+          }),
+        );
+      }
+      const fontMirrorTestResult = localFontMirrorSettings.enabled
+        ? await services.localFontMirrorService.validateTestFontFiles(testFontFiles, {
+            ...(options?.onProgress ? { onProgress: options.onProgress } : {}),
+          })
+        : {};
       setMirrorState({ enabled: true, status: 'idle' });
+      return fontMirrorTestResult.warning;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'S3-compatible connection failed.';
       setMirrorState({
@@ -1750,6 +1817,20 @@ export function useEditorViewModel(services: AppServices) {
       });
       throw new Error(message, { cause: error });
     }
+  }
+
+  async function prepareProjectFontsForPublicShare(
+    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+  ) {
+    const result = await services.localFontMirrorService.importProjectFonts(projectRef.current, {
+      ...(options?.onProgress ? { onProgress: options.onProgress } : {}),
+    });
+    if (result.project !== projectRef.current) {
+      setProject(result.project);
+      projectRef.current = result.project;
+      await editorViewModelRuntime.loadProjectFonts(result.project, services.fontImportService).catch(() => undefined);
+    }
+    return result;
   }
 
   function queueMirrorSync() {
@@ -2057,6 +2138,35 @@ export function useEditorViewModel(services: AppServices) {
         elementId: selectedElementId,
         font,
         fonts: result.fonts,
+        project: currentProject,
+      });
+    });
+  }
+
+  async function importLocalFontForSelection(family: string) {
+    const selectedElementId = selectedElementIdsRef.current[0];
+    if (!selectedElementId) throw new Error('Select a text element before adding a local font.');
+    const selectedElement = projectRef.current.elements[selectedElementId];
+    if (!selectedElement || selectedElement.type !== 'text') {
+      throw new Error('Select a text element before adding a local font.');
+    }
+
+    const result = await services.localFontMirrorService.importFontFamily(projectRef.current, {
+      family,
+      fontStyle: 'normal',
+      fontWeight: selectedElement.fontWeight >= 700 ? 700 : 400,
+    });
+    const font = result.addedFonts[0];
+    if (!font) {
+      throw new Error(result.warnings[0]?.message ?? 'Local font was not found.');
+    }
+
+    await editorViewModelRuntime.loadProjectFonts(result.project, services.fontImportService);
+    commitProject((currentProject) => {
+      return editorViewModelText.applyFontFamilyWithFonts({
+        elementId: selectedElementId,
+        font,
+        fonts: result.project.fonts ?? {},
         project: currentProject,
       });
     });
@@ -2968,6 +3078,8 @@ export function useEditorViewModel(services: AppServices) {
     mirrorState,
     mirrorDisabledBySettings,
     mirrorConfig,
+    hasMirrorConfig,
+    localFontMirrorSettings,
     settingsOpen,
     mirrorSettingsOpen,
     mediaSettingsOpen,
@@ -3001,6 +3113,7 @@ export function useEditorViewModel(services: AppServices) {
     selection,
     activeTab,
     availableFonts,
+    localFontOptions,
     downloadableFonts: services.fontImportService.listDownloadableFonts(),
     activeSlideLanguage,
     setActiveTab,
@@ -3024,6 +3137,9 @@ export function useEditorViewModel(services: AppServices) {
     insertStockMedia,
     saveMirrorConfig,
     testMirrorConnection,
+    setLocalFontMirrorEnabled,
+    chooseLocalFontMirrorFolder,
+    prepareProjectFontsForPublicShare,
     syncMirrorNow,
     requestMirrorNow,
     setMirrorEnabled,
@@ -3132,6 +3248,7 @@ export function useEditorViewModel(services: AppServices) {
     updateElementFrames,
     updateElementStyle,
     downloadFontForSelection,
+    importLocalFontForSelection,
     updateMediaPlayback,
     updatePageBackground,
     applyTheme,

--- a/apps/editor/src/ui/editor/toolbars/ToolbarMirrorButton.tsx
+++ b/apps/editor/src/ui/editor/toolbars/ToolbarMirrorButton.tsx
@@ -17,9 +17,9 @@ export function ToolbarMirrorButton({
   onMirrorToggle,
   onOpenMirrorSettings,
 }: ToolbarMirrorButtonProps) {
-  const disabled = !persistenceEnabled;
-  const label = disabled
-    ? 'Mirror disabled'
+  const needsLocalSave = !persistenceEnabled;
+  const label = needsLocalSave
+    ? 'Save deck before mirroring'
     : !mirrorState.enabled
       ? 'Mirror disabled'
       : mirrorState.status === 'syncing'
@@ -32,10 +32,11 @@ export function ToolbarMirrorButton({
   const className = [
     'stitch-icon-button',
     'mirror-status-button',
-    disabled || !mirrorState.enabled ? 'mirror-disabled' : '',
-    !disabled && mirrorState.status === 'syncing' ? 'mirror-syncing' : '',
-    !disabled && mirrorState.status === 'synced' ? 'mirror-synced' : '',
-    !disabled && mirrorState.status === 'failed' ? 'mirror-failed' : '',
+    needsLocalSave ? 'mirror-needs-save' : '',
+    !needsLocalSave && !mirrorState.enabled ? 'mirror-disabled' : '',
+    !needsLocalSave && mirrorState.status === 'syncing' ? 'mirror-syncing' : '',
+    !needsLocalSave && mirrorState.status === 'synced' ? 'mirror-synced' : '',
+    !needsLocalSave && mirrorState.status === 'failed' ? 'mirror-failed' : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -43,12 +44,15 @@ export function ToolbarMirrorButton({
   return (
     <button
       className={className}
-      disabled={disabled}
       title={mirrorState.error ?? label}
       type="button"
       aria-label={label}
       data-tour-id="mirror-status"
       onClick={() => {
+        if (needsLocalSave) {
+          onMirrorNow?.();
+          return;
+        }
         if (mirrorDisabledBySettings) {
           onOpenMirrorSettings?.();
           return;

--- a/apps/editor/src/ui/share/SharePanel.tsx
+++ b/apps/editor/src/ui/share/SharePanel.tsx
@@ -5,7 +5,9 @@ interface SharePanelProps {
   projectName: string;
   share?: ShareMetadata | undefined;
   publicLinkUnavailableReason?: string | undefined;
+  shareProgressLabel?: string | undefined;
   onClose: () => void;
+  onConfigurePublicLink?: () => void;
   onCopyLink: () => Promise<ShareMetadata>;
   onDownload: () => void;
   onPresent: () => void;
@@ -24,7 +26,9 @@ export function SharePanel({
   projectName,
   share,
   publicLinkUnavailableReason,
+  shareProgressLabel,
   onClose,
+  onConfigurePublicLink,
   onCopyLink,
   onDownload,
   onPresent,
@@ -36,13 +40,17 @@ export function SharePanel({
   const statusLabel = getStatusLabel(currentShare, isCopying);
   const shareAccessDescription =
     copyError ??
+    shareProgressLabel ??
     publicLinkUnavailableReason ??
     (currentShare
       ? 'Unlisted: anyone with the link can view.'
       : 'Create a public view link for this deck.');
 
   async function handleCopyLink() {
-    if (publicLinkUnavailable) return;
+    if (publicLinkUnavailable) {
+      onConfigurePublicLink?.();
+      return;
+    }
     setIsCopying(true);
     setCopyError(undefined);
     try {
@@ -83,7 +91,7 @@ export function SharePanel({
         className="share-copy-link-button font-orbitron"
         type="button"
         data-loading={isCopying ? 'true' : 'false'}
-        disabled={isCopying || publicLinkUnavailable}
+        disabled={isCopying}
         title={publicLinkUnavailableReason}
         onClick={() => {
           void handleCopyLink();
@@ -92,7 +100,7 @@ export function SharePanel({
         <span className="material-symbols-outlined" aria-hidden="true">
           link
         </span>
-        Copy link
+        {publicLinkUnavailable ? 'Configure mirror storage' : 'Copy link'}
       </button>
 
       {currentShare ? (

--- a/apps/editor/src/ui/styles/font-controls.css
+++ b/apps/editor/src/ui/styles/font-controls.css
@@ -1,16 +1,35 @@
 .font-control-row {
+  display: block;
+}
+
+.font-picker-trigger {
+  align-items: center;
+  background: #050d10;
+  border: 1px solid rgba(55, 253, 118, 0.36);
+  border-radius: 6px;
+  color: var(--ew-text);
+  cursor: pointer;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 38px;
-  gap: 8px;
-  align-items: end;
-}
-
-.font-control-select {
+  font-size: 13px;
+  grid-template-columns: minmax(0, 1fr) 18px;
+  height: 40px;
   min-width: 0;
+  padding: 0 10px;
+  text-align: left;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease;
+  width: 100%;
 }
 
-.font-add-button,
-.font-search-submit,
+.font-picker-trigger:hover,
+.font-picker-trigger:focus-visible,
+.font-picker-trigger[aria-expanded='true'] {
+  border-color: var(--ew-green);
+  box-shadow: 0 0 16px rgba(55, 253, 118, 0.1);
+  outline: 0;
+}
+
 .font-download-result {
   border: 1px solid rgba(55, 253, 118, 0.24);
   border-radius: 6px;
@@ -23,32 +42,11 @@
     transform 140ms ease;
 }
 
-.font-add-button,
-.font-search-submit {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 38px;
-  width: 38px;
-  height: 40px;
-  min-height: 0;
-  padding: 0;
-}
-
-.font-add-button:hover,
-.font-add-button:focus-visible,
-.font-search-submit:hover,
-.font-search-submit:focus-visible,
 .font-download-result:hover,
 .font-download-result:focus-visible {
   border-color: var(--ew-green);
   box-shadow: 0 0 16px rgba(55, 253, 118, 0.1);
   outline: 0;
-}
-
-.font-add-button[aria-expanded='true'] {
-  color: #000;
-  background: var(--ew-green);
 }
 
 .font-download-panel {
@@ -61,9 +59,7 @@
 }
 
 .font-download-search {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 38px;
-  gap: 8px;
+  display: block;
 }
 
 .font-download-search-box {
@@ -76,6 +72,39 @@
 .font-download-results {
   display: grid;
   gap: 6px;
+  max-height: min(46vh, 440px);
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-color: rgba(55, 253, 118, 0.65) rgba(255, 255, 255, 0.08);
+  scrollbar-width: thin;
+}
+
+.font-download-results::-webkit-scrollbar {
+  width: 8px;
+}
+
+.font-download-results::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+}
+
+.font-download-results::-webkit-scrollbar-thumb {
+  background: rgba(55, 253, 118, 0.65);
+  border-radius: 999px;
+}
+
+.font-result-group {
+  display: grid;
+  gap: 5px;
+}
+
+.font-result-group h4 {
+  color: var(--ew-muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  margin: 3px 0 0;
+  text-transform: uppercase;
 }
 
 .font-download-result {
@@ -89,6 +118,15 @@
   font: inherit;
   font-size: 12px;
   text-align: left;
+}
+
+.font-preview-result {
+  font-size: 15px;
+}
+
+.font-result-check {
+  color: var(--ew-green);
+  font-size: 17px;
 }
 
 .font-download-result:disabled {

--- a/apps/editor/src/ui/styles/mirror-settings.css
+++ b/apps/editor/src/ui/styles/mirror-settings.css
@@ -24,3 +24,164 @@
   font-size: 12px;
   padding: 0 9px;
 }
+
+.mirror-settings-section {
+  border: 1px solid rgba(122, 255, 199, 0.14);
+  border-radius: 6px;
+  background:
+    linear-gradient(135deg, rgba(55, 253, 118, 0.06), transparent 36%),
+    rgba(5, 13, 16, 0.62);
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+}
+
+.mirror-settings-section-heading {
+  align-items: start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.mirror-settings-section-heading h3 {
+  color: var(--ew-text);
+  font-size: 14px;
+  margin: 0 0 4px;
+}
+
+.mirror-settings-section-heading p,
+.mirror-settings-font-warning {
+  color: var(--ew-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.mirror-settings-font-toggle {
+  align-items: center;
+  border: 1px solid rgba(122, 255, 199, 0.2);
+  border-radius: 999px;
+  color: var(--ew-text);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  gap: 8px;
+  min-height: 30px;
+  padding: 4px 9px 4px 5px;
+  white-space: nowrap;
+}
+
+.mirror-settings-font-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mirror-settings-font-toggle-track {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  display: inline-flex;
+  height: 18px;
+  padding: 2px;
+  width: 32px;
+}
+
+.mirror-settings-font-toggle-thumb {
+  background: var(--ew-muted);
+  border-radius: 999px;
+  height: 12px;
+  transform: translateX(0);
+  transition:
+    background-color 140ms ease,
+    transform 140ms ease;
+  width: 12px;
+}
+
+.mirror-settings-font-toggle input:checked + .mirror-settings-font-toggle-track {
+  background: rgba(55, 253, 118, 0.14);
+  border-color: rgba(55, 253, 118, 0.38);
+}
+
+.mirror-settings-font-toggle input:checked + .mirror-settings-font-toggle-track .mirror-settings-font-toggle-thumb {
+  background: var(--ew-green);
+  transform: translateX(14px);
+}
+
+.mirror-settings-font-toggle:focus-within {
+  box-shadow: 0 0 0 2px rgba(55, 253, 118, 0.16);
+}
+
+.mirror-settings-font-hint {
+  align-items: flex-start;
+  color: var(--ew-muted);
+  display: flex;
+  font-size: 12px;
+  gap: 7px;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.mirror-settings-font-hint .material-symbols-outlined {
+  color: var(--ew-green-fixed);
+  font-size: 16px;
+  margin-top: 1px;
+}
+
+.mirror-settings-font-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mirror-settings-font-action {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(122, 255, 199, 0.18);
+  border-radius: 6px;
+  color: var(--ew-text);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  gap: 8px;
+  justify-content: center;
+  min-height: 34px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 0 10px;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.mirror-settings-font-action:hover:not(:disabled) {
+  background: rgba(55, 253, 118, 0.08);
+  border-color: rgba(55, 253, 118, 0.34);
+  color: var(--ew-green);
+}
+
+.mirror-settings-font-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.mirror-settings-font-action .material-symbols-outlined {
+  color: var(--ew-green-fixed);
+  font-size: 17px;
+}
+
+.mirror-settings-font-action span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mirror-settings-font-warning {
+  color: color-mix(in srgb, var(--ew-green-fixed) 68%, #f6c453);
+}

--- a/apps/editor/src/ui/styles/persistence-controls.css
+++ b/apps/editor/src/ui/styles/persistence-controls.css
@@ -83,6 +83,10 @@
   color: var(--ew-dim);
 }
 
+.mirror-needs-save {
+  color: #f6c453;
+}
+
 .mirror-syncing {
   color: #f6c453;
 }

--- a/apps/editor/tests/unit/app/composition.test.ts
+++ b/apps/editor/tests/unit/app/composition.test.ts
@@ -5,6 +5,7 @@ import { BrowserImageGenerationService } from '../../../src/services/image-gener
 import { DisabledProjectRepository } from '../../../src/services/storage/disabledProjectRepository';
 import { OpfsProjectRepository } from '../../../src/services/storage/opfsProjectRepository';
 import { BrowserStockMediaService } from '../../../src/services/stock-media/stockMediaService';
+import { BrowserLocalFontMirrorService } from '../../../src/services/fonts/localFontMirrorService';
 
 describe('createAppServices', () => {
   const testWindow = window as Window & { showDirectoryPicker?: unknown };
@@ -72,6 +73,10 @@ describe('createAppServices', () => {
 
   it('wires the browser stock media service', () => {
     expect(createAppServices().stockMediaService).toBeInstanceOf(BrowserStockMediaService);
+  });
+
+  it('wires the browser local font mirror service', () => {
+    expect(createAppServices().localFontMirrorService).toBeInstanceOf(BrowserLocalFontMirrorService);
   });
 
   it('starts new app services with a blank project by default', () => {

--- a/apps/editor/tests/unit/services/localFontMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/localFontMirrorService.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ProjectDocument } from '../../../src/domain/documents/model';
+import { BrowserLocalFontMirrorService } from '../../../src/services/fonts/localFontMirrorService';
+import { localFontMirrorPreferences } from '../../../src/services/fonts/localFontMirrorPreferences';
+
+function createFontFile(name: string) {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: 'font/woff2' });
+}
+
+function createFileHandle(file: File): FileSystemFileHandle {
+  return {
+    kind: 'file',
+    name: file.name,
+    getFile: () => Promise.resolve(file),
+  } as unknown as FileSystemFileHandle;
+}
+
+function createDirectoryHandle(files: File[], name = 'Fonts'): FileSystemDirectoryHandle {
+  return {
+    kind: 'directory',
+    name,
+    queryPermission: () => Promise.resolve('granted'),
+    requestPermission: () => Promise.resolve('granted'),
+    async *entries() {
+      for (const file of files) {
+        await Promise.resolve();
+        yield [file.name, createFileHandle(file)] as [string, FileSystemFileHandle];
+      }
+    },
+  } as unknown as FileSystemDirectoryHandle;
+}
+
+function createProject(): ProjectDocument {
+  return {
+    id: 'font-project',
+    name: 'Font project',
+    assets: {},
+    createdAt: '2026-07-14T00:00:00.000Z',
+    updatedAt: '2026-07-14T00:00:00.000Z',
+    pages: [
+      {
+        id: 'page-1',
+        name: 'Slide 1',
+        width: 1920,
+        height: 1080,
+        background: { type: 'color', color: '#050D10' },
+        elementIds: ['title'],
+      },
+    ],
+    elements: {
+      title: {
+        id: 'title',
+        type: 'text',
+        x: 0,
+        y: 0,
+        width: 600,
+        height: 120,
+        rotation: 0,
+        locked: false,
+        visible: true,
+        opacity: 1,
+        text: 'Hello',
+        fontFamily: 'Acme Sans',
+        fontSize: 80,
+        fontWeight: 700,
+        fill: '#ffffff',
+        align: 'left',
+      },
+    },
+  };
+}
+
+describe('BrowserLocalFontMirrorService', () => {
+  it('imports only matching used fonts from the selected local font folder', async () => {
+    localFontMirrorPreferences.write({ enabled: true, folderLabel: 'Fonts' });
+    const service = new BrowserLocalFontMirrorService({
+      createObjectURL: vi.fn(() => 'blob:acme-sans'),
+      fontDirectoryHandle: createDirectoryHandle([
+        createFontFile('AcmeSans-Bold.woff2'),
+        createFontFile('UnusedFont.woff2'),
+      ]),
+      now: () => new Date('2026-07-14T12:00:00.000Z'),
+    });
+
+    const result = await service.importProjectFonts(createProject());
+
+    expect(result.unresolvedFamilies).toEqual([]);
+    expect(result.addedFonts).toHaveLength(1);
+    expect(result.addedFonts[0]).toMatchObject({
+      id: 'font-acme-sans-700-acmesans-bold-woff2',
+      family: 'Acme Sans',
+      fileName: 'font-acme-sans-700-acmesans-bold-woff2.woff2',
+      fontWeight: 700,
+      mimeType: 'font/woff2',
+      objectUrl: 'blob:acme-sans',
+      source: 'uploaded',
+      storage: 'inline',
+    });
+    expect(Object.keys(result.project.fonts ?? {})).toHaveLength(1);
+    expect(result.project.updatedAt).toBe('2026-07-14T12:00:00.000Z');
+  });
+
+  it('lists available font families from the selected local font folder', async () => {
+    localFontMirrorPreferences.write({ enabled: true, folderLabel: 'Fonts' });
+    const service = new BrowserLocalFontMirrorService({
+      fontDirectoryHandle: createDirectoryHandle([
+        createFontFile('AcmeSans-Bold.woff2'),
+        createFontFile('AcmeSans-Regular.woff2'),
+        createFontFile('Orbitron.woff2'),
+      ]),
+    });
+
+    await expect(service.listAvailableFonts()).resolves.toEqual([
+      { family: 'Acme Sans', source: 'local-font-folder' },
+      { family: 'Orbitron', source: 'local-font-folder' },
+    ]);
+  });
+
+  it('imports a selected local font family even before it is used in the project', async () => {
+    localFontMirrorPreferences.write({ enabled: true, folderLabel: 'Fonts' });
+    const service = new BrowserLocalFontMirrorService({
+      createObjectURL: vi.fn(() => 'blob:orbitron'),
+      fontDirectoryHandle: createDirectoryHandle([createFontFile('Orbitron.woff2')]),
+      now: () => new Date('2026-07-14T12:30:00.000Z'),
+    });
+
+    const result = await service.importFontFamily(createProject(), {
+      family: 'Orbitron',
+      fontStyle: 'normal',
+      fontWeight: 400,
+    });
+
+    expect(result.unresolvedFamilies).toEqual([]);
+    expect(result.addedFonts).toHaveLength(1);
+    expect(result.addedFonts[0]).toMatchObject({
+      family: 'Orbitron',
+      fontWeight: 400,
+      objectUrl: 'blob:orbitron',
+      source: 'uploaded',
+    });
+    expect(result.project.updatedAt).toBe('2026-07-14T12:30:00.000Z');
+  });
+
+  it('skips families that are already embedded in the project', async () => {
+    localFontMirrorPreferences.write({ enabled: true, folderLabel: 'Fonts' });
+    const project = {
+      ...createProject(),
+      fonts: {
+        acme: {
+          id: 'acme',
+          family: 'Acme Sans',
+          requestedFamily: 'Acme Sans',
+          source: 'uploaded' as const,
+          fontStyle: 'normal' as const,
+          fontWeight: 700,
+          mimeType: 'font/woff2' as const,
+          fileName: 'acme.woff2',
+          storage: 'file' as const,
+        },
+      },
+    };
+    const service = new BrowserLocalFontMirrorService({
+      fontDirectoryHandle: createDirectoryHandle([createFontFile('AcmeSans-Bold.woff2')]),
+    });
+
+    const result = await service.importProjectFonts(project);
+
+    expect(result.addedFonts).toEqual([]);
+    expect(result.unresolvedFamilies).toEqual([]);
+    expect(result.project).toBe(project);
+  });
+
+  it('warns and allows sharing when a used font is not found locally', async () => {
+    localFontMirrorPreferences.write({ enabled: true, folderLabel: 'Fonts' });
+    const service = new BrowserLocalFontMirrorService({
+      fontDirectoryHandle: createDirectoryHandle([createFontFile('DifferentFont.woff2')]),
+    });
+
+    const result = await service.importProjectFonts(createProject());
+
+    expect(result.addedFonts).toEqual([]);
+    expect(result.unresolvedFamilies).toEqual(['Acme Sans']);
+    expect(result.warnings).toMatchObject([
+      {
+        code: 'local-font-not-found',
+        severity: 'warning',
+      },
+    ]);
+  });
+
+  it('returns two readable font files for mirror connection checks', async () => {
+    localFontMirrorPreferences.write({ enabled: true, folderLabel: 'Fonts' });
+    const service = new BrowserLocalFontMirrorService({
+      fontDirectoryHandle: createDirectoryHandle([
+        createFontFile('One.woff2'),
+        createFontFile('Two.woff2'),
+        createFontFile('Three.woff2'),
+      ]),
+    });
+
+    await expect(service.getTestFontFiles()).resolves.toHaveLength(2);
+  });
+
+});

--- a/apps/editor/tests/unit/services/shareService.test.ts
+++ b/apps/editor/tests/unit/services/shareService.test.ts
@@ -55,6 +55,25 @@ function createProjectWithInlineAsset(): ProjectDocument {
   return project;
 }
 
+function createProjectWithInlineFont(): ProjectDocument {
+  const project = createProjectWithInlineAsset();
+  project.fonts = {
+    acme: {
+      id: 'acme',
+      family: 'Acme Sans',
+      requestedFamily: 'Acme Sans',
+      source: 'uploaded',
+      fontStyle: 'normal',
+      fontWeight: 700,
+      mimeType: 'font/woff2',
+      fileName: 'acme-sans.woff2',
+      storage: 'inline',
+      objectUrl: 'data:font/woff2;base64,Zm9udA==',
+    },
+  };
+  return project;
+}
+
 describe('BrowserShareService', () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -121,6 +140,36 @@ describe('BrowserShareService', () => {
           },
         },
       },
+    });
+  });
+
+  it('publishes project fonts as public remote font files', async () => {
+    const uploadedBodies = new Map<string, Blob>();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        uploadedBodies.set(getRequestUrl(input), init.body as Blob);
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const mirrorService = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+    mirrorService.saveConfig(config);
+    const service = new BrowserShareService({
+      mirrorService,
+      origin: 'https://localstudio.test',
+    });
+
+    await service.createShare(createProjectWithInlineFont());
+
+    const fontUrl =
+      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/fonts/acme-sans.woff2';
+    const shareUrl =
+      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json';
+    expect(Array.from(uploadedBodies.keys())).toContain(fontUrl);
+    const sharePayload = JSON.parse(await uploadedBodies.get(shareUrl)!.text()) as PublicSharePayloadFixture;
+    expect(sharePayload.project.fonts?.acme).toMatchObject({
+      objectUrl: fontUrl,
+      storage: 'remote',
     });
   });
 

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -369,16 +369,48 @@ describe('DesignPanel', () => {
 
     expect(screen.queryByLabelText('Search downloadable fonts')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('Download additional font'));
+    fireEvent.click(screen.getByLabelText('Selected text font'));
     fireEvent.change(screen.getByLabelText('Search downloadable fonts'), {
       target: { value: 'mont' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Search fonts' }));
     expect(screen.getByLabelText('Downloadable font results')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Download Montserrat' }));
 
     expect(onDownloadFont).toHaveBeenCalledWith('Montserrat');
+  });
+
+  it('adds a selected local font from the configured font folder before applying it', async () => {
+    const onImportLocalFont = vi.fn(() => Promise.resolve());
+    const onUpdateElementStyle = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedText()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test'] }}
+        localFonts={[{ family: 'Acme Sans', source: 'local-font-folder' }]}
+        onImportLocalFont={onImportLocalFont}
+        onUpdateElementStyle={onUpdateElementStyle}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Selected text font'));
+    fireEvent.change(screen.getByLabelText('Search downloadable fonts'), {
+      target: { value: 'Acme' },
+    });
+    const localFontResult = screen.getByRole('button', { name: 'Add Acme Sans from local fonts' });
+    expect(localFontResult.querySelector('.ew-ellipsis')).toHaveStyle({ fontFamily: 'Acme Sans' });
+    fireEvent.click(localFontResult);
+
+    await waitFor(() => {
+      expect(onImportLocalFont).toHaveBeenCalledWith('Acme Sans');
+    });
+    expect(onUpdateElementStyle).not.toHaveBeenCalledWith('text-test', {
+      fontFamily: 'Acme Sans',
+    });
+    expect(screen.queryByRole('button', { name: 'Add Acme Sans from local fonts' })).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Acme Sans added to mirrored fonts');
   });
 
   it('finds Google font alternatives by system font aliases', () => {
@@ -394,7 +426,7 @@ describe('DesignPanel', () => {
       />,
     );
 
-    fireEvent.click(screen.getByLabelText('Download additional font'));
+    fireEvent.click(screen.getByLabelText('Selected text font'));
     fireEvent.change(screen.getByLabelText('Search downloadable fonts'), {
       target: { value: 'aria' },
     });
@@ -447,8 +479,9 @@ describe('DesignPanel', () => {
       />,
     );
 
-    expect(screen.getByLabelText('Selected text font')).toHaveValue('American Typewriter');
-    expect(screen.getByRole('option', { name: 'American Typewriter' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Selected text font')).toHaveTextContent('American Typewriter');
+    fireEvent.click(screen.getByLabelText('Selected text font'));
+    expect(screen.getByRole('button', { name: 'Apply American Typewriter' })).toBeInTheDocument();
   });
 
   it('focuses the selected text font list when requested', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
@@ -13,6 +13,8 @@ import { EditorShell } from '../../../../src/ui/editor/shell/EditorShell';
 import { editorShellTestHarness } from './EditorShell.test-harness';
 
 const {
+  RecordingMirrorService,
+  SavingProjectRepository,
   createAppServices,
   enableSyncedSharing,
   waitForShareButtonReady,
@@ -29,18 +31,48 @@ describe('EditorShell export and share workflows', () => {
     vi.restoreAllMocks();
   });
 
-  it('opens Share before MinIO is synced and disables only public link creation', () => {
-    render(<EditorShell services={createAppServices()} />);
+  it('saves the local project before opening Share when mirror storage is configured', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem('ew-canvas-ai.persistence-enabled', 'false');
+    const services = createAppServices({ skipStoredProjectLoad: true });
+    services.projectRepository = new SavingProjectRepository();
+    services.mirrorService = new RecordingMirrorService();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'Share' }));
+
+    expect(screen.getByRole('dialog', { name: 'Save local project' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Project folder name')).toHaveValue('Untitled AI Deck');
+
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
 
     expect(screen.getByRole('heading', { name: 'Share design' })).toBeInTheDocument();
     expect(
       screen.getByText('Public links cannot be created without remote storage.'),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Copy link' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Configure mirror storage' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Download' })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: 'Present' })).not.toBeDisabled();
+  });
+
+  it('saves the local project before opening mirror settings when storage is not configured', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem('ew-canvas-ai.persistence-enabled', 'false');
+    const services = createAppServices();
+    services.projectRepository = new SavingProjectRepository();
+    services.mirrorService = new RecordingMirrorService(null);
+
+    render(<EditorShell services={services} />);
+
+    await user.click(screen.getByRole('button', { name: 'Share' }));
+
+    expect(screen.getByRole('dialog', { name: 'Save local project' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Share design' })).not.toBeInTheDocument();
   });
 
   it('exports the current slide as a PNG file', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
@@ -190,7 +190,7 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
-    expect(await screen.findByRole('button', { name: 'Mirror disabled' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Save deck before mirroring' })).toBeInTheDocument();
     expect(secondMirrorService.syncProject).not.toHaveBeenCalled();
   });
 

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { MirrorSettingsPanel } from '../../../../src/ui/editor/panels/MirrorSettingsPanel';
 import type { MinioMirrorConfig } from '../../../../src/services/mirror/minioMirrorService';
+import type { LocalFontMirrorProgress } from '../../../../src/services/contracts/interfaces';
 
 const config: MinioMirrorConfig = {
   accessKey: 'localstudio',
@@ -16,6 +17,18 @@ const config: MinioMirrorConfig = {
   prefix: 'mirrors',
 };
 
+const localFontMirrorSettings = {
+  enabled: false,
+  folderLabel: undefined,
+  supported: true,
+  systemHint: '~/Library/Fonts or /Library/Fonts',
+};
+
+type TestConnectionHandler = (
+  config: MinioMirrorConfig,
+  options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
+) => Promise<string | void>;
+
 describe('MirrorSettingsPanel', () => {
   it('closes when clicking outside the panel', async () => {
     const user = userEvent.setup();
@@ -26,9 +39,12 @@ describe('MirrorSettingsPanel', () => {
         <button type="button">Outside target</button>
         <MirrorSettingsPanel
           config={config}
+          localFontMirrorSettings={localFontMirrorSettings}
           mirrorState={{ enabled: true, status: 'idle' }}
+          onChooseLocalFontFolder={vi.fn()}
           onClose={onClose}
           onEnabledChange={vi.fn()}
+          onLocalFontMirrorEnabledChange={vi.fn()}
           onSave={vi.fn()}
           onTestConnection={vi.fn()}
         />
@@ -44,14 +60,17 @@ describe('MirrorSettingsPanel', () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
     const onSave = vi.fn();
-    const onTestConnection = vi.fn(() => Promise.resolve());
+    const onTestConnection = vi.fn<TestConnectionHandler>(() => Promise.resolve());
 
     render(
       <MirrorSettingsPanel
         config={config}
+        localFontMirrorSettings={localFontMirrorSettings}
         mirrorState={{ enabled: true, status: 'idle' }}
+        onChooseLocalFontFolder={vi.fn()}
         onClose={onClose}
         onEnabledChange={vi.fn()}
+        onLocalFontMirrorEnabledChange={vi.fn()}
         onSave={onSave}
         onTestConnection={onTestConnection}
       />,
@@ -71,9 +90,7 @@ describe('MirrorSettingsPanel', () => {
     await user.clear(screen.getByLabelText('Prefix'));
     await user.type(screen.getByLabelText('Prefix'), 'public-projects');
     await user.click(screen.getByRole('button', { name: 'Test connection' }));
-    expect(onTestConnection).toHaveBeenCalledWith(
-      expect.objectContaining({ prefix: 'public-projects' }),
-    );
+    expect(onTestConnection.mock.calls[0]?.[0]).toMatchObject({ prefix: 'public-projects' });
     expect(await screen.findByText('S3-compatible connection is ready.')).toBeInTheDocument();
     expect(
       screen.getByText('Local S3-compatible default login: localstudio / localstudio123'),
@@ -98,10 +115,13 @@ describe('MirrorSettingsPanel', () => {
     render(
       <MirrorSettingsPanel
         config={config}
+        localFontMirrorSettings={localFontMirrorSettings}
         mirrorState={{ enabled: true, status: 'idle' }}
         onBack={onBack}
+        onChooseLocalFontFolder={vi.fn()}
         onClose={vi.fn()}
         onEnabledChange={vi.fn()}
+        onLocalFontMirrorEnabledChange={vi.fn()}
         onSave={vi.fn()}
         onTestConnection={vi.fn()}
       />,
@@ -112,24 +132,77 @@ describe('MirrorSettingsPanel', () => {
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
+  it('opens the font folder picker when local font mirroring is enabled', async () => {
+    const user = userEvent.setup();
+    const onChooseLocalFontFolder = vi.fn(() => Promise.resolve());
+    const onLocalFontMirrorEnabledChange = vi.fn();
+
+    render(
+      <MirrorSettingsPanel
+        config={config}
+        localFontMirrorSettings={localFontMirrorSettings}
+        mirrorState={{ enabled: true, status: 'idle' }}
+        onChooseLocalFontFolder={onChooseLocalFontFolder}
+        onClose={vi.fn()}
+        onEnabledChange={vi.fn()}
+        onLocalFontMirrorEnabledChange={onLocalFontMirrorEnabledChange}
+        onSave={vi.fn()}
+        onTestConnection={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /Off/i }));
+
+    expect(onChooseLocalFontFolder).toHaveBeenCalledTimes(1);
+    expect(onLocalFontMirrorEnabledChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('disables local font mirroring without opening the folder picker', async () => {
+    const user = userEvent.setup();
+    const onChooseLocalFontFolder = vi.fn(() => Promise.resolve());
+    const onLocalFontMirrorEnabledChange = vi.fn();
+
+    render(
+      <MirrorSettingsPanel
+        config={config}
+        localFontMirrorSettings={{ ...localFontMirrorSettings, enabled: true }}
+        mirrorState={{ enabled: true, status: 'idle' }}
+        onChooseLocalFontFolder={onChooseLocalFontFolder}
+        onClose={vi.fn()}
+        onEnabledChange={vi.fn()}
+        onLocalFontMirrorEnabledChange={onLocalFontMirrorEnabledChange}
+        onSave={vi.fn()}
+        onTestConnection={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /Enabled/i }));
+
+    expect(onChooseLocalFontFolder).not.toHaveBeenCalled();
+    expect(onLocalFontMirrorEnabledChange).toHaveBeenCalledWith(false);
+  });
+
   it('lets users disable mirroring from settings and keeps saving settings disabled while off', async () => {
     const user = userEvent.setup();
     const onEnabledChange = vi.fn();
     const onSave = vi.fn();
-    const onTestConnection = vi.fn(() => Promise.resolve());
+    const onTestConnection = vi.fn<TestConnectionHandler>(() => Promise.resolve());
 
     function StatefulMirrorSettingsPanel() {
       const [enabled, setEnabled] = useState(true);
       return (
         <MirrorSettingsPanel
           config={config}
+          localFontMirrorSettings={localFontMirrorSettings}
           mirrorDisabledBySettings={!enabled}
           mirrorState={{ enabled, status: enabled ? 'idle' : 'disabled' }}
+          onChooseLocalFontFolder={vi.fn()}
           onClose={vi.fn()}
           onEnabledChange={(nextEnabled) => {
             setEnabled(nextEnabled);
             onEnabledChange(nextEnabled);
           }}
+          onLocalFontMirrorEnabledChange={vi.fn()}
           onSave={onSave}
           onTestConnection={onTestConnection}
         />
@@ -154,7 +227,7 @@ describe('MirrorSettingsPanel', () => {
     await user.click(screen.getByRole('button', { name: 'Enable mirroring' }));
 
     expect(onEnabledChange).toHaveBeenLastCalledWith(true);
-    expect(onTestConnection).toHaveBeenCalledWith(config);
+    expect(onTestConnection.mock.calls.at(-1)?.[0]).toEqual(config);
     expect(await screen.findByText('S3-compatible connection is ready.')).toBeInTheDocument();
   });
 });

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.storage-share.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.storage-share.test.tsx
@@ -69,7 +69,10 @@ describe('TopToolbar storage and sharing actions', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Mirror disabled' })).toBeDisabled();
+    const unsavedMirrorButton = screen.getByRole('button', { name: 'Save deck before mirroring' });
+    expect(unsavedMirrorButton).not.toBeDisabled();
+    await user.click(unsavedMirrorButton);
+    expect(onMirrorNow).toHaveBeenCalledTimes(1);
 
     rerender(
       <TopToolbar
@@ -84,7 +87,7 @@ describe('TopToolbar storage and sharing actions', () => {
     const disabledMirrorButton = screen.getByRole('button', { name: 'Mirror disabled' });
     expect(disabledMirrorButton).not.toBeDisabled();
     await user.click(disabledMirrorButton);
-    expect(onMirrorNow).toHaveBeenCalledTimes(1);
+    expect(onMirrorNow).toHaveBeenCalledTimes(2);
 
     rerender(
       <TopToolbar
@@ -112,7 +115,7 @@ describe('TopToolbar storage and sharing actions', () => {
     expect(mirrorButton).toHaveClass('mirror-synced');
     await user.click(mirrorButton);
     expect(onMirrorToggle).toHaveBeenCalledWith(false);
-    expect(onMirrorNow).toHaveBeenCalledTimes(1);
+    expect(onMirrorNow).toHaveBeenCalledTimes(2);
   });
 
   it('opens mirror settings from the status icon when mirroring was disabled in settings', async () => {

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.test.tsx
@@ -277,7 +277,7 @@ describe('TopToolbar', () => {
       .map((button) => button.getAttribute('aria-label'));
     expect(editingActionLabels).toEqual([
       'Persistence disabled',
-      'Mirror disabled',
+      'Save deck before mirroring',
       'Version history',
       'Undo',
       'Redo',

--- a/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
@@ -50,6 +50,7 @@ describe('SharePanel', () => {
     const onCopyLink = vi.fn();
     const onDownload = vi.fn();
     const onPresent = vi.fn();
+    const onConfigurePublicLink = vi.fn();
     const message = 'Public links cannot be created without remote storage.';
 
     render(
@@ -57,6 +58,7 @@ describe('SharePanel', () => {
         projectName="Untitled AI Deck"
         publicLinkUnavailableReason={message}
         onClose={vi.fn()}
+        onConfigurePublicLink={onConfigurePublicLink}
         onCopyLink={onCopyLink}
         onDownload={onDownload}
         onPresent={onPresent}
@@ -64,15 +66,17 @@ describe('SharePanel', () => {
     );
 
     expect(screen.getByText(message)).toBeInTheDocument();
-    const copyButton = screen.getByRole('button', { name: 'Copy link' });
-    expect(copyButton).toBeDisabled();
-    expect(copyButton).toHaveAttribute('title', message);
-    expect(copyButton).toHaveAttribute('data-loading', 'false');
+    const configureButton = screen.getByRole('button', { name: 'Configure mirror storage' });
+    expect(configureButton).toBeEnabled();
+    expect(configureButton).toHaveAttribute('title', message);
+    expect(configureButton).toHaveAttribute('data-loading', 'false');
 
+    await user.click(configureButton);
     await user.click(screen.getByRole('button', { name: 'Download' }));
     await user.click(screen.getByRole('button', { name: 'Present' }));
 
     expect(onCopyLink).not.toHaveBeenCalled();
+    expect(onConfigurePublicLink).toHaveBeenCalledTimes(1);
     expect(onDownload).toHaveBeenCalledTimes(1);
     expect(onPresent).toHaveBeenCalledTimes(1);
   });

--- a/tests/e2e/editor/accessibility-smoke.spec.ts
+++ b/tests/e2e/editor/accessibility-smoke.spec.ts
@@ -1,10 +1,12 @@
 import { EditorAppPage } from '../pages/editor-app.page';
+import { installFakeOpfs } from '../support/fake-opfs';
 import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 
 const getServer = withIsolatedDevServer(test);
 
 test.describe('editor accessibility smoke journey', () => {
   test('opens dialogs and panels with named controls that can receive keyboard focus', async ({ page }) => {
+    await installFakeOpfs(page, { directoryPicker: true });
     const editor = new EditorAppPage(page, getServer().baseURL);
     await editor.gotoNewProject();
 
@@ -17,10 +19,14 @@ test.describe('editor accessibility smoke journey', () => {
     await expect(page.getByRole('dialog', { name: 'Keyboard shortcuts' })).toBeHidden();
 
     await page.getByRole('button', { name: 'Share' }).click();
-    await expect(page.getByRole('complementary', { name: 'Share design panel' })).toBeVisible();
-    await page.getByRole('button', { name: 'Close share panel' }).focus();
-    await expect(page.getByRole('button', { name: 'Close share panel' })).toBeFocused();
+    const localSave = page.getByRole('dialog', { name: 'Save local project' });
+    await expect(localSave).toBeVisible();
+    await localSave.getByRole('button', { name: 'Choose folder' }).click();
+    const mirrorSettings = page.getByRole('dialog', { name: 'Mirror settings' });
+    await expect(mirrorSettings).toBeVisible();
+    await page.getByRole('button', { name: 'Close mirror settings' }).focus();
+    await expect(page.getByRole('button', { name: 'Close mirror settings' })).toBeFocused();
     await page.keyboard.press('Enter');
-    await expect(page.getByRole('complementary', { name: 'Share design panel' })).toBeHidden();
+    await expect(mirrorSettings).toBeHidden();
   });
 });

--- a/tests/e2e/editor/font-download.spec.ts
+++ b/tests/e2e/editor/font-download.spec.ts
@@ -17,7 +17,7 @@ test.describe('editor font download journeys', () => {
     await editor.gotoNewProject();
     await addTextBoxAndOpenTextDesignControls(editor, page);
     await page.getByRole('button', { name: 'Bold selected text' }).click();
-    await page.getByRole('button', { name: 'Download additional font' }).click();
+    await page.getByLabel('Selected text font', { exact: true }).click();
     await page.getByLabel('Search downloadable fonts').fill('Montserrat');
     await page.getByRole('button', { name: 'Download Montserrat' }).click();
 
@@ -36,12 +36,12 @@ test.describe('editor font download journeys', () => {
     await editor.gotoNewProject();
     await addTextBoxAndOpenTextDesignControls(editor, page);
     await page.getByRole('button', { name: 'Bold selected text' }).click();
-    await page.getByRole('button', { name: 'Download additional font' }).click();
+    await page.getByLabel('Selected text font', { exact: true }).click();
     await page.getByLabel('Search downloadable fonts').fill('Montserrat');
     await page.getByRole('button', { name: 'Download Montserrat' }).click();
 
     await expect(page.getByRole('status')).toContainText('Montserrat downloaded and applied');
-    await expect(page.getByLabel('Selected text font', { exact: true })).toHaveValue('Montserrat');
+    await expect(page.getByLabel('Selected text font', { exact: true })).toContainText('Montserrat');
   });
 });
 

--- a/tests/e2e/editor/image-export-journey-page.ts
+++ b/tests/e2e/editor/image-export-journey-page.ts
@@ -1,10 +1,18 @@
 import { type Download, type Page } from '@playwright/test';
 
 import { EditorAppPage } from '../pages/editor-app.page';
+import { installFakeOpfs } from '../support/fake-opfs';
 import { expect } from '../support/journey-test';
+import { remoteMirrorImportConfig } from './remote-mirror-import-config';
 
 export const imageExportJourneyPage = {
   async downloadActivePagePng(page: Page, baseURL: string): Promise<Download> {
+    await installFakeOpfs(page, { directoryPicker: true });
+    await page.addInitScript((config) => {
+      window.localStorage.setItem('localstudio.minioMirror.config', JSON.stringify(config));
+      window.localStorage.setItem('ew-canvas-ai.mirror-enabled', 'false');
+    }, remoteMirrorImportConfig);
+
     const editor = new EditorAppPage(page, baseURL);
     await editor.gotoNewProject();
     await editor.renameProject('E2E Image Export');
@@ -14,6 +22,11 @@ export const imageExportJourneyPage = {
 
     const downloadPromise = page.waitForEvent('download');
     await page.getByRole('button', { name: 'Share' }).click();
+    const localSave = page.getByRole('dialog', { name: 'Save local project' });
+    if (await localSave.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await localSave.getByRole('button', { name: 'Choose folder' }).click();
+    }
+    await expect(page.getByRole('complementary', { name: 'Share design panel' })).toBeVisible();
     await page.getByRole('button', { name: 'Download' }).click();
     return downloadPromise;
   },

--- a/tests/e2e/editor/local-font-mirror-settings.spec.ts
+++ b/tests/e2e/editor/local-font-mirror-settings.spec.ts
@@ -1,14 +1,18 @@
 import { EditorAppPage } from '../pages/editor-app.page';
 import { installFakeOpfs } from '../support/fake-opfs';
 import { expect, test, withIsolatedDevServer } from '../support/journey-test';
+import { remoteMirrorShareRoutes } from './remote-mirror-share-routes';
 
 const getServer = withIsolatedDevServer(test);
 
 test.describe('local font mirror settings', () => {
   test('routes public share setup into mirror settings with local font mirroring guidance', async ({
+    context,
     page,
   }) => {
+    await context.grantPermissions(['clipboard-write'], { origin: getServer().baseURL });
     await installFakeOpfs(page, { directoryPicker: true });
+    const storedObjects = await remoteMirrorShareRoutes.install(context);
 
     const editor = new EditorAppPage(page, getServer().baseURL);
     await editor.gotoNewProject();
@@ -52,5 +56,41 @@ test.describe('local font mirror settings', () => {
     await localFontResult.click();
     await expect(page.getByRole('status')).toContainText('Acme Sans added to mirrored fonts');
     await expect(fontSelect).toContainText('Acme Sans');
+
+    await page
+      .getByRole('contentinfo', { name: 'Editor footer controls' })
+      .getByRole('button', { name: 'Mirror settings' })
+      .click();
+    await page.getByRole('dialog', { name: 'Settings' }).getByRole('button', { name: 'Mirror settings' }).click();
+    await expect(page.getByRole('dialog', { name: 'Mirror settings' })).toBeVisible();
+    await page.getByRole('button', { name: 'Enable mirroring' }).click();
+    await expect(page.getByText('S3-compatible connection is ready.')).toBeVisible();
+    await page.getByRole('button', { name: 'Save settings' }).click();
+    await expect(page.getByRole('dialog', { name: 'Mirror settings' })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Share' }).click();
+    await page.getByRole('button', { name: 'Copy link' }).click();
+    await expect(page.getByText('Copied')).toBeVisible({ timeout: 15_000 });
+
+    const storedKeys = Array.from(storedObjects.keys());
+    const mirroredFontKey = storedKeys.find(
+      (key) => key.includes('/public-shares/') && key.includes('/fonts/font-acme-sans-'),
+    );
+    expect(mirroredFontKey).toMatch(/public-shares\/.+\/fonts\/font-acme-sans-\d+-acmesans-regular-woff2\.woff2$/);
+    expect(storedKeys.some((key) => key.includes('/fonts/uploaded-font-'))).toBe(false);
+
+    const shareKey = storedKeys.find((key) => key.endsWith('/share.json'));
+    expect(shareKey).toBeTruthy();
+    const sharePayload = JSON.parse(storedObjects.get(shareKey!)!.body.toString()) as {
+      project: { fonts?: Record<string, { fileName: string; objectUrl: string; storage: string }> };
+    };
+    const mirroredFont = Object.values(sharePayload.project.fonts ?? {}).find((font) =>
+      font.fileName.startsWith('font-acme-sans-'),
+    );
+    expect(mirroredFont).toMatchObject({
+      storage: 'remote',
+    });
+    expect(mirroredFont?.objectUrl).toContain('/fonts/font-acme-sans-');
+    expect(mirroredFont?.objectUrl).not.toContain('/fonts/uploaded-font-');
   });
 });

--- a/tests/e2e/editor/local-font-mirror-settings.spec.ts
+++ b/tests/e2e/editor/local-font-mirror-settings.spec.ts
@@ -1,0 +1,56 @@
+import { EditorAppPage } from '../pages/editor-app.page';
+import { installFakeOpfs } from '../support/fake-opfs';
+import { expect, test, withIsolatedDevServer } from '../support/journey-test';
+
+const getServer = withIsolatedDevServer(test);
+
+test.describe('local font mirror settings', () => {
+  test('routes public share setup into mirror settings with local font mirroring guidance', async ({
+    page,
+  }) => {
+    await installFakeOpfs(page, { directoryPicker: true });
+
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await editor.gotoNewProject();
+    await page.evaluate(() => {
+      window.localStorage.setItem(
+        'localstudio.e2e.opfs.file:localstudio-e2e-root/AcmeSans-Regular.woff2',
+        'fake-font-file',
+      );
+    });
+
+    await page.getByRole('button', { name: 'Share' }).click();
+    const localSave = page.getByRole('dialog', { name: 'Save local project' });
+    await expect(localSave).toBeVisible();
+    await localSave.getByRole('button', { name: 'Choose folder' }).click();
+
+    const mirrorSettings = page.getByRole('dialog', { name: 'Mirror settings' });
+    await expect(mirrorSettings).toBeVisible();
+    await expect(mirrorSettings.getByRole('heading', { name: 'Mirror my local fonts' })).toBeVisible();
+    await expect(mirrorSettings).toContainText('Public viewers need those font files mirrored to storage');
+    await expect(mirrorSettings).toContainText(/Usual font folder for this system:/);
+    const localFontMirroring = mirrorSettings.getByRole('region', { name: 'Local font mirroring' });
+    await expect(localFontMirroring.getByRole('checkbox')).toBeVisible();
+    await expect(localFontMirroring.getByRole('button', { name: 'Choose font folder' })).toBeVisible();
+    await expect(localFontMirroring.getByRole('button', { name: 'Choose font files' })).toHaveCount(0);
+
+    await localFontMirroring.getByRole('checkbox').focus();
+    await page.keyboard.press('Space');
+    await expect(localFontMirroring.getByRole('button', { name: /Folder: localstudio-e2e-root/ })).toBeVisible();
+    await page.mouse.click(760, 120);
+    await expect(mirrorSettings).toBeHidden();
+
+    await editor.openTool('Text');
+    await page.getByRole('button', { name: 'Add a text box' }).click();
+    await editor.openTool('Design');
+    const fontSelect = page.getByLabel('Selected text font', { exact: true });
+    await page.getByLabel('Selected text font', { exact: true }).click();
+    await page.getByLabel('Search downloadable fonts').fill('Acme');
+    const localFontResult = page.getByRole('button', { name: 'Add Acme Sans from local fonts' });
+    await expect(localFontResult).toBeVisible();
+    await expect(localFontResult.locator('.ew-ellipsis')).toHaveCSS('font-family', /Acme Sans/);
+    await localFontResult.click();
+    await expect(page.getByRole('status')).toContainText('Acme Sans added to mirrored fonts');
+    await expect(fontSelect).toContainText('Acme Sans');
+  });
+});

--- a/tests/e2e/editor/remote-mirror-share-routes.ts
+++ b/tests/e2e/editor/remote-mirror-share-routes.ts
@@ -1,8 +1,10 @@
 import { type BrowserContext } from '@playwright/test';
 
+export type RemoteMirrorStoredObject = { body: Buffer; contentType: string };
+
 export const remoteMirrorShareRoutes = {
-  async install(context: BrowserContext): Promise<void> {
-    const storedObjects = new Map<string, { body: Buffer; contentType: string }>();
+  async install(context: BrowserContext): Promise<Map<string, RemoteMirrorStoredObject>> {
+    const storedObjects = new Map<string, RemoteMirrorStoredObject>();
     await context.route('http://localhost:9000/**', async (route) => {
       const request = route.request();
       const url = new URL(request.url());
@@ -34,5 +36,6 @@ export const remoteMirrorShareRoutes = {
       }
       await route.fulfill({ status: 200, body: '' });
     });
+    return storedObjects;
   },
 };

--- a/tests/e2e/editor/share-and-storage.spec.ts
+++ b/tests/e2e/editor/share-and-storage.spec.ts
@@ -1,24 +1,29 @@
 import { EditorAppPage } from '../pages/editor-app.page';
+import { installFakeOpfs } from '../support/fake-opfs';
 import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 
 const getServer = withIsolatedDevServer(test);
 
 test.describe('editor share and storage journey', () => {
   test('opens share and storage surfaces without connecting to remote storage', async ({ page }) => {
+    await installFakeOpfs(page, { directoryPicker: true });
     const editor = new EditorAppPage(page, getServer().baseURL);
     await editor.gotoNewProject();
 
     await page.getByRole('button', { name: 'Share' }).click();
-    await expect(page.getByRole('complementary', { name: 'Share design panel' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Copy link' })).toBeDisabled();
-    await expect(page.getByText('Public links cannot be created without remote storage.')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Download' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Present', exact: true })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Public view link', exact: true })).toBeDisabled();
-    await expect(page.getByRole('button', { name: 'Embed code', exact: true })).toBeDisabled();
-    await page.getByRole('button', { name: 'Close share panel' }).click();
+    const localSave = page.getByRole('dialog', { name: 'Save local project' });
+    await expect(localSave).toBeVisible();
+    await localSave.getByRole('button', { name: 'Choose folder' }).click();
 
-    await expect(page.getByRole('button', { name: 'Version history' })).toBeDisabled();
+    const mirrorSettings = page.getByRole('dialog', { name: 'Mirror settings' });
+    await expect(mirrorSettings).toBeVisible();
+    await expect(mirrorSettings.getByRole('heading', { name: 'Mirror project storage' })).toBeVisible();
+    await expect(mirrorSettings.getByRole('heading', { name: 'Mirror my local fonts' })).toBeVisible();
+    await mirrorSettings.getByRole('button', { name: 'Close mirror settings' }).focus();
+    await page.keyboard.press('Enter');
+    await expect(mirrorSettings).toBeHidden();
+
+    await expect(page.getByRole('button', { name: 'Version history' })).toBeEnabled();
     await page.getByRole('button', { name: 'Mirror settings' }).click();
     await expect(page.getByRole('dialog', { name: /settings|Mirror settings/i })).toBeVisible();
   });

--- a/tests/e2e/support/fake-opfs-directory-handle-runtime.ts
+++ b/tests/e2e/support/fake-opfs-directory-handle-runtime.ts
@@ -79,7 +79,12 @@ function createFakeOpfsDirectoryHandleClass(
         const [entryName, ...rest] = relativePath.split('/');
         if (!entryName || seen.has(entryName)) continue;
         seen.add(entryName);
-        yield [entryName, { kind: rest.length > 0 ? 'directory' : 'file' }];
+        yield [
+          entryName,
+          rest.length > 0
+            ? new FakeDirectoryHandle(entryName, pathRuntime.normalizePath(`${prefix}/${entryName}`))
+            : new FakeFileHandle(entryName, pathRuntime.normalizePath(`${prefix}/${entryName}`)),
+        ];
       }
     }
   };


### PR DESCRIPTION
## Summary
- Add local font folder mirroring workflow to the editor, including persistence, preferences, and service contracts.
- Wire the new font controls into the editor shell, left panel, toolbar, and text style inspector.
- Update share handling so mirrored font routes remain compatible with export and shared-view flows.
- Extend unit and e2e coverage for font download, mirror settings, and share route behavior.

## Testing
- Added and updated unit tests for composition, font mirroring, sharing, and editor UI panels.
- Added e2e coverage for local font mirror settings and font download flows.
- Local validation completed for the affected editor and share scenarios.