### PR TITLE
Clear presenter animation preview when closing presenter view

### DIFF
--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -322,9 +322,10 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     return presenterSessionServiceRef.current;
   }
 
-  function closePresenterViewSession() {
+  const closePresenterViewSession = useCallback(() => {
     presenterSessionServiceRef.current?.closePresenterWindow();
     presenterFullscreenEnteredRef.current = false;
+    vm.clearAnimationPreview();
     setAudienceFullscreenPromptOpen(false);
     setPresenterRemoteSession(undefined);
     setPresenterRemotePanelOpen(false);
@@ -332,7 +333,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     setPresenterRemoteStreamPeerId(undefined);
     setRemotePresenterActive(false);
     setPresenterSessionId(undefined);
-  }
+  }, [vm]);
 
   const openPresenterView = useCallback(() => {
     if (presenterSessionId) return;
@@ -940,6 +941,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     presenterRemoteStreamPeerId,
     presenterSessionId,
     remotePresenterActive,
+    closePresenterViewSession,
     vm,
   ]);
 
@@ -957,7 +959,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       if (presenterRemoteSession) return;
       queueMicrotask(closePresenterViewSession);
     }
-  }, [presenterRemoteSession, presenterSessionId, vm.isFullscreen]);
+  }, [closePresenterViewSession, presenterRemoteSession, presenterSessionId, vm.isFullscreen]);
 
   useEffect(() => {
     if (!presenterRemoteSession) return;

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -3266,6 +3266,7 @@ export function useEditorViewModel(services: AppServices) {
     playPresentationPreview,
     advanceAnimationPreview,
     advancePresentationPreview,
+    clearAnimationPreview,
     rewindPresentationPreview,
     updateTextContent,
     setElementVisibility,

--- a/apps/editor/tests/unit/ui/editor/EditorShell.presenter-fullscreen.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.presenter-fullscreen.test.tsx
@@ -96,6 +96,82 @@ describe('EditorShell presenter fullscreen workflows', () => {
     expect(popupClose).not.toHaveBeenCalled();
   });
 
+  it('stops presenter click navigation when the presenter window closes before audience fullscreen', async () => {
+    const project = sampleProject.createSampleProject();
+    project.pages = [
+      {
+        ...project.pages[0]!,
+        transition: { effect: 'reveal', delayMs: 0 },
+        animationBuilds: [],
+      },
+      {
+        id: 'page-2',
+        name: 'Slide 2',
+        width: 1920,
+        height: 1080,
+        background: { type: 'color', color: '#050D10' },
+        elementIds: [],
+        animationBuilds: [],
+      },
+    ];
+    const popupClose = vi.fn();
+    const popup = {
+      close: popupClose,
+      closed: false,
+      location: { href: '' },
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      value: vi.fn(() => popup),
+    });
+    const { container } = render(
+      <EditorShell services={createAppServices({ initialProject: project })} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Presentation play options' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Presenter view' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'presenter',
+      );
+    });
+
+    const presenterSessionId = new URL(popup.location.href).searchParams.get('presenterSession');
+    expect(presenterSessionId).toBeTruthy();
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          command: 'close',
+          sessionId: presenterSessionId,
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+        origin: window.location.origin,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(popupClose).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview',
+        'idle',
+      );
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'idle',
+      );
+      expect(screen.queryByRole('dialog', { name: 'Audience Window' })).not.toBeInTheDocument();
+    });
+
+    fireEvent.mouseDown(container.querySelector('canvas')!);
+
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+  });
+
   it('hides page insert controls in fullscreen presenter mode and restores a clean editor state on exit', async () => {
     const user = userEvent.setup();
     let fullscreenElement: Element | null = null;


### PR DESCRIPTION
## Summary
- Clear the animation preview state when the presenter window is closed so click-through navigation does not keep advancing slides.
- Keep the close handler stable with `useCallback` and include it in the fullscreen message effect dependencies.
- Add coverage for the close-before-audience-fullscreen path to verify the editor returns to idle state and stops advancing on canvas clicks.

## Testing
- Added a unit test covering presenter window close handling before audience fullscreen.
- Verified the editor resets to slide 1, clears animation preview state, and no longer responds to presenter click navigation in that scenario.