### PR TITLE
Adjust text frame height when changing font family

### DIFF
--- a/apps/editor/src/ui/editor/state/editorViewModelText.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelText.ts
@@ -31,6 +31,16 @@ function ensureTextElementMinimumHeight(project: ProjectDocument, elementId: str
   }).execute(project);
 }
 
+function fitTextElementHeightToContent(project: ProjectDocument, elementId: string) {
+  const element = project.elements[elementId];
+  if (!element || element.type !== 'text') return project;
+  const contentHeight = textTranslationLayout.getMinimumTextFrameHeight(element);
+  if (element.height === contentHeight) return project;
+  return new basicCommands.UpdateElementFrameCommand(elementId, {
+    height: contentHeight,
+  }).execute(project);
+}
+
 function updateTextContent(project: ProjectDocument, elementId: string, text: string) {
   return ensureTextElementMinimumHeight(
     new basicCommands.UpdateTextContentCommand(elementId, text).execute(project),
@@ -43,10 +53,10 @@ function updateElementStyle(
   elementId: string,
   patch: ElementStylePatch,
 ) {
-  return ensureTextElementMinimumHeight(
-    new basicCommands.UpdateElementStyleCommand(elementId, patch).execute(project),
-    elementId,
-  );
+  const nextProject = new basicCommands.UpdateElementStyleCommand(elementId, patch).execute(project);
+  if (patch.fontFamily !== undefined) return fitTextElementHeightToContent(nextProject, elementId);
+  if (patch.fontSize === undefined) return nextProject;
+  return ensureTextElementMinimumHeight(nextProject, elementId);
 }
 
 function applyFontFamilyWithFonts(input: {

--- a/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
+++ b/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
@@ -95,6 +95,21 @@ describe('editor view model text helpers', () => {
     expect(nextProject.elements['text-title']?.height).toBeGreaterThan(120);
   });
 
+  it('fits the text frame height when only the font family changes', () => {
+    const project = sampleProject.createSampleProject();
+    const originalHeight = project.elements['text-title']!.height;
+
+    const nextProject = editorViewModelText.updateElementStyle(project, 'text-title', {
+      fontFamily: 'Inter',
+    });
+
+    expect(nextProject.elements['text-title']).toMatchObject({
+      fontFamily: 'Inter',
+    });
+    expect(nextProject.elements['text-title']?.height).toBeLessThan(originalHeight);
+    expect(nextProject.elements['text-title']?.height).toBeGreaterThan(96);
+  });
+
   it('merges downloaded fonts before applying the selected family', () => {
     const project = sampleProject.createSampleProject();
     const font: ProjectFont = {

--- a/tests/e2e/editor/text-theme-and-layout.spec.ts
+++ b/tests/e2e/editor/text-theme-and-layout.spec.ts
@@ -33,10 +33,14 @@ test.describe('editor text theme and layout journey', () => {
     await editor.openTool('Design');
     await expect(page.getByLabel('Selected text font size')).toHaveValue('48');
     await expect(page.getByLabel('Selected text color')).toHaveValue('#00779a');
+    await page.getByLabel('Selected text font', { exact: true }).click();
+    await page.getByRole('button', { name: 'Apply Orbitron' }).click();
     await page
       .getByRole('tablist', { name: 'Movie inspector sections' })
       .getByRole('tab', { name: 'Arrange' })
       .click();
+    await expect.poll(async () => Number(await page.getByLabel('Selected element height').inputValue()))
+      .toBeLessThan(120);
     await expect(page.getByRole('button', { name: 'Group', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ungroup' })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Distribute' })).toBeDisabled();


### PR DESCRIPTION
## Summary
- Update text style handling so a font family change resizes the text frame to fit its new content height.
- Keep the existing minimum-height behavior for font size changes and other text style updates.
- Add unit coverage for the font-family-only path.
- Extend the e2e flow to verify the text frame height shrinks after applying a different font.

## Testing
- Unit tests added for `updateElementStyle` font-family resizing behavior.
- E2E coverage added for the editor text theme and layout journey.
- Not run (not requested).