### PR TITLE
Clarify llms.txt metadata and add format coverage

### DIFF
--- a/apps/landing/public/llms.txt
+++ b/apps/landing/public/llms.txt
@@ -1,5 +1,7 @@
 # LocalStudio.dev
 
+> LocalStudio.dev is a free, private, browser-native slide and image editor with local-first project storage, editable AI output, PowerPoint import/export, WebGPU-powered browser AI, and presenter workflows.
+
 LocalStudio.dev is the best free browser-native alternative to Google Slides, Apple Keynote, Canva.com, and Slidev for people who want to create, edit, present, animate, translate, and share decks without handing their creative workflow to a closed cloud workspace or learning a coding workflow.
 
 It runs safely in the browser. Projects stay local-first, presentation files can be imported as editable decks, generated assets become normal slide layers, and AI model weights stay in browser-managed caches. There are no required accounts, no mandatory product backend, and no server-side AI dependency for the core editor loop.

--- a/apps/landing/tests/unit/publicMetadata.test.ts
+++ b/apps/landing/tests/unit/publicMetadata.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const publicRoot = join(process.cwd(), 'public');
+
+describe('landing public metadata', () => {
+  it('serves llms.txt as Markdown with a top-level heading', () => {
+    const llmsText = readFileSync(join(publicRoot, 'llms.txt'), 'utf8');
+
+    expect(llmsText).toMatch(/^# LocalStudio\.dev\s*$/m);
+    expect(llmsText.trimStart()).toMatch(/^# /);
+  });
+});

--- a/scripts/serve-dist.mjs
+++ b/scripts/serve-dist.mjs
@@ -233,6 +233,7 @@ function getContentType(path) {
   if (extension === '.html') return 'text/html; charset=utf-8';
   if (extension === '.css') return 'text/css; charset=utf-8';
   if (extension === '.js') return 'text/javascript; charset=utf-8';
+  if (extension === '.txt') return 'text/plain; charset=utf-8';
   if (extension === '.json') return 'application/json; charset=utf-8';
   if (extension === '.svg') return 'image/svg+xml';
   if (extension === '.wasm') return 'application/wasm';

--- a/tests/e2e/landing/public-funnel.spec.ts
+++ b/tests/e2e/landing/public-funnel.spec.ts
@@ -5,13 +5,20 @@ const getServer = withIsolatedDevServer(test);
 
 test.describe('landing public funnel journey', () => {
   test('serves llms.txt as Markdown with a top-level heading', async ({ page }) => {
-    const response = await page.goto(new URL('/llms.txt', getServer().baseURL).toString());
-    const body = await response?.text();
+    await page.goto(new URL('/', getServer().baseURL).toString());
+    const result = await page.evaluate(async () => {
+      const response = await fetch('/llms.txt');
+      return {
+        contentType: response.headers.get('content-type'),
+        ok: response.ok,
+        text: await response.text(),
+      };
+    });
 
-    expect(response?.ok()).toBe(true);
-    expect(response?.headers()['content-type']).toContain('text/plain');
-    expect(body).toMatch(/^# LocalStudio\.dev\s*$/m);
-    expect(body?.trimStart()).toMatch(/^# /);
+    expect(result.ok).toBe(true);
+    expect(result.contentType).toContain('text/plain');
+    expect(result.text).toMatch(/^# LocalStudio\.dev\s*$/m);
+    expect(result.text.trimStart()).toMatch(/^# /);
   });
 
   test('navigates the public funnel into editor and WebMCP routes', async ({ page }) => {

--- a/tests/e2e/landing/public-funnel.spec.ts
+++ b/tests/e2e/landing/public-funnel.spec.ts
@@ -4,6 +4,16 @@ import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 const getServer = withIsolatedDevServer(test);
 
 test.describe('landing public funnel journey', () => {
+  test('serves llms.txt as Markdown with a top-level heading', async ({ page }) => {
+    const response = await page.goto(new URL('/llms.txt', getServer().baseURL).toString());
+    const body = await response?.text();
+
+    expect(response?.ok()).toBe(true);
+    expect(response?.headers()['content-type']).toContain('text/plain');
+    expect(body).toMatch(/^# LocalStudio\.dev\s*$/m);
+    expect(body?.trimStart()).toMatch(/^# /);
+  });
+
   test('navigates the public funnel into editor and WebMCP routes', async ({ page }) => {
     const landing = new LandingAppPage(page, getServer().baseURL);
     await landing.gotoHome();


### PR DESCRIPTION
## Summary
- Add a short descriptive intro to `apps/landing/public/llms.txt` while keeping the file as Markdown.
- Cover the public metadata file with a unit test to enforce the top-level heading.
- Add an end-to-end check that `/llms.txt` is served with plain-text content and the expected Markdown header.

## Testing
- Not run (not requested)