### PR TITLE
Show AI feature download progress in the editor panel

### DIFF
--- a/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
@@ -95,15 +95,6 @@ function getModelProgressStatus(
   return 'idle';
 }
 
-function getModelSetupTaskStatus(
-  modelStates: ModelState[],
-  modelId: string,
-): 'idle' | 'downloading' | 'ready' | 'failed' {
-  return getModelProgressStatus(
-    modelStates.find((model) => model.id === modelId)?.status ?? 'needs-download',
-  );
-}
-
 export function AiToolsPanel({
   activeSlideLanguage,
   modelStates,
@@ -189,36 +180,14 @@ export function AiToolsPanel({
       model.id !== aiModelCatalog.TRANSLATEGEMMA_MODEL_ID &&
       model.id !== aiModelCatalog.LANGUAGE_DETECTION_MODEL_ID,
   );
-  const hiddenModelSetupTasks = [
-    {
-      id: aiModelCatalog.GEMMA_LLM_MODEL_ID,
-      label: aiModelCatalog.GEMMA_LLM_DISPLAY_NAME,
-      onPrepare: onDownloadModel
-        ? () => onDownloadModel(aiModelCatalog.GEMMA_LLM_MODEL_ID)
-        : undefined,
-      status: getModelSetupTaskStatus(modelStates, aiModelCatalog.GEMMA_LLM_MODEL_ID),
-    },
-    {
-      id: aiModelCatalog.TRANSLATEGEMMA_MODEL_ID,
-      label: aiModelCatalog.TRANSLATEGEMMA_DISPLAY_NAME,
-      onPrepare: onDownloadModel
-        ? () => onDownloadModel(aiModelCatalog.TRANSLATEGEMMA_MODEL_ID)
-        : undefined,
-      status: getModelSetupTaskStatus(modelStates, aiModelCatalog.TRANSLATEGEMMA_MODEL_ID),
-    },
-  ];
   const setupTasks = [
-    ...(selectedPromptProvider?.modelId === aiModelCatalog.GEMMA_LLM_MODEL_ID
-      ? []
-      : [
-          {
-            disabled: selectedPromptProvider?.compatibility === 'incompatible',
-            id: selectedPromptProvider?.id ?? 'prompt-provider',
-            label: selectedPromptProvider?.label ?? 'LLM model',
-            onPrepare: onPreparePromptApi,
-            status: promptStatus,
-          },
-        ]),
+    {
+      disabled: selectedPromptProvider?.compatibility === 'incompatible',
+      id: selectedPromptProvider?.id ?? 'prompt-provider',
+      label: selectedPromptProvider?.label ?? 'LLM model',
+      onPrepare: onPreparePromptApi,
+      status: promptStatus,
+    },
     {
       disabled: selectedLanguageDetectionProvider?.compatibility === 'incompatible',
       id: selectedLanguageDetectionProvider?.id ?? 'language-detection-provider',
@@ -226,18 +195,13 @@ export function AiToolsPanel({
       onPrepare: onPrepareLanguageDetectionProvider,
       status: languageDetectionStatus,
     },
-    ...(selectedTranslationProvider?.modelId === aiModelCatalog.TRANSLATEGEMMA_MODEL_ID
-      ? []
-      : [
-          {
-            disabled: selectedTranslationProvider?.compatibility === 'incompatible',
-            id: selectedTranslationProvider?.id ?? 'translation-provider',
-            label: selectedTranslationProvider?.label ?? 'Translation model',
-            onPrepare: onPrepareTranslationProvider,
-            status: translationProviderStatus,
-          },
-        ]),
-    ...hiddenModelSetupTasks,
+    {
+      disabled: selectedTranslationProvider?.compatibility === 'incompatible',
+      id: selectedTranslationProvider?.id ?? 'translation-provider',
+      label: selectedTranslationProvider?.label ?? 'Translation model',
+      onPrepare: onPrepareTranslationProvider,
+      status: translationProviderStatus,
+    },
     ...visibleModelStates.map((model) => ({
       id: model.id,
       label: model.label,

--- a/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/AiToolsPanel.tsx
@@ -186,6 +186,7 @@ export function AiToolsPanel({
       id: selectedPromptProvider?.id ?? 'prompt-provider',
       label: selectedPromptProvider?.label ?? 'LLM model',
       onPrepare: onPreparePromptApi,
+      progress: promptProgress,
       status: promptStatus,
     },
     {
@@ -193,6 +194,7 @@ export function AiToolsPanel({
       id: selectedLanguageDetectionProvider?.id ?? 'language-detection-provider',
       label: selectedLanguageDetectionProvider?.label ?? 'Language detection model',
       onPrepare: onPrepareLanguageDetectionProvider,
+      progress: languageDetectionProgress,
       status: languageDetectionStatus,
     },
     {
@@ -200,12 +202,14 @@ export function AiToolsPanel({
       id: selectedTranslationProvider?.id ?? 'translation-provider',
       label: selectedTranslationProvider?.label ?? 'Translation model',
       onPrepare: onPrepareTranslationProvider,
+      progress: translationProviderProgress,
       status: translationProviderStatus,
     },
     ...visibleModelStates.map((model) => ({
       id: model.id,
       label: model.label,
       onPrepare: onDownloadModel ? () => onDownloadModel(model.id) : undefined,
+      progress: model.status === 'ready' ? 100 : model.progress,
       status: getModelProgressStatus(model.status),
     })),
   ];

--- a/apps/editor/src/ui/editor/panels/AiToolsSetupAction.tsx
+++ b/apps/editor/src/ui/editor/panels/AiToolsSetupAction.tsx
@@ -8,6 +8,7 @@ interface AiToolsSetupTask {
   id: string;
   label: string;
   onPrepare?: (() => Promise<void> | void) | undefined;
+  progress: number;
   status: AiToolsSetupTaskStatus;
 }
 
@@ -35,14 +36,36 @@ function getSetupSummary(tasks: AiToolsSetupTask[], preparing: boolean) {
   const downloadingCount = tasks.filter((task) => task.status === 'downloading').length;
   const pendingCount = getPendingTasks(tasks).length;
 
-  if (preparing || downloadingCount > 0) return 'Preparing required AI features...';
+  if (preparing || downloadingCount > 0) return 'Downloading required AI features...';
   if (pendingCount === 0) return 'AI features are ready.';
   return `${pendingCount} feature${pendingCount === 1 ? '' : 's'} need setup before the AI workflows feel instant.`;
+}
+
+function getVisibleTasks(tasks: AiToolsSetupTask[]) {
+  return tasks.filter(
+    (task) =>
+      !task.disabled &&
+      task.onPrepare &&
+      (task.status === 'idle' || task.status === 'failed' || task.status === 'downloading'),
+  );
+}
+
+function getTaskStatusLabel(status: AiToolsSetupTaskStatus) {
+  if (status === 'downloading') return 'Downloading';
+  if (status === 'failed') return 'Failed';
+  if (status === 'ready') return 'Ready';
+  return 'Pending';
+}
+
+function getTaskProgress(task: AiToolsSetupTask) {
+  if (task.status === 'ready') return 100;
+  return Math.max(0, Math.min(100, Math.round(task.progress)));
 }
 
 export function AiToolsSetupAction({ tasks }: AiToolsSetupActionProps) {
   const [preparing, setPreparing] = useState(false);
   const pendingTasks = getPendingTasks(tasks);
+  const visibleTasks = getVisibleTasks(tasks);
   const visible = hasSetupWork(tasks);
   const disabled = preparing || pendingTasks.length === 0;
   const summary = getSetupSummary(tasks, preparing);
@@ -81,8 +104,36 @@ export function AiToolsSetupAction({ tasks }: AiToolsSetupActionProps) {
           void prepareAllFeatures();
         }}
       >
-        {preparing ? 'Preparing...' : pendingTasks.length === 0 ? 'Ready' : 'Download all'}
+        {preparing ? 'Downloading...' : pendingTasks.length === 0 ? 'Ready' : 'Download all'}
       </button>
+      {visibleTasks.length > 0 ? (
+        <div className="ai-setup-task-list" aria-label="AI feature download progress">
+          {visibleTasks.map((task) => {
+            const progress = getTaskProgress(task);
+            return (
+              <div className="ai-setup-task" key={task.id}>
+                <div className="ai-setup-task-meta">
+                  <span>{task.label}</span>
+                  <strong>
+                    {getTaskStatusLabel(task.status)}
+                    {task.status === 'downloading' ? ` ${progress}%` : ''}
+                  </strong>
+                </div>
+                <div
+                  aria-label={`${task.label} download progress`}
+                  aria-valuemax={100}
+                  aria-valuemin={0}
+                  aria-valuenow={progress}
+                  className="model-progress"
+                  role="progressbar"
+                >
+                  <span style={{ width: `${progress}%` }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/editor/src/ui/styles/ai-tools.css
+++ b/apps/editor/src/ui/styles/ai-tools.css
@@ -58,6 +58,43 @@
   opacity: 0.68;
 }
 
+.ai-setup-task-list {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.ai-setup-task {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.ai-setup-task-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  color: var(--ew-muted);
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.ai-setup-task-meta span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-setup-task-meta strong {
+  flex: 0 0 auto;
+  color: var(--ew-text);
+  font-variant-numeric: tabular-nums;
+  font-weight: 800;
+}
+
 .tool-card,
 .model-row {
   display: grid;

--- a/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
@@ -83,7 +83,11 @@ describe('AiToolsPanel', () => {
     const progressBar = within(imageGenerationCard).getByLabelText('Image Generation Models progress');
     expect(progressBar.querySelector('span')).toHaveStyle({ width: '42%' });
     expect(within(imageGenerationCard).getByText('42%')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Preparing...' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Downloading...' })).toBeDisabled();
+    expect(screen.getByLabelText('Image Generation Models download progress')).toHaveAttribute(
+      'aria-valuenow',
+      '42',
+    );
 
     resolveDownload?.();
 
@@ -142,6 +146,56 @@ describe('AiToolsPanel', () => {
 
     expect(calls).toEqual(['prompt', 'language-detection', 'translation', 'image-generation-models']);
     expect(onDownloadModel).toHaveBeenCalledWith('image-generation-models');
+  });
+
+  it('shows setup progress for each downloading AI feature', () => {
+    const imageGenerationState: ModelState = {
+      id: 'image-generation-models',
+      label: 'Image Generation Models',
+      description: 'Text-to-image model for generated slide assets.',
+      progress: 72,
+      provider: 'transformers',
+      required: false,
+      status: 'downloading',
+    };
+
+    render(
+      <AiToolsPanel
+        languageDetectionPreparation={{ progress: 41, status: 'downloading' }}
+        languageDetectionProviderStates={[languageDetectionProvider]}
+        modelStates={[imageGenerationState]}
+        onDownloadModel={() => Promise.resolve()}
+        onPrepareLanguageDetectionProvider={() => Promise.resolve()}
+        onPreparePromptApi={() => Promise.resolve()}
+        onPrepareTranslationProvider={() => Promise.resolve()}
+        promptPreparation={{ availability: 'downloading', progress: 28, status: 'downloading' }}
+        promptProviderStates={[gemmaProvider]}
+        translationPreparation={{ progress: 64, status: 'downloading' }}
+        translationProviderStates={[translateGemmaProvider]}
+      />,
+    );
+
+    const setup = screen.getByLabelText('AI feature setup');
+
+    expect(setup).toHaveTextContent('Downloading required AI features...');
+    expect(within(setup).getByLabelText('Gemma 4 E2B download progress')).toHaveAttribute(
+      'aria-valuenow',
+      '28',
+    );
+    expect(
+      within(setup).getByLabelText('XLM-RoBERTa Base 270M download progress'),
+    ).toHaveAttribute('aria-valuenow', '41');
+    expect(within(setup).getByLabelText('TranslateGemma 4B download progress')).toHaveAttribute(
+      'aria-valuenow',
+      '64',
+    );
+    expect(
+      within(setup).getByLabelText('Image Generation Models download progress'),
+    ).toHaveAttribute('aria-valuenow', '72');
+    expect(within(setup).getByText('Downloading 28%')).toBeInTheDocument();
+    expect(within(setup).getByText('Downloading 41%')).toBeInTheDocument();
+    expect(within(setup).getByText('Downloading 64%')).toBeInTheDocument();
+    expect(within(setup).getByText('Downloading 72%')).toBeInTheDocument();
   });
 
   it('hides the setup action when all downloadable AI features are ready', () => {

--- a/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/AiToolsPanel.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, within } from '@testing-library/react';
+import { useState } from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { aiModelCatalog } from '../../../../src/services/model-setup/aiModelCatalog';
@@ -42,6 +43,55 @@ const languageDetectionProvider: AiProviderState = {
 };
 
 describe('AiToolsPanel', () => {
+  it('starts visible model row progress when the setup action downloads all features', async () => {
+    const user = userEvent.setup();
+    let resolveDownload: (() => void) | undefined;
+    const imageGenerationState: ModelState = {
+      id: 'image-generation-models',
+      label: 'Image Generation Models',
+      description: 'Text-to-image model for generated slide assets.',
+      progress: 0,
+      provider: 'transformers',
+      required: false,
+      status: 'needs-download',
+    };
+
+    function PanelHarness() {
+      const [modelState, setModelState] = useState(imageGenerationState);
+
+      return (
+        <AiToolsPanel
+          modelStates={[modelState]}
+          onDownloadModel={() =>
+            new Promise<void>((resolve) => {
+              setModelState({ ...imageGenerationState, progress: 42, status: 'downloading' });
+              resolveDownload = () => {
+                setModelState({ ...imageGenerationState, progress: 100, status: 'ready' });
+                resolve();
+              };
+            })
+          }
+        />
+      );
+    }
+
+    render(<PanelHarness />);
+
+    await user.click(screen.getByRole('button', { name: 'Download all' }));
+
+    const imageGenerationCard = screen.getByRole('article', { name: 'Image Generation Models' });
+    const progressBar = within(imageGenerationCard).getByLabelText('Image Generation Models progress');
+    expect(progressBar.querySelector('span')).toHaveStyle({ width: '42%' });
+    expect(within(imageGenerationCard).getByText('42%')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Preparing...' })).toBeDisabled();
+
+    resolveDownload?.();
+
+    await waitFor(() => {
+      expect(within(imageGenerationCard).getByText('Ready')).toBeInTheDocument();
+    });
+  });
+
   it('downloads all pending AI features from one setup action', async () => {
     const user = userEvent.setup();
     const calls: string[] = [];
@@ -90,14 +140,8 @@ describe('AiToolsPanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'Download all' }));
 
-    expect(calls).toEqual([
-      'language-detection',
-      aiModelCatalog.GEMMA_LLM_MODEL_ID,
-      aiModelCatalog.TRANSLATEGEMMA_MODEL_ID,
-      'image-generation-models',
-    ]);
-    expect(onPreparePromptApi).not.toHaveBeenCalled();
-    expect(onPrepareTranslationProvider).not.toHaveBeenCalled();
+    expect(calls).toEqual(['prompt', 'language-detection', 'translation', 'image-generation-models']);
+    expect(onDownloadModel).toHaveBeenCalledWith('image-generation-models');
   });
 
   it('hides the setup action when all downloadable AI features are ready', () => {

--- a/tests/e2e/editor/ai-tools-status.spec.ts
+++ b/tests/e2e/editor/ai-tools-status.spec.ts
@@ -15,8 +15,8 @@ test.describe('editor AI tools status journey', () => {
     await expect(page.getByRole('button', { name: /Download all|Ready/ })).toBeVisible();
     await expect(page.getByLabel('LLM Model', { exact: true }).first()).toBeVisible();
     await expect(page.getByLabel('Translation Model', { exact: true })).toBeVisible();
-    await expect(page.getByText('Image Editing Models')).toBeVisible();
-    await expect(page.getByText('Image Generation Models')).toBeVisible();
+    await expect(page.getByRole('article', { name: 'Image Editing Models' })).toBeVisible();
+    await expect(page.getByRole('article', { name: 'Image Generation Models' })).toBeVisible();
     await expect(page.getByLabel('Create image prompt')).toBeVisible();
     await expect(
       page.getByRole('button', { name: /Download|Prepare|Create image/ }).first(),


### PR DESCRIPTION
## Summary
- Surface per-feature download progress in the AI setup action instead of only a single aggregate state.
- Keep hidden prompt, language detection, and translation setup tasks visible while they are downloading, with labels and progress bars.
- Update editor AI panel tests and E2E selectors to match the revised progress UI and article-based model cards.

## Testing
- Added unit coverage for setup task progress rendering and download-all behavior.
- Updated E2E assertions for the new model card selectors.
- Not run (not requested).