### PR TITLE
Fix material icon clipping in editor toolbar

### DIFF
--- a/apps/editor/src/ui/styles/foundation.css
+++ b/apps/editor/src/ui/styles/foundation.css
@@ -40,8 +40,11 @@ button {
 }
 
 .material-symbols-outlined {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 1em;
-  overflow: hidden;
+  overflow: visible;
   color: transparent;
   font-family: 'Material Symbols Outlined';
   font-size: 20px;

--- a/apps/editor/src/ui/styles/toolbar-actions.css
+++ b/apps/editor/src/ui/styles/toolbar-actions.css
@@ -8,6 +8,10 @@
 }
 
 .material-symbols-outlined {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
   font-size: 20px;
   font-variation-settings: 'FILL' 0;
   line-height: 1;


### PR DESCRIPTION
## Summary
- Adjust `material-symbols-outlined` styling to prevent icons from being clipped.
- Center the icon glyphs with `inline-flex` alignment in both foundation and toolbar action styles.
- Allow visible overflow so the full symbol render is preserved.

## Testing
- Not run (not requested)