### PR TITLE
Refocus the active page after exiting presentation mode

### DIFF
--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -443,6 +443,7 @@ export function useEditorViewModel(services: AppServices) {
           presenterPageIdRef.current ?? animationPreviewRef.current?.pageId ?? activePageIdRef.current;
         if (previewPageId && projectRef.current.pages.some((page) => page.id === previewPageId)) {
           setActivePageId(previewPageId);
+          setActivePageFocusKey((current) => current + 1);
         }
         clearAnimationPreview();
         presenterPageIdRef.current = undefined;

--- a/tests/e2e/editor/presenter-keyboard-pause-shortcuts.ts
+++ b/tests/e2e/editor/presenter-keyboard-pause-shortcuts.ts
@@ -17,5 +17,8 @@ export const presenterKeyboardPauseShortcuts = {
     await shortcuts.getByRole('button', { name: 'Quit presentation mode' }).click();
     await expect(shortcuts).toBeHidden();
     await expect.poll(() => page.evaluate(() => Boolean(document.fullscreenElement))).toBe(false);
+    await expect(
+      page.locator('.scroll-page-active').getByRole('button', { name: 'Rename Keyboard close' }),
+    ).toBeInViewport();
   },
 };


### PR DESCRIPTION
## Summary
- Force the active page focus state to refresh when exiting fullscreen presentation mode.
- Add an end-to-end assertion to verify the page remains in view after quitting presentation mode.

## Testing
- Added E2E coverage for the presenter keyboard pause flow.
- Not run (not requested).