### PR TITLE
Fix GIF and video autoplay resets in presentation preview

### DIFF
--- a/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
+++ b/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
@@ -10,6 +10,7 @@ export interface AnimationPreviewState {
   mode: 'editor' | 'presenter';
   pageId: string;
   phase: 'transition' | 'animation' | 'waiting' | 'complete';
+  playbackRunId?: number;
   playing: boolean;
   waitingForClick: boolean;
 }
@@ -23,7 +24,9 @@ interface AnimationPreviewControllerOptions {
 }
 
 function getBuildPlaybackDurationMs(build: ElementAnimationBuild) {
-  return Math.max(0, build.durationMs ?? build.delayMs);
+  const durationMs = Math.max(0, build.durationMs ?? build.delayMs);
+  if (build.mediaAction === 'play') return Math.max(75, durationMs);
+  return durationMs;
 }
 
 export function useAnimationPreviewController({
@@ -37,6 +40,7 @@ export function useAnimationPreviewController({
   const animationPreviewQueueRef = useRef<ElementAnimationBuild[]>([]);
   const animationPreviewTimeoutsRef = useRef<number[]>([]);
   const animationPreviewFrameRef = useRef<number | undefined>(undefined);
+  const animationPreviewRunIdRef = useRef(0);
 
   function clearAnimationPreviewTimers() {
     for (const timeoutId of animationPreviewTimeoutsRef.current) {
@@ -196,6 +200,7 @@ export function useAnimationPreviewController({
     animationPreviewQueueRef.current = builds;
     const transitionDelay = page.transition?.delayMs ?? 0;
     if (mode === 'presenter') onPresenterPageChange?.(page.id);
+    animationPreviewRunIdRef.current += 1;
     setAnimationPreview({
       activeBuild: undefined,
       activeBuildElementId: undefined,
@@ -206,6 +211,7 @@ export function useAnimationPreviewController({
       mode,
       pageId: page.id,
       phase: transitionDelay > 0 ? 'transition' : builds.length > 0 ? 'animation' : 'complete',
+      playbackRunId: animationPreviewRunIdRef.current,
       playing: true,
       waitingForClick: false,
     });

--- a/apps/editor/src/ui/editor/canvas/CanvasMediaElement.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasMediaElement.tsx
@@ -164,6 +164,32 @@ function CanvasVideoElement({
     previewMode,
   ]);
 
+  useEffect(() => {
+    const video = videoRef.current;
+    if (
+      !video ||
+      !previewMode ||
+      !element.autoplayInPreview ||
+      element.startOnClick ||
+      animationState.hidden ||
+      animationState.activeBuild?.mediaAction === 'play' ||
+      animationState.playbackRunId === undefined
+    ) {
+      return;
+    }
+    stopReversePlayback();
+    video.currentTime = Math.max(0, element.trimStartSeconds);
+    playVideo(video);
+  }, [
+    animationState.activeBuild,
+    animationState.hidden,
+    animationState.playbackRunId,
+    element.autoplayInPreview,
+    element.startOnClick,
+    element.trimStartSeconds,
+    previewMode,
+  ]);
+
   function playReverse(video: HTMLVideoElement) {
     stopReversePlayback();
     video.pause();
@@ -241,11 +267,18 @@ export function CanvasMediaElement({
   scale: { x: number; y: number };
 }) {
   if (element.type === 'gif') {
+    const shouldPlayGif =
+      element.playing &&
+      (!previewMode || !animationState.hidden || Boolean(animationState.activeBuild));
+    const gifPlaybackKey = animationState.activeBuild
+      ? `${element.id}-${animationState.playbackRunId ?? 'static'}-${animationState.activeBuild.id}`
+      : `${element.id}-${animationState.playbackRunId ?? 'static'}-${shouldPlayGif ? 'playing' : 'hidden'}`;
     return (
       <img
         aria-label={assetName}
         className="canvas-media-element"
-        src={element.playing ? assetUrl : undefined}
+        key={gifPlaybackKey}
+        src={shouldPlayGif ? assetUrl : undefined}
         style={getMediaStyle(element, scale, interactive, opacity)}
       />
     );

--- a/apps/editor/src/ui/editor/canvas/CanvasMediaElement.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasMediaElement.tsx
@@ -41,6 +41,7 @@ function CanvasVideoElement({
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const reverseIntervalRef = useRef<number | undefined>(undefined);
+  const handledMediaActionBuildRef = useRef<string | undefined>(undefined);
   const previousTrimRef = useRef<
     | {
         assetUrl: string | undefined;
@@ -52,7 +53,11 @@ function CanvasVideoElement({
   >(undefined);
   const repeatMode = element.repeatMode ?? (element.loop ? 'loop' : 'none');
   const autoplay =
-    previewMode && element.autoplayInPreview && !element.startOnClick && !animationState.hidden;
+    previewMode &&
+    element.autoplayInPreview &&
+    !element.startOnClick &&
+    !animationState.hidden &&
+    !animationState.mediaActionPending;
 
   function stopReversePlayback() {
     if (reverseIntervalRef.current === undefined) return;
@@ -144,13 +149,16 @@ function CanvasVideoElement({
     const video = videoRef.current;
     if (!video || !previewMode || !element.autoplayInPreview) return;
     if (animationState.activeBuild?.mediaAction === 'play') {
+      const buildPlaybackKey = `${animationState.playbackRunId ?? 'static'}-${animationState.activeBuild.id}`;
+      if (handledMediaActionBuildRef.current === buildPlaybackKey) return;
       stopReversePlayback();
       video.currentTime = Math.max(0, element.trimStartSeconds);
+      handledMediaActionBuildRef.current = buildPlaybackKey;
       if (movieStartPlayback.consumeStartedBuild(video, animationState.activeBuild.id)) return;
       playVideo(video);
       return;
     }
-    if (animationState.hidden || element.startOnClick) {
+    if (animationState.hidden || element.startOnClick || animationState.mediaActionPending) {
       stopReversePlayback();
       video.pause();
       video.currentTime = Math.max(0, element.trimStartSeconds);
@@ -158,6 +166,8 @@ function CanvasVideoElement({
   }, [
     animationState.activeBuild,
     animationState.hidden,
+    animationState.mediaActionPending,
+    animationState.playbackRunId,
     element.autoplayInPreview,
     element.startOnClick,
     element.trimStartSeconds,
@@ -173,6 +183,7 @@ function CanvasVideoElement({
       element.startOnClick ||
       animationState.hidden ||
       animationState.activeBuild?.mediaAction === 'play' ||
+      animationState.mediaActionPending ||
       animationState.playbackRunId === undefined
     ) {
       return;
@@ -183,6 +194,7 @@ function CanvasVideoElement({
   }, [
     animationState.activeBuild,
     animationState.hidden,
+    animationState.mediaActionPending,
     animationState.playbackRunId,
     element.autoplayInPreview,
     element.startOnClick,

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -79,6 +79,7 @@ interface CanvasWorkspaceProps {
         mode?: 'editor' | 'presenter';
         pageId: string;
         phase: 'transition' | 'animation' | 'waiting' | 'complete';
+        playbackRunId?: number;
         playing: boolean;
         waitingForClick: boolean;
       }
@@ -824,6 +825,8 @@ export function CanvasWorkspace({
     return {
       activeBuild,
       hidden: animationPreviewHiddenElementIds.includes(element.id),
+      playbackRunId:
+        animationPreview?.pageId === activePageId ? animationPreview.playbackRunId : undefined,
       preset: activeBuild
         ? animationPresetEngine.getRenderState({
             bounds: {

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -821,10 +821,17 @@ export function CanvasWorkspace({
   function getElementAnimationState(element: DesignElement): ElementAnimationRenderState {
     const activeBuild =
       activeAnimationBuild?.elementId === element.id ? activeAnimationBuild : undefined;
+    const mediaActionBuild =
+      animationPreview?.pageId === activePageId
+        ? page?.animationBuilds?.find(
+            (build) => build.elementId === element.id && build.mediaAction === 'play',
+          )
+        : undefined;
     const progress = activeBuild ? clampAnimationProgress(animationPreview?.animationProgress) : 1;
     return {
       activeBuild,
       hidden: animationPreviewHiddenElementIds.includes(element.id),
+      mediaActionPending: Boolean(mediaActionBuild),
       playbackRunId:
         animationPreview?.pageId === activePageId ? animationPreview.playbackRunId : undefined,
       preset: activeBuild

--- a/apps/editor/src/ui/editor/canvas/canvas-element-props.ts
+++ b/apps/editor/src/ui/editor/canvas/canvas-element-props.ts
@@ -35,6 +35,7 @@ export interface CommonElementProps {
 export interface ElementAnimationRenderState {
   activeBuild: ElementAnimationPreviewBuild | undefined;
   hidden: boolean;
+  mediaActionPending: boolean;
   preset: AnimationPresetRenderState | undefined;
   playbackRunId: number | undefined;
   progress: number;

--- a/apps/editor/src/ui/editor/canvas/canvas-element-props.ts
+++ b/apps/editor/src/ui/editor/canvas/canvas-element-props.ts
@@ -36,5 +36,6 @@ export interface ElementAnimationRenderState {
   activeBuild: ElementAnimationPreviewBuild | undefined;
   hidden: boolean;
   preset: AnimationPresetRenderState | undefined;
+  playbackRunId: number | undefined;
   progress: number;
 }

--- a/apps/editor/tests/unit/app/App.test.tsx
+++ b/apps/editor/tests/unit/app/App.test.tsx
@@ -4,17 +4,33 @@ import { App } from '../../../src/App';
 import { sampleProject } from '../../../src/domain/projects/sampleProject';
 import { TRANSLATION_LANGUAGE_OPTIONS } from '../../../src/ui/editor/translation/translationLanguages';
 
+const originalMatchMedia = window.matchMedia;
+
 describe('App', () => {
   beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+    window.localStorage.clear();
     vi.stubGlobal('showDirectoryPicker', vi.fn());
     vi.stubGlobal('Translator', {
       availability: vi.fn().mockResolvedValue('available'),
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({
+        addEventListener: vi.fn(),
+        matches: false,
+        removeEventListener: vi.fn(),
+      }),
     });
   });
 
   afterEach(() => {
     window.history.replaceState({}, '', '/');
     window.localStorage.clear();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: originalMatchMedia,
+    });
     Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: undefined,
@@ -25,7 +41,9 @@ describe('App', () => {
   it('renders the application root', async () => {
     render(<App />);
 
-    expect(await screen.findByRole('heading', { name: 'LocalStudio.dev' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'LocalStudio.dev' }, { timeout: 5000 }),
+    ).toBeInTheDocument();
   });
 
   it('starts with a blank project when requested from a new project tab', async () => {

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.media.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.media.test.tsx
@@ -286,6 +286,75 @@ describe('CanvasWorkspace media elements', () => {
     pauseSpy.mockRestore();
   });
 
+  it('restarts autoplay videos when fullscreen presentation playback starts', async () => {
+    const playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockImplementation(() => Promise.resolve());
+    const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    const project = createMediaProject();
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+      />,
+    );
+
+    const video = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+    video.currentTime = 5;
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: undefined,
+          animationProgress: 0,
+          hiddenElementIds: [],
+          mode: 'presenter',
+          pageId: 'page-1',
+          phase: 'complete',
+          playbackRunId: 1,
+          playing: true,
+          waitingForClick: false,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    await waitFor(() => expect(playSpy).toHaveBeenCalledTimes(1));
+    expect(video.currentTime).toBe(2);
+
+    video.currentTime = 5;
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: undefined,
+          animationProgress: 0,
+          hiddenElementIds: [],
+          mode: 'presenter',
+          pageId: 'page-1',
+          phase: 'complete',
+          playbackRunId: 2,
+          playing: true,
+          waitingForClick: false,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    await waitFor(() => expect(playSpy).toHaveBeenCalledTimes(2));
+    expect(video.currentTime).toBe(2);
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+  });
+
   it('renders GIF media as an animated non-image element', () => {
     const project = createMediaProject();
     const { container } = render(
@@ -297,6 +366,140 @@ describe('CanvasWorkspace media elements', () => {
     );
 
     expect(container.querySelector('img[aria-label="Animated loop"]')).toBeInTheDocument();
+  });
+
+  it('mounts animated GIF sources only when preview playback reaches a hidden build', () => {
+    const project = createMediaProject();
+    project.pages[0]!.animationBuilds = [
+      {
+        id: 'gif-build',
+        elementId: 'gif-demo',
+        effect: 'reveal',
+        trigger: 'after-transition',
+        delayMs: 0,
+        durationMs: 500,
+      },
+    ];
+    const build = project.pages[0]!.animationBuilds[0];
+
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: undefined,
+          animationProgress: 0,
+          hiddenElementIds: ['gif-demo'],
+          pageId: 'page-1',
+          phase: 'transition',
+          playing: true,
+          waitingForClick: false,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    const hiddenGif = container.querySelector(
+      'img[aria-label="Animated loop"]',
+    ) as HTMLImageElement;
+    expect(hiddenGif.getAttribute('src')).toBeNull();
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuild: build,
+          activeBuildElementId: 'gif-demo',
+          animationProgress: 0,
+          hiddenElementIds: ['gif-demo'],
+          pageId: 'page-1',
+          phase: 'animation',
+          playing: true,
+          waitingForClick: false,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    const activeGif = container.querySelector(
+      'img[aria-label="Animated loop"]',
+    ) as HTMLImageElement;
+    expect(activeGif.getAttribute('src')).toBe('blob:gif');
+  });
+
+  it('restarts visible GIFs when fullscreen presentation playback starts', () => {
+    const project = createMediaProject();
+    const { container, rerender } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+      />,
+    );
+
+    const editorGif = container.querySelector(
+      'img[aria-label="Animated loop"]',
+    ) as HTMLImageElement;
+    expect(editorGif.getAttribute('src')).toBe('blob:gif');
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: undefined,
+          animationProgress: 0,
+          hiddenElementIds: [],
+          mode: 'presenter',
+          pageId: 'page-1',
+          phase: 'complete',
+          playbackRunId: 1,
+          playing: true,
+          waitingForClick: false,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    const firstPresentationGif = container.querySelector(
+      'img[aria-label="Animated loop"]',
+    ) as HTMLImageElement;
+    expect(firstPresentationGif).not.toBe(editorGif);
+    expect(firstPresentationGif.getAttribute('src')).toBe('blob:gif');
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: undefined,
+          animationProgress: 0,
+          hiddenElementIds: [],
+          mode: 'presenter',
+          pageId: 'page-1',
+          phase: 'complete',
+          playbackRunId: 2,
+          playing: true,
+          waitingForClick: false,
+        }}
+        presentationMode
+        readOnly
+      />,
+    );
+
+    const secondPresentationGif = container.querySelector(
+      'img[aria-label="Animated loop"]',
+    ) as HTMLImageElement;
+    expect(secondPresentationGif).not.toBe(firstPresentationGif);
+    expect(secondPresentationGif.getAttribute('src')).toBe('blob:gif');
   });
 
   it('shows the object animation toolbar action for selected media elements', () => {

--- a/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/useAnimationPreviewController.test.tsx
@@ -189,6 +189,76 @@ describe('useAnimationPreviewController', () => {
     });
   });
 
+  it('keeps automatic zero-duration media-play builds active for a render frame', () => {
+    const project = createProject();
+    project.assets.video = {
+      id: 'video',
+      type: 'video',
+      name: 'Clip',
+      mimeType: 'video/mp4',
+    };
+    project.elements.video = {
+      id: 'video',
+      type: 'video',
+      assetId: 'video',
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360,
+      rotation: 0,
+      opacity: 1,
+      visible: true,
+      locked: false,
+      loop: false,
+      controls: true,
+      muted: false,
+      autoplayInPreview: true,
+      trimStartSeconds: 0,
+    };
+    project.pages[0]!.elementIds = ['video'];
+    project.pages[0]!.animationBuilds = [
+      {
+        id: 'video-play',
+        elementId: 'video',
+        effect: 'reveal',
+        trigger: 'after-transition',
+        delayMs: 0,
+        durationMs: 0,
+        mediaAction: 'play',
+      },
+    ];
+    const projectRef = { current: project };
+    const activePageIdRef = { current: 'page-1' };
+    const { result } = renderHook(() =>
+      useAnimationPreviewController({
+        activePageIdRef,
+        projectRef,
+        setActivePageId: vi.fn(),
+        setSelectedElementIds: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.playAnimationPreview('page-1', 'presenter');
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(result.current.animationPreview).toMatchObject({
+      activeBuildElementId: 'video',
+      phase: 'animation',
+      waitingForClick: false,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(75);
+    });
+
+    expect(result.current.animationPreview).toMatchObject({
+      activeBuildElementId: undefined,
+      phase: 'complete',
+    });
+  });
+
   it('reports the current presenter page synchronously during presentation navigation', () => {
     const projectRef = { current: createProject() };
     const activePageIdRef = { current: 'page-1' };
@@ -228,6 +298,31 @@ describe('useAnimationPreviewController', () => {
     expect(onPresenterPageChange).toHaveBeenCalledWith('page-1');
     expect(onPresenterPageChange).toHaveBeenLastCalledWith('page-2');
     expect(activePageIdRef.current).toBe('page-2');
+  });
+
+  it('assigns a fresh playback run id when replaying the same slide', () => {
+    const projectRef = { current: createProject() };
+    const activePageIdRef = { current: 'page-1' };
+    const { result } = renderHook(() =>
+      useAnimationPreviewController({
+        activePageIdRef,
+        projectRef,
+        setActivePageId: vi.fn(),
+        setSelectedElementIds: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.playPresentationPreview('page-1');
+    });
+
+    const firstRunId = result.current.animationPreview?.playbackRunId;
+
+    act(() => {
+      result.current.playPresentationPreview('page-1');
+    });
+
+    expect(result.current.animationPreview?.playbackRunId).toBe((firstRunId ?? 0) + 1);
   });
 
   it('skips hidden slides during presenter navigation', () => {


### PR DESCRIPTION
## Summary
- Add a playback run identifier so each presenter replay can force media elements to remount or restart cleanly.
- Keep zero-duration `mediaAction: play` builds active long enough for preview rendering to catch them.
- Restart autoplay videos and GIFs when fullscreen presentation playback begins, including replaying the same slide.
- Add unit coverage for preview run IDs, video restart behavior, and GIF playback mounting/restart cases.

## Testing
- Added and updated unit tests for animation preview timing and media restart behavior.
- Not run (not requested).