### PR TITLE
Add hyperlink support for text elements across editor and exports

### DIFF
--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -59,6 +59,7 @@ export type ElementStylePatch = Partial<{
   fontFamily: string;
   fontSize: number;
   fontWeight: number;
+  hyperlink: string | null;
   opacity: number;
   stroke: string | null;
   strokeWidth: number;

--- a/apps/editor/src/domain/commands/elements/element-edit-commands.ts
+++ b/apps/editor/src/domain/commands/elements/element-edit-commands.ts
@@ -142,8 +142,9 @@ class UpdateElementStyleCommand implements EditorCommand {
     let nextElement: DesignElement = { ...element, opacity };
 
     if (element.type === 'text') {
-      nextElement = {
-        ...nextElement,
+      const nextTextElement = {
+        ...element,
+        opacity,
         ...(this.patch.align ? { align: this.patch.align } : {}),
         ...(typeof this.patch.fill === 'string' ? { fill: this.patch.fill } : {}),
         ...(this.patch.fontFamily ? { fontFamily: this.patch.fontFamily } : {}),
@@ -152,6 +153,13 @@ class UpdateElementStyleCommand implements EditorCommand {
           : {}),
         ...(this.patch.fontWeight !== undefined ? { fontWeight: this.patch.fontWeight } : {}),
       };
+      if (typeof this.patch.hyperlink === 'string') {
+        nextTextElement.hyperlink = this.patch.hyperlink;
+      }
+      if (this.patch.hyperlink === null) {
+        delete nextTextElement.hyperlink;
+      }
+      nextElement = nextTextElement;
     }
 
     if (element.type === 'shape') {

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -222,6 +222,7 @@ export interface TextElement extends BaseElement {
   fontWeight: number;
   fill: string;
   align: 'left' | 'center' | 'right';
+  hyperlink?: string;
   lineHeight?: number;
   verticalAlign?: 'bottom' | 'middle' | 'top';
 }

--- a/apps/editor/src/services/exporting/pptxExportService.ts
+++ b/apps/editor/src/services/exporting/pptxExportService.ts
@@ -182,10 +182,12 @@ function addTextElement(slide: PptxGenJS.Slide, element: Extract<DesignElement, 
     fit: 'shrink',
     fontFace: element.fontFamily,
     fontSize: element.fontSize,
+    ...(element.hyperlink ? { hyperlink: { url: element.hyperlink } } : {}),
     margin: 0,
     objectName: element.id,
     rotate: element.rotation,
     transparency: getTransparency(element.opacity),
+    ...(element.hyperlink ? { underline: { style: 'sng' as const } } : {}),
     valign: element.verticalAlign ?? 'top',
   });
 }

--- a/apps/editor/src/services/presenter/presenterRemoteStateFactory.ts
+++ b/apps/editor/src/services/presenter/presenterRemoteStateFactory.ts
@@ -291,6 +291,7 @@ function createSlidePreviewElement(
       fontFamily: element.fontFamily,
       fontSize: element.fontSize,
       fontWeight: element.fontWeight,
+      hyperlink: element.hyperlink,
       kind: 'text',
       lineHeight: element.lineHeight,
       text: element.text,

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -711,6 +711,14 @@ export function CanvasWorkspace({
     };
   }
 
+  function getLinkedTextElementFromEventTarget(target: Konva.Node) {
+    const elementEntry = Object.entries(nodeRefs.current).find(([, node]) => node === target);
+    if (!elementEntry) return undefined;
+    const element = project.elements[elementEntry[0]];
+    if (!element || element.type !== 'text' || !element.hyperlink) return undefined;
+    return element;
+  }
+
   function getCommonElementProps(element: DesignElement, options: { interactive?: boolean } = {}): CommonElementProps {
     const isInteractive = options.interactive ?? true;
     const isBackgroundSelectionTarget = element.id === backgroundSelectionTargetId;
@@ -741,6 +749,13 @@ export function CanvasWorkspace({
       y: element.y * scaleY + (animationTransform?.y ?? 0),
       onClick: (event: Konva.KonvaEventObject<MouseEvent>) => {
         if (!isInteractive) return;
+        if (element.type === 'text' && element.hyperlink && (presentationMode || readOnly)) {
+          event.cancelBubble = true;
+          event.evt.preventDefault();
+          event.evt.stopPropagation();
+          window.open(element.hyperlink, '_blank', 'noopener,noreferrer');
+          return;
+        }
         if (canAdvanceAnimationPreviewByClick) {
           event.cancelBubble = true;
           onAnimationPreviewAdvance?.();
@@ -901,6 +916,8 @@ export function CanvasWorkspace({
   }
 
   function handleStagePointerDown(event: Konva.KonvaEventObject<MouseEvent | TouchEvent>) {
+    const linkedTextElement = getLinkedTextElementFromEventTarget(event.target);
+    if (linkedTextElement && (presentationMode || readOnly)) return;
     if (canAdvanceAnimationPreviewByClick) {
       movieStartPlayback.playPendingMovieStart(artboardRef.current, project, animationPreview);
       onAnimationPreviewAdvance?.();
@@ -1091,6 +1108,7 @@ export function CanvasWorkspace({
                     lineHeight={element.lineHeight ?? 1.05}
                     padding={TEXT_FRAME_PADDING * scaleY}
                     ref={nodeRef}
+                    {...(element.hyperlink ? { textDecoration: 'underline' } : {})}
                     verticalAlign={element.verticalAlign ?? 'top'}
                     visible={editingTextId !== element.id}
                   />

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -719,6 +719,12 @@ export function CanvasWorkspace({
     return element;
   }
 
+  function isClickableLinkedText(
+    element: DesignElement,
+  ): element is Extract<DesignElement, { type: 'text' }> {
+    return element.type === 'text' && Boolean(element.hyperlink) && (presentationMode || readOnly);
+  }
+
   function getCommonElementProps(element: DesignElement, options: { interactive?: boolean } = {}): CommonElementProps {
     const isInteractive = options.interactive ?? true;
     const isBackgroundSelectionTarget = element.id === backgroundSelectionTargetId;
@@ -793,11 +799,27 @@ export function CanvasWorkspace({
       },
       onDragMove: handleDragMove,
       onMouseEnter: (event: Konva.KonvaEventObject<MouseEvent>) => {
+        if (isClickableLinkedText(element)) {
+          const container = event.target.getStage()?.container();
+          if (container) {
+            container.style.cursor = 'pointer';
+            container.title = element.hyperlink ?? '';
+          }
+          return;
+        }
         if (!isBackgroundSelectionTarget && !isProcessing) return;
         const container = event.target.getStage()?.container();
         if (container) container.style.cursor = isProcessing ? 'progress' : 'crosshair';
       },
       onMouseLeave: (event: Konva.KonvaEventObject<MouseEvent>) => {
+        if (isClickableLinkedText(element)) {
+          const container = event.target.getStage()?.container();
+          if (container) {
+            container.style.cursor = '';
+            container.removeAttribute('title');
+          }
+          return;
+        }
         if (!isBackgroundSelectionTarget && !isProcessing) return;
         if (isBackgroundSelectionTarget) setBackgroundPreviewPoint(null);
         const container = event.target.getStage()?.container();

--- a/apps/editor/src/ui/editor/state/text-translation-layout.ts
+++ b/apps/editor/src/ui/editor/state/text-translation-layout.ts
@@ -94,7 +94,6 @@ function estimateWrappedLineCount(text: string, fontSize: number, availableWidth
       const wordWidth = estimateSingleLineTextWidth(word, fontSize);
       if (currentLineWidth === 0) {
         currentLineWidth = wordWidth;
-        paragraphLineCount += Math.max(0, Math.ceil(wordWidth / safeAvailableWidth) - 1);
         continue;
       }
 
@@ -106,7 +105,6 @@ function estimateWrappedLineCount(text: string, fontSize: number, availableWidth
 
       paragraphLineCount += 1;
       currentLineWidth = wordWidth;
-      paragraphLineCount += Math.max(0, Math.ceil(wordWidth / safeAvailableWidth) - 1);
     }
 
     return lineCount + paragraphLineCount;

--- a/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { ElementStylePatch } from '../../../domain/commands/elements/basicCommands';
 import type { TextElement } from '../../../domain/documents/model';
 
@@ -15,6 +16,13 @@ const FONT_SIZE_STEP = 4;
 const REGULAR_WEIGHT = 600;
 const BOLD_WEIGHT = 800;
 
+function normalizeHyperlink(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^(https?:|mailto:|tel:)/i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
 export function TextSelectionToolbar({
   disabled = false,
   canTranslateSelection = false,
@@ -24,12 +32,17 @@ export function TextSelectionToolbar({
   onTranslateSelectedText,
   onUpdateElementStyle,
 }: TextSelectionToolbarProps) {
+  const [showLinkEditor, setShowLinkEditor] = useState(false);
+  const [linkDraft, setLinkDraft] = useState({ elementId: element.id, value: element.hyperlink ?? '' });
+  const linkValue = linkDraft.elementId === element.id ? linkDraft.value : (element.hyperlink ?? '');
+
   function updateStyle(patch: ElementStylePatch) {
     if (disabled || element.locked) return;
     onUpdateElementStyle?.(element.id, patch);
   }
 
   const isBold = element.fontWeight >= BOLD_WEIGHT;
+  const hasHyperlink = Boolean(element.hyperlink);
 
   return (
     <div className="text-selection-toolbar" role="toolbar" aria-label="Text editing controls">
@@ -137,6 +150,61 @@ export function TextSelectionToolbar({
           </button>
         ))}
       </div>
+
+      <button
+        aria-expanded={showLinkEditor}
+        aria-label="Edit text hyperlink"
+        aria-pressed={hasHyperlink}
+        className={
+          hasHyperlink ? 'text-toolbar-button text-toolbar-button-active' : 'text-toolbar-button'
+        }
+        disabled={disabled || element.locked}
+        title="Edit text hyperlink"
+        type="button"
+        onClick={() => {
+          setShowLinkEditor((current) => !current);
+        }}
+      >
+        <span className="material-symbols-outlined" aria-hidden="true">
+          link
+        </span>
+      </button>
+
+      {showLinkEditor ? (
+        <form
+          className="text-toolbar-link-editor"
+          onSubmit={(event) => {
+            event.preventDefault();
+            updateStyle({ hyperlink: normalizeHyperlink(linkValue) });
+            setShowLinkEditor(false);
+          }}
+        >
+          <input
+            aria-label="Text hyperlink URL"
+            disabled={disabled || element.locked}
+            placeholder="https://example.com"
+            type="text"
+            value={linkValue}
+            onChange={(event) => {
+              setLinkDraft({ elementId: element.id, value: event.target.value });
+            }}
+          />
+          <button disabled={disabled || element.locked} type="submit">
+            Apply
+          </button>
+          <button
+            disabled={disabled || element.locked || !hasHyperlink}
+            type="button"
+            onClick={() => {
+              setLinkDraft({ elementId: element.id, value: '' });
+              updateStyle({ hyperlink: null });
+              setShowLinkEditor(false);
+            }}
+          >
+            Clear
+          </button>
+        </form>
+      ) : null}
 
       <button
         aria-label="Animate"

--- a/apps/editor/src/ui/styles/text-format-toolbar.css
+++ b/apps/editor/src/ui/styles/text-format-toolbar.css
@@ -119,6 +119,42 @@
   color: var(--ew-green);
 }
 
+.text-toolbar-link-editor {
+  display: inline-grid;
+  grid-template-columns: 180px 54px 52px;
+  gap: 4px;
+  align-items: center;
+  padding-left: 5px;
+  border-left: 1px solid rgba(55, 253, 118, 0.18);
+}
+
+.text-toolbar-link-editor input,
+.text-toolbar-link-editor button {
+  height: 30px;
+  border: 1px solid rgba(55, 253, 118, 0.18);
+  border-radius: 4px;
+  background: rgba(12, 22, 13, 0.95);
+  color: var(--ew-text);
+  font:
+    700 12px 'Open Sans',
+    sans-serif;
+}
+
+.text-toolbar-link-editor input {
+  min-width: 0;
+  padding: 0 8px;
+}
+
+.text-toolbar-link-editor button {
+  cursor: pointer;
+}
+
+.text-toolbar-link-editor button:hover:not(:disabled) {
+  background: rgba(55, 253, 118, 0.12);
+  border-color: rgba(55, 253, 118, 0.56);
+  color: var(--ew-green);
+}
+
 .text-toolbar-segment {
   display: inline-flex;
   align-items: center;

--- a/apps/editor/tests/unit/services/pptxExportService.test.ts
+++ b/apps/editor/tests/unit/services/pptxExportService.test.ts
@@ -90,6 +90,7 @@ function createExportProject(): ProjectDocument {
         fontWeight: 700,
         fill: '#ffcc00',
         align: 'center',
+        hyperlink: 'https://localstudio.dev',
       },
       image: {
         id: 'image',
@@ -274,6 +275,7 @@ describe('BrowserPptxExportService', () => {
 
     const slideRelsXml = readEntry(entries, 'ppt/slides/_rels/slide1.xml.rels');
     const relationshipTargets = readRelationshipTargets(slideRelsXml, 'ppt/slides/slide1.xml');
+    expect(relationshipTargets).toContain('https://localstudio.dev');
     expect(relationshipTargets.some((target) => target.startsWith('ppt/media/'))).toBe(true);
     for (const target of relationshipTargets.filter((item) => item.startsWith('ppt/media/'))) {
       expect(entries[target]).toBeDefined();
@@ -281,6 +283,7 @@ describe('BrowserPptxExportService', () => {
 
     const slideXml = readEntry(entries, 'ppt/slides/slide1.xml');
     expect(slideXml).toContain('Editable title');
+    expect(slideXml).toContain(' u="sng"');
     expect(slideXml).not.toContain('Hidden');
     expect(slideXml).toContain('<p:transition dur="500" advClick="0" advTm="250"><p:fade/></p:transition>');
     expect(slideXml).toContain('<p:timing>');

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.animation.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.animation.test.tsx
@@ -153,6 +153,15 @@ describe('CanvasWorkspace animation preview', () => {
       | Konva.Text
       | undefined;
     expect(textNode).toBeDefined();
+    const stageContainer = stageRef.current?.container();
+    expect(stageContainer).toBeDefined();
+
+    act(() => {
+      textNode!.fire('mouseenter', { target: textNode });
+    });
+
+    expect(stageContainer!.style.cursor).toBe('pointer');
+    expect(stageContainer).toHaveAttribute('title', 'https://localstudio.dev');
 
     const preventDefault = vi.fn();
     const stopPropagation = vi.fn();
@@ -172,6 +181,13 @@ describe('CanvasWorkspace animation preview', () => {
       'noopener,noreferrer',
     );
     expect(onAnimationPreviewAdvance).not.toHaveBeenCalled();
+
+    act(() => {
+      textNode!.fire('mouseleave', { target: textNode });
+    });
+
+    expect(stageContainer!.style.cursor).toBe('');
+    expect(stageContainer).not.toHaveAttribute('title');
     openSpy.mockRestore();
   });
 

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.animation.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.animation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createRef } from 'react';
 import type Konva from 'konva';
 import { vi } from 'vitest';
@@ -110,6 +110,69 @@ describe('CanvasWorkspace animation preview', () => {
     fireEvent.mouseDown(container.querySelector('canvas')!);
 
     expect(onAnimationPreviewAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens linked text without advancing click-triggered presenter builds', () => {
+    const onAnimationPreviewAdvance = vi.fn();
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+    const stageRef = createRef<Konva.Stage>();
+    const baseProject = sampleProject.createSampleProject();
+    const project = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'text-title': {
+          ...baseProject.elements['text-title']!,
+          hyperlink: 'https://localstudio.dev',
+        },
+      },
+    };
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuildElementId: 'image-hero',
+          pageId: 'page-1',
+          phase: 'waiting',
+          hiddenElementIds: ['image-hero'],
+          playing: true,
+          waitingForClick: true,
+        }}
+        presentationMode
+        stageRef={stageRef}
+        onAnimationPreviewAdvance={onAnimationPreviewAdvance}
+      />,
+    );
+
+    const textNode = stageRef.current
+      ?.find('Text')
+      .find((node) => (node as Konva.Text).text() === 'AI Design Revolution') as
+      | Konva.Text
+      | undefined;
+    expect(textNode).toBeDefined();
+
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+    act(() => {
+      textNode!.fire('mousedown', { evt: { button: 0 }, target: textNode });
+      textNode!.fire('click', {
+        evt: { preventDefault, shiftKey: false, stopPropagation },
+        target: textNode,
+      });
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://localstudio.dev',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    expect(onAnimationPreviewAdvance).not.toHaveBeenCalled();
+    openSpy.mockRestore();
   });
 
   it('hides canvas quick actions while animation preview is active', () => {

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -43,6 +43,37 @@ describe('CanvasWorkspace', () => {
     expect(screen.queryByText('Selected Image')).not.toBeInTheDocument();
   });
 
+  it('underlines linked text elements on the canvas', () => {
+    const stageRef = createRef<Konva.Stage>();
+    const baseProject = sampleProject.createSampleProject();
+    const project = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'text-title': {
+          ...baseProject.elements['text-title']!,
+          hyperlink: 'https://localstudio.dev',
+        },
+      },
+    };
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-title'] }}
+        stageRef={stageRef}
+      />,
+    );
+
+    const textNode = stageRef.current
+      ?.find('Text')
+      .find((node) => (node as Konva.Text).text() === 'AI Design Revolution') as
+      | Konva.Text
+      | undefined;
+    expect(textNode?.textDecoration()).toBe('underline');
+  });
+
   it('uses layout sizing instead of transform scaling for zoom', () => {
     render(
       <CanvasWorkspace

--- a/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
@@ -181,5 +181,13 @@ describe('ScrollingCanvasWorkspace', () => {
 
     await user.click(screen.getByRole('button', { name: 'Align text left' }));
     expect(onUpdateElementStyle).toHaveBeenCalledWith('text-subtitle', { align: 'left' });
+
+    await user.click(screen.getByRole('button', { name: 'Edit text hyperlink' }));
+    await user.clear(screen.getByRole('textbox', { name: 'Text hyperlink URL' }));
+    await user.type(screen.getByRole('textbox', { name: 'Text hyperlink URL' }), 'localstudio.dev');
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(onUpdateElementStyle).toHaveBeenCalledWith('text-subtitle', {
+      hyperlink: 'https://localstudio.dev',
+    });
   });
 });

--- a/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
+++ b/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
@@ -84,6 +84,29 @@ describe('editor view model text helpers', () => {
     expect(patch.height).toBeGreaterThan(1);
   });
 
+  it('does not reserve phantom lines for a single unbroken URL when resized narrower', () => {
+    const baseProject = sampleProject.createSampleProject();
+    const project = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'text-title': {
+          ...baseProject.elements['text-title']!,
+          fontSize: 96,
+          text: 'https://github.com/obra/superpower',
+        },
+      },
+    };
+
+    const patch = editorViewModelText.getFramePatchWithTextMinimum(project, 'text-title', {
+      height: 1,
+      width: 420,
+    });
+
+    expect(patch.width).toBe(420);
+    expect(patch.height).toBeLessThan(130);
+  });
+
   it('expands a text element after style updates increase font size', () => {
     const project = createProjectWithShortTitleFrame();
 

--- a/apps/joystick/src/app/SlideCanvas.tsx
+++ b/apps/joystick/src/app/SlideCanvas.tsx
@@ -106,6 +106,42 @@ export function SlideCanvas({
           );
         }
         if (element.kind === 'text') {
+          if (element.hyperlink) {
+            return (
+              <a
+                aria-label={`Open ${element.text}`}
+                className="joystick-slide-element joystick-slide-text"
+                href={element.hyperlink}
+                key={element.id}
+                rel="noreferrer"
+                style={{
+                  ...style,
+                  alignItems:
+                    element.verticalAlign === 'bottom'
+                      ? 'flex-end'
+                      : element.verticalAlign === 'middle'
+                        ? 'center'
+                        : 'flex-start',
+                  color: element.fill,
+                  fontFamily: element.fontFamily,
+                  fontSize: `${Math.max(compact ? 3 : 5, (element.fontSize / preview.width) * 100)}cqw`,
+                  fontWeight: element.fontWeight,
+                  justifyContent:
+                    element.align === 'right'
+                      ? 'flex-end'
+                      : element.align === 'center'
+                        ? 'center'
+                        : 'flex-start',
+                  lineHeight: element.lineHeight ?? 1.05,
+                  textAlign: element.align,
+                  textDecoration: 'underline',
+                }}
+                target="_blank"
+              >
+                {element.text}
+              </a>
+            );
+          }
           return (
             <span
               className="joystick-slide-element joystick-slide-text"

--- a/apps/joystick/src/styles/joystick.css
+++ b/apps/joystick/src/styles/joystick.css
@@ -521,6 +521,8 @@ input {
 .joystick-slide-text {
   display: flex;
   overflow: hidden;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.12em;
   white-space: pre-wrap;
 }
 

--- a/apps/joystick/tests/unit/presenterRemoteProtocol.test.ts
+++ b/apps/joystick/tests/unit/presenterRemoteProtocol.test.ts
@@ -66,6 +66,7 @@ describe('presenter remote protocol', () => {
               fontSize: 64,
               fontWeight: 800,
               height: 120,
+              hyperlink: 'https://localstudio.dev',
               id: 'title',
               kind: 'text',
               opacity: 1,

--- a/packages/presenter-remote/src/protocol.ts
+++ b/packages/presenter-remote/src/protocol.ts
@@ -25,6 +25,7 @@ export type PresenterRemoteSlidePreviewElement =
       fontSize: number;
       fontWeight: number;
       height: number;
+      hyperlink?: string | undefined;
       id: string;
       kind: 'text';
       lineHeight?: number | undefined;
@@ -204,6 +205,7 @@ function isPreviewElement(value: unknown): value is PresenterRemoteSlidePreviewE
       typeof value.fontSize === 'number' &&
       typeof value.fontWeight === 'number' &&
       typeof value.fill === 'string' &&
+      (value.hyperlink === undefined || typeof value.hyperlink === 'string') &&
       (value.align === 'left' || value.align === 'center' || value.align === 'right')
     );
   }

--- a/tests/e2e/editor/text-theme-and-layout.spec.ts
+++ b/tests/e2e/editor/text-theme-and-layout.spec.ts
@@ -20,8 +20,15 @@ test.describe('editor text theme and layout journey', () => {
     await toolbar.getByRole('spinbutton', { name: 'Text font size' }).fill('48');
     await toolbar.getByRole('button', { name: 'Bold text' }).click();
     await toolbar.getByRole('button', { name: 'Align text right' }).click();
+    await toolbar.getByRole('button', { name: 'Edit text hyperlink' }).click();
+    await toolbar.getByRole('textbox', { name: 'Text hyperlink URL' }).fill('localstudio.dev');
+    await toolbar.getByRole('button', { name: 'Apply' }).click();
     await toolbar.getByLabel('Text color').fill('#00779a');
     await expect(toolbar.getByRole('button', { name: 'Bold text' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await expect(toolbar.getByRole('button', { name: 'Edit text hyperlink' })).toHaveAttribute(
       'aria-pressed',
       'true',
     );


### PR DESCRIPTION
## Summary
- Add hyperlink support to text elements in the editor model, style commands, and presenter preview protocol.
- Extend the text toolbar with link edit/apply/clear controls and render linked text as underlined in the canvas and joystick preview.
- Make linked text open in a new tab in presentation and read-only modes without advancing animation playback.
- Preserve hyperlink data through PPTX export and tighten wrapped-line estimation for long unbroken URLs.
- Add unit and end-to-end coverage for toolbar updates, canvas behavior, export output, and text layout.

## Testing
- Added and updated unit tests for hyperlink editing, canvas rendering, presenter protocol handling, PPTX export, and wrapped text sizing.
- Added an end-to-end editor flow covering hyperlink assignment from the text toolbar.
- Not run (not requested).