### PR TITLE
Add Google Analytics tracking to core app entry pages

### DIFF
--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -3,6 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FDGKZ1Q1XC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-FDGKZ1Q1XC");
+    </script>
     <meta
       name="description"
       content="LocalStudio.dev editor is a browser-native AI slide workspace for creating, editing, importing, presenting, and sharing local-first decks."

--- a/apps/joystick/index.html
+++ b/apps/joystick/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#07140d" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FDGKZ1Q1XC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-FDGKZ1Q1XC");
+    </script>
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="LocalStack 🕹️" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#f8f5ed" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FDGKZ1Q1XC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-FDGKZ1Q1XC");
+    </script>
     <meta
       name="description"
       content="LocalStudio.dev is a local-first AI design studio for generating editable slides, images, translations, and image edits with browser-native Web AI."


### PR DESCRIPTION
## Summary
- Added the Google Analytics `gtag.js` snippet to the editor, joystick, and landing app entry pages.
- Uses the same measurement ID across all three surfaces for unified traffic tracking.

## Testing
- Not run (not requested)