### PR TITLE
Download stock media before inserting and persist remote assets as local files

### DIFF
--- a/.agents/skills/localstudio-finish-checks/SKILL.md
+++ b/.agents/skills/localstudio-finish-checks/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: localstudio-finish-checks
-description: LocalStudio project completion workflow. Use before claiming a LocalStudio/canva-webai-clone code task is done, especially after frontend, editor, Playwright, export, import, sharing, persistence, or UI workflow changes, to run the scenario E2E test, lint, typecheck, and start a non-default-port dev server for user verification.
+description: LocalStudio project completion workflow. Use before claiming a LocalStudio/canva-webai-clone code task is done, especially after frontend, editor, Playwright, export, import, sharing, persistence, or UI workflow changes, to run the scenario E2E test, typecheck, lint, the full local test suite, and start a non-default-port dev server for user verification.
 ---
 
 # LocalStudio Finish Checks
 
 ## Overview
 
-Use this skill at the end of a LocalStudio implementation before final handoff. It enforces a concrete verification order: scenario E2E first, typecheck and lint next, then a user-verification dev server on a non-default port.
+Use this skill at the end of a LocalStudio implementation before final handoff. It enforces a concrete verification order: scenario E2E first, typecheck and lint next, the full local test suite before handoff, then a user-verification dev server on a non-default port.
 
 ## Workflow
 
@@ -40,7 +40,16 @@ Use this skill at the end of a LocalStudio implementation before final handoff. 
      ```
    - Do not describe lint as passing unless the full `npm run lint` command passed.
 
-5. Start a manual verification server on a non-default port.
+5. Run the full local test suite.
+   - This is required even when focused tests, typecheck, and lint pass, because the goal is to catch CI-breaking regressions before handoff.
+   - Run:
+     ```bash
+     npm test
+     ```
+   - If `npm test` fails because of unrelated pre-existing failures, report the failing workspace/spec and the first representative error, then run the narrow task-related tests again so the task-specific result is still clear.
+   - Do not describe the full local suite as passing unless the full `npm test` command passed.
+
+6. Start a manual verification server on a non-default port.
    - This repo's `scripts/dev.mjs` reads `PORT`; `npm run dev -- --port <port>` is ignored.
    - Use `PORT=5174 npm run dev` by default. If that port is busy, use `5175`, `5176`, and so on.
    - If sandboxing blocks binding a port with `listen EPERM`, rerun the same command with approval/escalation.
@@ -51,7 +60,7 @@ Use this skill at the end of a LocalStudio implementation before final handoff. 
 
 ## Handoff Rules
 
-- Summarize the scenario E2E command, typecheck result, lint result, and server URL.
+- Summarize the scenario E2E command, typecheck result, lint result, full `npm test` result, and server URL.
 - Mention known non-blocking warnings, such as JSDOM media API warnings, only if they appear in successful verification output.
 - If any required verification fails for task-related reasons, fix it before final handoff.
 - If a required verification cannot run, say why and do not imply the task is fully verified.

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -340,6 +340,12 @@ export interface StockMediaItem {
   downloadLocation?: string | undefined;
 }
 
+export interface DownloadedStockMedia {
+  blob: Blob;
+  mimeType: string;
+  objectUrl: string;
+}
+
 export interface StockMediaService {
   loadConfig(): StockMediaConfig | null;
   saveConfig(config: StockMediaConfig): void;
@@ -347,6 +353,7 @@ export interface StockMediaService {
   getProviderState(): StockMediaProviderState;
   searchImages(query: string): Promise<StockMediaItem[]>;
   searchGifs(query: string): Promise<StockMediaItem[]>;
+  downloadMedia(item: StockMediaItem, sourceUrl?: string): Promise<DownloadedStockMedia>;
   trackImageDownload(item: StockMediaItem): Promise<void>;
 }
 

--- a/apps/editor/src/services/stock-media/stockMediaService.ts
+++ b/apps/editor/src/services/stock-media/stockMediaService.ts
@@ -1,4 +1,5 @@
 import type {
+  DownloadedStockMedia,
   StockMediaConfig,
   StockMediaItem,
   StockMediaProviderState,
@@ -10,6 +11,10 @@ import { createApi } from 'unsplash-js';
 
 const CONFIG_STORAGE_KEY = 'localstudio.ai.stock-media-config';
 const DEFAULT_LIMIT = 30;
+
+function getDefaultFetch() {
+  return globalThis.fetch.bind(globalThis);
+}
 
 interface BrowserStockMediaServiceOptions {
   fetch?: typeof fetch;
@@ -72,6 +77,16 @@ function readString(value: unknown) {
 function readPositiveNumber(value: unknown, fallback: number) {
   const parsed = typeof value === 'number' ? value : Number.parseInt(readString(value), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getBlobMimeType(blob: Blob, fallback: string) {
+  return readString(blob.type) || fallback;
+}
+
+function getStockMediaFallbackMimeType(item: StockMediaItem, sourceUrl: string) {
+  if (item.kind === 'image') return 'image/jpeg';
+  if (sourceUrl === item.videoUrl) return 'video/mp4';
+  return 'image/gif';
 }
 
 function isSafeRemoteUrl(value: unknown): value is string {
@@ -156,7 +171,7 @@ export class BrowserStockMediaService implements StockMediaService {
   private readonly storage: BrowserKeyValueStorage | undefined;
 
   constructor(options: BrowserStockMediaServiceOptions = {}) {
-    this.requestFetch = options.fetch ?? fetch;
+    this.requestFetch = options.fetch ?? getDefaultFetch();
     this.storage = options.storage ?? browserStorage.getBrowserLocalStorage();
   }
 
@@ -219,6 +234,22 @@ export class BrowserStockMediaService implements StockMediaService {
         : giphy.trending({ limit: DEFAULT_LIMIT, rating: 'g' }),
     );
     return (payload.data ?? []).map(mapGiphyGif).filter((item): item is StockMediaItem => Boolean(item));
+  }
+
+  async downloadMedia(item: StockMediaItem, sourceUrl = item.mediaUrl): Promise<DownloadedStockMedia> {
+    if (!isSafeRemoteUrl(sourceUrl)) throw new Error('Stock media download URL is invalid.');
+
+    const response = await this.requestFetch(sourceUrl);
+    if (!response.ok) throw new Error('Stock media download failed.');
+
+    const blob = await response.blob();
+    const mimeType = getBlobMimeType(blob, getStockMediaFallbackMimeType(item, sourceUrl));
+    const objectUrlBlob = blob.type === mimeType ? blob : new Blob([blob], { type: mimeType });
+    return {
+      blob,
+      mimeType,
+      objectUrl: URL.createObjectURL(objectUrlBlob),
+    };
   }
 
   private async withConfiguredFetch<T>(operation: () => Promise<T>): Promise<T> {

--- a/apps/editor/src/services/storage/assetFileUtils.ts
+++ b/apps/editor/src/services/storage/assetFileUtils.ts
@@ -16,6 +16,15 @@ function isBlobUrl(value: string | undefined): value is string {
   return Boolean(value?.startsWith('blob:'));
 }
 
+function isSafeRemoteUrl(value: string | undefined): value is string {
+  if (!value) return false;
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function dataUrlToBlob(dataUrl: string) {
   const [metadata, base64 = ''] = dataUrl.split(',');
   const mimeType = metadata?.match(/^data:(.*?);base64$/)?.[1] ?? 'application/octet-stream';
@@ -27,7 +36,11 @@ function isReadableObjectUrl(value: string | undefined): value is string {
   return isDataUrl(value) || isBlobUrl(value);
 }
 
-async function objectUrlToBlob(objectUrl: string, requestFetch: typeof fetch = fetch) {
+function getDefaultFetch() {
+  return globalThis.fetch.bind(globalThis);
+}
+
+async function objectUrlToBlob(objectUrl: string, requestFetch: typeof fetch = getDefaultFetch()) {
   if (isDataUrl(objectUrl)) return dataUrlToBlob(objectUrl);
   return requestFetch(objectUrl).then((response) => response.blob());
 }
@@ -42,12 +55,27 @@ function objectUrlToBlobIfReadable(
   return requestFetch(objectUrl).then((response) => response.blob());
 }
 
+async function remoteObjectUrlToLocalObjectUrl(
+  objectUrl: string | undefined,
+  mimeType: string,
+  requestFetch: typeof fetch | undefined,
+) {
+  if (!isSafeRemoteUrl(objectUrl) || !requestFetch) return undefined;
+  const response = await requestFetch(objectUrl);
+  if (!response.ok) return undefined;
+  const blob = await response.blob();
+  const typedBlob = blob.type ? blob : new Blob([blob], { type: mimeType });
+  return URL.createObjectURL(typedBlob);
+}
+
 export const assetFileUtils = {
   getAssetFileExtension,
   isDataUrl,
   isBlobUrl,
+  isSafeRemoteUrl,
   dataUrlToBlob,
   isReadableObjectUrl,
   objectUrlToBlob,
   objectUrlToBlobIfReadable,
+  remoteObjectUrlToLocalObjectUrl,
 };

--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -12,6 +12,7 @@ import { assetFileUtils } from './assetFileUtils';
 import { projectVersionHistoryUtils } from './projectVersionHistoryUtils';
 
 interface FileSystemProjectRepositoryOptions {
+  fetch?: typeof fetch;
   pickDirectory?: () => Promise<FileSystemDirectoryHandle>;
   recentProjectStore?: RecentProjectHandleStore;
 }
@@ -128,6 +129,11 @@ async function readProjectNameFromMirrorFiles(files: MirrorFile[]) {
 
 function isNotFoundError(error: unknown) {
   return error instanceof DOMException && error.name === 'NotFoundError';
+}
+
+function getDefaultFetch() {
+  if (typeof globalThis.fetch !== 'function') return undefined;
+  return globalThis.fetch.bind(globalThis);
 }
 
 export class BrowserFileSystemProjectRepository implements ProjectRepository {
@@ -536,7 +542,21 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
 
     for (const [assetId, asset] of Object.entries(project.assets)) {
       if (asset.storage !== 'file' || !asset.fileName) {
-        assets[assetId] = asset;
+        const objectUrl =
+          asset.storage === 'remote'
+            ? await assetFileUtils.remoteObjectUrlToLocalObjectUrl(
+                asset.objectUrl,
+                asset.mimeType,
+                this.options.fetch ?? getDefaultFetch(),
+              )
+            : undefined;
+        if (objectUrl) {
+          const { storage, ...assetWithoutStorage } = asset;
+          void storage;
+          assets[assetId] = { ...assetWithoutStorage, objectUrl };
+        } else {
+          assets[assetId] = asset;
+        }
         continue;
       }
       try {

--- a/apps/editor/src/services/storage/opfsProjectRepository.ts
+++ b/apps/editor/src/services/storage/opfsProjectRepository.ts
@@ -11,6 +11,7 @@ import { assetFileUtils } from './assetFileUtils';
 import { projectVersionHistoryUtils } from './projectVersionHistoryUtils';
 
 interface OpfsProjectRepositoryOptions {
+  fetch?: typeof fetch;
   getRootDirectory?: () => Promise<FileSystemDirectoryHandle>;
   storage?: BrowserKeyValueStorage;
 }
@@ -118,6 +119,11 @@ async function readProjectNameFromMirrorFiles(files: MirrorFile[]) {
 
 function isNotFoundError(error: unknown) {
   return error instanceof DOMException && error.name === 'NotFoundError';
+}
+
+function getDefaultFetch() {
+  if (typeof globalThis.fetch !== 'function') return undefined;
+  return globalThis.fetch.bind(globalThis);
 }
 
 function normalizeProjectDirectoryName(projectName: string | undefined) {
@@ -493,7 +499,21 @@ export class OpfsProjectRepository implements ProjectRepository {
 
     for (const [assetId, asset] of Object.entries(project.assets)) {
       if (asset.storage !== 'file' || !asset.fileName) {
-        assets[assetId] = asset;
+        const objectUrl =
+          asset.storage === 'remote'
+            ? await assetFileUtils.remoteObjectUrlToLocalObjectUrl(
+                asset.objectUrl,
+                asset.mimeType,
+                this.options.fetch ?? getDefaultFetch(),
+              )
+            : undefined;
+        if (objectUrl) {
+          const { storage, ...assetWithoutStorage } = asset;
+          void storage;
+          assets[assetId] = { ...assetWithoutStorage, objectUrl };
+        } else {
+          assets[assetId] = asset;
+        }
         continue;
       }
       try {

--- a/apps/editor/src/ui/editor/state/use-stock-media-library.ts
+++ b/apps/editor/src/ui/editor/state/use-stock-media-library.ts
@@ -4,6 +4,7 @@ import { fitImageWithinPage } from '../../../domain/images/imageSizing';
 import type { ProjectDocument } from '../../../domain/documents/model';
 import { createPrefixedId } from '../../../services/ids/idUtils';
 import type {
+  DownloadedStockMedia,
   StockMediaConfig,
   StockMediaItem,
   StockMediaProviderState,
@@ -123,10 +124,29 @@ export function useStockMediaLibrary({
     );
   }
 
-  function insertRemoteImage(item: StockMediaItem) {
+  async function downloadStockMedia(item: StockMediaItem, sourceUrl?: string) {
+    return stockMediaService.downloadMedia(item, sourceUrl);
+  }
+
+  function setInsertError(item: StockMediaItem) {
+    setStockMediaError((current) => ({
+      ...current,
+      [item.kind === 'image' ? 'images' : 'gifs']: 'Download failed',
+    }));
+  }
+
+  async function insertRemoteImage(item: StockMediaItem) {
     if (item.kind !== 'image') return;
     const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
     if (!page) return;
+
+    let media: DownloadedStockMedia;
+    try {
+      media = await downloadStockMedia(item);
+    } catch {
+      setInsertError(item);
+      return;
+    }
 
     const assetId = createPrefixedId('asset');
     const elementId = createPrefixedId('image');
@@ -144,9 +164,8 @@ export function useStockMediaLibrary({
             id: assetId,
             type: 'image',
             name: item.title,
-            mimeType: 'image/jpeg',
-            objectUrl: item.mediaUrl,
-            storage: 'remote',
+            mimeType: media.mimeType,
+            objectUrl: media.objectUrl,
           },
           element: {
             id: elementId,
@@ -168,10 +187,18 @@ export function useStockMediaLibrary({
     void stockMediaService.trackImageDownload(item).catch(() => undefined);
   }
 
-  function commitRemoteGifElement(item: StockMediaItem) {
+  async function commitRemoteGifElement(item: StockMediaItem) {
     if (item.kind !== 'gif') return;
     const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
     if (!page) return;
+
+    let media: DownloadedStockMedia;
+    try {
+      media = await downloadStockMedia(item);
+    } catch {
+      setInsertError(item);
+      return;
+    }
 
     const assetId = createPrefixedId('asset');
     const elementId = createPrefixedId('gif');
@@ -189,9 +216,8 @@ export function useStockMediaLibrary({
             id: assetId,
             type: 'gif',
             name: item.title,
-            mimeType: 'image/gif',
-            objectUrl: item.mediaUrl,
-            storage: 'remote',
+            mimeType: media.mimeType,
+            objectUrl: media.objectUrl,
           },
           element: {
             id: elementId,
@@ -213,10 +239,18 @@ export function useStockMediaLibrary({
     addRecentStockMedia(item);
   }
 
-  function insertRemoteVideoElement(item: StockMediaItem, videoUrl: string) {
+  async function insertRemoteVideoElement(item: StockMediaItem, videoUrl: string) {
     if (item.kind !== 'gif') return;
     const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
     if (!page) return;
+
+    let media: DownloadedStockMedia;
+    try {
+      media = await downloadStockMedia(item, videoUrl);
+    } catch {
+      setInsertError(item);
+      return;
+    }
 
     const assetId = createPrefixedId('asset');
     const elementId = createPrefixedId('video');
@@ -234,9 +268,8 @@ export function useStockMediaLibrary({
             id: assetId,
             type: 'video',
             name: item.title,
-            mimeType: 'video/mp4',
-            objectUrl: videoUrl,
-            storage: 'remote',
+            mimeType: media.mimeType,
+            objectUrl: media.objectUrl,
           },
           element: {
             id: elementId,
@@ -263,21 +296,21 @@ export function useStockMediaLibrary({
     addRecentStockMedia(item);
   }
 
-  function insertRemoteGif(item: StockMediaItem) {
+  async function insertRemoteGif(item: StockMediaItem) {
     if (item.kind !== 'gif') return;
     if (item.videoUrl) {
-      insertRemoteVideoElement(item, item.videoUrl);
+      await insertRemoteVideoElement(item, item.videoUrl);
     } else {
-      commitRemoteGifElement(item);
+      await commitRemoteGifElement(item);
     }
   }
 
   function insertStockMedia(item: StockMediaItem) {
     if (item.kind === 'gif') {
-      insertRemoteGif(item);
+      void insertRemoteGif(item);
       return;
     }
-    insertRemoteImage(item);
+    void insertRemoteImage(item);
   }
 
   useEffect(() => {

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
@@ -146,6 +146,59 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     expect(loaded?.assets['asset-hero']?.objectUrl).toMatch(/^blob:/);
   });
 
+  it('downloads remote image assets on import and saves them as local files', async () => {
+    const directory = new MockDirectoryHandle();
+    const fetchRemoteAsset = vi.fn(() =>
+      Promise.resolve(
+        new Response('remote image', { headers: { 'content-type': 'image/png' } }),
+      ),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('remote image', { headers: { 'content-type': 'image/png' } }),
+    );
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:remote-image');
+    directory.files.set(
+      'project.json',
+      JSON.stringify({
+        ...sampleProject.createSampleProject(),
+        assets: {
+          'asset-remote': {
+            id: 'asset-remote',
+            type: 'image',
+            name: 'Remote image',
+            mimeType: 'image/png',
+            objectUrl: 'https://images.unsplash.com/legacy-photo.png',
+            storage: 'remote',
+          },
+        },
+      }),
+    );
+    const repository = new BrowserFileSystemProjectRepository({
+      fetch: fetchRemoteAsset as unknown as typeof fetch,
+      pickDirectory: () => Promise.resolve(directory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+
+    const loaded = await repository.importProject();
+    if (!loaded) throw new Error('Expected project to load');
+    await repository.saveProject(loaded);
+
+    expect(fetchRemoteAsset).toHaveBeenCalledWith('https://images.unsplash.com/legacy-photo.png');
+    expect(createObjectUrl).toHaveBeenCalled();
+    expect(loaded.assets['asset-remote']).toMatchObject({
+      objectUrl: 'blob:remote-image',
+    });
+    expect(loaded.assets['asset-remote']?.storage).toBeUndefined();
+    const assetsDirectory = directory.directories.get('assets')!;
+    expect(await (assetsDirectory.files.get('asset-remote.png') as Blob).text()).toBe('remote image');
+    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    expect(savedProject.assets['asset-remote']).toMatchObject({
+      fileName: 'asset-remote.png',
+      storage: 'file',
+    });
+    expect(savedProject.assets['asset-remote']?.objectUrl).toBeUndefined();
+  });
+
   it('keeps hydrated file-backed object URLs out of project.json when saved again', async () => {
     const directory = new MockDirectoryHandle();
     const assetsDirectory = new MockDirectoryHandle();

--- a/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/opfsProjectRepository.test.ts
@@ -176,6 +176,65 @@ describe('OpfsProjectRepository', () => {
     expect(createObjectUrl).toHaveBeenCalled();
   });
 
+  it('downloads remote assets on OPFS load and saves them as local files', async () => {
+    const root = new MockDirectoryHandle();
+    const storage = new MemoryStorage();
+    const fetchRemoteAsset = vi.fn(() =>
+      Promise.resolve(
+        new Response('remote gif', { headers: { 'content-type': 'image/gif' } }),
+      ),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('remote gif', { headers: { 'content-type': 'image/gif' } }),
+    );
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:remote-gif');
+    const project: ProjectDocument = {
+      ...sampleProject.createSampleProject(),
+      assets: {
+        'asset-remote': {
+          id: 'asset-remote',
+          type: 'gif',
+          name: 'Remote GIF',
+          mimeType: 'image/gif',
+          objectUrl: 'https://media.giphy.com/media/legacy/giphy.gif',
+          storage: 'remote',
+        },
+      },
+    };
+
+    await new OpfsProjectRepository({
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage,
+    }).saveProject(project);
+    const projectDirectory = await getProjectDirectory(root, project.name);
+    projectDirectory.files.set('project.json', JSON.stringify(project));
+
+    const repository = new OpfsProjectRepository({
+      fetch: fetchRemoteAsset as unknown as typeof fetch,
+      getRootDirectory: () => Promise.resolve(root as unknown as FileSystemDirectoryHandle),
+      storage,
+    });
+    const loaded = await repository.loadProject();
+    if (!loaded) throw new Error('Expected project to load');
+    await repository.saveProject(loaded);
+
+    expect(fetchRemoteAsset).toHaveBeenCalledWith('https://media.giphy.com/media/legacy/giphy.gif');
+    expect(createObjectUrl).toHaveBeenCalled();
+    expect(loaded.assets['asset-remote']).toMatchObject({
+      objectUrl: 'blob:remote-gif',
+    });
+    expect(loaded.assets['asset-remote']?.storage).toBeUndefined();
+    expect(await (projectDirectory.directories.get('assets')!.files.get('asset-remote.gif') as Blob).text()).toBe('remote gif');
+    const savedProject = JSON.parse(
+      await readMockText(projectDirectory.files.get('project.json')!),
+    ) as ProjectDocument;
+    expect(savedProject.assets['asset-remote']).toMatchObject({
+      fileName: 'asset-remote.gif',
+      storage: 'file',
+    });
+    expect(savedProject.assets['asset-remote']?.objectUrl).toBeUndefined();
+  });
+
   it('persists project fonts under fonts and hydrates object URLs on load', async () => {
     const root = new MockDirectoryHandle();
     const storage = new MemoryStorage();

--- a/apps/editor/tests/unit/services/stockMediaService.test.ts
+++ b/apps/editor/tests/unit/services/stockMediaService.test.ts
@@ -40,6 +40,7 @@ describe('BrowserStockMediaService', () => {
   });
 
   it('maps Unsplash search results and tracks the photo download URL', async () => {
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:unsplash-photo');
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = getRequestUrl(input);
       const headers = input instanceof Request ? input.headers : undefined;
@@ -73,6 +74,11 @@ describe('BrowserStockMediaService', () => {
         expect(headers?.get('authorization')).toBe('Client-ID unsplash-key');
         return Promise.resolve(Response.json({ url: 'https://images.unsplash.com/downloaded' }));
       }
+      if (url === 'https://images.unsplash.com/photo-1?ixid=abc&fm=jpg&w=1080') {
+        return Promise.resolve(
+          new Response('photo-bytes', { headers: { 'content-type': 'image/jpeg' } }),
+        );
+      }
       return Promise.resolve(new Response('', { status: 404 }));
     });
     const service = new BrowserStockMediaService({ fetch: fetchMock });
@@ -96,15 +102,29 @@ describe('BrowserStockMediaService', () => {
       },
     ]);
 
+    await expect(service.downloadMedia(results[0]!)).resolves.toMatchObject({
+      mimeType: 'image/jpeg',
+      objectUrl: 'blob:unsplash-photo',
+    });
     await service.trackImageDownload(results[0]!);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it('maps GIPHY search results to animated GIF media', async () => {
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:giphy-video');
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
-      const url = new URL(getRequestUrl(input));
-      expect(url.origin).toBe('https://api.giphy.com');
+      const rawUrl = getRequestUrl(input);
+      if (rawUrl === 'https://media.giphy.com/media/gif-1/giphy.mp4') {
+        return Promise.resolve(
+          new Response('video-bytes', { headers: { 'content-type': 'video/mp4' } }),
+        );
+      }
+      const url = new URL(rawUrl);
+      if (url.origin !== 'https://api.giphy.com') {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
       expect(url.pathname).toBe('/v1/gifs/search');
       expect(url.searchParams.get('api_key')).toBe('giphy-key');
       expect(url.searchParams.get('limit')).toBe('30');
@@ -145,7 +165,9 @@ describe('BrowserStockMediaService', () => {
     const service = new BrowserStockMediaService({ fetch: fetchMock });
     service.saveConfig({ unsplashAccessKey: '', giphyApiKey: 'giphy-key' });
 
-    await expect(service.searchGifs('launch')).resolves.toEqual([
+    const results = await service.searchGifs('launch');
+
+    expect(results).toEqual([
       {
         id: 'gif-1',
         provider: 'giphy',
@@ -160,5 +182,11 @@ describe('BrowserStockMediaService', () => {
         height: 270,
       },
     ]);
+    createObjectUrl.mockClear();
+    await expect(service.downloadMedia(results[0]!, results[0]!.videoUrl)).resolves.toMatchObject({
+      mimeType: 'video/mp4',
+      objectUrl: 'blob:giphy-video',
+    });
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.elements-stock.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.elements-stock.test.tsx
@@ -68,7 +68,12 @@ describe('EditorShell elements and stock media workflows', () => {
         expect.stringMatching(/^image-/),
       );
     });
-    expect(stockMediaService.trackedItems).toEqual([stockImage]);
+    expect(stockMediaService.downloadedItems).toEqual([
+      { item: stockImage, sourceUrl: stockImage.mediaUrl },
+    ]);
+    await waitFor(() => {
+      expect(stockMediaService.trackedItems).toEqual([stockImage]);
+    });
   });
 
   it('inserts an Unsplash image before download tracking finishes', async () => {
@@ -107,10 +112,7 @@ describe('EditorShell elements and stock media workflows', () => {
       );
     });
     expect(screen.getByLabelText('Launch GIF').tagName.toLowerCase()).toBe('video');
-    expect(screen.getByLabelText('Launch GIF')).toHaveAttribute(
-      'src',
-      'https://media.giphy.com/media/gif-1/giphy.mp4',
-    );
+    expect(screen.getByLabelText('Launch GIF')).toHaveAttribute('src', 'blob:giphy-video');
   });
 
   it('inserts a GIPHY GIF movie before video metadata finishes loading', async () => {
@@ -130,10 +132,7 @@ describe('EditorShell elements and stock media workflows', () => {
         expect.stringMatching(/^video-/),
       );
     });
-    expect(screen.getByLabelText('Launch GIF')).toHaveAttribute(
-      'src',
-      'https://media.giphy.com/media/gif-1/giphy.mp4',
-    );
+    expect(screen.getByLabelText('Launch GIF')).toHaveAttribute('src', 'blob:giphy-video');
   });
 
   it('shows a generic API key error when stock image search is rejected', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.media-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.media-fixtures.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import type { ProjectDocument } from '../../../../src/domain/documents/model';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import type {
+  DownloadedStockMedia,
   StockMediaConfig,
   StockMediaItem,
   StockMediaProviderState,
@@ -35,6 +36,7 @@ const stockGif: StockMediaItem = {
 };
 
 class ReadyStockMediaService implements StockMediaService {
+  downloadedItems: Array<{ item: StockMediaItem; sourceUrl: string }> = [];
   trackedItems: StockMediaItem[] = [];
 
   loadConfig(): StockMediaConfig {
@@ -62,6 +64,22 @@ class ReadyStockMediaService implements StockMediaService {
 
   searchGifs(): Promise<StockMediaItem[]> {
     return Promise.resolve([stockGif]);
+  }
+
+  downloadMedia(item: StockMediaItem, sourceUrl = item.mediaUrl): Promise<DownloadedStockMedia> {
+    this.downloadedItems.push({ item, sourceUrl });
+    return Promise.resolve({
+      blob: new Blob(['stock-media'], {
+        type: sourceUrl.endsWith('.mp4') ? 'video/mp4' : item.kind === 'gif' ? 'image/gif' : 'image/jpeg',
+      }),
+      mimeType: sourceUrl.endsWith('.mp4') ? 'video/mp4' : item.kind === 'gif' ? 'image/gif' : 'image/jpeg',
+      objectUrl:
+        sourceUrl === stockGif.videoUrl
+          ? 'blob:giphy-video'
+          : item.kind === 'gif'
+            ? 'blob:giphy-gif'
+            : 'blob:unsplash-image',
+    });
   }
 
   trackImageDownload(item: StockMediaItem): Promise<void> {

--- a/tests/e2e/editor/stock-media-routes.ts
+++ b/tests/e2e/editor/stock-media-routes.ts
@@ -67,13 +67,13 @@ export const stockMediaRoutes = {
           'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lMFeWAAAAABJRU5ErkJggg==',
           'base64',
         ),
-        contentType: 'image/png',
+        headers: { 'access-control-allow-origin': '*', 'content-type': 'image/png' },
       });
     });
     await page.route('https://media.giphy.com/**', async (route) => {
       await route.fulfill({
         body: Buffer.from('R0lGODlhAQABAAAAACw=', 'base64'),
-        contentType: 'image/gif',
+        headers: { 'access-control-allow-origin': '*', 'content-type': 'image/gif' },
       });
     });
   },


### PR DESCRIPTION
## Summary
- Added a `downloadMedia` contract for stock media services and wired editor insert flows to fetch media before creating assets.
- Normalized downloaded images, GIFs, and GIF videos to local blob URLs with detected or fallback MIME types.
- Converted remote assets to local files during browser filesystem and OPFS project import so saved projects no longer depend on remote URLs.
- Updated unit and E2E coverage for download handling, local persistence, and the new blob URL behavior.

## Testing
- Updated unit tests for stock media download, import/save hydration, and remote-to-local asset conversion.
- Updated editor shell tests to validate blob-based media insertion.
- Updated E2E stock media route fixtures for browser download behavior.