### PR TITLE
Retry autosave and surface persistence failures in the editor toolbar

### DIFF
--- a/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
@@ -57,6 +57,7 @@ export function EditorToolbarSurface({
       mirrorState={vm.mirrorState}
       mirrorDisabledBySettings={vm.mirrorDisabledBySettings}
       persistenceAttention={vm.persistenceAttention}
+      persistenceError={vm.persistenceError}
       operationNotice={imageExportNotice ?? vm.operationNotice}
       localProjectSetupPanel={
         vm.localProjectSetupOpen ? (

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -121,6 +121,8 @@ const PROMPT_API_REQUIRED_MESSAGE = 'LLM model must be prepared before using pro
 const IMAGE_GENERATION_MODEL_REQUIRED_MESSAGE =
   'Download image generation models before creating images.';
 const IMAGE_PROMPT_MODE_REQUIRED_MESSAGE = 'Use Create image from the + menu to generate images.';
+const AUTOSAVE_RETRY_LIMIT = 5;
+const AUTOSAVE_RETRY_DELAY_MS = 1000;
 type TranslationScope = 'selection' | 'slide' | 'deck';
 
 const DECK_TRANSLATION_CONCURRENCY = 3;
@@ -188,9 +190,8 @@ export function useEditorViewModel(services: AppServices) {
   const [missingPowerPointFonts, setMissingPowerPointFonts] = useState<MissingPowerPointFont[]>(
     [],
   );
-  const [hasPersistedLocalProject, setHasPersistedLocalProject] = useState(
-    shouldRestoreStoredProject,
-  );
+  const [hasPersistedLocalProject, setHasPersistedLocalProject] = useState(false);
+  const hasPersistedLocalProjectRef = useRef(hasPersistedLocalProject);
   const [activePageId, setActivePageId] = useState(initialProject.pages[0]?.id ?? '');
   const [activePageFocusKey, setActivePageFocusKey] = useState(0);
   const activePageIdRef = useRef(activePageId);
@@ -273,6 +274,7 @@ export function useEditorViewModel(services: AppServices) {
   const [remoteImportOpen, setRemoteImportOpen] = useState(false);
   const [localProjectSetupOpen, setLocalProjectSetupOpen] = useState(false);
   const [persistenceAttention, setPersistenceAttention] = useState(false);
+  const [persistenceError, setPersistenceError] = useState(false);
   const { operationNotice, showOperationNotice } = useOperationNotice();
   const [isExportingPowerPoint, setIsExportingPowerPoint] = useState(false);
   const [remoteImportStatus, setRemoteImportStatus] = useState<RemoteImportStatus>('loading');
@@ -342,6 +344,7 @@ export function useEditorViewModel(services: AppServices) {
   projectRef.current = project;
   activePageIdRef.current = activePageId;
   selectedElementIdsRef.current = selectedElementIds;
+  hasPersistedLocalProjectRef.current = hasPersistedLocalProject;
   mirrorConfigRef.current = hasMirrorConfig ? mirrorConfig : null;
   queueMirrorSyncRef.current = queueMirrorSync;
   syncMirrorNowRef.current = (projectToSync) => {
@@ -350,7 +353,10 @@ export function useEditorViewModel(services: AppServices) {
   const wasFullscreenRef = useRef(false);
   const presenterPageIdRef = useRef<string | undefined>(undefined);
   const languageDetectionSequenceRef = useRef(0);
+  const initialRestorePendingRef = useRef(shouldRestoreStoredProject);
   const skipNextProjectSaveRef = useRef(shouldRestoreStoredProject);
+  const autosaveRunIdRef = useRef(0);
+  const autosaveRetryTimeoutRef = useRef<number | undefined>(undefined);
   const lastVersionProjectRef = useRef<ProjectDocument>(initialProject);
   const needsFreshPersistenceTargetRef = useRef(false);
   const selection = useMemo<SelectionState>(
@@ -505,14 +511,23 @@ export function useEditorViewModel(services: AppServices) {
           }
           editorViewModelProject.writeProjectNameToUrl(normalizedProject.name);
           setHasPersistedLocalProject(true);
+          setPersistenceError(false);
           if (storedMirrorConfig && shouldEnableStoredMirror) {
             syncMirrorNowRef.current(normalizedProject);
           }
+        } else if (initialRestorePendingRef.current) {
+          setHasPersistedLocalProject(false);
+          setPersistenceEnabled(false);
+          if (typeof window !== 'undefined') {
+            editorPreferences.writePersistencePreference(false);
+          }
         }
+        initialRestorePendingRef.current = false;
         setHasLoadedProject(true);
       })
       .catch(() => {
         if (!isMounted) return;
+        initialRestorePendingRef.current = false;
         setPersistenceEnabled(false);
         setHasLoadedProject(true);
         if (typeof window !== 'undefined') {
@@ -538,39 +553,66 @@ export function useEditorViewModel(services: AppServices) {
       skipNextProjectSaveRef.current = false;
       return;
     }
-    void services.projectRepository
-      .saveProject(project)
-      .then(async () => {
-        setHasPersistedLocalProject(true);
-        setLastEditedAt(project.updatedAt);
-        setSaveAnimationKey((current) => current + 1);
-        if (!services.projectRepository.saveVersion) return;
-        const entry = await services.projectRepository.saveVersion(project, {
-          previousProject: lastVersionProjectRef.current,
-        });
-        lastVersionProjectRef.current = project;
-        setLastEditedAt(entry.createdAt);
-        setVersionHistoryEntries((current) => [
-          entry,
-          ...current.filter((item) => item.id !== entry.id),
-        ]);
-      })
-      .then(() => {
-        queueMirrorSyncRef.current();
-        editorViewModelProject.writeProjectNameToUrl(project.name);
-      })
-      .catch(() => {
-        setPersistenceEnabled(false);
-        if (typeof window !== 'undefined') {
-          editorPreferences.writePersistencePreference(false);
-        }
+    if (autosaveRetryTimeoutRef.current !== undefined) {
+      window.clearTimeout(autosaveRetryTimeoutRef.current);
+      autosaveRetryTimeoutRef.current = undefined;
+    }
+    const autosaveRunId = autosaveRunIdRef.current + 1;
+    autosaveRunIdRef.current = autosaveRunId;
+
+    async function saveProjectWithVersion(projectToSave: ProjectDocument) {
+      await services.projectRepository.saveProject(projectToSave);
+      setHasPersistedLocalProject(true);
+      setLastEditedAt(projectToSave.updatedAt);
+      setSaveAnimationKey((current) => current + 1);
+      if (!services.projectRepository.saveVersion) return;
+      const entry = await services.projectRepository.saveVersion(projectToSave, {
+        previousProject: lastVersionProjectRef.current,
       });
+      lastVersionProjectRef.current = projectToSave;
+      setLastEditedAt(entry.createdAt);
+      setVersionHistoryEntries((current) => [
+        entry,
+        ...current.filter((item) => item.id !== entry.id),
+      ]);
+    }
+
+    function retryAutosave(projectToSave: ProjectDocument, attempt: number) {
+      void saveProjectWithVersion(projectToSave)
+        .then(() => {
+          if (autosaveRunIdRef.current !== autosaveRunId) return;
+          setPersistenceError(false);
+          setPersistenceAttention(false);
+          queueMirrorSyncRef.current();
+          editorViewModelProject.writeProjectNameToUrl(projectToSave.name);
+        })
+        .catch(() => {
+          if (autosaveRunIdRef.current !== autosaveRunId) return;
+          if (attempt < AUTOSAVE_RETRY_LIMIT) {
+            autosaveRetryTimeoutRef.current = window.setTimeout(() => {
+              retryAutosave(projectToSave, attempt + 1);
+            }, AUTOSAVE_RETRY_DELAY_MS);
+            return;
+          }
+          setPersistenceEnabled(false);
+          setPersistenceAttention(false);
+          setPersistenceError(true);
+          if (typeof window !== 'undefined') {
+            editorPreferences.writePersistencePreference(false);
+          }
+        });
+    }
+
+    retryAutosave(project, 1);
   }, [hasLoadedProject, persistenceEnabled, project, services.projectRepository]);
 
   useEffect(() => {
     return () => {
       if (mirrorDebounceRef.current !== undefined) {
         window.clearTimeout(mirrorDebounceRef.current);
+      }
+      if (autosaveRetryTimeoutRef.current !== undefined) {
+        window.clearTimeout(autosaveRetryTimeoutRef.current);
       }
     };
   }, []);
@@ -1239,9 +1281,15 @@ export function useEditorViewModel(services: AppServices) {
 
   function setPersistence(nextEnabled: boolean) {
     if (!nextEnabled) {
+      autosaveRunIdRef.current += 1;
+      if (autosaveRetryTimeoutRef.current !== undefined) {
+        window.clearTimeout(autosaveRetryTimeoutRef.current);
+        autosaveRetryTimeoutRef.current = undefined;
+      }
       setPersistenceEnabled(false);
       setLocalProjectSetupOpen(false);
       setPersistenceAttention(false);
+      setPersistenceError(false);
       showOperationNotice(undefined);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
@@ -1249,7 +1297,7 @@ export function useEditorViewModel(services: AppServices) {
       return true;
     }
 
-    if (hasPersistedLocalProject) {
+    if (hasPersistedLocalProjectRef.current) {
       return reenablePersistence();
     }
 
@@ -1279,6 +1327,7 @@ export function useEditorViewModel(services: AppServices) {
       skipNextProjectSaveRef.current = true;
       setPersistenceEnabled(true);
       setPersistenceAttention(false);
+      setPersistenceError(false);
       showOperationNotice(undefined);
       setLocalProjectSetupOpen(false);
       editorViewModelProject.writeProjectNameToUrl(projectToSave.name);
@@ -1288,6 +1337,7 @@ export function useEditorViewModel(services: AppServices) {
       return true;
     } catch {
       setPersistenceEnabled(false);
+      setPersistenceError(true);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
@@ -1321,9 +1371,11 @@ export function useEditorViewModel(services: AppServices) {
     }
     try {
       await persistCurrentProject();
+      setPersistenceError(false);
       editorViewModelProject.writeProjectNameToUrl(projectRef.current.name);
     } catch {
       setPersistenceEnabled(false);
+      setPersistenceError(true);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
@@ -1347,6 +1399,7 @@ export function useEditorViewModel(services: AppServices) {
       setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       setPersistenceAttention(false);
+      setPersistenceError(false);
       showOperationNotice(undefined);
       setLocalProjectSetupOpen(false);
       setLastEditedAt(projectToSave.updatedAt);
@@ -1358,6 +1411,7 @@ export function useEditorViewModel(services: AppServices) {
       }
     } catch {
       setPersistenceEnabled(false);
+      setPersistenceError(true);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
@@ -1393,6 +1447,7 @@ export function useEditorViewModel(services: AppServices) {
       setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
       setPersistenceAttention(false);
+      setPersistenceError(false);
       showOperationNotice(undefined);
       setLocalProjectSetupOpen(false);
       editorViewModelProject.writeProjectNameToUrl(nextProject.name);
@@ -1402,6 +1457,7 @@ export function useEditorViewModel(services: AppServices) {
       return true;
     } catch {
       setPersistenceEnabled(false);
+      setPersistenceError(true);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
@@ -1426,6 +1482,7 @@ export function useEditorViewModel(services: AppServices) {
       skipNextProjectSaveRef.current = true;
       setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
+      setPersistenceError(false);
       lastVersionProjectRef.current = normalizedProject;
       needsFreshPersistenceTargetRef.current = false;
       setLastEditedAt(normalizedProject.updatedAt);
@@ -1441,6 +1498,7 @@ export function useEditorViewModel(services: AppServices) {
       }
     } catch {
       setPersistenceEnabled(false);
+      setPersistenceError(true);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
@@ -1553,6 +1611,7 @@ export function useEditorViewModel(services: AppServices) {
       skipNextProjectSaveRef.current = true;
       setHasPersistedLocalProject(false);
       setPersistenceEnabled(false);
+      setPersistenceError(false);
       lastVersionProjectRef.current = normalizedProject;
       needsFreshPersistenceTargetRef.current = true;
       setLastEditedAt(normalizedProject.updatedAt);
@@ -1963,6 +2022,7 @@ export function useEditorViewModel(services: AppServices) {
       skipNextProjectSaveRef.current = true;
       setHasPersistedLocalProject(true);
       setPersistenceEnabled(true);
+      setPersistenceError(false);
       lastVersionProjectRef.current = normalizedProject;
       needsFreshPersistenceTargetRef.current = false;
       setLastEditedAt(normalizedProject.updatedAt);
@@ -3074,6 +3134,7 @@ export function useEditorViewModel(services: AppServices) {
     missingPowerPointFonts,
     mediaImportProgress,
     persistenceAttention,
+    persistenceError,
     operationNotice,
     isExportingPowerPoint,
     mirrorState,

--- a/apps/editor/src/ui/editor/toolbars/ToolbarPersistenceButton.tsx
+++ b/apps/editor/src/ui/editor/toolbars/ToolbarPersistenceButton.tsx
@@ -4,6 +4,7 @@ interface ToolbarPersistenceButtonProps {
   persistenceAttention: boolean;
   persistenceAvailable: boolean;
   persistenceEnabled: boolean;
+  persistenceError: boolean;
   persistenceMode: PersistenceStorageMode;
   onPersistenceToggle: ((enabled: boolean) => void) | undefined;
 }
@@ -12,6 +13,7 @@ export function ToolbarPersistenceButton({
   persistenceAttention,
   persistenceAvailable,
   persistenceEnabled,
+  persistenceError,
   persistenceMode,
   onPersistenceToggle,
 }: ToolbarPersistenceButtonProps) {
@@ -26,6 +28,8 @@ export function ToolbarPersistenceButton({
         : 'Persistence disabled';
   const persistenceTitle = !persistenceAvailable
     ? 'Local project persistence is not available in this browser.'
+    : persistenceError
+      ? 'Autosave failed after 5 attempts. Re-enable persistence to continue saving locally.'
     : persistenceMode === 'opfs'
       ? persistenceEnabled
         ? 'Browser-private project storage is enabled. Files are stored by this browser profile and are not visible in Finder.'
@@ -35,6 +39,8 @@ export function ToolbarPersistenceButton({
         : 'Save this deck to a local folder';
   const className = !persistenceAvailable
     ? 'stitch-icon-button persistence-off persistence-unavailable'
+    : persistenceError
+      ? `stitch-icon-button ${persistenceEnabled ? 'persistence-on' : 'persistence-off'} persistence-error`
     : persistenceEnabled
       ? 'stitch-icon-button persistence-on'
       : persistenceAttention

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -28,6 +28,7 @@ interface TopToolbarProps {
   mirrorDisabledBySettings?: boolean;
   localProjectSetupPanel?: ReactNode;
   persistenceAttention?: boolean;
+  persistenceError?: boolean;
   operationNotice?: OperationNoticeState | undefined;
   saveAnimationKey?: number;
   canTranslateDeck?: boolean;
@@ -111,6 +112,7 @@ export function TopToolbar({
   mirrorDisabledBySettings = false,
   localProjectSetupPanel,
   persistenceAttention = false,
+  persistenceError = false,
   operationNotice,
   saveAnimationKey = 0,
   canTranslateDeck = false,
@@ -535,6 +537,7 @@ export function TopToolbar({
             persistenceAttention={persistenceAttention}
             persistenceAvailable={persistenceAvailable}
             persistenceEnabled={persistenceEnabled}
+            persistenceError={persistenceError}
             persistenceMode={persistenceMode}
             onPersistenceToggle={onPersistenceToggle}
           />

--- a/apps/editor/src/ui/styles/persistence-controls.css
+++ b/apps/editor/src/ui/styles/persistence-controls.css
@@ -11,6 +11,11 @@
   animation: persistencePulse 900ms ease-in-out infinite;
 }
 
+.persistence-error {
+  color: #ffb4ab;
+  animation: persistencePulse 900ms ease-in-out infinite;
+}
+
 .operation-notice {
   position: absolute;
   top: 42px;

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
@@ -54,6 +54,27 @@ class SavingProjectRepository implements ProjectRepository {
   }
 }
 
+class RetryingAutosaveProjectRepository extends SavingProjectRepository {
+  autosaveAttempts = 0;
+  private hasCompletedInitialSave = false;
+
+  constructor(private readonly failingAutosaveAttempts: number) {
+    super();
+  }
+
+  override saveProject(project: ProjectDocument): Promise<void> {
+    if (!this.hasCompletedInitialSave) {
+      this.hasCompletedInitialSave = true;
+      return super.saveProject(project);
+    }
+    this.autosaveAttempts += 1;
+    if (this.autosaveAttempts <= this.failingAutosaveAttempts) {
+      return Promise.reject(new Error('Autosave failed'));
+    }
+    return super.saveProject(project);
+  }
+}
+
 class VersionHistoryProjectRepository extends SavingProjectRepository {
   constructor(
     private readonly project: ProjectDocument,
@@ -259,6 +280,7 @@ export const editorShellPersistenceFixtures = {
   LoadingProjectRepository,
   RecordingMirrorService,
   RecordingShareService,
+  RetryingAutosaveProjectRepository,
   RejectingLoadProjectRepository,
   RejectingProjectRepository,
   RemoteMirrorImportingProjectRepository,

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-mirror.test.tsx
@@ -12,6 +12,7 @@ const {
   ImportingProjectRepository,
   RejectingLoadProjectRepository,
   RejectingProjectRepository,
+  RetryingAutosaveProjectRepository,
   SavingProjectRepository,
   VersionHistoryProjectRepository,
   createAppServices,
@@ -19,6 +20,7 @@ const {
 
 describe('EditorShell persistence and mirror workflows', () => {
   afterEach(() => {
+    vi.useRealTimers();
     window.history.pushState({}, '', '/editor/');
     vi.restoreAllMocks();
   });
@@ -98,6 +100,53 @@ describe('EditorShell persistence and mirror workflows', () => {
     await user.type(screen.getByRole('textbox', { name: 'Project name' }), 'Autosaved Deck{Enter}');
 
     expect(repository.savedProjects.at(-1)?.name).toBe('Autosaved Deck');
+  });
+
+  it('retries autosave before marking persistence for re-enable', async () => {
+    vi.useFakeTimers();
+    const services = createAppServices();
+    const repository = new RetryingAutosaveProjectRepository(5);
+    services.projectRepository = repository;
+
+    try {
+      render(<EditorShell services={services} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+      window.localStorage.setItem('ew-canvas-ai.persistence-enabled', 'true');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit project name Untitled AI Deck' }));
+      const projectNameInput = screen.getByRole('textbox', { name: 'Project name' });
+      fireEvent.change(projectNameInput, { target: { value: 'Autosave Retry Deck' } });
+      fireEvent.blur(projectNameInput);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(repository.autosaveAttempts).toBe(1);
+      expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+      expect(screen.queryByText(/Local autosave failed/)).not.toBeInTheDocument();
+      expect(window.localStorage.getItem('ew-canvas-ai.persistence-enabled')).toBe('true');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      const persistenceButton = screen.getByRole('button', { name: 'Persistence disabled' });
+      expect(repository.autosaveAttempts).toBe(5);
+      expect(persistenceButton).toHaveClass('persistence-error');
+      expect(persistenceButton).toHaveAttribute(
+        'title',
+        'Autosave failed after 5 attempts. Re-enable persistence to continue saving locally.',
+      );
+      expect(window.localStorage.getItem('ew-canvas-ai.persistence-enabled')).toBe('false');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('saves the current project as a new local folder from the File menu', () => {


### PR DESCRIPTION
## Summary
- Add autosave retries with a capped backoff so transient local-save failures can recover before persistence is disabled.
- Surface a persistence error state in the toolbar when autosave exhausts retries, with clearer messaging and styling.
- Reset the error state when persistence is successfully re-enabled or a later save succeeds.
- Cover the retry and failure path with a new unit test fixture and persistence workflow test.

## Testing
- Added unit coverage for repeated autosave failures, retry count progression, and the final disabled/error state.
- Existing persistence workflow coverage continues to validate re-enable behavior and successful save paths.