### PR TITLE
Update mirror settings for S3 and MinIO workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,16 +130,27 @@ Default local settings:
 - API endpoint: `http://localhost:9000`
 - Console: `http://localhost:9001`
 - Bucket: `localstudio`
-- Access key: `localstudio`
-- Secret key: `localstudio123`
+- Writer access key: `localstudio-writer`
+- Writer secret key: `localstudio-writer`
+- Reader access key: `localstudio-reader`
+- Reader secret key: `localstudio-reader`
+- Root console login: `localstudio-root` / `localstudio-root123`
 - Region: `us-east-1`
 - Public base URL: `http://localhost:9000/localstudio`
 - Prefix: `mirrors`
 - Path-style URLs: enabled
 
-In the editor, open `Settings` -> `Mirror Settings` and enter those values. Use `File` -> `Mirror Now` to force an
-upload, or `File` -> `Import Remote` on another computer to download a mirrored project into a new local folder and
-continue syncing.
+In the editor, open `Settings` -> `Mirror Settings` and enter those values. Use the writer key for project sync,
+public share publishing, and remote mirror cleanup. Use the reader key for read-only deck access, imports, and public
+deck viewers so public links do not expose credentials that can write or modify presentations.
+
+Use `File` -> `Mirror Now` to force an upload, or `File` -> `Import Remote` on another computer to download a mirrored
+project into a new local folder and continue syncing.
+
+Local font mirroring can be enabled in the same settings panel. Choose the local font folder, then the panel shows
+`Fonts found in this directory` with a searchable dropdown of the readable fonts from that folder. Testing the storage
+connection checks S3-compatible access only; it does not upload local font test files. Fonts are mirrored when you
+publish or update a public share that needs them.
 
 The dev compose file sets the `localstudio` bucket to public download mode so mirrored files can be shared through the
 public base URL. For production, use a bucket or prefix policy that matches what you intend to publish. Browser-stored

--- a/README.md
+++ b/README.md
@@ -136,13 +136,33 @@ Default local settings:
 - Reader secret key: `localstudio-reader`
 - Root console login: `localstudio-root` / `localstudio-root123`
 - Region: `us-east-1`
-- Public base URL: `http://localhost:9000/localstudio`
 - Prefix: `mirrors`
 - Path-style URLs: enabled
 
 In the editor, open `Settings` -> `Mirror Settings` and enter those values. Use the writer key for project sync,
 public share publishing, and remote mirror cleanup. Use the reader key for read-only deck access, imports, and public
 deck viewers so public links do not expose credentials that can write or modify presentations.
+Public object URLs are derived from the endpoint, bucket, and path-style URL setting.
+The reader policy should allow `s3:ListBucket` on the bucket for Test/Import Remote and `s3:GetObject` on mirrored
+objects for public deck loading, but it should not allow write or delete actions.
+
+Production MinIO/S3-compatible deployments must expose the S3 API endpoint to the browser, not the MinIO Console URL.
+For example, use the ingress/service that targets MinIO port `9000`; the console normally targets `9001`.
+Set CORS so the editor origin can call the S3 API (`MINIO_API_CORS_ALLOW_ORIGIN=*` is acceptable for local/dev; use a
+specific editor origin in production when possible).
+
+Required policies:
+
+- Reader: `s3:ListBucket` and `s3:GetBucketLocation` on `arn:aws:s3:::<bucket>`, plus `s3:GetObject` on
+  `arn:aws:s3:::<bucket>/*`.
+- Writer: `s3:ListBucket` and `s3:GetBucketLocation` on `arn:aws:s3:::<bucket>`, plus `s3:GetObject`, `s3:PutObject`,
+  and `s3:DeleteObject` on `arn:aws:s3:::<bucket>/*`.
+- Public viewers need object download access for published deck payloads and assets. The local compose setup uses
+  anonymous bucket download for this; production can use an equivalent bucket/prefix policy or CDN in front of the
+  bucket.
+
+If reader/writer passwords change, rerun the MinIO bootstrap job or remove/recreate those MinIO users; otherwise MinIO
+may keep the previous credentials and the editor will report `403` on Test connection.
 
 Use `File` -> `Mirror Now` to force an upload, or `File` -> `Import Remote` on another computer to download a mirrored
 project into a new local folder and continue syncing.
@@ -153,7 +173,7 @@ connection checks S3-compatible access only; it does not upload local font test 
 publish or update a public share that needs them.
 
 The dev compose file sets the `localstudio` bucket to public download mode so mirrored files can be shared through the
-public base URL. For production, use a bucket or prefix policy that matches what you intend to publish. Browser-stored
+derived public object URLs. For production, use a bucket or prefix policy that matches what you intend to publish. Browser-stored
 keys are persisted locally, so avoid root credentials outside local development.
 
 ## Quick Start

--- a/apps/docs/guide/local-projects/mirroring.md
+++ b/apps/docs/guide/local-projects/mirroring.md
@@ -4,9 +4,9 @@ Mirroring syncs a local project folder to S3-compatible storage so assets and pu
 
 ## Mirror Settings
 
-The editor supports endpoint, bucket, region, writer access key, writer secret key, reader access key, reader secret key, public base URL, prefix, and path-style URL settings.
+The editor supports endpoint, bucket, region, writer access key, writer secret key, reader access key, reader secret key, prefix, and path-style URL settings. Public object URLs are derived from the endpoint, bucket, and path-style URL setting.
 
-Use writer credentials for project sync, public share publishing, and remote mirror cleanup. Use reader credentials for read-only deck access, imports, and public deck viewers. When you make a deck public, configure a read-only reader API key so people opening the public URL can load the deck payload and assets without getting credentials that can write or modify presentations.
+Use writer credentials for project sync, public share publishing, and remote mirror cleanup. Use reader credentials for read-only deck access, imports, and public deck viewers. When you make a deck public, configure a read-only reader API key so people opening the public URL can load the deck payload and assets without getting credentials that can write or modify presentations. The reader policy should allow `s3:ListBucket` on the bucket for Test/Import Remote and `s3:GetObject` on mirrored objects for public deck loading, but it should not allow write or delete actions.
 
 The local MinIO compose file creates these development credentials:
 

--- a/apps/docs/guide/local-projects/mirroring.md
+++ b/apps/docs/guide/local-projects/mirroring.md
@@ -4,7 +4,15 @@ Mirroring syncs a local project folder to S3-compatible storage so assets and pu
 
 ## Mirror Settings
 
-The editor supports endpoint, bucket, region, access key, secret key, public base URL, prefix, and path-style URL settings.
+The editor supports endpoint, bucket, region, writer access key, writer secret key, reader access key, reader secret key, public base URL, prefix, and path-style URL settings.
+
+Use writer credentials for project sync, public share publishing, and remote mirror cleanup. Use reader credentials for read-only deck access, imports, and public deck viewers. When you make a deck public, configure a read-only reader API key so people opening the public URL can load the deck payload and assets without getting credentials that can write or modify presentations.
+
+The local MinIO compose file creates these development credentials:
+
+- Writer: `localstudio-writer` / `localstudio-writer`
+- Reader: `localstudio-reader` / `localstudio-reader`
+- Root console login: `localstudio-root` / `localstudio-root123`
 
 ## Use Carefully
 

--- a/apps/editor/src/services/mirror/minioMirrorFiles.ts
+++ b/apps/editor/src/services/mirror/minioMirrorFiles.ts
@@ -169,7 +169,10 @@ async function createMirrorFiles(
     projectName: project.name,
     syncedAt: now().toISOString(),
     files: manifestFiles,
-    ...(config.publicBaseUrl.trim() ? { publicBaseUrl: config.publicBaseUrl.trim() } : {}),
+    publicBaseUrl: (config.publicBaseUrl.trim() || minioObjectUtils.createDefaultPublicBaseUrl(config)).replace(
+      /\/+$/g,
+      '',
+    ),
   };
   files.push(await createFileEntry(MIRROR_MANIFEST_FILE_NAME, storageObjectUtils.jsonBlob(manifest)));
 

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -214,7 +214,14 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
         : '',
     });
     const response = await this.signedFetch(url, 'GET', config, getReaderCredentials(config));
-    if (!response.ok) throw new Error(`Could not list MinIO mirrors (${response.status}).`);
+    if (!response.ok) {
+      if (response.status === 403) {
+        throw new Error(
+          'Reader credentials cannot list the bucket or prefix (403). Grant read-only ListBucket on the bucket for Test/Import Remote, and GetObject on mirrored objects for public deck loading. Also verify the reader secret and region.',
+        );
+      }
+      throw new Error(`Could not list MinIO mirrors (${response.status}).`);
+    }
     const manifestKeys = parseMirrorProjects(await response.text());
     const manifests = await Promise.all(
       manifestKeys.map(async (key) => {

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -17,11 +17,20 @@ export interface MinioMirrorConfig {
   endpoint: string;
   bucket: string;
   region: string;
-  accessKey: string;
-  secretKey: string;
+  accessKey?: string;
+  secretKey?: string;
+  writerAccessKey?: string;
+  writerSecretKey?: string;
+  readerAccessKey?: string;
+  readerSecretKey?: string;
   pathStyle: boolean;
   publicBaseUrl: string;
   prefix: string;
+}
+
+export interface MinioMirrorCredentials {
+  accessKey: string;
+  secretKey: string;
 }
 
 interface MinioMirrorServiceOptions {
@@ -33,15 +42,33 @@ interface MinioMirrorServiceOptions {
 const CONFIG_STORAGE_KEY = 'localstudio.minioMirror.config';
 
 const DEFAULT_MINIO_MIRROR_CONFIG: MinioMirrorConfig = {
-  accessKey: 'localstudio',
+  accessKey: 'localstudio-writer',
   bucket: 'localstudio',
   endpoint: 'http://localhost:9000',
   pathStyle: true,
   publicBaseUrl: 'http://localhost:9000/localstudio',
   region: 'us-east-1',
-  secretKey: 'localstudio123',
+  secretKey: 'localstudio-writer',
+  writerAccessKey: 'localstudio-writer',
+  writerSecretKey: 'localstudio-writer',
+  readerAccessKey: 'localstudio-reader',
+  readerSecretKey: 'localstudio-reader',
   prefix: 'mirrors',
 };
+
+const LOCAL_MINIO_SPLIT_CREDENTIALS = {
+  accessKey: 'localstudio-writer',
+  secretKey: 'localstudio-writer',
+  writerAccessKey: 'localstudio-writer',
+  writerSecretKey: 'localstudio-writer',
+  readerAccessKey: 'localstudio-reader',
+  readerSecretKey: 'localstudio-reader',
+} as const;
+
+const LEGACY_LOCAL_MINIO_CREDENTIALS = {
+  accessKey: 'localstudio',
+  secretKey: 'localstudio123',
+} as const;
 
 const DELETE_BATCH_SIZE = 25;
 
@@ -63,6 +90,43 @@ function getProjectRoot(config: MinioMirrorConfig, projectKey: string) {
 
 function getProjectFileKey(config: MinioMirrorConfig, projectKey: string, path: string) {
   return storageObjectUtils.joinObjectKey(getProjectRoot(config, projectKey), path);
+}
+
+function isLegacyLocalMinioConfig(config: MinioMirrorConfig) {
+  return (
+    !config.writerAccessKey &&
+    !config.writerSecretKey &&
+    !config.readerAccessKey &&
+    !config.readerSecretKey &&
+    config.accessKey === LEGACY_LOCAL_MINIO_CREDENTIALS.accessKey &&
+    config.secretKey === LEGACY_LOCAL_MINIO_CREDENTIALS.secretKey &&
+    config.endpoint.replace(/\/+$/g, '') === DEFAULT_MINIO_MIRROR_CONFIG.endpoint &&
+    config.bucket === DEFAULT_MINIO_MIRROR_CONFIG.bucket
+  );
+}
+
+function normalizeMirrorConfig(config: MinioMirrorConfig): MinioMirrorConfig {
+  if (isLegacyLocalMinioConfig(config)) {
+    return {
+      ...config,
+      ...LOCAL_MINIO_SPLIT_CREDENTIALS,
+    };
+  }
+  return config;
+}
+
+function getWriterCredentials(config: MinioMirrorConfig): MinioMirrorCredentials {
+  return {
+    accessKey: config.writerAccessKey || config.accessKey || '',
+    secretKey: config.writerSecretKey || config.secretKey || '',
+  };
+}
+
+function getReaderCredentials(config: MinioMirrorConfig): MinioMirrorCredentials {
+  return {
+    accessKey: config.readerAccessKey || config.writerAccessKey || config.accessKey || '',
+    secretKey: config.readerSecretKey || config.writerSecretKey || config.secretKey || '',
+  };
 }
 
 function parseMirrorProjects(xml: string) {
@@ -104,7 +168,8 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
   }
 
   loadConfig(): MinioMirrorConfig | null {
-    return browserStorage.readStorageJson<MinioMirrorConfig>(this.storage, CONFIG_STORAGE_KEY);
+    const config = browserStorage.readStorageJson<MinioMirrorConfig>(this.storage, CONFIG_STORAGE_KEY);
+    return config ? normalizeMirrorConfig(config) : null;
   }
 
   saveConfig(config: MinioMirrorConfig): void {
@@ -148,7 +213,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
         ? `${storageObjectUtils.normalizeObjectKeyPart(config.prefix)}/`
         : '',
     });
-    const response = await this.signedFetch(url, 'GET', config);
+    const response = await this.signedFetch(url, 'GET', config, getReaderCredentials(config));
     if (!response.ok) throw new Error(`Could not list MinIO mirrors (${response.status}).`);
     const manifestKeys = parseMirrorProjects(await response.text());
     const manifests = await Promise.all(
@@ -157,6 +222,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
           minioObjectUtils.createObjectUrl(config, key),
           'GET',
           config,
+          getReaderCredentials(config),
         );
         if (!response.ok) return undefined;
         const manifest = (await response.json()) as MirrorManifest;
@@ -179,6 +245,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
       ),
       'GET',
       config,
+      getReaderCredentials(config),
     );
     if (!manifestResponse.ok)
       throw new Error(`Could not download MinIO mirror manifest (${manifestResponse.status}).`);
@@ -189,6 +256,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
           minioObjectUtils.createObjectUrl(config, getProjectFileKey(config, projectKey, path)),
           'GET',
           config,
+          getReaderCredentials(config),
         );
         if (!response.ok)
           throw new Error(`Could not download mirrored file ${path} (${response.status}).`);
@@ -212,7 +280,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
         'max-keys': '1000',
         prefix: projectPrefix,
       });
-      const listResponse = await this.signedFetch(url, 'GET', config);
+      const listResponse = await this.signedFetch(url, 'GET', config, getWriterCredentials(config));
       if (!listResponse.ok)
         throw new Error(`Could not list MinIO mirror objects (${listResponse.status}).`);
 
@@ -224,6 +292,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
               minioObjectUtils.createObjectUrl(config, key),
               'DELETE',
               config,
+              getWriterCredentials(config),
             );
             if (!response.ok)
               throw new Error(`Could not delete mirrored object ${key} (${response.status}).`);
@@ -250,6 +319,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
       ),
       'GET',
       config,
+      getWriterCredentials(config),
     );
     if (response.status === 404) return null;
     if (!response.ok) throw new Error(`Could not read MinIO mirror manifest (${response.status}).`);
@@ -261,6 +331,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
       minioObjectUtils.createObjectUrl(config, key),
       'PUT',
       config,
+      getWriterCredentials(config),
       blob,
       blob.type,
     );
@@ -271,11 +342,18 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
     url: URL,
     method: string,
     config: MinioMirrorConfig,
+    credentials: MinioMirrorCredentials,
     body?: Blob,
     contentType?: string,
   ) {
     const init: RequestInit = {
-      headers: await minioObjectUtils.createSignedHeaders(config, method, url, contentType),
+      headers: await minioObjectUtils.createSignedHeaders(
+        config,
+        method,
+        url,
+        credentials,
+        contentType,
+      ),
       method,
     };
     if (body) init.body = body;

--- a/apps/editor/src/services/mirror/minioObjectUtils.ts
+++ b/apps/editor/src/services/mirror/minioObjectUtils.ts
@@ -52,8 +52,20 @@ function createObjectUrl(config: MinioMirrorConfig, key = '', query: Record<stri
   return url;
 }
 
+function createDefaultPublicBaseUrl(config: MinioMirrorConfig) {
+  const endpoint = new URL(config.endpoint.trim().replace(/\/+$/g, ''));
+  const bucket = encodeURIComponent(config.bucket.trim());
+  if (!bucket) return endpoint.origin;
+  return config.pathStyle
+    ? `${endpoint.origin}/${bucket}`
+    : `${endpoint.protocol}//${bucket}.${endpoint.host}`;
+}
+
 function createPublicObjectUrl(config: MinioMirrorConfig, key: string) {
-  const publicBaseUrl = config.publicBaseUrl.trim().replace(/\/+$/g, '');
+  const publicBaseUrl = (config.publicBaseUrl.trim() || createDefaultPublicBaseUrl(config)).replace(
+    /\/+$/g,
+    '',
+  );
   return `${publicBaseUrl}/${encodeKeyPath(key)}`;
 }
 
@@ -117,6 +129,7 @@ export const minioObjectUtils = {
   encodeKeyPath,
   sha256Hex,
   createObjectUrl,
+  createDefaultPublicBaseUrl,
   createPublicObjectUrl,
   createSignedHeaders,
 };

--- a/apps/editor/src/services/mirror/minioObjectUtils.ts
+++ b/apps/editor/src/services/mirror/minioObjectUtils.ts
@@ -1,4 +1,4 @@
-import type { MinioMirrorConfig } from './minioMirrorService';
+import type { MinioMirrorConfig, MinioMirrorCredentials } from './minioMirrorService';
 
 function encodeKeyPath(key: string) {
   return key.split('/').map(encodeURIComponent).join('/');
@@ -29,8 +29,12 @@ async function hmacHex(key: ArrayBuffer | Uint8Array, value: string) {
   return Array.from(await hmacSha256(key, value), (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
-async function getSigningKey(config: MinioMirrorConfig, dateStamp: string) {
-  const kDate = await hmacSha256(new TextEncoder().encode(`AWS4${config.secretKey}`), dateStamp);
+async function getSigningKey(
+  config: MinioMirrorConfig,
+  credentials: MinioMirrorCredentials,
+  dateStamp: string,
+) {
+  const kDate = await hmacSha256(new TextEncoder().encode(`AWS4${credentials.secretKey}`), dateStamp);
   const kRegion = await hmacSha256(kDate, config.region);
   const kService = await hmacSha256(kRegion, 's3');
   return hmacSha256(kService, 'aws4_request');
@@ -57,6 +61,7 @@ async function createSignedHeaders(
   config: MinioMirrorConfig,
   method: string,
   url: URL,
+  credentials: MinioMirrorCredentials,
   contentType?: string,
 ) {
   const now = new Date();
@@ -94,14 +99,17 @@ async function createSignedHeaders(
     credentialScope,
     Array.from(new Uint8Array(canonicalRequestHash), (byte) => byte.toString(16).padStart(2, '0')).join(''),
   ].join('\n');
-  const signature = await hmacHex(await getSigningKey(config, dateStamp), stringToSign);
+  const signature = await hmacHex(
+    await getSigningKey(config, credentials, dateStamp),
+    stringToSign,
+  );
 
   const requestHeaders = Object.fromEntries(
     Object.entries(signingHeaders).filter(([name]) => name !== 'host'),
   );
   return {
     ...requestHeaders,
-    authorization: `AWS4-HMAC-SHA256 Credential=${config.accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    authorization: `AWS4-HMAC-SHA256 Credential=${credentials.accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
   };
 }
 

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -11,6 +11,7 @@ import type {
   LocalFontMirrorSettings,
   MirrorState,
 } from '../../../services/contracts/interfaces';
+import { minioObjectUtils } from '../../../services/mirror/minioObjectUtils';
 import type { MinioMirrorConfig } from '../../../services/mirror/minioMirrorService';
 
 interface MirrorSettingsPanelProps {
@@ -85,12 +86,11 @@ export function MirrorSettingsPanel({
     const writerSecretKey = draft.writerSecretKey?.trim() || draft.secretKey?.trim() || '';
     const readerAccessKey = draft.readerAccessKey?.trim() || writerAccessKey;
     const readerSecretKey = draft.readerSecretKey?.trim() || writerSecretKey;
-    return {
+    const nextConfig = {
       ...draft,
       accessKey: writerAccessKey,
       bucket: draft.bucket.trim(),
       endpoint: draft.endpoint.trim().replace(/\/+$/g, ''),
-      publicBaseUrl: draft.publicBaseUrl.trim().replace(/\/+$/g, ''),
       region: draft.region.trim() || 'us-east-1',
       readerAccessKey,
       readerSecretKey,
@@ -99,6 +99,10 @@ export function MirrorSettingsPanel({
       writerAccessKey,
       writerSecretKey,
     };
+    return {
+      ...nextConfig,
+      publicBaseUrl: minioObjectUtils.createDefaultPublicBaseUrl(nextConfig).replace(/\/+$/g, ''),
+    };
   }
 
   async function testConnection() {
@@ -106,7 +110,9 @@ export function MirrorSettingsPanel({
     setConnectionError(undefined);
     setConnectionDetail('Checking storage');
     try {
-      const warning = await onTestConnection(normalizedDraft(), {
+      const config = normalizedDraft();
+      validateStorageEndpoint(config.endpoint);
+      const warning = await onTestConnection(config, {
         onProgress: (progress) => setConnectionDetail(progress.label),
       });
       setConnectionStatus('ready');
@@ -194,357 +200,369 @@ export function MirrorSettingsPanel({
       aria-label="Mirror settings"
       data-tour-id="mirror-settings-panel"
     >
-      <div className="mirror-settings-header ew-split-row-start">
-        <div className="settings-panel-title-row">
-          {onBack ? (
-            <button
-              className="stitch-icon-button settings-panel-back-button"
-              type="button"
-              aria-label="Back to settings"
-              onClick={onBack}
-            >
-              <span className="material-symbols-outlined" aria-hidden="true">
-                arrow_back
-              </span>
-            </button>
-          ) : null}
-          <div>
-            <h2>Mirror settings</h2>
-            <p>Sync this local project folder to S3-compatible storage.</p>
-          </div>
-        </div>
-        <button
-          className="stitch-icon-button"
-          type="button"
-          aria-label="Close mirror settings"
-          onClick={onClose}
-        >
-          <span className="material-symbols-outlined" aria-hidden="true">
-            close
-          </span>
-        </button>
-      </div>
-
-      <section className="mirror-settings-section" aria-label="Mirror project storage">
-        <div className="mirror-settings-section-heading">
-          <div>
-            <h3>Mirror project storage</h3>
-            <p>Store public deck assets in an S3-compatible bucket.</p>
-          </div>
-        </div>
-
-        <div className="mirror-settings-grid ew-field-scope" data-tour-id="mirror-settings-fields">
-          <label>
-            <span>Endpoint</span>
-            <input
-              value={draft.endpoint}
-              onChange={(event) => updateDraft({ endpoint: event.target.value })}
-            />
-          </label>
-          <label>
-            <span>Bucket</span>
-            <input
-              value={draft.bucket}
-              onChange={(event) => updateDraft({ bucket: event.target.value })}
-            />
-          </label>
-          <label>
-            <span>Region</span>
-            <input
-              value={draft.region}
-              onChange={(event) => updateDraft({ region: event.target.value })}
-            />
-          </label>
-          <label>
-            <span>Writer access key</span>
-            <input
-              value={draft.writerAccessKey ?? draft.accessKey ?? ''}
-              onChange={(event) => updateDraft({ writerAccessKey: event.target.value })}
-            />
-          </label>
-          <label>
-            <span>Writer secret key</span>
-            <span className="mirror-secret-control">
-              <input
-                aria-label="Writer secret key"
-                type={secretVisible ? 'text' : 'password'}
-                value={draft.writerSecretKey ?? draft.secretKey ?? ''}
-                onChange={(event) => updateDraft({ writerSecretKey: event.target.value })}
-              />
+      <div className="mirror-settings-content">
+        <div className="mirror-settings-header ew-split-row-start">
+          <div className="settings-panel-title-row">
+            {onBack ? (
               <button
-                className="stitch-icon-button mirror-secret-toggle"
+                className="stitch-icon-button settings-panel-back-button"
                 type="button"
-                aria-label={secretVisible ? 'Hide secret key' : 'Show secret key'}
-                onClick={() => setSecretVisible((current) => !current)}
+                aria-label="Back to settings"
+                onClick={onBack}
               >
                 <span className="material-symbols-outlined" aria-hidden="true">
-                  {secretVisible ? 'visibility_off' : 'visibility'}
+                  arrow_back
                 </span>
               </button>
-            </span>
-          </label>
-          <label>
-            <span>Reader access key</span>
-            <input
-              value={draft.readerAccessKey ?? draft.writerAccessKey ?? draft.accessKey ?? ''}
-              onChange={(event) => updateDraft({ readerAccessKey: event.target.value })}
-            />
-          </label>
-          <label>
-            <span>Reader secret key</span>
-            <span className="mirror-secret-control">
-              <input
-                aria-label="Reader secret key"
-                type={secretVisible ? 'text' : 'password'}
-                value={draft.readerSecretKey ?? draft.writerSecretKey ?? draft.secretKey ?? ''}
-                onChange={(event) => updateDraft({ readerSecretKey: event.target.value })}
-              />
-              <button
-                className="stitch-icon-button mirror-secret-toggle"
-                type="button"
-                aria-label={secretVisible ? 'Hide reader secret key' : 'Show reader secret key'}
-                onClick={() => setSecretVisible((current) => !current)}
-              >
-                <span className="material-symbols-outlined" aria-hidden="true">
-                  {secretVisible ? 'visibility_off' : 'visibility'}
-                </span>
-              </button>
-            </span>
-          </label>
-          <label>
-            <span>Public base URL</span>
-            <input
-              value={draft.publicBaseUrl}
-              onChange={(event) => updateDraft({ publicBaseUrl: event.target.value })}
-            />
-          </label>
-          <label>
-            <span>Prefix</span>
-            <input
-              value={draft.prefix}
-              onChange={(event) => updateDraft({ prefix: event.target.value })}
-            />
-          </label>
-          <label className="mirror-checkbox-row">
-            <input
-              checked={draft.pathStyle}
-              type="checkbox"
-              onChange={(event) => updateDraft({ pathStyle: event.target.checked })}
-            />
-            <span>Path-style URLs</span>
-          </label>
-        </div>
-
-        <p
-          className={
-            mirrorState.status === 'failed' || connectionStatus === 'failed'
-              ? 'mirror-settings-status mirror-settings-status-error'
-              : 'mirror-settings-status'
-          }
-        >
-          {connectionStatus === 'ready' ? (
-            <>
-              <span className="material-symbols-outlined" aria-hidden="true">
-                check_circle
-              </span>
-              S3-compatible connection is ready.
-            </>
-          ) : connectionStatus === 'failed' ? (
-            connectionError
-          ) : mirrorState.status === 'failed' ? (
-            (mirrorState.error ?? 'S3-compatible connection failed.')
-          ) : mirrorState.status === 'syncing' || connectionStatus === 'testing' ? (
-            'Checking S3-compatible connection...'
-          ) : mirrorState.status === 'synced' ? (
-            'S3-compatible connection is ready.'
-          ) : (
-            'Keys are stored in this browser profile.'
-          )}
-        </p>
-
-        <div className="mirror-settings-help">
-          <p>
-            Public decks should use the read-only key so viewers can load assets without write
-            access.
-          </p>
-          <p>
-            Local S3-compatible defaults: writer localstudio-writer / localstudio-writer; reader
-            localstudio-reader / localstudio-reader
-          </p>
-          {connectionStatus === 'ready' ? (
-            <div className="mirror-settings-links">
-              <a href={consoleUrl} target="_blank" rel="noreferrer">
-                Open storage console
-              </a>
+            ) : null}
+            <div>
+              <h2>Mirror settings</h2>
+              <p>Sync this local project folder to S3-compatible storage.</p>
             </div>
-          ) : null}
-        </div>
-      </section>
-
-      <section
-        className="mirror-settings-section mirror-settings-fonts"
-        aria-label="Local font mirroring"
-      >
-        <div className="mirror-settings-section-heading">
-          <div>
-            <h3>Mirror my local fonts</h3>
-            <p>
-              LocalStudio can use fonts installed on this machine while editing. Public viewers need
-              those font files mirrored to storage before they can see the same typography.
-            </p>
           </div>
-          <label className="mirror-settings-font-toggle">
-            <input
-              checked={localFontMirrorSettings.enabled}
-              type="checkbox"
-              onChange={(event) => void setLocalFontMirroringEnabled(event.target.checked)}
-            />
-            <span aria-hidden="true" className="mirror-settings-font-toggle-track">
-              <span className="mirror-settings-font-toggle-thumb" />
-            </span>
-            <span>{localFontMirrorSettings.enabled ? 'Enabled' : 'Off'}</span>
-          </label>
-        </div>
-        <div className="mirror-settings-font-hint">
-          <span className="material-symbols-outlined" aria-hidden="true">
-            travel_explore
-          </span>
-          <span>
-            Usual font folder for this system: <strong>{localFontMirrorSettings.systemHint}</strong>
-          </span>
-        </div>
-        <div className="mirror-settings-font-actions">
           <button
-            className="mirror-settings-font-action"
+            className="stitch-icon-button"
             type="button"
-            disabled={!localFontMirrorSettings.supported || folderStatus === 'choosing'}
-            onClick={() => void chooseFontFolder()}
+            aria-label="Close mirror settings"
+            onClick={onClose}
           >
             <span className="material-symbols-outlined" aria-hidden="true">
-              folder_open
-            </span>
-            <span>
-              {folderStatus === 'choosing'
-                ? 'Choosing font folder...'
-                : localFontMirrorSettings.folderLabel
-                  ? `Folder: ${localFontMirrorSettings.folderLabel}`
-                  : 'Choose font folder'}
+              close
             </span>
           </button>
-          {!localFontMirrorSettings.supported ? (
-            <span className="mirror-settings-font-warning">
-              This browser cannot remember a local font folder.
-            </span>
-          ) : null}
-          {folderError ? <span className="mirror-settings-font-warning">{folderError}</span> : null}
         </div>
-        {localFontMirrorSettings.folderLabel ? (
-          <div className="mirror-settings-font-browser">
-            <div className="mirror-settings-font-browser-heading">
-              <span>Fonts found in this folder</span>
-              <strong>{localFontFamilies.length}</strong>
+
+      </div>
+
+      <div className="mirror-settings-scroll">
+        <section className="mirror-settings-section" aria-label="Mirror project storage">
+          <div className="mirror-settings-section-heading">
+            <div>
+              <h3>Mirror project storage</h3>
+              <p>Use the S3 API endpoint, not the MinIO Console URL.</p>
             </div>
-            <button
-              className="font-picker-trigger mirror-settings-font-dropdown-trigger"
-              type="button"
-              aria-expanded={fontDropdownOpen}
-              aria-controls="mirror-settings-font-dropdown"
-              onClick={() => setFontDropdownOpen((current) => !current)}
-            >
-              <span className="material-symbols-outlined" aria-hidden="true">
-                text_fields
-              </span>
-              <span>
-                {localFontFamilies.length > 0
-                  ? `${localFontFamilies.length} fonts available`
-                  : 'No readable fonts found'}
-              </span>
-              <span className="material-symbols-outlined" aria-hidden="true">
-                {fontDropdownOpen ? 'expand_less' : 'expand_more'}
-              </span>
-            </button>
-            {fontDropdownOpen ? (
-              <div
-                className="font-download-panel mirror-settings-font-dropdown"
-                id="mirror-settings-font-dropdown"
-              >
-                <label className="layer-search font-download-search-box ew-surface ew-compact-row">
+          </div>
+
+          <div
+            className="mirror-settings-grid ew-field-scope"
+            data-tour-id="mirror-settings-fields"
+          >
+            <label>
+              <span>S3 API endpoint</span>
+              <input
+                value={draft.endpoint}
+                onChange={(event) => updateDraft({ endpoint: event.target.value })}
+              />
+            </label>
+            <label>
+              <span>Bucket</span>
+              <input
+                value={draft.bucket}
+                onChange={(event) => updateDraft({ bucket: event.target.value })}
+              />
+            </label>
+            <label>
+              <span>Region</span>
+              <input
+                value={draft.region}
+                onChange={(event) => updateDraft({ region: event.target.value })}
+              />
+            </label>
+            <label>
+              <span>Writer access key</span>
+              <input
+                value={draft.writerAccessKey ?? draft.accessKey ?? ''}
+                onChange={(event) => updateDraft({ writerAccessKey: event.target.value })}
+              />
+            </label>
+            <label>
+              <span>Writer secret key</span>
+              <span className="mirror-secret-control">
+                <input
+                  aria-label="Writer secret key"
+                  type={secretVisible ? 'text' : 'password'}
+                  value={draft.writerSecretKey ?? draft.secretKey ?? ''}
+                  onChange={(event) => updateDraft({ writerSecretKey: event.target.value })}
+                />
+                <button
+                  className="stitch-icon-button mirror-secret-toggle"
+                  type="button"
+                  aria-label={secretVisible ? 'Hide secret key' : 'Show secret key'}
+                  onClick={() => setSecretVisible((current) => !current)}
+                >
                   <span className="material-symbols-outlined" aria-hidden="true">
-                    search
+                    {secretVisible ? 'visibility_off' : 'visibility'}
                   </span>
-                  <input
-                    aria-label="Search fonts found in this folder"
-                    placeholder="Search fonts"
-                    type="search"
-                    value={fontSearchQuery}
-                    onChange={(event) => setFontSearchQuery(event.target.value)}
-                  />
-                </label>
-                <div className="font-download-results mirror-settings-font-results" role="listbox">
-                  {filteredLocalFontFamilies.length > 0 ? (
-                    <section className="font-result-group" aria-label="Local font folder results">
-                      <h4>Local font folder</h4>
-                      {filteredLocalFontFamilies.map((family) => (
-                        <button
-                          key={family}
-                          className="font-download-result font-preview-result"
-                          type="button"
-                          role="option"
-                          aria-selected="false"
-                          onClick={() => setFontSearchQuery(family)}
-                        >
-                          <span className="ew-ellipsis" style={{ fontFamily: family }}>
-                            {family}
-                          </span>
-                          <span className="material-symbols-outlined font-result-check" aria-hidden="true">
-                            text_fields
-                          </span>
-                        </button>
-                      ))}
-                    </section>
-                  ) : (
-                    <p className="panel-muted">No fonts match that search.</p>
-                  )}
-                </div>
+                </button>
+              </span>
+            </label>
+            <label>
+              <span>Reader access key</span>
+              <input
+                value={draft.readerAccessKey ?? draft.writerAccessKey ?? draft.accessKey ?? ''}
+                onChange={(event) => updateDraft({ readerAccessKey: event.target.value })}
+              />
+            </label>
+            <label>
+              <span>Reader secret key</span>
+              <span className="mirror-secret-control">
+                <input
+                  aria-label="Reader secret key"
+                  type={secretVisible ? 'text' : 'password'}
+                  value={draft.readerSecretKey ?? draft.writerSecretKey ?? draft.secretKey ?? ''}
+                  onChange={(event) => updateDraft({ readerSecretKey: event.target.value })}
+                />
+                <button
+                  className="stitch-icon-button mirror-secret-toggle"
+                  type="button"
+                  aria-label={secretVisible ? 'Hide reader secret key' : 'Show reader secret key'}
+                  onClick={() => setSecretVisible((current) => !current)}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    {secretVisible ? 'visibility_off' : 'visibility'}
+                  </span>
+                </button>
+              </span>
+            </label>
+            <label>
+              <span>Prefix</span>
+              <input
+                value={draft.prefix}
+                onChange={(event) => updateDraft({ prefix: event.target.value })}
+              />
+            </label>
+            <label className="mirror-checkbox-row">
+              <input
+                checked={draft.pathStyle}
+                type="checkbox"
+                onChange={(event) => updateDraft({ pathStyle: event.target.checked })}
+              />
+              <span>Path-style URLs</span>
+            </label>
+          </div>
+
+          <p
+            className={
+              mirrorState.status === 'failed' || connectionStatus === 'failed'
+                ? 'mirror-settings-status mirror-settings-status-error'
+                : 'mirror-settings-status'
+            }
+          >
+            {connectionStatus === 'ready' ? (
+              <>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  check_circle
+                </span>
+                S3-compatible connection is ready.
+              </>
+            ) : connectionStatus === 'failed' ? (
+              connectionError
+            ) : mirrorState.status === 'failed' ? (
+              (mirrorState.error ?? 'S3-compatible connection failed.')
+            ) : mirrorState.status === 'syncing' || connectionStatus === 'testing' ? (
+              'Checking S3-compatible connection...'
+            ) : mirrorState.status === 'synced' ? (
+              'S3-compatible connection is ready.'
+            ) : (
+              'Keys are stored in this browser profile.'
+            )}
+          </p>
+
+          <div className="mirror-settings-help">
+            <p>
+              Public decks should use the read-only key so viewers can load assets without write
+              access.
+            </p>
+            <p>
+              Local S3-compatible defaults: writer localstudio-writer / localstudio-writer; reader
+              localstudio-reader / localstudio-reader
+            </p>
+            {connectionStatus === 'ready' ? (
+              <div className="mirror-settings-links">
+                <a href={consoleUrl} target="_blank" rel="noreferrer">
+                  Open storage console
+                </a>
               </div>
             ) : null}
           </div>
-        ) : null}
-      </section>
+        </section>
 
-      <div className="mirror-settings-actions" data-tour-id="mirror-settings-actions">
-        <button
-          className={
-            mirrorState.enabled
-              ? 'footer-toggle mirror-settings-toggle-danger'
-              : 'footer-toggle mirror-settings-toggle-success'
-          }
-          type="button"
-          onClick={() => {
-            const nextEnabled = !mirrorState.enabled;
-            onEnabledChange(nextEnabled);
-            if (nextEnabled) void testConnection();
-          }}
+        <section
+          className="mirror-settings-section mirror-settings-fonts"
+          aria-label="Local font mirroring"
         >
-          {mirrorState.enabled ? 'Disable mirroring' : 'Enable mirroring'}
-        </button>
-        <button className="footer-toggle" type="button" onClick={() => void testConnection()}>
-          {connectionStatus === 'testing'
-            ? (connectionDetail ?? 'Checking S3-compatible connection...')
-            : 'Test connection'}
-        </button>
-        <button
-          className="export-button font-orbitron"
-          disabled={mirrorDisabledBySettings}
-          type="button"
-          onClick={() => onSave(normalizedDraft())}
-        >
-          Save settings
-        </button>
+          <div className="mirror-settings-section-heading">
+            <div>
+              <h3>Mirror my local fonts</h3>
+              <p>
+                LocalStudio can use fonts installed on this machine while editing. Public viewers
+                need those font files mirrored to storage before they can see the same typography.
+              </p>
+            </div>
+            <label className="mirror-settings-font-toggle">
+              <input
+                checked={localFontMirrorSettings.enabled}
+                type="checkbox"
+                onChange={(event) => void setLocalFontMirroringEnabled(event.target.checked)}
+              />
+              <span aria-hidden="true" className="mirror-settings-font-toggle-track">
+                <span className="mirror-settings-font-toggle-thumb" />
+              </span>
+              <span>{localFontMirrorSettings.enabled ? 'Enabled' : 'Off'}</span>
+            </label>
+          </div>
+          <div className="mirror-settings-font-hint">
+            <span className="material-symbols-outlined" aria-hidden="true">
+              travel_explore
+            </span>
+            <span>
+              Usual font folder for this system:{' '}
+              <strong>{localFontMirrorSettings.systemHint}</strong>
+            </span>
+          </div>
+          <div className="mirror-settings-font-actions">
+            <button
+              className="mirror-settings-font-action"
+              type="button"
+              disabled={!localFontMirrorSettings.supported || folderStatus === 'choosing'}
+              onClick={() => void chooseFontFolder()}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                folder_open
+              </span>
+              <span>
+                {folderStatus === 'choosing'
+                  ? 'Choosing font folder...'
+                  : localFontMirrorSettings.folderLabel
+                    ? `Folder: ${localFontMirrorSettings.folderLabel}`
+                    : 'Choose font folder'}
+              </span>
+            </button>
+            {!localFontMirrorSettings.supported ? (
+              <span className="mirror-settings-font-warning">
+                This browser cannot remember a local font folder.
+              </span>
+            ) : null}
+            {folderError ? (
+              <span className="mirror-settings-font-warning">{folderError}</span>
+            ) : null}
+          </div>
+          {localFontMirrorSettings.folderLabel ? (
+            <div className="mirror-settings-font-browser">
+              <div className="mirror-settings-font-browser-heading">
+                <span>Fonts found in this folder</span>
+                <strong>{localFontFamilies.length}</strong>
+              </div>
+              <button
+                className="font-picker-trigger mirror-settings-font-dropdown-trigger"
+                type="button"
+                aria-expanded={fontDropdownOpen}
+                aria-controls="mirror-settings-font-dropdown"
+                onClick={() => setFontDropdownOpen((current) => !current)}
+              >
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  text_fields
+                </span>
+                <span>
+                  {localFontFamilies.length > 0
+                    ? `${localFontFamilies.length} fonts available`
+                    : 'No readable fonts found'}
+                </span>
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  {fontDropdownOpen ? 'expand_less' : 'expand_more'}
+                </span>
+              </button>
+              {fontDropdownOpen ? (
+                <div
+                  className="font-download-panel mirror-settings-font-dropdown"
+                  id="mirror-settings-font-dropdown"
+                >
+                  <label className="layer-search font-download-search-box ew-surface ew-compact-row">
+                    <span className="material-symbols-outlined" aria-hidden="true">
+                      search
+                    </span>
+                    <input
+                      aria-label="Search fonts found in this folder"
+                      placeholder="Search fonts"
+                      type="search"
+                      value={fontSearchQuery}
+                      onChange={(event) => setFontSearchQuery(event.target.value)}
+                    />
+                  </label>
+                  <div
+                    className="font-download-results mirror-settings-font-results"
+                    role="listbox"
+                  >
+                    {filteredLocalFontFamilies.length > 0 ? (
+                      <section className="font-result-group" aria-label="Local font folder results">
+                        <h4>Local font folder</h4>
+                        {filteredLocalFontFamilies.map((family) => (
+                          <button
+                            key={family}
+                            className="font-download-result font-preview-result"
+                            type="button"
+                            role="option"
+                            aria-selected="false"
+                            onClick={() => setFontSearchQuery(family)}
+                          >
+                            <span className="ew-ellipsis" style={{ fontFamily: family }}>
+                              {family}
+                            </span>
+                            <span
+                              className="material-symbols-outlined font-result-check"
+                              aria-hidden="true"
+                            >
+                              text_fields
+                            </span>
+                          </button>
+                        ))}
+                      </section>
+                    ) : (
+                      <p className="panel-muted">No fonts match that search.</p>
+                    )}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </section>
+
       </div>
-      {connectionStatus === 'ready' && connectionDetail ? (
-        <p className="mirror-settings-status">{connectionDetail}</p>
-      ) : null}
+      <div className="mirror-settings-bottom">
+        <div className="mirror-settings-actions" data-tour-id="mirror-settings-actions">
+          <button
+            className={
+              mirrorState.enabled
+                ? 'footer-toggle mirror-settings-toggle-danger'
+                : 'footer-toggle mirror-settings-toggle-success'
+            }
+            type="button"
+            onClick={() => {
+              const nextEnabled = !mirrorState.enabled;
+              onEnabledChange(nextEnabled);
+              if (nextEnabled) void testConnection();
+            }}
+          >
+            {mirrorState.enabled ? 'Disable mirroring' : 'Enable mirroring'}
+          </button>
+          <button className="footer-toggle" type="button" onClick={() => void testConnection()}>
+            {connectionStatus === 'testing'
+              ? (connectionDetail ?? 'Checking S3-compatible connection...')
+              : 'Test connection'}
+          </button>
+          <button
+            className="export-button font-orbitron"
+            disabled={mirrorDisabledBySettings}
+            type="button"
+            onClick={() => onSave(normalizedDraft())}
+          >
+            Save settings
+          </button>
+        </div>
+        {connectionStatus === 'ready' && connectionDetail ? (
+          <p className="mirror-settings-status">{connectionDetail}</p>
+        ) : null}
+      </div>
       <button
         aria-label="Resize mirror settings panel"
         className="mirror-settings-resize-handle"
@@ -560,4 +578,19 @@ export function MirrorSettingsPanel({
       />
     </aside>
   );
+}
+
+function validateStorageEndpoint(endpoint: string) {
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw new Error('Enter a valid S3 API endpoint URL.');
+  }
+
+  if (url.hostname.toLowerCase().includes('console') || url.port === '9001') {
+    throw new Error(
+      'Use the S3 API endpoint, not the MinIO Console URL. MinIO usually serves the API on port 9000 and the console on port 9001.',
+    );
+  }
 }

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -1,9 +1,9 @@
 import {
+  type CSSProperties,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type PointerEvent as ReactPointerEvent,
 } from 'react';
 import type {
   FontCatalogItem,
@@ -46,6 +46,7 @@ export function MirrorSettingsPanel({
   onTestConnection,
 }: MirrorSettingsPanelProps) {
   const panelRef = useRef<HTMLElement>(null);
+  const resizeStartRef = useRef<{ pointerX: number; width: number } | undefined>(undefined);
   const [draft, setDraft] = useState(config);
   const [secretVisible, setSecretVisible] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'ready' | 'failed'>(
@@ -57,7 +58,8 @@ export function MirrorSettingsPanel({
   const [folderError, setFolderError] = useState<string | undefined>();
   const [fontDropdownOpen, setFontDropdownOpen] = useState(false);
   const [fontSearchQuery, setFontSearchQuery] = useState('');
-  const [panelPosition, setPanelPosition] = useState<{ left: number; top: number } | undefined>();
+  const [panelWidth, setPanelWidth] = useState(440);
+  const [resizing, setResizing] = useState(false);
 
   const localFontFamilies = useMemo(
     () =>
@@ -141,36 +143,6 @@ export function MirrorSettingsPanel({
 
   const consoleUrl = draft.endpoint.replace(/\/+$/g, '');
 
-  function startPanelDrag(event: ReactPointerEvent<HTMLDivElement>) {
-    if (isInteractiveDragTarget(event.target)) return;
-    const panel = panelRef.current;
-    if (!panel) return;
-    const rect = panel.getBoundingClientRect();
-    const offsetX = event.clientX - rect.left;
-    const offsetY = event.clientY - rect.top;
-    event.currentTarget.setPointerCapture?.(event.pointerId);
-    setPanelPosition({ left: rect.left, top: rect.top });
-
-    function movePanel(pointerEvent: PointerEvent) {
-      const maxLeft = Math.max(8, window.innerWidth - rect.width - 8);
-      const maxTop = Math.max(8, window.innerHeight - rect.height - 8);
-      setPanelPosition({
-        left: Math.min(Math.max(8, pointerEvent.clientX - offsetX), maxLeft),
-        top: Math.min(Math.max(8, pointerEvent.clientY - offsetY), maxTop),
-      });
-    }
-
-    function stopPanelDrag() {
-      window.removeEventListener('pointermove', movePanel);
-      window.removeEventListener('pointerup', stopPanelDrag);
-      window.removeEventListener('pointercancel', stopPanelDrag);
-    }
-
-    window.addEventListener('pointermove', movePanel);
-    window.addEventListener('pointerup', stopPanelDrag);
-    window.addEventListener('pointercancel', stopPanelDrag);
-  }
-
   useEffect(() => {
     function handlePointerDown(event: PointerEvent) {
       const target = event.target;
@@ -183,21 +155,46 @@ export function MirrorSettingsPanel({
     return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [onClose]);
 
+  useEffect(() => {
+    if (!resizing) return undefined;
+
+    function handlePointerMove(event: PointerEvent) {
+      const resizeStart = resizeStartRef.current;
+      if (!resizeStart) return;
+      const maxWidth = Math.min(640, Math.max(320, window.innerWidth - 32));
+      setPanelWidth(
+        Math.min(maxWidth, Math.max(320, resizeStart.width + event.clientX - resizeStart.pointerX)),
+      );
+    }
+
+    function handlePointerUp() {
+      resizeStartRef.current = undefined;
+      setResizing(false);
+    }
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+    window.addEventListener('pointercancel', handlePointerUp, { once: true });
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+    };
+  }, [resizing]);
+
   return (
     <aside
       ref={panelRef}
-      className="mirror-settings-panel"
-      style={
-        panelPosition
-          ? { bottom: 'auto', left: panelPosition.left, top: panelPosition.top }
-          : undefined
+      className={
+        resizing ? 'mirror-settings-panel mirror-settings-panel-resizing' : 'mirror-settings-panel'
       }
+      style={{ '--mirror-settings-panel-width': `${panelWidth}px` } as CSSProperties}
       role="dialog"
       aria-modal="false"
       aria-label="Mirror settings"
       data-tour-id="mirror-settings-panel"
     >
-      <div className="mirror-settings-header ew-split-row-start" onPointerDown={startPanelDrag}>
+      <div className="mirror-settings-header ew-split-row-start">
         <div className="settings-panel-title-row">
           {onBack ? (
             <button
@@ -548,11 +545,19 @@ export function MirrorSettingsPanel({
       {connectionStatus === 'ready' && connectionDetail ? (
         <p className="mirror-settings-status">{connectionDetail}</p>
       ) : null}
+      <button
+        aria-label="Resize mirror settings panel"
+        className="mirror-settings-resize-handle"
+        type="button"
+        onPointerDown={(event) => {
+          resizeStartRef.current = {
+            pointerX: event.clientX,
+            width: panelRef.current?.getBoundingClientRect().width ?? panelWidth,
+          };
+          setResizing(true);
+          event.currentTarget.setPointerCapture?.(event.pointerId);
+        }}
+      />
     </aside>
   );
-}
-
-function isInteractiveDragTarget(target: EventTarget) {
-  if (!(target instanceof HTMLElement)) return false;
-  return Boolean(target.closest('button, a, input, textarea, select, [role="button"]'));
 }

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
 import type {
+  FontCatalogItem,
   LocalFontMirrorProgress,
   LocalFontMirrorSettings,
   MirrorState,
@@ -9,6 +16,7 @@ import type { MinioMirrorConfig } from '../../../services/mirror/minioMirrorServ
 interface MirrorSettingsPanelProps {
   config: MinioMirrorConfig;
   localFontMirrorSettings: LocalFontMirrorSettings;
+  localFontOptions?: FontCatalogItem[];
   mirrorState: MirrorState;
   mirrorDisabledBySettings?: boolean;
   onBack?: () => void;
@@ -26,6 +34,7 @@ interface MirrorSettingsPanelProps {
 export function MirrorSettingsPanel({
   config,
   localFontMirrorSettings,
+  localFontOptions = [],
   mirrorState,
   mirrorDisabledBySettings = false,
   onBack,
@@ -46,20 +55,47 @@ export function MirrorSettingsPanel({
   const [connectionDetail, setConnectionDetail] = useState<string | undefined>();
   const [folderStatus, setFolderStatus] = useState<'idle' | 'choosing' | 'failed'>('idle');
   const [folderError, setFolderError] = useState<string | undefined>();
+  const [fontDropdownOpen, setFontDropdownOpen] = useState(false);
+  const [fontSearchQuery, setFontSearchQuery] = useState('');
+  const [panelPosition, setPanelPosition] = useState<{ left: number; top: number } | undefined>();
+
+  const localFontFamilies = useMemo(
+    () =>
+      Array.from(new Set(localFontOptions.map((font) => font.family))).sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    [localFontOptions],
+  );
+  const filteredLocalFontFamilies = useMemo(() => {
+    const query = fontSearchQuery.trim().toLowerCase();
+    if (!query) return localFontFamilies.slice(0, 24);
+    return localFontFamilies
+      .filter((family) => family.toLowerCase().includes(query))
+      .slice(0, 24);
+  }, [fontSearchQuery, localFontFamilies]);
 
   function updateDraft(patch: Partial<MinioMirrorConfig>) {
     setDraft((current) => ({ ...current, ...patch }));
   }
 
   function normalizedDraft(): MinioMirrorConfig {
+    const writerAccessKey = draft.writerAccessKey?.trim() || draft.accessKey?.trim() || '';
+    const writerSecretKey = draft.writerSecretKey?.trim() || draft.secretKey?.trim() || '';
+    const readerAccessKey = draft.readerAccessKey?.trim() || writerAccessKey;
+    const readerSecretKey = draft.readerSecretKey?.trim() || writerSecretKey;
     return {
       ...draft,
-      accessKey: draft.accessKey.trim(),
+      accessKey: writerAccessKey,
       bucket: draft.bucket.trim(),
       endpoint: draft.endpoint.trim().replace(/\/+$/g, ''),
       publicBaseUrl: draft.publicBaseUrl.trim().replace(/\/+$/g, ''),
       region: draft.region.trim() || 'us-east-1',
+      readerAccessKey,
+      readerSecretKey,
       prefix: draft.prefix.trim(),
+      secretKey: writerSecretKey,
+      writerAccessKey,
+      writerSecretKey,
     };
   }
 
@@ -103,8 +139,37 @@ export function MirrorSettingsPanel({
     await chooseFontFolder();
   }
 
-  const publicBucketUrl = `${draft.endpoint.replace(/\/+$/g, '')}/${draft.bucket.trim()}`;
   const consoleUrl = draft.endpoint.replace(/\/+$/g, '');
+
+  function startPanelDrag(event: ReactPointerEvent<HTMLDivElement>) {
+    if (isInteractiveDragTarget(event.target)) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const rect = panel.getBoundingClientRect();
+    const offsetX = event.clientX - rect.left;
+    const offsetY = event.clientY - rect.top;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    setPanelPosition({ left: rect.left, top: rect.top });
+
+    function movePanel(pointerEvent: PointerEvent) {
+      const maxLeft = Math.max(8, window.innerWidth - rect.width - 8);
+      const maxTop = Math.max(8, window.innerHeight - rect.height - 8);
+      setPanelPosition({
+        left: Math.min(Math.max(8, pointerEvent.clientX - offsetX), maxLeft),
+        top: Math.min(Math.max(8, pointerEvent.clientY - offsetY), maxTop),
+      });
+    }
+
+    function stopPanelDrag() {
+      window.removeEventListener('pointermove', movePanel);
+      window.removeEventListener('pointerup', stopPanelDrag);
+      window.removeEventListener('pointercancel', stopPanelDrag);
+    }
+
+    window.addEventListener('pointermove', movePanel);
+    window.addEventListener('pointerup', stopPanelDrag);
+    window.addEventListener('pointercancel', stopPanelDrag);
+  }
 
   useEffect(() => {
     function handlePointerDown(event: PointerEvent) {
@@ -122,12 +187,17 @@ export function MirrorSettingsPanel({
     <aside
       ref={panelRef}
       className="mirror-settings-panel"
+      style={
+        panelPosition
+          ? { bottom: 'auto', left: panelPosition.left, top: panelPosition.top }
+          : undefined
+      }
       role="dialog"
       aria-modal="false"
       aria-label="Mirror settings"
       data-tour-id="mirror-settings-panel"
     >
-      <div className="mirror-settings-header ew-split-row-start">
+      <div className="mirror-settings-header ew-split-row-start" onPointerDown={startPanelDrag}>
         <div className="settings-panel-title-row">
           {onBack ? (
             <button
@@ -189,25 +259,53 @@ export function MirrorSettingsPanel({
             />
           </label>
           <label>
-            <span>Access key</span>
+            <span>Writer access key</span>
             <input
-              value={draft.accessKey}
-              onChange={(event) => updateDraft({ accessKey: event.target.value })}
+              value={draft.writerAccessKey ?? draft.accessKey ?? ''}
+              onChange={(event) => updateDraft({ writerAccessKey: event.target.value })}
             />
           </label>
           <label>
-            <span>Secret key</span>
+            <span>Writer secret key</span>
             <span className="mirror-secret-control">
               <input
-                aria-label="Secret key"
+                aria-label="Writer secret key"
                 type={secretVisible ? 'text' : 'password'}
-                value={draft.secretKey}
-                onChange={(event) => updateDraft({ secretKey: event.target.value })}
+                value={draft.writerSecretKey ?? draft.secretKey ?? ''}
+                onChange={(event) => updateDraft({ writerSecretKey: event.target.value })}
               />
               <button
                 className="stitch-icon-button mirror-secret-toggle"
                 type="button"
                 aria-label={secretVisible ? 'Hide secret key' : 'Show secret key'}
+                onClick={() => setSecretVisible((current) => !current)}
+              >
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  {secretVisible ? 'visibility_off' : 'visibility'}
+                </span>
+              </button>
+            </span>
+          </label>
+          <label>
+            <span>Reader access key</span>
+            <input
+              value={draft.readerAccessKey ?? draft.writerAccessKey ?? draft.accessKey ?? ''}
+              onChange={(event) => updateDraft({ readerAccessKey: event.target.value })}
+            />
+          </label>
+          <label>
+            <span>Reader secret key</span>
+            <span className="mirror-secret-control">
+              <input
+                aria-label="Reader secret key"
+                type={secretVisible ? 'text' : 'password'}
+                value={draft.readerSecretKey ?? draft.writerSecretKey ?? draft.secretKey ?? ''}
+                onChange={(event) => updateDraft({ readerSecretKey: event.target.value })}
+              />
+              <button
+                className="stitch-icon-button mirror-secret-toggle"
+                type="button"
+                aria-label={secretVisible ? 'Hide reader secret key' : 'Show reader secret key'}
                 onClick={() => setSecretVisible((current) => !current)}
               >
                 <span className="material-symbols-outlined" aria-hidden="true">
@@ -268,12 +366,16 @@ export function MirrorSettingsPanel({
         </p>
 
         <div className="mirror-settings-help">
-          <p>Local S3-compatible default login: localstudio / localstudio123</p>
+          <p>
+            Public decks should use the read-only key so viewers can load assets without write
+            access.
+          </p>
+          <p>
+            Local S3-compatible defaults: writer localstudio-writer / localstudio-writer; reader
+            localstudio-reader / localstudio-reader
+          </p>
           {connectionStatus === 'ready' ? (
             <div className="mirror-settings-links">
-              <a href={publicBucketUrl} target="_blank" rel="noreferrer">
-                Open public bucket
-              </a>
               <a href={consoleUrl} target="_blank" rel="noreferrer">
                 Open storage console
               </a>
@@ -339,6 +441,78 @@ export function MirrorSettingsPanel({
           ) : null}
           {folderError ? <span className="mirror-settings-font-warning">{folderError}</span> : null}
         </div>
+        {localFontMirrorSettings.folderLabel ? (
+          <div className="mirror-settings-font-browser">
+            <div className="mirror-settings-font-browser-heading">
+              <span>Fonts found in this folder</span>
+              <strong>{localFontFamilies.length}</strong>
+            </div>
+            <button
+              className="font-picker-trigger mirror-settings-font-dropdown-trigger"
+              type="button"
+              aria-expanded={fontDropdownOpen}
+              aria-controls="mirror-settings-font-dropdown"
+              onClick={() => setFontDropdownOpen((current) => !current)}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                text_fields
+              </span>
+              <span>
+                {localFontFamilies.length > 0
+                  ? `${localFontFamilies.length} fonts available`
+                  : 'No readable fonts found'}
+              </span>
+              <span className="material-symbols-outlined" aria-hidden="true">
+                {fontDropdownOpen ? 'expand_less' : 'expand_more'}
+              </span>
+            </button>
+            {fontDropdownOpen ? (
+              <div
+                className="font-download-panel mirror-settings-font-dropdown"
+                id="mirror-settings-font-dropdown"
+              >
+                <label className="layer-search font-download-search-box ew-surface ew-compact-row">
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    search
+                  </span>
+                  <input
+                    aria-label="Search fonts found in this folder"
+                    placeholder="Search fonts"
+                    type="search"
+                    value={fontSearchQuery}
+                    onChange={(event) => setFontSearchQuery(event.target.value)}
+                  />
+                </label>
+                <div className="font-download-results mirror-settings-font-results" role="listbox">
+                  {filteredLocalFontFamilies.length > 0 ? (
+                    <section className="font-result-group" aria-label="Local font folder results">
+                      <h4>Local font folder</h4>
+                      {filteredLocalFontFamilies.map((family) => (
+                        <button
+                          key={family}
+                          className="font-download-result font-preview-result"
+                          type="button"
+                          role="option"
+                          aria-selected="false"
+                          onClick={() => setFontSearchQuery(family)}
+                        >
+                          <span className="ew-ellipsis" style={{ fontFamily: family }}>
+                            {family}
+                          </span>
+                          <span className="material-symbols-outlined font-result-check" aria-hidden="true">
+                            text_fields
+                          </span>
+                        </button>
+                      ))}
+                    </section>
+                  ) : (
+                    <p className="panel-muted">No fonts match that search.</p>
+                  )}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </section>
 
       <div className="mirror-settings-actions" data-tour-id="mirror-settings-actions">
@@ -376,4 +550,9 @@ export function MirrorSettingsPanel({
       ) : null}
     </aside>
   );
+}
+
+function isInteractiveDragTarget(target: EventTarget) {
+  if (!(target instanceof HTMLElement)) return false;
+  return Boolean(target.closest('button, a, input, textarea, select, [role="button"]'));
 }

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1477,6 +1477,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         <MirrorSettingsPanel
           config={vm.mirrorConfig}
           localFontMirrorSettings={vm.localFontMirrorSettings}
+          localFontOptions={vm.localFontOptions}
           mirrorState={vm.mirrorState}
           mirrorDisabledBySettings={vm.mirrorDisabledBySettings}
           onBack={() => {

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -38,7 +38,6 @@ import { pptxFontRequests } from '../../../services/importing/pptx/pptxFontReque
 import { pptxImportLogger } from '../../../services/importing/pptx/pptxImportLogger';
 import { minioMirrorService } from '../../../services/mirror/minioMirrorService';
 import type { MinioMirrorConfig } from '../../../services/mirror/minioMirrorService';
-import { storageObjectUtils } from '../../../services/storage/storageObjectUtils';
 import { aiModelCatalog } from '../../../services/model-setup/aiModelCatalog';
 import { imageGenerationModel } from '../../../services/image-generation/imageGenerationModel';
 import { createPrefixedId } from '../../../services/ids/idUtils';
@@ -1781,34 +1780,7 @@ export function useEditorViewModel(services: AppServices) {
     try {
       options?.onProgress?.({ label: 'Checking storage', stage: 'checking-local-fonts' });
       await services.mirrorService.listProjects(config);
-      const testFontFiles = localFontMirrorSettings.enabled
-        ? await services.localFontMirrorService.getTestFontFiles({
-            ...(options?.onProgress ? { onProgress: options.onProgress } : {}),
-          })
-        : [];
-      if (localFontMirrorSettings.enabled && testFontFiles.length > 0) {
-        if (!services.mirrorService.uploadPublicObject) {
-          throw new Error('Mirror storage does not support public font uploads.');
-        }
-        options?.onProgress?.({ label: 'Uploading test fonts', stage: 'uploading-test-fonts' });
-        await Promise.all(
-          testFontFiles.map((file, index) => {
-            const key = storageObjectUtils.joinObjectKey(
-              storageObjectUtils.normalizeObjectKeyPart(config.prefix),
-              'font-mirror-test',
-              `${Date.now().toString(36)}-${index + 1}-${file.name}`,
-            );
-            return services.mirrorService.uploadPublicObject?.(key, file, config) ?? Promise.resolve();
-          }),
-        );
-      }
-      const fontMirrorTestResult = localFontMirrorSettings.enabled
-        ? await services.localFontMirrorService.validateTestFontFiles(testFontFiles, {
-            ...(options?.onProgress ? { onProgress: options.onProgress } : {}),
-          })
-        : {};
       setMirrorState({ enabled: true, status: 'idle' });
-      return fontMirrorTestResult.warning;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'S3-compatible connection failed.';
       setMirrorState({

--- a/apps/editor/src/ui/share/SharePanel.tsx
+++ b/apps/editor/src/ui/share/SharePanel.tsx
@@ -85,6 +85,10 @@ export function SharePanel({
       <section className="share-access-block" aria-label="Share access">
         <span className="share-status-pill">{copyError ? 'Share failed' : statusLabel}</span>
         <p>{shareAccessDescription}</p>
+        <p className="share-access-note">
+          Public links should use a read-only storage key so viewers cannot write or modify
+          presentations.
+        </p>
       </section>
 
       <button

--- a/apps/editor/src/ui/styles/mirror-settings-details.css
+++ b/apps/editor/src/ui/styles/mirror-settings-details.css
@@ -68,8 +68,14 @@
 
 .mirror-settings-actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
+}
+
+.mirror-settings-actions .footer-toggle,
+.mirror-settings-actions .export-button {
+  flex: 1 1 118px;
 }
 
 .mirror-settings-toggle-danger {

--- a/apps/editor/src/ui/styles/mirror-settings.css
+++ b/apps/editor/src/ui/styles/mirror-settings.css
@@ -185,3 +185,52 @@
 .mirror-settings-font-warning {
   color: color-mix(in srgb, var(--ew-green-fixed) 68%, #f6c453);
 }
+
+.mirror-settings-font-browser {
+  display: grid;
+  gap: 8px;
+}
+
+.mirror-settings-font-browser-heading {
+  align-items: center;
+  color: var(--ew-muted);
+  display: flex;
+  font-size: 11px;
+  font-weight: 800;
+  gap: 8px;
+  justify-content: space-between;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mirror-settings-font-browser-heading strong {
+  color: var(--ew-green);
+  font-size: 12px;
+}
+
+.mirror-settings-font-dropdown-trigger {
+  font-size: 12px;
+  font-weight: 800;
+  grid-template-columns: 18px minmax(0, 1fr) 18px;
+  height: 36px;
+}
+
+.mirror-settings-font-dropdown-trigger .material-symbols-outlined {
+  color: var(--ew-green-fixed);
+  font-size: 17px;
+}
+
+.mirror-settings-font-dropdown-trigger span:nth-child(2) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mirror-settings-font-dropdown {
+  padding: 8px;
+}
+
+.mirror-settings-font-results {
+  max-height: 184px;
+}

--- a/apps/editor/src/ui/styles/mirror-settings.css
+++ b/apps/editor/src/ui/styles/mirror-settings.css
@@ -15,7 +15,8 @@
 
 .mirror-settings-grid label:first-child,
 .mirror-settings-grid label:nth-child(6),
-.mirror-settings-grid label:nth-child(7) {
+.mirror-settings-grid label:nth-child(7),
+.mirror-settings-grid label:nth-child(8) {
   grid-column: 1 / -1;
 }
 

--- a/apps/editor/src/ui/styles/settings.css
+++ b/apps/editor/src/ui/styles/settings.css
@@ -19,18 +19,48 @@
     0 0 24px rgba(55, 253, 118, 0.08);
 }
 
-.mirror-settings-header {
-  cursor: grab;
-  touch-action: none;
+.mirror-settings-panel-resizing {
   user-select: none;
 }
 
-.mirror-settings-header:active {
-  cursor: grabbing;
+.mirror-settings-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  bottom: 0;
+  z-index: 20;
+  width: 8px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  cursor: ew-resize;
+  padding: 0;
+}
+
+.mirror-settings-resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: rgba(55, 253, 118, 0.34);
+}
+
+.mirror-settings-resize-handle:hover::before,
+.mirror-settings-panel-resizing .mirror-settings-resize-handle::before {
+  left: 2px;
+  width: 3px;
+  background: var(--ew-green);
+  box-shadow: 0 0 18px rgba(55, 253, 118, 0.34);
 }
 
 .settings-panel {
   width: min(280px, calc(100vw - 32px));
+}
+
+.mirror-settings-panel {
+  width: min(var(--mirror-settings-panel-width, 440px), calc(100vw - 32px));
 }
 
 .media-integration-settings-panel {

--- a/apps/editor/src/ui/styles/settings.css
+++ b/apps/editor/src/ui/styles/settings.css
@@ -8,6 +8,8 @@
   width: min(440px, calc(100vw - 32px));
   display: grid;
   gap: 14px;
+  max-height: calc(100dvh - 84px);
+  overflow-y: auto;
   padding: 16px;
   border: 1px solid rgba(122, 255, 199, 0.2);
   border-radius: 8px;
@@ -15,6 +17,16 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.48),
     0 0 24px rgba(55, 253, 118, 0.08);
+}
+
+.mirror-settings-header {
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.mirror-settings-header:active {
+  cursor: grabbing;
 }
 
 .settings-panel {

--- a/apps/editor/src/ui/styles/settings.css
+++ b/apps/editor/src/ui/styles/settings.css
@@ -26,10 +26,10 @@
 .mirror-settings-resize-handle {
   position: absolute;
   top: 0;
-  right: -4px;
+  right: -12px;
   bottom: 0;
   z-index: 20;
-  width: 8px;
+  width: 12px;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -42,14 +42,14 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 3px;
+  left: 5px;
   width: 1px;
   background: rgba(55, 253, 118, 0.34);
 }
 
 .mirror-settings-resize-handle:hover::before,
 .mirror-settings-panel-resizing .mirror-settings-resize-handle::before {
-  left: 2px;
+  left: 4px;
   width: 3px;
   background: var(--ew-green);
   box-shadow: 0 0 18px rgba(55, 253, 118, 0.34);
@@ -60,7 +60,37 @@
 }
 
 .mirror-settings-panel {
+  top: 56px;
+  bottom: 52px;
+  gap: 0;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: visible;
+  padding: 0;
   width: min(var(--mirror-settings-panel-width, 440px), calc(100vw - 32px));
+}
+
+.mirror-settings-content,
+.mirror-settings-scroll,
+.mirror-settings-bottom {
+  display: grid;
+  gap: 14px;
+}
+
+.mirror-settings-content {
+  border-bottom: 1px solid rgba(122, 255, 199, 0.14);
+  padding: 16px 16px 12px;
+}
+
+.mirror-settings-bottom {
+  border-top: 1px solid rgba(122, 255, 199, 0.14);
+  padding: 12px 16px 16px;
+}
+
+.mirror-settings-scroll {
+  min-height: 0;
+  max-height: none;
+  overflow-y: auto;
+  padding: 14px 16px 16px;
 }
 
 .media-integration-settings-panel {

--- a/apps/editor/src/ui/styles/share-panel.css
+++ b/apps/editor/src/ui/styles/share-panel.css
@@ -30,6 +30,10 @@
   font-size: 13px;
 }
 
+.share-access-note {
+  padding-top: 2px;
+}
+
 .share-access-block {
   display: grid;
   gap: 8px;

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -19,6 +19,19 @@ const config: MinioMirrorConfig = {
   prefix: 'mirrors',
 };
 
+const splitCredentialConfig: MinioMirrorConfig = {
+  bucket: 'localstudio',
+  endpoint: 'http://localhost:9000',
+  pathStyle: true,
+  publicBaseUrl: 'http://localhost:9000/localstudio',
+  region: 'us-east-1',
+  prefix: 'mirrors',
+  writerAccessKey: 'writer-key',
+  writerSecretKey: 'writer-secret',
+  readerAccessKey: 'reader-key',
+  readerSecretKey: 'reader-secret',
+};
+
 class VersionedRepository implements ProjectRepository {
   constructor(
     private readonly versions: VersionHistoryEntry[],
@@ -46,6 +59,11 @@ function getRequestUrl(input: RequestInfo | URL) {
   if (input instanceof URL) return input.toString();
   if (input instanceof Request) return input.url;
   return input;
+}
+
+function getAuthorizationCredential(init: RequestInit | undefined) {
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.authorization?.match(/Credential=([^/]+)/)?.[1];
 }
 
 describe('minioMirrorService.createMirrorFiles', () => {
@@ -140,6 +158,12 @@ describe('minioMirrorService.createMirrorFiles', () => {
 
 describe('minioMirrorService.MinioMirrorService', () => {
   it('persists MinIO mirror config in browser key-value storage', () => {
+    const persistedConfig: MinioMirrorConfig = {
+      ...config,
+      accessKey: 'persisted-access',
+      bucket: 'persisted-bucket',
+      secretKey: 'persisted-secret',
+    };
     const records = new Map<string, string>();
     const storage = {
       getItem: vi.fn((key: string) => records.get(key) ?? null),
@@ -152,18 +176,75 @@ describe('minioMirrorService.MinioMirrorService', () => {
     };
     const service = new minioMirrorService.MinioMirrorService({ storage });
 
-    service.saveConfig(config);
+    service.saveConfig(persistedConfig);
 
     expect(storage.setItem).toHaveBeenCalledWith(
       'localstudio.minioMirror.config',
-      JSON.stringify(config),
+      JSON.stringify(persistedConfig),
     );
-    expect(service.loadConfig()).toEqual(config);
+    expect(service.loadConfig()).toEqual(persistedConfig);
 
     service.clearConfig();
 
     expect(storage.removeItem).toHaveBeenCalledWith('localstudio.minioMirror.config');
     expect(service.loadConfig()).toBeNull();
+  });
+
+  it('migrates the legacy local MinIO default config to split reader and writer defaults', () => {
+    const records = new Map<string, string>([
+      [
+        'localstudio.minioMirror.config',
+        JSON.stringify({
+          accessKey: 'localstudio',
+          bucket: 'localstudio',
+          endpoint: 'http://localhost:9000',
+          pathStyle: true,
+          publicBaseUrl: 'http://localhost:9000/localstudio',
+          region: 'us-east-1',
+          secretKey: 'localstudio123',
+          prefix: 'mirrors',
+        } satisfies MinioMirrorConfig),
+      ],
+    ]);
+    const storage = {
+      getItem: vi.fn((key: string) => records.get(key) ?? null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+    const service = new minioMirrorService.MinioMirrorService({ storage });
+
+    expect(service.loadConfig()).toMatchObject({
+      accessKey: 'localstudio-writer',
+      secretKey: 'localstudio-writer',
+      writerAccessKey: 'localstudio-writer',
+      writerSecretKey: 'localstudio-writer',
+      readerAccessKey: 'localstudio-reader',
+      readerSecretKey: 'localstudio-reader',
+    });
+  });
+
+  it('keeps custom legacy S3 credentials when no split reader and writer keys exist', () => {
+    const customConfig: MinioMirrorConfig = {
+      accessKey: 'custom-access',
+      bucket: 'custom-bucket',
+      endpoint: 'https://storage.example.test',
+      pathStyle: true,
+      publicBaseUrl: 'https://cdn.example.test/custom-bucket',
+      region: 'us-east-1',
+      secretKey: 'custom-secret',
+      prefix: 'mirrors',
+    };
+    const records = new Map<string, string>([
+      ['localstudio.minioMirror.config', JSON.stringify(customConfig)],
+    ]);
+    const storage = {
+      getItem: vi.fn((key: string) => records.get(key) ?? null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    };
+    const service = new minioMirrorService.MinioMirrorService({ storage });
+
+    expect(service.loadConfig()).toEqual(customConfig);
   });
 
   it('binds the browser fetch function when no fetch override is provided', async () => {
@@ -237,6 +318,76 @@ describe('minioMirrorService.MinioMirrorService', () => {
       .map(([input]) => getRequestUrl(input));
     expect(putUrls.some((url) => url.endsWith('/project.json'))).toBe(false);
     expect(putUrls.some((url) => url.endsWith('/localstudio-mirror.json'))).toBe(true);
+  });
+
+  it('uses writer credentials when sync checks and uploads mirror files', async () => {
+    const project = sampleProject.createSampleProject();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({
+      fetch: fetchMock,
+      now: () => new Date('2026-06-30T10:00:00.000Z'),
+    });
+
+    await service.syncProject(project, new VersionedRepository([], project), splitCredentialConfig);
+
+    const getCredentials = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'GET')
+      .map(([, init]) => getAuthorizationCredential(init));
+    const putCredentials = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'PUT')
+      .map(([, init]) => getAuthorizationCredential(init));
+    expect(getCredentials).toContain('writer-key');
+    expect(getCredentials).not.toContain('reader-key');
+    expect(putCredentials).toContain('writer-key');
+    expect(putCredentials).not.toContain('reader-key');
+  });
+
+  it('uses reader credentials when listing remote mirrors', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.includes('list-type=2')) {
+        return Promise.resolve(
+          new Response(
+            '<ListBucketResult><Contents><Key>mirrors/Client/localstudio-mirror.json</Key></Contents></ListBucketResult>',
+            { status: 200 },
+          ),
+        );
+      }
+      if (init?.method === 'GET' && url.endsWith('/mirrors/Client/localstudio-mirror.json')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              schemaVersion: 1,
+              projectId: 'project-client',
+              projectName: 'Client',
+              syncedAt: '2026-06-30T10:00:00.000Z',
+              publicBaseUrl: splitCredentialConfig.publicBaseUrl,
+              files: {},
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await service.listProjects(splitCredentialConfig);
+
+    const getCredentials = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'GET')
+      .map(([, init]) => getAuthorizationCredential(init));
+    expect(getCredentials).toContain('reader-key');
+    expect(getCredentials).not.toContain('writer-key');
   });
 
   it('does not set the forbidden Host header on signed browser requests', async () => {

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -157,6 +157,26 @@ describe('minioMirrorService.createMirrorFiles', () => {
 });
 
 describe('minioMirrorService.MinioMirrorService', () => {
+  it('derives public object URLs from endpoint, bucket, and URL mode when no public base is set', () => {
+    const service = new minioMirrorService.MinioMirrorService();
+
+    expect(
+      service.getPublicObjectUrl('mirrors/deck/project.json', {
+        ...config,
+        publicBaseUrl: '',
+      }),
+    ).toBe('http://localhost:9000/localstudio/mirrors/deck/project.json');
+    expect(
+      service.getPublicObjectUrl('mirrors/deck/project.json', {
+        ...config,
+        bucket: 'decks',
+        endpoint: 'https://s3.example.test',
+        pathStyle: false,
+        publicBaseUrl: '',
+      }),
+    ).toBe('https://decks.s3.example.test/mirrors/deck/project.json');
+  });
+
   it('persists MinIO mirror config in browser key-value storage', () => {
     const persistedConfig: MinioMirrorConfig = {
       ...config,
@@ -388,6 +408,15 @@ describe('minioMirrorService.MinioMirrorService', () => {
       .map(([, init]) => getAuthorizationCredential(init));
     expect(getCredentials).toContain('reader-key');
     expect(getCredentials).not.toContain('writer-key');
+  });
+
+  it('explains when reader credentials cannot list remote mirrors', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 403 })));
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await expect(service.listProjects(splitCredentialConfig)).rejects.toThrow(
+      /Reader credentials cannot list the bucket or prefix/,
+    );
   });
 
   it('does not set the forbidden Host header on signed browser requests', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
@@ -229,6 +229,43 @@ describe('EditorShell mirror workflows', () => {
     );
   });
 
+  it('tests mirror storage without uploading local font test files', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const mirrorService = new RecordingMirrorService();
+    const getTestFontFiles = vi
+      .spyOn(services.localFontMirrorService, 'getTestFontFiles')
+      .mockResolvedValue([
+        new File(['font'], 'local-font.woff2', { type: 'font/woff2' }),
+      ]);
+    const validateTestFontFiles = vi
+      .spyOn(services.localFontMirrorService, 'validateTestFontFiles')
+      .mockResolvedValue({});
+    vi.spyOn(services.localFontMirrorService, 'getSettings').mockReturnValue({
+      enabled: true,
+      folderLabel: 'Local fonts',
+      supported: true,
+      systemHint: '~/Library/Fonts or /Library/Fonts',
+    });
+    vi.spyOn(services.localFontMirrorService, 'listAvailableFonts').mockResolvedValue([]);
+    services.mirrorService = mirrorService;
+    render(<EditorShell services={services} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mirror settings' }));
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
+        name: 'Mirror settings',
+      }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Test connection' }));
+
+    await waitFor(() => {
+      expect(mirrorService.listProjects).toHaveBeenCalledWith(mirrorConfig);
+    });
+    expect(getTestFontFiles).not.toHaveBeenCalled();
+    expect(validateTestFontFiles).not.toHaveBeenCalled();
+  });
+
   it('displays the remote project name after importing a mirrored project', async () => {
     const services = createAppServices();
     const repository = new RemoteMirrorImportingProjectRepository();

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
@@ -92,13 +92,17 @@ class LoadingProjectRepository implements ProjectRepository {
 }
 
 const mirrorConfig: MinioMirrorConfig = {
-  accessKey: 'localstudio',
+  accessKey: 'localstudio-writer',
   bucket: 'localstudio',
   endpoint: 'http://localhost:9000',
   pathStyle: true,
   publicBaseUrl: 'http://localhost:9000/localstudio',
+  readerAccessKey: 'localstudio-reader',
+  readerSecretKey: 'localstudio-reader',
   region: 'us-east-1',
-  secretKey: 'localstudio123',
+  secretKey: 'localstudio-writer',
+  writerAccessKey: 'localstudio-writer',
+  writerSecretKey: 'localstudio-writer',
   prefix: 'mirrors',
 };
 

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -119,7 +119,7 @@ describe('MirrorSettingsPanel', () => {
     );
   });
 
-  it('lets users drag the mirror settings panel by its header', () => {
+  it('lets users resize the mirror settings panel from the edge handle', () => {
     render(
       <MirrorSettingsPanel
         config={config}
@@ -147,15 +147,15 @@ describe('MirrorSettingsPanel', () => {
       toJSON: () => ({}),
     });
 
-    fireEvent.pointerDown(screen.getByText('Mirror settings'), {
-      clientX: 26,
-      clientY: 62,
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Resize mirror settings panel' }), {
+      clientX: 456,
+      clientY: 240,
       pointerId: 1,
     });
-    fireEvent.pointerMove(window, { clientX: 120, clientY: 140, pointerId: 1 });
+    fireEvent.pointerMove(window, { clientX: 536, clientY: 240, pointerId: 1 });
     fireEvent.pointerUp(window, { pointerId: 1 });
 
-    expect(panel).toHaveStyle({ bottom: 'auto', left: '110px', top: '130px' });
+    expect(panel).toHaveStyle({ '--mirror-settings-panel-width': '520px' });
   });
 
   it('returns to the settings list from the back button', async () => {

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
@@ -7,13 +7,17 @@ import type { MinioMirrorConfig } from '../../../../src/services/mirror/minioMir
 import type { LocalFontMirrorProgress } from '../../../../src/services/contracts/interfaces';
 
 const config: MinioMirrorConfig = {
-  accessKey: 'localstudio',
+  accessKey: 'localstudio-writer',
   bucket: 'localstudio',
   endpoint: 'http://localhost:9000',
   pathStyle: true,
   publicBaseUrl: 'http://localhost:9000/localstudio',
+  readerAccessKey: 'localstudio-reader',
+  readerSecretKey: 'localstudio-reader',
   region: 'us-east-1',
-  secretKey: 'localstudio123',
+  secretKey: 'localstudio-writer',
+  writerAccessKey: 'localstudio-writer',
+  writerSecretKey: 'localstudio-writer',
   prefix: 'mirrors',
 };
 
@@ -79,33 +83,79 @@ describe('MirrorSettingsPanel', () => {
     expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
     expect(screen.getByLabelText('Endpoint')).toHaveValue('http://localhost:9000');
     expect(screen.getByLabelText('Bucket')).toHaveValue('localstudio');
-    const secretInput = screen.getByLabelText('Secret key');
-    expect(secretInput).toHaveValue('localstudio123');
-    expect(secretInput).toHaveAttribute('type', 'password');
+    expect(screen.getByLabelText('Writer access key')).toHaveValue('localstudio-writer');
+    expect(screen.getByLabelText('Reader access key')).toHaveValue('localstudio-reader');
+    const writerSecretInput = screen.getByLabelText('Writer secret key');
+    const readerSecretInput = screen.getByLabelText('Reader secret key');
+    expect(writerSecretInput).toHaveValue('localstudio-writer');
+    expect(readerSecretInput).toHaveValue('localstudio-reader');
+    expect(writerSecretInput).toHaveAttribute('type', 'password');
     expect(screen.getByLabelText('Path-style URLs')).toBeChecked();
 
     await user.click(screen.getByRole('button', { name: 'Show secret key' }));
-    expect(secretInput).toHaveAttribute('type', 'text');
+    expect(writerSecretInput).toHaveAttribute('type', 'text');
+    expect(readerSecretInput).toHaveAttribute('type', 'text');
 
     await user.clear(screen.getByLabelText('Prefix'));
     await user.type(screen.getByLabelText('Prefix'), 'public-projects');
     await user.click(screen.getByRole('button', { name: 'Test connection' }));
     expect(onTestConnection.mock.calls[0]?.[0]).toMatchObject({ prefix: 'public-projects' });
     expect(await screen.findByText('S3-compatible connection is ready.')).toBeInTheDocument();
-    expect(
-      screen.getByText('Local S3-compatible default login: localstudio / localstudio123'),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Open public bucket' })).toHaveAttribute(
-      'href',
-      'http://localhost:9000/localstudio',
-    );
+    expect(screen.getByText(/Public decks should use the read-only key/)).toBeInTheDocument();
+    expect(screen.getByText(/writer localstudio-writer/)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Open public bucket' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open storage console' })).toHaveAttribute(
       'href',
       'http://localhost:9000',
     );
 
     await user.click(screen.getByRole('button', { name: 'Save settings' }));
-    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ prefix: 'public-projects' }));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: 'public-projects',
+        readerAccessKey: 'localstudio-reader',
+        writerAccessKey: 'localstudio-writer',
+      }),
+    );
+  });
+
+  it('lets users drag the mirror settings panel by its header', () => {
+    render(
+      <MirrorSettingsPanel
+        config={config}
+        localFontMirrorSettings={localFontMirrorSettings}
+        mirrorState={{ enabled: true, status: 'idle' }}
+        onChooseLocalFontFolder={vi.fn()}
+        onClose={vi.fn()}
+        onEnabledChange={vi.fn()}
+        onLocalFontMirrorEnabledChange={vi.fn()}
+        onSave={vi.fn()}
+        onTestConnection={vi.fn()}
+      />,
+    );
+
+    const panel = screen.getByRole('dialog', { name: 'Mirror settings' });
+    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue({
+      bottom: 452,
+      height: 400,
+      left: 16,
+      right: 456,
+      top: 52,
+      width: 440,
+      x: 16,
+      y: 52,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.pointerDown(screen.getByText('Mirror settings'), {
+      clientX: 26,
+      clientY: 62,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(window, { clientX: 120, clientY: 140, pointerId: 1 });
+    fireEvent.pointerUp(window, { pointerId: 1 });
+
+    expect(panel).toHaveStyle({ bottom: 'auto', left: '110px', top: '130px' });
   });
 
   it('returns to the settings list from the back button', async () => {
@@ -155,6 +205,42 @@ describe('MirrorSettingsPanel', () => {
 
     expect(onChooseLocalFontFolder).toHaveBeenCalledTimes(1);
     expect(onLocalFontMirrorEnabledChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it('shows searchable fonts found in the selected local font folder', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MirrorSettingsPanel
+        config={config}
+        localFontMirrorSettings={{
+          ...localFontMirrorSettings,
+          enabled: true,
+          folderLabel: 'Fonts',
+        }}
+        localFontOptions={[
+          { family: 'Acme Sans', source: 'local-font-folder' },
+          { family: 'Inter Display', source: 'local-font-folder' },
+          { family: 'Montserrat', source: 'local-font-folder' },
+        ]}
+        mirrorState={{ enabled: true, status: 'idle' }}
+        onChooseLocalFontFolder={vi.fn()}
+        onClose={vi.fn()}
+        onEnabledChange={vi.fn()}
+        onLocalFontMirrorEnabledChange={vi.fn()}
+        onSave={vi.fn()}
+        onTestConnection={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Fonts found in this folder')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /3 fonts available/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /3 fonts available/i }));
+    await user.type(screen.getByLabelText('Search fonts found in this folder'), 'mont');
+
+    expect(screen.getByRole('option', { name: /Montserrat/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Acme Sans/i })).not.toBeInTheDocument();
   });
 
   it('disables local font mirroring without opening the folder picker', async () => {

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -81,10 +81,11 @@ describe('MirrorSettingsPanel', () => {
     );
 
     expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Endpoint')).toHaveValue('http://localhost:9000');
+    expect(screen.getByLabelText('S3 API endpoint')).toHaveValue('http://localhost:9000');
     expect(screen.getByLabelText('Bucket')).toHaveValue('localstudio');
     expect(screen.getByLabelText('Writer access key')).toHaveValue('localstudio-writer');
     expect(screen.getByLabelText('Reader access key')).toHaveValue('localstudio-reader');
+    expect(screen.queryByLabelText('Public base URL')).not.toBeInTheDocument();
     const writerSecretInput = screen.getByLabelText('Writer secret key');
     const readerSecretInput = screen.getByLabelText('Reader secret key');
     expect(writerSecretInput).toHaveValue('localstudio-writer');
@@ -113,8 +114,44 @@ describe('MirrorSettingsPanel', () => {
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({
         prefix: 'public-projects',
+        publicBaseUrl: 'http://localhost:9000/localstudio',
         readerAccessKey: 'localstudio-reader',
         writerAccessKey: 'localstudio-writer',
+      }),
+    );
+  });
+
+  it('derives public base URL from endpoint, bucket, and URL mode when saving', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+
+    render(
+      <MirrorSettingsPanel
+        config={config}
+        localFontMirrorSettings={localFontMirrorSettings}
+        mirrorState={{ enabled: true, status: 'idle' }}
+        onChooseLocalFontFolder={vi.fn()}
+        onClose={vi.fn()}
+        onEnabledChange={vi.fn()}
+        onLocalFontMirrorEnabledChange={vi.fn()}
+        onSave={onSave}
+        onTestConnection={vi.fn()}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText('S3 API endpoint'));
+    await user.type(screen.getByLabelText('S3 API endpoint'), 'https://s3.example.test');
+    await user.clear(screen.getByLabelText('Bucket'));
+    await user.type(screen.getByLabelText('Bucket'), 'decks');
+    await user.click(screen.getByLabelText('Path-style URLs'));
+    await user.click(screen.getByRole('button', { name: 'Save settings' }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bucket: 'decks',
+        endpoint: 'https://s3.example.test',
+        pathStyle: false,
+        publicBaseUrl: 'https://decks.s3.example.test',
       }),
     );
   });

--- a/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
@@ -40,6 +40,7 @@ describe('SharePanel', () => {
 
     expect(screen.getByRole('heading', { name: 'Share design' })).toBeInTheDocument();
     expect(screen.getByText('Not shared yet')).toBeInTheDocument();
+    expect(screen.getByText(/Public links should use a read-only storage key/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Public view link' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Embed code' })).toBeDisabled();

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -3,8 +3,8 @@ services:
     image: quay.io/minio/minio:latest
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: localstudio
-      MINIO_ROOT_PASSWORD: localstudio123
+      MINIO_ROOT_USER: localstudio-root
+      MINIO_ROOT_PASSWORD: localstudio-root123
       MINIO_API_CORS_ALLOW_ORIGIN: '*'
     ports:
       - '9000:9000'
@@ -16,13 +16,66 @@ services:
     image: quay.io/minio/mc:latest
     depends_on:
       - minio
-    entrypoint: >
-      /bin/sh -c "
-      until mc alias set local http://minio:9000 localstudio localstudio123; do sleep 1; done;
-      mc mb --ignore-existing local/localstudio;
-      mc anonymous set download local/localstudio;
-      echo 'MinIO bucket localstudio is ready for LocalStudio mirroring.';
-      "
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        until mc alias set local http://minio:9000 localstudio-root localstudio-root123; do sleep 1; done;
+        mc mb --ignore-existing local/localstudio;
+        mc admin user remove local localstudio-writer || true;
+        mc admin user remove local localstudio-reader || true;
+        mc admin user add local localstudio-writer localstudio-writer || true;
+        mc admin user add local localstudio-reader localstudio-reader || true;
+        cat >/tmp/localstudio-writer-policy.json <<'EOF'
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+              ],
+              "Resource": ["arn:aws:s3:::localstudio"]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject"
+              ],
+              "Resource": ["arn:aws:s3:::localstudio/*"]
+            }
+          ]
+        }
+        EOF
+        cat >/tmp/localstudio-reader-policy.json <<'EOF'
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+              ],
+              "Resource": ["arn:aws:s3:::localstudio"]
+            },
+            {
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::localstudio/*"]
+            }
+          ]
+        }
+        EOF
+        mc admin policy create local localstudio-writer /tmp/localstudio-writer-policy.json || true;
+        mc admin policy create local localstudio-reader /tmp/localstudio-reader-policy.json || true;
+        mc admin policy attach local localstudio-writer --user localstudio-writer;
+        mc admin policy attach local localstudio-reader --user localstudio-reader;
+        mc anonymous set download local/localstudio;
+        echo 'MinIO bucket localstudio is ready. Use localstudio-writer for writes and localstudio-reader for read-only public decks.';
 
 volumes:
   minio-data:

--- a/tests/e2e/editor/remote-mirror-import-config.ts
+++ b/tests/e2e/editor/remote-mirror-import-config.ts
@@ -1,10 +1,14 @@
 export const remoteMirrorImportConfig = {
-  accessKey: 'localstudio',
+  accessKey: 'localstudio-writer',
   bucket: 'localstudio',
   endpoint: 'http://localhost:9000',
   pathStyle: true,
   prefix: 'mirrors',
   publicBaseUrl: 'http://localhost:9000/localstudio',
+  readerAccessKey: 'localstudio-reader',
+  readerSecretKey: 'localstudio-reader',
   region: 'us-east-1',
-  secretKey: 'localstudio123',
+  secretKey: 'localstudio-writer',
+  writerAccessKey: 'localstudio-writer',
+  writerSecretKey: 'localstudio-writer',
 };


### PR DESCRIPTION
## Summary
- Refine mirror configuration UI and share/editor integration to support S3-style settings alongside MinIO.
- Update mirror service, object utilities, and import/config fixtures to align with the new persistence flow.
- Refresh documentation and styling for the mirror settings experience.
- Add and update unit and E2E coverage around mirror behavior and panel interactions.

## Testing
- Unit tests updated for mirror service, editor shell persistence, mirror settings panel, and share panel.
- E2E coverage updated for remote mirror import configuration.
- Not run (not requested).