### PR TITLE
Fix public share link UX

### DIFF
--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -30,6 +30,7 @@ import { VersionHistoryPanel } from '../panels/VersionHistoryPanel';
 import { presentationMovieControls, type MovieHoldState } from '../media/presentationMovieControls';
 import { useEditorViewModel, type OperationNoticeState } from '../state/useEditorViewModel';
 import { SharePanel } from '../../share/SharePanel';
+import { copyShareText } from '../../share/shareClipboard';
 import { KeyboardShortcutsDialog, type KeyboardShortcutAction } from '../../components/KeyboardShortcutsDialog';
 import { editorShellBrowserUtils } from '../browser/editorShellBrowserUtils';
 import { BrowserPresenterSessionService } from '../../../services/presenter/presenterSessionService';
@@ -272,7 +273,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         : await services.shareService.createShare(projectToShare);
       const copiedShare: ShareMetadata = { ...nextShare, status: 'copied' };
       setShareMetadata(copiedShare);
-      await navigator.clipboard?.writeText(copiedShare.publicUrl);
+      copyShareText(copiedShare.publicUrl);
       return copiedShare;
     } finally {
       setShareProgressLabel(undefined);

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -6,6 +6,7 @@ import type {
 } from '../../domain/documents/model';
 import type { FontImportService, ShareService } from '../../services/contracts/interfaces';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
+import { preloadPublicDeckAssets } from './publicDeckAssetPreloader';
 
 interface PublicDeckViewerProps {
   shareId: string;
@@ -258,9 +259,11 @@ export function PublicDeckViewer({
 
   useEffect(() => {
     let isActive = true;
+    const preloadController = new AbortController();
     void shareService.getShare(shareId).then(async (record) => {
       if (!isActive) return;
       if (record) {
+        void preloadPublicDeckAssets(record.project, { signal: preloadController.signal });
         await fontImportService.loadProjectFonts(record.project).catch(() => undefined);
       }
       if (!isActive) return;
@@ -274,6 +277,7 @@ export function PublicDeckViewer({
     });
     return () => {
       isActive = false;
+      preloadController.abort();
     };
   }, [fontImportService, playPresentationPage, shareId, shareService]);
 

--- a/apps/editor/src/ui/share/SharePanel.tsx
+++ b/apps/editor/src/ui/share/SharePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { ShareMetadata } from '../../services/contracts/interfaces';
+import { copyShareText } from './shareClipboard';
 
 interface SharePanelProps {
   projectName: string;
@@ -145,7 +146,7 @@ export function SharePanel({
           disabled={!currentShare}
           onClick={() => {
             if (!currentShare) return;
-            void navigator.clipboard?.writeText(currentShare.embedHtml);
+            copyShareText(currentShare.embedHtml);
           }}
         >
           <span className="share-action-icon material-symbols-outlined" aria-hidden="true">

--- a/apps/editor/src/ui/share/publicDeckAssetPreloader.ts
+++ b/apps/editor/src/ui/share/publicDeckAssetPreloader.ts
@@ -1,0 +1,76 @@
+import type { ProjectDocument } from '../../domain/documents/model';
+
+interface PublicDeckAssetPreloadOptions {
+  fetchImpl?: typeof fetch | undefined;
+  signal?: AbortSignal | undefined;
+}
+
+const PUBLIC_DECK_PRELOAD_CONCURRENCY = 4;
+
+function getFetchImpl(options: PublicDeckAssetPreloadOptions) {
+  if (options.fetchImpl) return options.fetchImpl;
+  if (typeof fetch === 'undefined') return undefined;
+  return fetch.bind(globalThis);
+}
+
+function normalizePreloadUrl(value: string | undefined) {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value, window.location.href);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function collectPublicDeckAssetUrls(project: ProjectDocument) {
+  const urls = new Set<string>();
+  for (const asset of Object.values(project.assets)) {
+    const url = normalizePreloadUrl(asset.objectUrl);
+    if (url) urls.add(url);
+  }
+  for (const font of Object.values(project.fonts ?? {})) {
+    const objectUrl = normalizePreloadUrl(font.objectUrl);
+    const sourceUrl = normalizePreloadUrl(font.sourceUrl);
+    if (objectUrl) urls.add(objectUrl);
+    if (sourceUrl) urls.add(sourceUrl);
+  }
+  return Array.from(urls);
+}
+
+async function preloadUrl(url: string, options: PublicDeckAssetPreloadOptions) {
+  const fetchImpl = getFetchImpl(options);
+  if (!fetchImpl || options.signal?.aborted) return;
+  const requestInit: RequestInit = {
+    cache: 'force-cache',
+    credentials: 'omit',
+    mode: 'cors',
+    ...(options.signal ? { signal: options.signal } : {}),
+  };
+  await fetchImpl(url, requestInit).catch(() => undefined);
+}
+
+async function preloadUrlQueue(urls: string[], options: PublicDeckAssetPreloadOptions) {
+  let nextIndex = 0;
+  async function worker() {
+    while (!options.signal?.aborted) {
+      const url = urls[nextIndex];
+      nextIndex += 1;
+      if (!url) return;
+      await preloadUrl(url, options);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(PUBLIC_DECK_PRELOAD_CONCURRENCY, urls.length) }, () => worker()),
+  );
+}
+
+export function preloadPublicDeckAssets(
+  project: ProjectDocument,
+  options: PublicDeckAssetPreloadOptions = {},
+) {
+  const urls = collectPublicDeckAssetUrls(project);
+  if (urls.length === 0) return Promise.resolve();
+  return preloadUrlQueue(urls, options);
+}

--- a/apps/editor/src/ui/share/shareClipboard.ts
+++ b/apps/editor/src/ui/share/shareClipboard.ts
@@ -1,0 +1,17 @@
+export function copyShareText(text: string) {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.position = 'fixed';
+  textArea.style.top = '0';
+  textArea.style.left = '-9999px';
+  textArea.style.opacity = '0';
+  document.body.append(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    return document.execCommand('copy');
+  } finally {
+    textArea.remove();
+  }
+}

--- a/apps/editor/src/ui/styles/share-panel.css
+++ b/apps/editor/src/ui/styles/share-panel.css
@@ -55,10 +55,11 @@
   align-items: center;
   justify-content: center;
   gap: 10px;
-  color: #fff;
-  background: linear-gradient(135deg, #9b37ff, #7c3cff);
+  color: var(--ew-on-primary);
+  background: var(--ew-green);
   border: 0;
-  border-radius: 8px;
+  border-radius: 4px;
+  font-weight: 900;
   cursor: pointer;
 }
 
@@ -105,14 +106,17 @@
 .share-action-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px 8px;
+  gap: 12px;
 }
 
 .share-action-button {
   min-width: 0;
-  display: grid;
+  min-height: 76px;
+  display: inline-grid;
+  grid-template-rows: 40px minmax(28px, auto);
+  align-items: start;
   justify-items: center;
-  gap: 8px;
+  gap: 7px;
   color: #20242c;
   background: transparent;
   border: 0;
@@ -127,17 +131,18 @@
 }
 
 .share-action-icon {
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   color: #363b45;
   background: #eef0f4;
-  border-radius: 999px;
+  border-radius: 4px;
+  font-size: 22px;
 }
 
 .share-action-button-accent .share-action-icon {
-  color: #fff;
-  background: #ff5f0a;
+  color: var(--ew-on-primary);
+  background: var(--ew-green);
 }

--- a/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
@@ -359,12 +359,17 @@ describe('EditorShell export and share workflows', () => {
 
   it('creates and shows a public link from the share panel', async () => {
     vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000301');
-    const writeText = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn();
+    const execCommand = vi.fn().mockReturnValue(true);
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
         writeText,
       },
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
     });
     const services = createAppServices();
     enableSyncedSharing(services);
@@ -381,7 +386,8 @@ describe('EditorShell export and share workflows', () => {
       'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000301/share.json',
     )}`;
     expect(await screen.findByDisplayValue(expectedPublicUrl)).toBeInTheDocument();
-    expect(writeText).toHaveBeenCalledWith(expectedPublicUrl);
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it('enters fullscreen presentation mode from the share panel', async () => {

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import type {
   FontImportResult,
@@ -25,6 +25,11 @@ describe('PublicDeckViewer', () => {
 
   beforeEach(() => {
     window.history.replaceState({}, '', '/');
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   function getRequestUrl(input: RequestInfo | URL) {
@@ -72,6 +77,65 @@ describe('PublicDeckViewer', () => {
     expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-selected-elements', '');
     expect(screen.getByRole('button', { name: 'Previous slide' })).toBeDisabled();
     expect(screen.getByText('1 / 1')).toBeInTheDocument();
+  });
+
+  it('preloads public deck assets in the browser after the share record loads', async () => {
+    const project = sampleProject.createSampleProject();
+    project.assets['remote-image'] = {
+      id: 'remote-image',
+      type: 'image',
+      name: 'Remote image',
+      mimeType: 'image/png',
+      objectUrl: 'https://cdn.localstudio.test/assets/remote-image.png',
+      storage: 'remote',
+    };
+    project.fonts = {
+      brand: {
+        id: 'brand',
+        family: 'Brand Sans',
+        requestedFamily: 'Brand Sans',
+        source: 'uploaded',
+        fontStyle: 'normal',
+        fontWeight: 700,
+        mimeType: 'font/woff2',
+        fileName: 'brand.woff2',
+        storage: 'remote',
+        objectUrl: 'https://cdn.localstudio.test/fonts/brand.woff2',
+      },
+    };
+    const preloadFetch = vi.mocked(globalThis.fetch);
+    const { share, shareService } = createRemoteShare(
+      '00000000-0000-4000-8000-000000000206',
+      project,
+    );
+
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
+
+    await screen.findByLabelText('Public presentation');
+    await waitFor(() => {
+      expect(preloadFetch).toHaveBeenCalledWith(
+        'https://cdn.localstudio.test/assets/remote-image.png',
+        expect.objectContaining({
+          cache: 'force-cache',
+          credentials: 'omit',
+          mode: 'cors',
+        }),
+      );
+      expect(preloadFetch).toHaveBeenCalledWith(
+        'https://cdn.localstudio.test/fonts/brand.woff2',
+        expect.objectContaining({
+          cache: 'force-cache',
+          credentials: 'omit',
+          mode: 'cors',
+        }),
+      );
+    });
   });
 
   it('keeps embeds in a compact shared deck layout', async () => {

--- a/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ShareMetadata } from '../../../../src/services/contracts/interfaces';
 import { SharePanel } from '../../../../src/ui/share/SharePanel';
 
@@ -18,6 +18,8 @@ function createShareMetadata(overrides: Partial<ShareMetadata> = {}): ShareMetad
 }
 
 describe('SharePanel', () => {
+  const execCommandDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand');
+
   beforeEach(() => {
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
@@ -25,6 +27,19 @@ describe('SharePanel', () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (execCommandDescriptor) {
+      Object.defineProperty(document, 'execCommand', execCommandDescriptor);
+    } else {
+      Reflect.deleteProperty(document, 'execCommand');
+    }
   });
 
   it('shows the not shared state before publishing', () => {
@@ -104,6 +119,38 @@ describe('SharePanel', () => {
     expect(await screen.findByDisplayValue('https://localstudio.test/s/share-panel-id')).toBeInTheDocument();
     expect(screen.getByDisplayValue('<iframe src="https://localstudio.test/embed/share-panel-id"></iframe>')).toBeInTheDocument();
     expect(screen.getByText('Copied')).toBeInTheDocument();
+  });
+
+  it('copies embed code without the Clipboard permissions API', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(
+      <SharePanel
+        projectName="Untitled AI Deck"
+        share={createShareMetadata()}
+        onClose={vi.fn()}
+        onCopyLink={vi.fn()}
+        onDownload={vi.fn()}
+        onPresent={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Embed code' }));
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it('shows an error when share publishing fails', async () => {

--- a/tests/e2e/editor/share-failure-recovery-page.ts
+++ b/tests/e2e/editor/share-failure-recovery-page.ts
@@ -6,19 +6,8 @@ import { expect } from '../support/journey-test';
 import { shareFailureMirrorRoute } from './share-failure-mirror-route';
 
 export const shareFailureRecoveryPage = {
-  async recoverMirrorAndReportClipboardFailure(page: Page, baseURL: string) {
+  async recoverMirrorAndCreatePublicLink(page: Page, baseURL: string) {
     await installFakeOpfs(page);
-    await page.addInitScript(() => {
-      Object.defineProperty(navigator, 'clipboard', {
-        configurable: true,
-        value: {
-          writeText: async () => {
-            await Promise.resolve();
-            throw new Error('Clipboard write denied by test browser');
-          },
-        },
-      });
-    });
 
     const mirrorRoute = await shareFailureMirrorRoute.install(page);
     const editor = new EditorAppPage(page, baseURL);
@@ -52,7 +41,8 @@ export const shareFailureRecoveryPage = {
     ).toBeVisible();
     await page.getByRole('button', { name: 'Share', exact: true }).click();
     await page.getByRole('button', { name: 'Copy link' }).click();
-    await expect(page.getByText('Share failed')).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText('Clipboard write denied by test browser')).toBeVisible();
+    await expect(page.getByText('Copied')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByLabel('Published share links')).toContainText('Public URL');
+    await expect(page.getByText('Clipboard write denied by test browser')).toBeHidden();
   },
 };

--- a/tests/e2e/editor/share-failure-retry.spec.ts
+++ b/tests/e2e/editor/share-failure-retry.spec.ts
@@ -4,12 +4,7 @@ import { shareFailureRecoveryPage } from './share-failure-recovery-page';
 const getServer = withIsolatedDevServer(test);
 
 test.describe('editor share and mirror failure recovery journey', () => {
-  test('recovers from mirror connection failure and reports clipboard copy failure', async ({
-    page,
-  }) => {
-    await shareFailureRecoveryPage.recoverMirrorAndReportClipboardFailure(
-      page,
-      getServer().baseURL,
-    );
+  test('recovers from mirror connection failure and creates a public link', async ({ page }) => {
+    await shareFailureRecoveryPage.recoverMirrorAndCreatePublicLink(page, getServer().baseURL);
   });
 });


### PR DESCRIPTION
## Summary

- Align the share panel actions with fixed-size design-system controls.
- Copy public share links and embed snippets through a selection-based copy helper instead of the Clipboard permissions API.
- Start asynchronous public deck asset/font preloading in the viewer after the share payload loads, so later slide navigation is warmed by the browser cache.

## Validation

- `npm run test --workspace @localstudio/editor -- tests/unit/ui/share/SharePanel.test.tsx tests/unit/ui/share/PublicDeckViewer.test.tsx tests/unit/ui/editor/EditorShell.export-share.test.tsx`
- `npm run test --workspace @localstudio/editor -- tests/unit/testOrganization.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `E2E_COVERAGE=0 npm run test:e2e -- tests/e2e/editor/remote-mirror-share.spec.ts`

Note: the normal E2E scenario passed, but the coverage wrapper hit the known aggregate `0.00% bytes < 80%` path, so the scenario was rerun with `E2E_COVERAGE=0`.