### PR TITLE
Optimize share publishing and mirror enable flow

### DIFF
--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -302,6 +302,7 @@ export interface ShareService {
   createShare(project: ProjectDocument): Promise<ShareMetadata>;
   updateShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata>;
   getShare(shareId: string): Promise<ShareRecord | null>;
+  getProjectShareMetadata(project: ProjectDocument): ShareMetadata;
   getPublicUrl(shareId: string): string;
   getEmbedUrl(shareId: string): string;
   getEmbedHtml(shareId: string): string;

--- a/apps/editor/src/services/sharing/shareService.ts
+++ b/apps/editor/src/services/sharing/shareService.ts
@@ -38,6 +38,12 @@ function createShareId() {
   return `share-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+function getProjectShareId(project: ProjectDocument) {
+  const normalizedProjectId = project.id.trim().replace(/[^a-zA-Z0-9_-]+/g, '-');
+  if (!normalizedProjectId) return createShareId();
+  return `project-${normalizedProjectId}`;
+}
+
 function cloneProject(project: ProjectDocument): ProjectDocument {
   return JSON.parse(JSON.stringify(project)) as ProjectDocument;
 }
@@ -79,7 +85,7 @@ export class BrowserShareService implements ShareService {
   }
 
   async createShare(project: ProjectDocument): Promise<ShareMetadata> {
-    return this.publishShare(createShareId(), project);
+    return this.publishShare(getProjectShareId(project), project);
   }
 
   async updateShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata> {
@@ -124,6 +130,18 @@ export class BrowserShareService implements ShareService {
 
   getEmbedHtml(shareId: string): string {
     return `<iframe src="${escapeHtmlAttribute(this.getEmbedUrl(shareId))}" width="960" height="540" style="border:0;aspect-ratio:16/9;width:100%;max-width:960px;" allowfullscreen></iframe>`;
+  }
+
+  getProjectShareMetadata(project: ProjectDocument): ShareMetadata {
+    return this.toMetadata(
+      {
+        shareId: getProjectShareId(project),
+        createdAt: project.createdAt,
+        updatedAt: project.updatedAt,
+        project,
+      },
+      'published',
+    );
   }
 
   private getShareSourceUrl() {

--- a/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/MirrorSettingsPanel.tsx
@@ -23,7 +23,7 @@ interface MirrorSettingsPanelProps {
   onBack?: () => void;
   onChooseLocalFontFolder: () => Promise<void>;
   onClose: () => void;
-  onEnabledChange: (enabled: boolean) => void;
+  onEnabledChange: (enabled: boolean, config: MinioMirrorConfig) => void;
   onLocalFontMirrorEnabledChange: (enabled: boolean) => void;
   onSave: (config: MinioMirrorConfig) => void;
   onTestConnection: (
@@ -539,8 +539,7 @@ export function MirrorSettingsPanel({
             type="button"
             onClick={() => {
               const nextEnabled = !mirrorState.enabled;
-              onEnabledChange(nextEnabled);
-              if (nextEnabled) void testConnection();
+              onEnabledChange(nextEnabled, normalizedDraft());
             }}
           >
             {mirrorState.enabled ? 'Disable mirroring' : 'Enable mirroring'}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -121,7 +121,6 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const [isExportingImages, setIsExportingImages] = useState(false);
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
   const [shareMetadata, setShareMetadata] = useState<ShareMetadata | undefined>();
-  const [shareProgressLabel, setShareProgressLabel] = useState<string | undefined>();
   const stageRef = useRef<Konva.Stage>(null);
   const imageExportStageRef = useRef<Konva.Stage>(null);
   const workspaceRef = useRef<HTMLElement>(null);
@@ -132,6 +131,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const imageExportNoticeTimeoutRef = useRef<number | undefined>(undefined);
   const presenterFullscreenEnteredRef = useRef(false);
   const pendingShareAfterLocalSaveRef = useRef(false);
+  const sharePublishPromiseRef = useRef<Promise<ShareMetadata> | undefined>(undefined);
   const toolbarImageInputRef = useRef<HTMLInputElement>(null);
   const hasSelection = vm.selection.elementIds.length > 0;
   const isHistoryReadOnly = vm.versionHistoryOpen;
@@ -152,6 +152,35 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const publicSharingAvailable = vm.mirrorState.enabled && vm.mirrorState.status === 'synced';
   const publicSharingUnavailableReason = 'Public links cannot be created without remote storage.';
   const hasDirectoryPersistence = services.persistenceMode === 'directory';
+
+  const publishCurrentProjectShare = useCallback(async () => {
+    if (sharePublishPromiseRef.current) return sharePublishPromiseRef.current;
+    const preparedShare = services.shareService.getProjectShareMetadata(vm.project);
+    const shareId = shareMetadata?.shareId ?? preparedShare.shareId;
+    setShareMetadata((current) => ({
+      ...(current ?? preparedShare),
+      shareId,
+      status: 'syncing',
+    }));
+
+    const publishPromise = (async () => {
+      const fontResult = await prepareProjectFontsForPublicShareRef.current();
+      return services.shareService.updateShare(shareId, fontResult.project);
+    })();
+    sharePublishPromiseRef.current = publishPromise;
+    try {
+      const nextShare = await publishPromise;
+      setShareMetadata(nextShare);
+      return nextShare;
+    } catch (error) {
+      setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
+      throw error;
+    } finally {
+      if (sharePublishPromiseRef.current === publishPromise) {
+        sharePublishPromiseRef.current = undefined;
+      }
+    }
+  }, [services.shareService, shareMetadata?.shareId, vm.project]);
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -255,29 +284,14 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   }
 
   async function copyPublicShareLink() {
-    setShareProgressLabel('Checking local fonts');
-    try {
-      const fontResult = await vm.prepareProjectFontsForPublicShare({
-        onProgress: (progress) => setShareProgressLabel(progress.label),
-      });
-      if (fontResult.unresolvedFamilies.length > 0) {
-        setShareProgressLabel(
-          `Publishing with fallback risk for ${fontResult.unresolvedFamilies.join(', ')}`,
-        );
-      } else {
-        setShareProgressLabel('Publishing public link');
-      }
-      const projectToShare = fontResult.project;
-      const nextShare = shareMetadata
-        ? await services.shareService.updateShare(shareMetadata.shareId, projectToShare)
-        : await services.shareService.createShare(projectToShare);
-      const copiedShare: ShareMetadata = { ...nextShare, status: 'copied' };
-      setShareMetadata(copiedShare);
-      copyShareText(copiedShare.publicUrl);
-      return copiedShare;
-    } finally {
-      setShareProgressLabel(undefined);
-    }
+    const preparedShare =
+      shareMetadata?.status === 'published' || shareMetadata?.status === 'copied'
+        ? shareMetadata
+        : await publishCurrentProjectShare();
+    const copiedShare: ShareMetadata = { ...preparedShare, status: 'copied' };
+    setShareMetadata(copiedShare);
+    copyShareText(copiedShare.publicUrl);
+    return copiedShare;
   }
 
   function continueShareAfterLocalSave() {
@@ -1087,9 +1101,8 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   );
 
   useEffect(() => {
-    const shareId = shareMetadata?.shareId;
-    if (!shareId) return undefined;
     if (!publicSharingAvailable) {
+      if (!shareMetadata?.shareId) return undefined;
       const timeoutId = window.setTimeout(() => {
         setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
       }, 0);
@@ -1097,26 +1110,14 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         window.clearTimeout(timeoutId);
       };
     }
-    const timeoutId = window.setTimeout(() => {
-      setShareMetadata((current) => (current ? { ...current, status: 'syncing' } : current));
-      void (async () => {
-        const fontResult = await prepareProjectFontsForPublicShareRef.current();
-        return services.shareService.updateShare(shareId, fontResult.project);
-      })()
-        .then((nextShare) => {
-          setShareMetadata(nextShare);
-        })
-        .catch(() => {
-          setShareMetadata((current) =>
-            current ? { ...current, status: 'sync-failed' } : current,
-          );
-        });
-    }, 1000);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [publicSharingAvailable, services.shareService, shareMetadata?.shareId, vm.project]);
+    void publishCurrentProjectShare().catch(() => undefined);
+    return undefined;
+  }, [
+    publishCurrentProjectShare,
+    publicSharingAvailable,
+    shareMetadata?.shareId,
+    vm.mirrorState.status,
+  ]);
 
   return (
     <div className="app-shell">
@@ -1427,7 +1428,6 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         <SharePanel
           projectName={vm.project.name}
           share={shareMetadata}
-          shareProgressLabel={shareProgressLabel}
           onClose={() => {
             setSharePanelOpen(false);
           }}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -1799,19 +1799,29 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function saveMirrorConfig(config: MinioMirrorConfig) {
-    services.mirrorService.saveConfig(config);
+    persistMirrorConfig(config);
     editorPreferences.writeMirrorPreference(true);
-    setMirrorConfig(config);
-    setHasMirrorConfig(true);
     setMirrorDisabledBySettings(false);
-    mirrorConfigRef.current = config;
     setMirrorState({ enabled: true, status: 'idle' });
     setMirrorSettingsOpen(false);
     void syncMirrorNow();
   }
 
-  function setMirrorEnabled(enabled: boolean, options?: { fromSettings?: boolean }) {
+  function persistMirrorConfig(config: MinioMirrorConfig) {
+    services.mirrorService.saveConfig(config);
+    setMirrorConfig(config);
+    setHasMirrorConfig(true);
+    mirrorConfigRef.current = config;
+  }
+
+  function setMirrorEnabled(
+    enabled: boolean,
+    options?: { config?: MinioMirrorConfig | undefined; fromSettings?: boolean },
+  ) {
     if (enabled) {
+      if (options?.config) {
+        persistMirrorConfig(options.config);
+      }
       if (!mirrorConfigRef.current) {
         openMirrorSettings();
         return;
@@ -1827,8 +1837,8 @@ export function useEditorViewModel(services: AppServices) {
     setMirrorState({ enabled: false, status: 'disabled' });
   }
 
-  function setMirrorEnabledFromSettings(enabled: boolean) {
-    setMirrorEnabled(enabled, { fromSettings: true });
+  function setMirrorEnabledFromSettings(enabled: boolean, config: MinioMirrorConfig) {
+    setMirrorEnabled(enabled, { config, fromSettings: true });
   }
 
   async function testMirrorConnection(

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -17,6 +17,7 @@ interface PublicDeckViewerProps {
 
 type ViewerState =
   | { status: 'loading' }
+  | { status: 'preloading'; loaded: number; project: ProjectDocument; total: number }
   | { status: 'missing' }
   | { status: 'ready'; project: ProjectDocument };
 
@@ -34,6 +35,11 @@ interface AnimationPreviewState {
 
 function getBuildPlaybackDurationMs(build: ElementAnimationBuild) {
   return Math.max(0, build.durationMs ?? build.delayMs);
+}
+
+function hasReachedPlaybackThreshold(loaded: number, total: number) {
+  if (total === 0) return true;
+  return loaded / total >= 0.5;
 }
 
 export function PublicDeckViewer({
@@ -262,18 +268,43 @@ export function PublicDeckViewer({
     const preloadController = new AbortController();
     void shareService.getShare(shareId).then(async (record) => {
       if (!isActive) return;
-      if (record) {
-        void preloadPublicDeckAssets(record.project, { signal: preloadController.signal });
-        await fontImportService.loadProjectFonts(record.project).catch(() => undefined);
-      }
-      if (!isActive) return;
-      setViewerState(record ? { status: 'ready', project: record.project } : { status: 'missing' });
-      if (record) {
-        playPresentationPage(record.project, 0);
-      } else {
+      if (!record) {
+        setViewerState({ status: 'missing' });
         setActivePageIndex(0);
         setAnimationPreview(undefined);
+        return;
       }
+      const shareRecord = record;
+
+      let hasStartedPlayback = false;
+      function startPlaybackWhenReady(loaded: number, total: number) {
+        if (!isActive || hasStartedPlayback || !hasReachedPlaybackThreshold(loaded, total)) return;
+        hasStartedPlayback = true;
+        setViewerState({ status: 'ready', project: shareRecord.project });
+        playPresentationPage(shareRecord.project, 0);
+      }
+
+      setViewerState({ status: 'preloading', loaded: 0, project: shareRecord.project, total: 0 });
+      await fontImportService.loadProjectFonts(shareRecord.project).catch(() => undefined);
+      if (!isActive) return;
+      await preloadPublicDeckAssets(shareRecord.project, {
+        signal: preloadController.signal,
+        onProgress: (progress) => {
+          if (!isActive) return;
+          setViewerState((current) =>
+            current.status === 'preloading'
+              ? {
+                  status: 'preloading',
+                  loaded: progress.loaded,
+                  project: shareRecord.project,
+                  total: progress.total,
+                }
+              : current,
+          );
+          startPlaybackWhenReady(progress.loaded, progress.total);
+        },
+      });
+      startPlaybackWhenReady(1, 1);
     });
     return () => {
       isActive = false;
@@ -310,6 +341,26 @@ export function PublicDeckViewer({
     return (
       <main className={viewerClassName}>
         <p className="public-deck-status">Loading deck...</p>
+      </main>
+    );
+  }
+
+  if (viewerState.status === 'preloading') {
+    const loadedPercent =
+      viewerState.total > 0 ? Math.min(100, Math.round((viewerState.loaded / viewerState.total) * 100)) : 0;
+    return (
+      <main className={viewerClassName}>
+        <section className="public-deck-loading" aria-label="Preparing shared deck">
+          <p className="public-deck-status">Preparing media...</p>
+          <div className="public-deck-loading-track" aria-hidden="true">
+            <span style={{ width: `${loadedPercent}%` }} />
+          </div>
+          <p className="public-deck-status">
+            {viewerState.total > 0
+              ? `${viewerState.loaded} / ${viewerState.total} assets ready`
+              : 'Checking assets'}
+          </p>
+        </section>
       </main>
     );
   }

--- a/apps/editor/src/ui/share/SharePanel.tsx
+++ b/apps/editor/src/ui/share/SharePanel.tsx
@@ -15,7 +15,7 @@ interface SharePanelProps {
 }
 
 function getStatusLabel(share: ShareMetadata | undefined, isCopying: boolean) {
-  if (isCopying) return 'Creating link...';
+  if (isCopying) return 'Copying link...';
   if (!share) return 'Not shared yet';
   if (share.status === 'copied') return 'Copied';
   if (share.status === 'syncing') return 'Syncing';
@@ -34,9 +34,10 @@ export function SharePanel({
   onDownload,
   onPresent,
 }: SharePanelProps) {
-  const [currentShare, setCurrentShare] = useState<ShareMetadata | undefined>(share);
+  const [lastCopiedShare, setLastCopiedShare] = useState<ShareMetadata | undefined>();
   const [isCopying, setIsCopying] = useState(false);
   const [copyError, setCopyError] = useState<string | undefined>();
+  const currentShare = share ?? lastCopiedShare;
   const publicLinkUnavailable = Boolean(publicLinkUnavailableReason);
   const statusLabel = getStatusLabel(currentShare, isCopying);
   const shareAccessDescription =
@@ -45,7 +46,7 @@ export function SharePanel({
     publicLinkUnavailableReason ??
     (currentShare
       ? 'Unlisted: anyone with the link can view.'
-      : 'Create a public view link for this deck.');
+      : 'Sync the deck to prepare a public view link.');
 
   async function handleCopyLink() {
     if (publicLinkUnavailable) {
@@ -56,7 +57,7 @@ export function SharePanel({
     setCopyError(undefined);
     try {
       const nextShare = await onCopyLink();
-      setCurrentShare(nextShare);
+      setLastCopiedShare(nextShare);
     } catch (error) {
       setCopyError(error instanceof Error ? error.message : 'Could not create the share link.');
     } finally {

--- a/apps/editor/src/ui/share/publicDeckAssetPreloader.ts
+++ b/apps/editor/src/ui/share/publicDeckAssetPreloader.ts
@@ -2,10 +2,17 @@ import type { ProjectDocument } from '../../domain/documents/model';
 
 interface PublicDeckAssetPreloadOptions {
   fetchImpl?: typeof fetch | undefined;
+  onProgress?: (progress: PublicDeckAssetPreloadProgress) => void;
   signal?: AbortSignal | undefined;
 }
 
 const PUBLIC_DECK_PRELOAD_CONCURRENCY = 4;
+const PUBLIC_DECK_PRELOAD_TIMEOUT_MS = 5000;
+
+export interface PublicDeckAssetPreloadProgress {
+  loaded: number;
+  total: number;
+}
 
 function getFetchImpl(options: PublicDeckAssetPreloadOptions) {
   if (options.fetchImpl) return options.fetchImpl;
@@ -42,23 +49,39 @@ function collectPublicDeckAssetUrls(project: ProjectDocument) {
 async function preloadUrl(url: string, options: PublicDeckAssetPreloadOptions) {
   const fetchImpl = getFetchImpl(options);
   if (!fetchImpl || options.signal?.aborted) return;
+  const timeoutController = new AbortController();
+  const timeoutId = window.setTimeout(() => {
+    timeoutController.abort();
+  }, PUBLIC_DECK_PRELOAD_TIMEOUT_MS);
+  const abortPreload = () => {
+    timeoutController.abort();
+  };
+  options.signal?.addEventListener('abort', abortPreload, { once: true });
   const requestInit: RequestInit = {
     cache: 'force-cache',
     credentials: 'omit',
     mode: 'cors',
-    ...(options.signal ? { signal: options.signal } : {}),
+    signal: timeoutController.signal,
   };
-  await fetchImpl(url, requestInit).catch(() => undefined);
+  try {
+    await fetchImpl(url, requestInit).catch(() => undefined);
+  } finally {
+    window.clearTimeout(timeoutId);
+    options.signal?.removeEventListener('abort', abortPreload);
+  }
 }
 
 async function preloadUrlQueue(urls: string[], options: PublicDeckAssetPreloadOptions) {
   let nextIndex = 0;
+  let loaded = 0;
   async function worker() {
     while (!options.signal?.aborted) {
       const url = urls[nextIndex];
       nextIndex += 1;
       if (!url) return;
       await preloadUrl(url, options);
+      loaded += 1;
+      options.onProgress?.({ loaded, total: urls.length });
     }
   }
   await Promise.all(
@@ -72,5 +95,6 @@ export function preloadPublicDeckAssets(
 ) {
   const urls = collectPublicDeckAssetUrls(project);
   if (urls.length === 0) return Promise.resolve();
+  options.onProgress?.({ loaded: 0, total: urls.length });
   return preloadUrlQueue(urls, options);
 }

--- a/apps/editor/src/ui/styles/public-deck-viewer.css
+++ b/apps/editor/src/ui/styles/public-deck-viewer.css
@@ -122,3 +122,27 @@
   gap: 8px;
   text-align: center;
 }
+
+.public-deck-loading {
+  align-self: center;
+  justify-self: center;
+  width: min(320px, calc(100vw - 48px));
+  display: grid;
+  gap: 10px;
+  text-align: center;
+}
+
+.public-deck-loading-track {
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.public-deck-loading-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--ew-green);
+  transition: width 160ms ease;
+}

--- a/apps/editor/tests/unit/services/shareService.test.ts
+++ b/apps/editor/tests/unit/services/shareService.test.ts
@@ -77,7 +77,6 @@ function createProjectWithInlineFont(): ProjectDocument {
 describe('BrowserShareService', () => {
   beforeEach(() => {
     window.localStorage.clear();
-    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000001');
   });
 
   it('publishes a public share payload and local assets to MinIO', async () => {
@@ -102,40 +101,40 @@ describe('BrowserShareService', () => {
 
     const share = await service.createShare(createProjectWithInlineAsset());
 
-    expect(share.shareId).toBe('00000000-0000-4000-8000-000000000001');
+    expect(share.shareId).toBe('project-project-1');
     const publicUrl = new URL(share.publicUrl);
     expect(publicUrl.pathname).toBe('/editor/');
-    expect(publicUrl.searchParams.get('share')).toBe('00000000-0000-4000-8000-000000000001');
+    expect(publicUrl.searchParams.get('share')).toBe('project-project-1');
     expect(publicUrl.searchParams.get('src')).toBe(
-      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json',
+      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
     );
-    expect(share.embedHtml).toContain('/editor/?embed=00000000-0000-4000-8000-000000000001');
+    expect(share.embedHtml).toContain('/editor/?embed=project-project-1');
     expect(share.embedHtml).toContain('src=');
 
     const putUrls = Array.from(uploadedBodies.keys());
     expect(putUrls).toContain(
-      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/assets/asset-inline.png',
+      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/assets/asset-inline.png',
     );
     expect(putUrls).toContain(
-      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json',
+      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
     );
 
     const sharePayload = JSON.parse(
       await uploadedBodies
         .get(
-          'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json',
+          'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
         )!
         .text(),
     ) as unknown as PublicSharePayloadFixture;
     expect(sharePayload).toMatchObject({
       schemaVersion: 1,
-      shareId: '00000000-0000-4000-8000-000000000001',
+      shareId: 'project-project-1',
       project: {
         name: 'Untitled AI Deck',
         assets: {
           'asset-inline': {
             objectUrl:
-              'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/assets/asset-inline.png',
+              'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/assets/asset-inline.png',
             storage: 'remote',
           },
         },
@@ -162,9 +161,9 @@ describe('BrowserShareService', () => {
     await service.createShare(createProjectWithInlineFont());
 
     const fontUrl =
-      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/fonts/acme-sans.woff2';
+      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/fonts/acme-sans.woff2';
     const shareUrl =
-      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000001/share.json';
+      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json';
     expect(Array.from(uploadedBodies.keys())).toContain(fontUrl);
     const sharePayload = JSON.parse(await uploadedBodies.get(shareUrl)!.text()) as PublicSharePayloadFixture;
     expect(sharePayload.project.fonts?.acme).toMatchObject({
@@ -182,6 +181,23 @@ describe('BrowserShareService', () => {
     await expect(service.createShare(sampleProject.createSampleProject())).rejects.toThrow(
       'Public sharing requires active external storage.',
     );
+  });
+
+  it('returns prepared metadata for a project without uploading share files', () => {
+    const fetchMock = vi.fn();
+    const service = new BrowserShareService({
+      mirrorService: new minioMirrorService.MinioMirrorService({ fetch: fetchMock }),
+      origin: 'https://localstudio.test',
+    });
+
+    const share = service.getProjectShareMetadata(sampleProject.createSampleProject());
+
+    expect(share).toMatchObject({
+      shareId: 'project-project-1',
+      publicUrl: 'https://localstudio.test/editor/?share=project-project-1',
+      status: 'published',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('encodes share ids and escapes embed iframe URLs', () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
@@ -357,8 +357,7 @@ describe('EditorShell export and share workflows', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
-  it('creates and shows a public link from the share panel', async () => {
-    vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000301');
+  it('copies and shows the prepared project public link from the share panel', async () => {
     const writeText = vi.fn();
     const execCommand = vi.fn().mockReturnValue(true);
     Object.defineProperty(navigator, 'clipboard', {
@@ -382,8 +381,8 @@ describe('EditorShell export and share workflows', () => {
 
     const expectedPublicUrl = `${
       window.location.origin
-    }/editor/s/00000000-0000-4000-8000-000000000301?src=${encodeURIComponent(
-      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000301/share.json',
+    }/editor/s/project-project-1?src=${encodeURIComponent(
+      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
     )}`;
     expect(await screen.findByDisplayValue(expectedPublicUrl)).toBeInTheDocument();
     expect(execCommand).toHaveBeenCalledWith('copy');

--- a/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
@@ -222,7 +222,6 @@ describe('EditorShell mirror workflows', () => {
     expect(screen.getByRole('dialog', { name: 'Mirror settings' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Enable mirroring' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
 
     expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toHaveClass(
       'mirror-synced',

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
@@ -183,6 +183,10 @@ class RecordingShareService implements ShareService {
       Promise.resolve(this.records.get(shareId) ?? null),
   );
 
+  getProjectShareMetadata(project: ProjectDocument): ShareMetadata {
+    return this.createMetadata(`project-${project.id}`, project.updatedAt);
+  }
+
   getPublicUrl(shareId: string): string {
     return `${this.origin}/editor/s/${shareId}?src=${encodeURIComponent(
       `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`,

--- a/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/MirrorSettingsPanel.test.tsx
@@ -323,7 +323,7 @@ describe('MirrorSettingsPanel', () => {
           onClose={vi.fn()}
           onEnabledChange={(nextEnabled) => {
             setEnabled(nextEnabled);
-            onEnabledChange(nextEnabled);
+            onEnabledChange(nextEnabled, config);
           }}
           onLocalFontMirrorEnabledChange={vi.fn()}
           onSave={onSave}
@@ -340,7 +340,7 @@ describe('MirrorSettingsPanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'Disable mirroring' }));
 
-    expect(onEnabledChange).toHaveBeenCalledWith(false);
+    expect(onEnabledChange).toHaveBeenCalledWith(false, config);
     expect(screen.getByRole('button', { name: 'Enable mirroring' })).toHaveClass(
       'mirror-settings-toggle-success',
     );
@@ -349,7 +349,11 @@ describe('MirrorSettingsPanel', () => {
 
     await user.click(screen.getByRole('button', { name: 'Enable mirroring' }));
 
-    expect(onEnabledChange).toHaveBeenLastCalledWith(true);
+    expect(onEnabledChange).toHaveBeenLastCalledWith(true, config);
+    expect(onTestConnection).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Test connection' }));
+
     expect(onTestConnection.mock.calls.at(-1)?.[0]).toEqual(config);
     expect(await screen.findByText('S3-compatible connection is ready.')).toBeInTheDocument();
   });

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
@@ -60,6 +60,14 @@ describe('PublicDeckViewer', () => {
       );
     });
     return { share, shareService: new BrowserShareService({ fetch: requestFetch }) };
+  }
+
+  function createDeferredResponse() {
+    let resolve!: (response: Response) => void;
+    const promise = new Promise<Response>((nextResolve) => {
+      resolve = nextResolve;
+    });
+    return { promise, resolve };
   }
 
   it('renders a shared deck in read-only mode', async () => {
@@ -136,6 +144,57 @@ describe('PublicDeckViewer', () => {
         }),
       );
     });
+  });
+
+  it('keeps the loading screen until half of the public deck assets are cached', async () => {
+    const project = sampleProject.createBlankProject();
+    project.assets = Object.fromEntries(
+      Array.from({ length: 4 }, (_, index) => [
+        `remote-image-${index}`,
+        {
+          id: `remote-image-${index}`,
+          type: 'image' as const,
+          name: `Remote image ${index}`,
+          mimeType: 'image/png',
+          objectUrl: `https://cdn.localstudio.test/assets/remote-image-${index}.png`,
+          storage: 'remote' as const,
+        },
+      ]),
+    );
+    const deferredResponses = Array.from({ length: 4 }, () => createDeferredResponse());
+    let nextResponseIndex = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => {
+        const response = deferredResponses[nextResponseIndex];
+        nextResponseIndex += 1;
+        return response!.promise;
+      }),
+    );
+    const { share, shareService } = createRemoteShare(
+      '00000000-0000-4000-8000-000000000207',
+      project,
+    );
+
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
+
+    expect(await screen.findByLabelText('Preparing shared deck')).toBeInTheDocument();
+    act(() => {
+      deferredResponses[0]!.resolve(new Response(null, { status: 204 }));
+    });
+    expect(await screen.findByText('1 / 4 assets ready')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Public presentation')).not.toBeInTheDocument();
+
+    act(() => {
+      deferredResponses[1]!.resolve(new Response(null, { status: 204 }));
+    });
+    expect(await screen.findByLabelText('Public presentation')).toBeInTheDocument();
   });
 
   it('keeps embeds in a compact shared deck layout', async () => {

--- a/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
@@ -42,7 +42,7 @@ describe('SharePanel', () => {
     }
   });
 
-  it('shows the not shared state before publishing', () => {
+  it('shows the not shared state before the synced link is available', () => {
     render(
       <SharePanel
         projectName="Untitled AI Deck"
@@ -97,7 +97,7 @@ describe('SharePanel', () => {
     expect(onPresent).toHaveBeenCalledTimes(1);
   });
 
-  it('creates a share and copies the public URL', async () => {
+  it('copies the prepared public URL', async () => {
     const user = userEvent.setup();
     const onCopyLink = vi.fn().mockResolvedValue(createShareMetadata({ status: 'copied' }));
 
@@ -153,9 +153,9 @@ describe('SharePanel', () => {
     expect(writeText).not.toHaveBeenCalled();
   });
 
-  it('shows an error when share publishing fails', async () => {
+  it('shows an error when link copying fails', async () => {
     const user = userEvent.setup();
-    const onCopyLink = vi.fn().mockRejectedValue(new Error('Could not upload share.json'));
+    const onCopyLink = vi.fn().mockRejectedValue(new Error('Could not copy share link'));
 
     render(
       <SharePanel
@@ -170,7 +170,7 @@ describe('SharePanel', () => {
     await user.click(screen.getByRole('button', { name: 'Copy link' }));
 
     expect(await screen.findByText('Share failed')).toBeInTheDocument();
-    expect(screen.getByText('Could not upload share.json')).toBeInTheDocument();
+    expect(screen.getByText('Could not copy share link')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy link' })).not.toBeDisabled();
   });
 

--- a/tests/e2e/editor/remote-mirror-share-settings.ts
+++ b/tests/e2e/editor/remote-mirror-share-settings.ts
@@ -14,8 +14,8 @@ export const remoteMirrorShareSettings = {
       .click();
     await expect(page.getByRole('dialog', { name: 'Mirror settings' })).toBeVisible();
     await page.getByRole('button', { name: 'Enable mirroring' }).click();
-    await expect(page.getByText(/S3-compatible connection is ready|Connection is ready/)).toBeVisible();
-    await page.getByRole('button', { name: 'Save settings' }).click();
+    await expect(page.getByRole('button', { name: /Mirror up to date|Mirror syncing|Mirror ready/ })).toBeVisible();
+    await page.getByRole('button', { name: 'Close mirror settings' }).click();
     await expect(page.getByRole('dialog', { name: 'Mirror settings' })).toBeHidden();
     await expect(page.getByRole('button', { name: /Mirror up to date|Mirror syncing|Mirror ready/ })).toBeVisible();
   },


### PR DESCRIPTION
## Summary
- Reuse a project-derived share ID and expose prepared share metadata without uploading
- Simplify share copying by publishing once and reusing the prepared metadata in the share panel
- Improve public deck loading with asset preloading progress and earlier playback start
- Persist mirror config when enabling from settings so the toggle works without an extra save step
- Update related tests for the new share, mirror, and preload behavior

## Testing
- Updated unit tests for share service, editor shell share flow, mirror settings, and preloader behavior
- Not run (not requested)