### PR TITLE
Fix public deck media preloading

### DIFF
--- a/apps/editor/src/ui/editor/canvas/CanvasReadOnlyMediaElement.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasReadOnlyMediaElement.tsx
@@ -6,6 +6,7 @@ import type { CommonElementProps } from './canvas-element-props';
 interface CanvasReadOnlyMediaElementProps {
   commonProps: CommonElementProps;
   element: GifElement | VideoElement;
+  hidePlaceholder?: boolean;
   label: string;
   nodeRef: (node: Konva.Node | null) => void;
 }
@@ -13,9 +14,20 @@ interface CanvasReadOnlyMediaElementProps {
 export function CanvasReadOnlyMediaElement({
   commonProps,
   element,
+  hidePlaceholder = false,
   label,
   nodeRef,
 }: CanvasReadOnlyMediaElementProps) {
+  if (element.type === 'video' && hidePlaceholder) {
+    return (
+      <Rect
+        {...commonProps}
+        fill="rgba(0,0,0,0.01)"
+        ref={nodeRef}
+      />
+    );
+  }
+
   return (
     <Group {...commonProps} key={element.id} ref={nodeRef}>
       <Rect

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -63,6 +63,7 @@ interface CanvasWorkspaceProps {
   stageRef?: RefObject<Konva.Stage | null>;
   presentationMode?: boolean;
   readOnly?: boolean;
+  hideReadOnlyMediaPlaceholder?: boolean;
   zoomPercent?: number;
   backgroundSelectionMode?: boolean;
   backgroundSelectionNotice?: string | undefined;
@@ -176,6 +177,7 @@ export function CanvasWorkspace({
   stageRef,
   presentationMode = false,
   readOnly = false,
+  hideReadOnlyMediaPlaceholder = false,
   zoomPercent = 100,
   backgroundSelectionMode = false,
   backgroundSelectionNotice,
@@ -1108,6 +1110,7 @@ export function CanvasWorkspace({
                       <CanvasReadOnlyMediaElement
                         commonProps={commonProps}
                         element={element}
+                        hidePlaceholder={hideReadOnlyMediaPlaceholder}
                         key={element.id}
                         label={asset?.name ?? (element.type === 'video' ? 'Imported video' : 'Imported GIF')}
                         nodeRef={nodeRef}

--- a/apps/editor/src/ui/editor/media/ProjectVideoPreloader.tsx
+++ b/apps/editor/src/ui/editor/media/ProjectVideoPreloader.tsx
@@ -5,22 +5,26 @@ interface ProjectVideoPreloaderProps {
 }
 
 export function ProjectVideoPreloader({ project }: ProjectVideoPreloaderProps) {
-  const videoAssets = Object.values(project.assets).filter(
-    (asset) => asset.type === 'video' && asset.objectUrl,
+  const mediaAssets = Object.values(project.assets).filter(
+    (asset) => (asset.type === 'video' || asset.type === 'gif') && asset.objectUrl,
   );
-  if (videoAssets.length === 0) return null;
+  if (mediaAssets.length === 0) return null;
 
   return (
     <div className="project-video-preloader" aria-hidden="true">
-      {videoAssets.map((asset) => (
-        <video
-          key={asset.id}
-          muted
-          playsInline
-          preload="auto"
-          src={asset.objectUrl}
-        />
-      ))}
+      {mediaAssets.map((asset) =>
+        asset.type === 'video' ? (
+          <video
+            key={asset.id}
+            muted
+            playsInline
+            preload="auto"
+            src={asset.objectUrl}
+          />
+        ) : (
+          <img key={asset.id} alt="" src={asset.objectUrl} />
+        ),
+      )}
     </div>
   );
 }

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -6,6 +6,7 @@ import type {
 } from '../../domain/documents/model';
 import type { FontImportService, ShareService } from '../../services/contracts/interfaces';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
+import { ProjectVideoPreloader } from '../editor/media/ProjectVideoPreloader';
 import { preloadPublicDeckAssets } from './publicDeckAssetPreloader';
 
 interface PublicDeckViewerProps {
@@ -16,8 +17,7 @@ interface PublicDeckViewerProps {
 }
 
 type ViewerState =
-  | { status: 'loading' }
-  | { status: 'preloading'; loaded: number; project: ProjectDocument; total: number }
+  | { status: 'preloading'; loaded: number; project?: ProjectDocument; total: number }
   | { status: 'missing' }
   | { status: 'ready'; project: ProjectDocument };
 
@@ -37,9 +37,97 @@ function getBuildPlaybackDurationMs(build: ElementAnimationBuild) {
   return Math.max(0, build.durationMs ?? build.delayMs);
 }
 
-function hasReachedPlaybackThreshold(loaded: number, total: number) {
+function hasFinishedAssetPreload(loaded: number, total: number) {
   if (total === 0) return true;
-  return loaded / total >= 0.5;
+  return loaded >= total;
+}
+
+const PUBLIC_DECK_PAGE_MEDIA_PRELOAD_TIMEOUT_MS = 5000;
+
+type PageMediaPreloadEntry = { type: 'gif' | 'video'; url: string };
+
+function getPageMediaPreloadEntries(project: ProjectDocument, pageIndex: number) {
+  const page = project.pages[pageIndex];
+  if (!page) return [];
+  const entries = new Map<string, PageMediaPreloadEntry>();
+  for (const elementId of page.elementIds) {
+    const element = project.elements[elementId];
+    if (
+      !element ||
+      (element.type !== 'video' && element.type !== 'gif') ||
+      element.visible === false
+    ) {
+      continue;
+    }
+    const assetUrl = project.assets[element.assetId]?.objectUrl;
+    if (assetUrl) entries.set(`${element.type}:${assetUrl}`, { type: element.type, url: assetUrl });
+  }
+  return Array.from(entries.values());
+}
+
+function preloadPageGif(url: string, signal: AbortSignal) {
+  if (signal.aborted || typeof Image === 'undefined') return Promise.resolve();
+  const image = new Image();
+
+  return new Promise<void>((resolve) => {
+    let timeoutId: number | undefined;
+    const finish = () => {
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      image.removeEventListener('load', finish);
+      image.removeEventListener('error', finish);
+      signal.removeEventListener('abort', finish);
+      resolve();
+    };
+
+    timeoutId = window.setTimeout(finish, PUBLIC_DECK_PAGE_MEDIA_PRELOAD_TIMEOUT_MS);
+    image.addEventListener('load', finish, { once: true });
+    image.addEventListener('error', finish, { once: true });
+    signal.addEventListener('abort', finish, { once: true });
+    image.src = url;
+  });
+}
+
+function preloadPageVideo(url: string, signal: AbortSignal) {
+  if (signal.aborted || typeof document === 'undefined') return Promise.resolve();
+  const video = document.createElement('video');
+  video.muted = true;
+  video.playsInline = true;
+  video.preload = 'auto';
+
+  return new Promise<void>((resolve) => {
+    let timeoutId: number | undefined;
+    const finish = () => {
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      video.removeEventListener('loadeddata', finish);
+      video.removeEventListener('error', finish);
+      signal.removeEventListener('abort', finish);
+      video.removeAttribute('src');
+      video.load();
+      resolve();
+    };
+
+    timeoutId = window.setTimeout(finish, PUBLIC_DECK_PAGE_MEDIA_PRELOAD_TIMEOUT_MS);
+    video.addEventListener('loadeddata', finish, { once: true });
+    video.addEventListener('error', finish, { once: true });
+    signal.addEventListener('abort', finish, { once: true });
+    video.src = url;
+    video.load();
+  });
+}
+
+async function preloadPageMedia(entries: PageMediaPreloadEntry[], signal: AbortSignal) {
+  if (entries.length === 0) return;
+  await Promise.all(
+    entries.map((entry) =>
+      entry.type === 'gif' ? preloadPageGif(entry.url, signal) : preloadPageVideo(entry.url, signal),
+    ),
+  );
 }
 
 export function PublicDeckViewer({
@@ -48,12 +136,17 @@ export function PublicDeckViewer({
   shareService,
   embed = false,
 }: PublicDeckViewerProps) {
-  const [viewerState, setViewerState] = useState<ViewerState>({ status: 'loading' });
+  const [viewerState, setViewerState] = useState<ViewerState>({
+    status: 'preloading',
+    loaded: 0,
+    total: 0,
+  });
   const [activePageIndex, setActivePageIndex] = useState(0);
   const [animationPreview, setAnimationPreview] = useState<AnimationPreviewState | undefined>();
   const animationQueueRef = useRef<ElementAnimationBuild[]>([]);
   const animationTimeoutsRef = useRef<number[]>([]);
   const animationFrameRef = useRef<number | undefined>(undefined);
+  const pagePreloadAbortRef = useRef<AbortController | undefined>(undefined);
   const runNextAnimationBuildRef = useRef<() => void>(() => undefined);
   const emptySelection = useMemo<SelectionState>(() => ({ pageId: '', elementIds: [] }), []);
   const viewerClassName = embed
@@ -208,7 +301,7 @@ export function PublicDeckViewer({
     scheduleAnimation,
   ]);
 
-  const playPresentationPage = useCallback(
+  const showPresentationPage = useCallback(
     (project: ProjectDocument, pageIndex: number) => {
       const page = project.pages[pageIndex];
       if (!page) return;
@@ -240,6 +333,28 @@ export function PublicDeckViewer({
       scheduleAnimation(runNextAnimationBuild, transitionDelay);
     },
     [clearAnimationTimers, completeAnimationSlide, runNextAnimationBuild, scheduleAnimation],
+  );
+
+  const playPresentationPage = useCallback(
+    (project: ProjectDocument, pageIndex: number) => {
+      const mediaEntries = getPageMediaPreloadEntries(project, pageIndex);
+      pagePreloadAbortRef.current?.abort();
+      if (mediaEntries.length === 0) {
+        showPresentationPage(project, pageIndex);
+        return;
+      }
+
+      const preloadController = new AbortController();
+      pagePreloadAbortRef.current = preloadController;
+      void preloadPageMedia(mediaEntries, preloadController.signal).then(() => {
+        if (preloadController.signal.aborted) return;
+        if (pagePreloadAbortRef.current === preloadController) {
+          pagePreloadAbortRef.current = undefined;
+        }
+        showPresentationPage(project, pageIndex);
+      });
+    },
+    [showPresentationPage],
   );
 
   const advancePresentation = useCallback(() => {
@@ -278,16 +393,14 @@ export function PublicDeckViewer({
 
       let hasStartedPlayback = false;
       function startPlaybackWhenReady(loaded: number, total: number) {
-        if (!isActive || hasStartedPlayback || !hasReachedPlaybackThreshold(loaded, total)) return;
+        if (!isActive || hasStartedPlayback || !hasFinishedAssetPreload(loaded, total)) return;
         hasStartedPlayback = true;
         setViewerState({ status: 'ready', project: shareRecord.project });
         playPresentationPage(shareRecord.project, 0);
       }
 
       setViewerState({ status: 'preloading', loaded: 0, project: shareRecord.project, total: 0 });
-      await fontImportService.loadProjectFonts(shareRecord.project).catch(() => undefined);
-      if (!isActive) return;
-      await preloadPublicDeckAssets(shareRecord.project, {
+      const assetPreloadPromise = preloadPublicDeckAssets(shareRecord.project, {
         signal: preloadController.signal,
         onProgress: (progress) => {
           if (!isActive) return;
@@ -304,6 +417,11 @@ export function PublicDeckViewer({
           startPlaybackWhenReady(progress.loaded, progress.total);
         },
       });
+      await Promise.all([
+        fontImportService.loadProjectFonts(shareRecord.project).catch(() => undefined),
+        assetPreloadPromise,
+      ]);
+      if (!isActive) return;
       startPlaybackWhenReady(1, 1);
     });
     return () => {
@@ -314,6 +432,7 @@ export function PublicDeckViewer({
 
   useEffect(() => {
     return () => {
+      pagePreloadAbortRef.current?.abort();
       clearAnimationTimers();
     };
   }, [clearAnimationTimers]);
@@ -337,19 +456,12 @@ export function PublicDeckViewer({
     };
   }, [advancePresentation, rewindPresentation, viewerState.status]);
 
-  if (viewerState.status === 'loading') {
-    return (
-      <main className={viewerClassName}>
-        <p className="public-deck-status">Loading deck...</p>
-      </main>
-    );
-  }
-
   if (viewerState.status === 'preloading') {
     const loadedPercent =
       viewerState.total > 0 ? Math.min(100, Math.round((viewerState.loaded / viewerState.total) * 100)) : 0;
     return (
       <main className={viewerClassName}>
+        {viewerState.project ? <ProjectVideoPreloader project={viewerState.project} /> : null}
         <section className="public-deck-loading" aria-label="Preparing shared deck">
           <p className="public-deck-status">Preparing media...</p>
           <div className="public-deck-loading-track" aria-hidden="true">
@@ -396,11 +508,13 @@ export function PublicDeckViewer({
       className={viewerClassName}
       aria-label={embed ? 'Embedded shared deck' : 'Public presentation'}
     >
+      <ProjectVideoPreloader project={project} />
       <section className="public-deck-stage-shell" aria-label="Shared slide preview">
         <CanvasWorkspace
           project={project}
           activePageId={activePage.id}
           selection={{ ...emptySelection, pageId: activePage.id }}
+          hideReadOnlyMediaPlaceholder
           presentationMode
           readOnly
           zoomPercent={100}

--- a/apps/editor/src/ui/share/publicDeckAssetPreloader.ts
+++ b/apps/editor/src/ui/share/publicDeckAssetPreloader.ts
@@ -1,4 +1,5 @@
 import type { ProjectDocument } from '../../domain/documents/model';
+import { canvasWorkspaceUtils } from '../editor/canvas/canvasWorkspaceUtils';
 
 interface PublicDeckAssetPreloadOptions {
   fetchImpl?: typeof fetch | undefined;
@@ -32,18 +33,31 @@ function normalizePreloadUrl(value: string | undefined) {
 }
 
 function collectPublicDeckAssetUrls(project: ProjectDocument) {
-  const urls = new Set<string>();
+  const imageUrls = new Set<string>();
+  const requestUrls = new Set<string>();
+  const videoUrls = new Set<string>();
   for (const asset of Object.values(project.assets)) {
     const url = normalizePreloadUrl(asset.objectUrl);
-    if (url) urls.add(url);
+    if (!url) continue;
+    if (asset.type === 'image' || asset.type === 'gif') {
+      imageUrls.add(url);
+    } else if (asset.type === 'video') {
+      videoUrls.add(url);
+    } else {
+      requestUrls.add(url);
+    }
   }
   for (const font of Object.values(project.fonts ?? {})) {
     const objectUrl = normalizePreloadUrl(font.objectUrl);
     const sourceUrl = normalizePreloadUrl(font.sourceUrl);
-    if (objectUrl) urls.add(objectUrl);
-    if (sourceUrl) urls.add(sourceUrl);
+    if (objectUrl) requestUrls.add(objectUrl);
+    if (sourceUrl) requestUrls.add(sourceUrl);
   }
-  return Array.from(urls);
+  return {
+    imageUrls: Array.from(imageUrls),
+    requestUrls: Array.from(requestUrls),
+    videoUrls: Array.from(videoUrls),
+  };
 }
 
 async function preloadUrl(url: string, options: PublicDeckAssetPreloadOptions) {
@@ -71,21 +85,91 @@ async function preloadUrl(url: string, options: PublicDeckAssetPreloadOptions) {
   }
 }
 
-async function preloadUrlQueue(urls: string[], options: PublicDeckAssetPreloadOptions) {
+async function preloadCanvasImageUrl(url: string, options: PublicDeckAssetPreloadOptions) {
+  if (options.signal?.aborted) return;
+  let timeoutId: number | undefined;
+  let resolveTimeout: (() => void) | undefined;
+  const clearPreloadTimeout = () => {
+    if (timeoutId === undefined) return;
+    window.clearTimeout(timeoutId);
+    timeoutId = undefined;
+  };
+  const abortPreload = () => {
+    clearPreloadTimeout();
+    resolveTimeout?.();
+  };
+  const timeoutPromise = new Promise<void>((resolve) => {
+    resolveTimeout = resolve;
+    timeoutId = window.setTimeout(resolve, PUBLIC_DECK_PRELOAD_TIMEOUT_MS);
+    options.signal?.addEventListener('abort', abortPreload, { once: true });
+  });
+  try {
+    await Promise.race([
+      canvasWorkspaceUtils.preloadCanvasImage(url).then(() => undefined, () => undefined),
+      timeoutPromise,
+    ]);
+  } finally {
+    clearPreloadTimeout();
+    resolveTimeout = undefined;
+    options.signal?.removeEventListener('abort', abortPreload);
+  }
+}
+
+async function preloadVideoUrl(url: string, options: PublicDeckAssetPreloadOptions) {
+  if (options.signal?.aborted) return;
+  const video = document.createElement('video');
+  video.muted = true;
+  video.playsInline = true;
+  video.preload = 'auto';
+
+  await new Promise<void>((resolve) => {
+    let timeoutId: number | undefined;
+    const finish = () => {
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      video.removeEventListener('loadeddata', finish);
+      video.removeEventListener('error', finish);
+      options.signal?.removeEventListener('abort', finish);
+      video.removeAttribute('src');
+      video.load();
+      resolve();
+    };
+
+    timeoutId = window.setTimeout(finish, PUBLIC_DECK_PRELOAD_TIMEOUT_MS);
+    video.addEventListener('loadeddata', finish, { once: true });
+    video.addEventListener('error', finish, { once: true });
+    options.signal?.addEventListener('abort', finish, { once: true });
+    video.src = url;
+    video.load();
+  });
+}
+
+async function preloadUrlQueue(
+  entries: Array<{ type: 'image' | 'request' | 'video'; url: string }>,
+  options: PublicDeckAssetPreloadOptions,
+) {
   let nextIndex = 0;
   let loaded = 0;
   async function worker() {
     while (!options.signal?.aborted) {
-      const url = urls[nextIndex];
+      const entry = entries[nextIndex];
       nextIndex += 1;
-      if (!url) return;
-      await preloadUrl(url, options);
+      if (!entry) return;
+      if (entry.type === 'image') {
+        await preloadCanvasImageUrl(entry.url, options);
+      } else if (entry.type === 'video') {
+        await preloadVideoUrl(entry.url, options);
+      } else {
+        await preloadUrl(entry.url, options);
+      }
       loaded += 1;
-      options.onProgress?.({ loaded, total: urls.length });
+      options.onProgress?.({ loaded, total: entries.length });
     }
   }
   await Promise.all(
-    Array.from({ length: Math.min(PUBLIC_DECK_PRELOAD_CONCURRENCY, urls.length) }, () => worker()),
+    Array.from({ length: Math.min(PUBLIC_DECK_PRELOAD_CONCURRENCY, entries.length) }, () => worker()),
   );
 }
 
@@ -93,8 +177,13 @@ export function preloadPublicDeckAssets(
   project: ProjectDocument,
   options: PublicDeckAssetPreloadOptions = {},
 ) {
-  const urls = collectPublicDeckAssetUrls(project);
-  if (urls.length === 0) return Promise.resolve();
-  options.onProgress?.({ loaded: 0, total: urls.length });
-  return preloadUrlQueue(urls, options);
+  const { imageUrls, requestUrls, videoUrls } = collectPublicDeckAssetUrls(project);
+  const entries: Array<{ type: 'image' | 'request' | 'video'; url: string }> = [
+    ...imageUrls.map((url) => ({ type: 'image' as const, url })),
+    ...videoUrls.map((url) => ({ type: 'video' as const, url })),
+    ...requestUrls.map((url) => ({ type: 'request' as const, url })),
+  ];
+  if (entries.length === 0) return Promise.resolve();
+  options.onProgress?.({ loaded: 0, total: entries.length });
+  return preloadUrlQueue(entries, options);
 }

--- a/apps/editor/src/ui/styles/artboard-frame.css
+++ b/apps/editor/src/ui/styles/artboard-frame.css
@@ -47,6 +47,7 @@
   pointer-events: none;
 }
 
+.project-video-preloader img,
 .project-video-preloader video {
   width: 1px;
   height: 1px;

--- a/apps/editor/tests/unit/ui/editor/ProjectVideoPreloader.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/ProjectVideoPreloader.test.tsx
@@ -3,7 +3,7 @@ import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import { ProjectVideoPreloader } from '../../../../src/ui/editor/media/ProjectVideoPreloader';
 
 describe('ProjectVideoPreloader', () => {
-  it('preloads project video assets without exposing playback controls', () => {
+  it('preloads project video and GIF assets without exposing playback controls', () => {
     const project = sampleProject.createSampleProject();
     project.assets['asset-video'] = {
       id: 'asset-video',
@@ -12,12 +12,21 @@ describe('ProjectVideoPreloader', () => {
       mimeType: 'video/mp4',
       objectUrl: 'blob:video',
     };
+    project.assets['asset-gif'] = {
+      id: 'asset-gif',
+      type: 'gif',
+      name: 'Imported GIF',
+      mimeType: 'image/gif',
+      objectUrl: 'blob:gif',
+    };
 
     const { container } = render(<ProjectVideoPreloader project={project} />);
     const video = container.querySelector('video[src="blob:video"]') as HTMLVideoElement;
+    const gif = container.querySelector('img[src="blob:gif"]');
 
     expect(video).toBeInTheDocument();
     expect(video.preload).toBe('auto');
     expect(video.controls).toBe(false);
+    expect(gif).toBeInTheDocument();
   });
 });

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -8,9 +8,29 @@ import type {
   ShareRecord,
 } from '../../../../src/services/contracts/interfaces';
 import { BrowserShareService } from '../../../../src/services/sharing/shareService';
+import { canvasWorkspaceUtils } from '../../../../src/ui/editor/canvas/canvasWorkspaceUtils';
 import { PublicDeckViewer } from '../../../../src/ui/share/PublicDeckViewer';
 
 describe('PublicDeckViewer', () => {
+  let preloadedVideoUrls: string[];
+
+  class MockPreloadImage extends EventTarget {
+    naturalHeight = 480;
+    naturalWidth = 640;
+    private imageSrc = '';
+
+    get src() {
+      return this.imageSrc;
+    }
+
+    set src(value: string) {
+      this.imageSrc = value;
+      queueMicrotask(() => {
+        this.dispatchEvent(new Event('load'));
+      });
+    }
+  }
+
   const fontImportService: FontImportService = {
     listDownloadableFonts() {
       return [];
@@ -24,11 +44,24 @@ describe('PublicDeckViewer', () => {
   };
 
   beforeEach(() => {
+    preloadedVideoUrls = [];
     window.history.replaceState({}, '', '/');
+    vi.stubGlobal('Image', MockPreloadImage);
     vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))));
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(function loadMedia(
+      this: HTMLMediaElement,
+    ) {
+      if (this instanceof HTMLVideoElement && this.src) {
+        preloadedVideoUrls.push(this.src);
+        queueMicrotask(() => {
+          this.dispatchEvent(new Event('loadeddata'));
+        });
+      }
+    });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -87,6 +120,32 @@ describe('PublicDeckViewer', () => {
     expect(screen.getByText('1 / 1')).toBeInTheDocument();
   });
 
+  it('starts public share routes on the media preparation progress UI', () => {
+    const deferredShare = createDeferredResponse();
+    const sourceUrl =
+      'http://localhost:9000/localstudio/mirrors/public-shares/00000000-0000-4000-8000-000000000208/share.json';
+    window.history.replaceState(
+      {},
+      '',
+      `/editor/s/00000000-0000-4000-8000-000000000208?src=${encodeURIComponent(sourceUrl)}`,
+    );
+    const shareService = new BrowserShareService({
+      fetch: vi.fn(() => deferredShare.promise),
+    });
+
+    render(
+      <PublicDeckViewer
+        shareId="00000000-0000-4000-8000-000000000208"
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
+
+    expect(screen.getByLabelText('Preparing shared deck')).toBeInTheDocument();
+    expect(screen.getByText('Checking assets')).toBeInTheDocument();
+    expect(screen.queryByText('Loading deck...')).not.toBeInTheDocument();
+  });
+
   it('preloads public deck assets in the browser after the share record loads', async () => {
     const project = sampleProject.createSampleProject();
     project.assets['remote-image'] = {
@@ -95,6 +154,22 @@ describe('PublicDeckViewer', () => {
       name: 'Remote image',
       mimeType: 'image/png',
       objectUrl: 'https://cdn.localstudio.test/assets/remote-image.png',
+      storage: 'remote',
+    };
+    project.assets['remote-video'] = {
+      id: 'remote-video',
+      type: 'video',
+      name: 'Remote video',
+      mimeType: 'video/mp4',
+      objectUrl: 'https://cdn.localstudio.test/assets/remote-video.mp4',
+      storage: 'remote',
+    };
+    project.assets['remote-gif'] = {
+      id: 'remote-gif',
+      type: 'gif',
+      name: 'Remote GIF',
+      mimeType: 'image/gif',
+      objectUrl: 'https://cdn.localstudio.test/assets/remote-loop.gif',
       storage: 'remote',
     };
     project.fonts = {
@@ -111,6 +186,7 @@ describe('PublicDeckViewer', () => {
         objectUrl: 'https://cdn.localstudio.test/fonts/brand.woff2',
       },
     };
+    const preloadImageSpy = vi.spyOn(canvasWorkspaceUtils, 'preloadCanvasImage');
     const preloadFetch = vi.mocked(globalThis.fetch);
     const { share, shareService } = createRemoteShare(
       '00000000-0000-4000-8000-000000000206',
@@ -127,14 +203,13 @@ describe('PublicDeckViewer', () => {
 
     await screen.findByLabelText('Public presentation');
     await waitFor(() => {
-      expect(preloadFetch).toHaveBeenCalledWith(
+      expect(preloadImageSpy).toHaveBeenCalledWith(
         'https://cdn.localstudio.test/assets/remote-image.png',
-        expect.objectContaining({
-          cache: 'force-cache',
-          credentials: 'omit',
-          mode: 'cors',
-        }),
       );
+      expect(preloadImageSpy).toHaveBeenCalledWith(
+        'https://cdn.localstudio.test/assets/remote-loop.gif',
+      );
+      expect(preloadedVideoUrls).toContain('https://cdn.localstudio.test/assets/remote-video.mp4');
       expect(preloadFetch).toHaveBeenCalledWith(
         'https://cdn.localstudio.test/fonts/brand.woff2',
         expect.objectContaining({
@@ -146,17 +221,21 @@ describe('PublicDeckViewer', () => {
     });
   });
 
-  it('keeps the loading screen until half of the public deck assets are cached', async () => {
+  it('keeps the loading screen until every public deck asset has been preloaded', async () => {
     const project = sampleProject.createBlankProject();
-    project.assets = Object.fromEntries(
+    project.fonts = Object.fromEntries(
       Array.from({ length: 4 }, (_, index) => [
-        `remote-image-${index}`,
+        `remote-font-${index}`,
         {
-          id: `remote-image-${index}`,
-          type: 'image' as const,
-          name: `Remote image ${index}`,
-          mimeType: 'image/png',
-          objectUrl: `https://cdn.localstudio.test/assets/remote-image-${index}.png`,
+          family: `Remote Font ${index}`,
+          fileName: `remote-font-${index}.woff2`,
+          fontStyle: 'normal' as const,
+          fontWeight: 400,
+          id: `remote-font-${index}`,
+          mimeType: 'font/woff2' as const,
+          objectUrl: `https://cdn.localstudio.test/fonts/remote-font-${index}.woff2`,
+          requestedFamily: `Remote Font ${index}`,
+          source: 'uploaded' as const,
           storage: 'remote' as const,
         },
       ]),
@@ -193,6 +272,18 @@ describe('PublicDeckViewer', () => {
 
     act(() => {
       deferredResponses[1]!.resolve(new Response(null, { status: 204 }));
+    });
+    expect(await screen.findByText('2 / 4 assets ready')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Public presentation')).not.toBeInTheDocument();
+
+    act(() => {
+      deferredResponses[2]!.resolve(new Response(null, { status: 204 }));
+    });
+    expect(await screen.findByText('3 / 4 assets ready')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Public presentation')).not.toBeInTheDocument();
+
+    act(() => {
+      deferredResponses[3]!.resolve(new Response(null, { status: 204 }));
     });
     expect(await screen.findByLabelText('Public presentation')).toBeInTheDocument();
   });
@@ -244,6 +335,135 @@ describe('PublicDeckViewer', () => {
 
     await user.click(screen.getByRole('button', { name: 'Previous slide' }));
     expect(screen.getByText('1 / 2')).toBeInTheDocument();
+  });
+
+  it('waits for target slide videos and GIFs before changing public deck slides', async () => {
+    const user = userEvent.setup();
+    const project = sampleProject.createSampleProject();
+    project.assets['remote-slide-video'] = {
+      id: 'remote-slide-video',
+      type: 'video',
+      name: 'Slide video',
+      mimeType: 'video/mp4',
+      objectUrl: 'https://cdn.localstudio.test/assets/slide-video.mp4',
+      storage: 'remote',
+    };
+    project.assets['remote-slide-gif'] = {
+      id: 'remote-slide-gif',
+      type: 'gif',
+      name: 'Slide GIF',
+      mimeType: 'image/gif',
+      objectUrl: 'https://cdn.localstudio.test/assets/slide-loop.gif',
+      storage: 'remote',
+    };
+    project.elements['video-slide'] = {
+      assetId: 'remote-slide-video',
+      autoplayInPreview: false,
+      controls: false,
+      height: 360,
+      id: 'video-slide',
+      locked: false,
+      loop: false,
+      muted: true,
+      opacity: 1,
+      playAcrossSlides: false,
+      repeatMode: 'none',
+      rotation: 0,
+      startOnClick: false,
+      trimStartSeconds: 0,
+      type: 'video',
+      visible: true,
+      volume: 1,
+      width: 640,
+      x: 200,
+      y: 200,
+    };
+    project.elements['gif-slide'] = {
+      assetId: 'remote-slide-gif',
+      height: 240,
+      id: 'gif-slide',
+      locked: false,
+      opacity: 1,
+      playing: true,
+      rotation: 0,
+      type: 'gif',
+      visible: true,
+      width: 320,
+      x: 900,
+      y: 200,
+    };
+    project.pages.push({
+      id: 'page-2',
+      name: 'Slide 2',
+      width: 1920,
+      height: 1080,
+      background: { type: 'color', color: '#111111' },
+      elementIds: ['video-slide', 'gif-slide'],
+    });
+    const { share, shareService } = createRemoteShare(
+      '00000000-0000-4000-8000-000000000209',
+      project,
+    );
+
+    render(
+      <PublicDeckViewer
+        shareId={share.shareId}
+        fontImportService={fontImportService}
+        shareService={shareService}
+      />,
+    );
+
+    expect(await screen.findByText('1 / 2')).toBeInTheDocument();
+    let releaseTargetSlideGif: (() => void) | undefined;
+    let releaseTargetSlideVideo: (() => void) | undefined;
+    class DelayedTargetSlideImage extends EventTarget {
+      naturalHeight = 480;
+      naturalWidth = 640;
+      private imageSrc = '';
+
+      get src() {
+        return this.imageSrc;
+      }
+
+      set src(value: string) {
+        this.imageSrc = value;
+        if (value.includes('slide-loop.gif')) {
+          releaseTargetSlideGif = () => {
+            this.dispatchEvent(new Event('load'));
+          };
+          return;
+        }
+        queueMicrotask(() => {
+          this.dispatchEvent(new Event('load'));
+        });
+      }
+    }
+    vi.stubGlobal('Image', DelayedTargetSlideImage);
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(function loadMedia(
+      this: HTMLMediaElement,
+    ) {
+      if (this instanceof HTMLVideoElement && this.src.includes('slide-video.mp4')) {
+        releaseTargetSlideVideo = () => {
+          this.dispatchEvent(new Event('loadeddata'));
+        };
+      }
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Next slide' }));
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    expect(screen.queryByText('2 / 2')).not.toBeInTheDocument();
+
+    act(() => {
+      releaseTargetSlideVideo?.();
+    });
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    expect(screen.queryByText('2 / 2')).not.toBeInTheDocument();
+
+    act(() => {
+      releaseTargetSlideGif?.();
+    });
+
+    expect(await screen.findByText('2 / 2')).toBeInTheDocument();
   });
 
   it('rewinds shared deck slides with the left arrow key after advancing', async () => {

--- a/tests/e2e/editor/generated-and-public-accessibility.spec.ts
+++ b/tests/e2e/editor/generated-and-public-accessibility.spec.ts
@@ -1,7 +1,9 @@
+import { readFile } from 'node:fs/promises';
 import { EditorAppPage } from '../pages/editor-app.page';
 import { PublicDeckPage } from '../pages/public-deck.page';
 import { installMockAiProviders } from '../support/mock-ai';
 import { createSharePayload } from '../support/share-payload';
+import { createTinyPngFixture, getBigBuckBunnyMp4Fixture } from '../support/test-assets';
 import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 
 const getServer = withIsolatedDevServer(test);
@@ -36,16 +38,81 @@ test.describe('generated and public accessibility regression journeys', () => {
     );
   });
 
-  test('keeps public deck navigation keyboard operable', async ({ page }) => {
+  test('keeps public deck navigation keyboard operable', async ({ page }, testInfo) => {
     const payload = createSharePayload();
+    payload.project.assets['asset-accessible-video'] = {
+      id: 'asset-accessible-video',
+      mimeType: 'video/mp4',
+      name: 'Accessible media clip',
+      objectUrl: 'http://localhost/e2e-accessible-video.mp4',
+      type: 'video',
+    };
+    payload.project.assets['asset-accessible-gif'] = {
+      id: 'asset-accessible-gif',
+      mimeType: 'image/gif',
+      name: 'Accessible animated loop',
+      objectUrl: 'http://localhost/e2e-accessible-loop.png',
+      type: 'gif',
+    };
+    payload.project.elements['video-accessible'] = {
+      assetId: 'asset-accessible-video',
+      autoplayInPreview: false,
+      controls: false,
+      height: 180,
+      id: 'video-accessible',
+      locked: false,
+      loop: false,
+      muted: true,
+      opacity: 1,
+      playAcrossSlides: false,
+      repeatMode: 'none',
+      rotation: 0,
+      startOnClick: false,
+      trimStartSeconds: 0,
+      type: 'video',
+      visible: true,
+      volume: 1,
+      width: 320,
+      x: 120,
+      y: 220,
+    };
+    payload.project.elements['gif-accessible'] = {
+      assetId: 'asset-accessible-gif',
+      height: 120,
+      id: 'gif-accessible',
+      locked: false,
+      opacity: 1,
+      playing: true,
+      rotation: 0,
+      type: 'gif',
+      visible: true,
+      width: 160,
+      x: 500,
+      y: 220,
+    };
+    payload.project.pages[0].elementIds.push('video-accessible', 'gif-accessible');
     await page.route('**/e2e-accessible-share.json', async (route) => {
       await route.fulfill({ contentType: 'application/json', json: payload });
+    });
+    await page.route('**/e2e-accessible-video.mp4', async (route) => {
+      await route.fulfill({
+        body: await readFile(getBigBuckBunnyMp4Fixture()),
+        contentType: 'video/mp4',
+      });
+    });
+    await page.route('**/e2e-accessible-loop.png', async (route) => {
+      await route.fulfill({
+        body: await readFile(await createTinyPngFixture(testInfo)),
+        contentType: 'image/png',
+      });
     });
 
     const publicDeck = new PublicDeckPage(page, getServer().baseURL);
     const shareSrc = encodeURIComponent('http://localhost/e2e-accessible-share.json');
     await publicDeck.goto(`/editor/?share=e2e-share&src=${shareSrc}`);
     await publicDeck.expectReady(false);
+    await expect(page.locator('video[aria-label="Accessible media clip"]')).toBeVisible();
+    await expect(page.locator('img[aria-label="Accessible animated loop"]')).toBeVisible();
 
     const nextButton = page.getByRole('button', { name: 'Next slide' });
     await nextButton.focus();

--- a/tests/e2e/pages/public-deck.page.ts
+++ b/tests/e2e/pages/public-deck.page.ts
@@ -6,6 +6,10 @@ export class PublicDeckPage extends BasePage {
     super(page, baseURL);
   }
 
+  async goto(path: string) {
+    await this.page.goto(this.url(path), { waitUntil: 'domcontentloaded' });
+  }
+
   async expectReady(embed = false) {
     await expect(
       this.page.getByRole('main', {

--- a/tests/e2e/public-deck/media-playback.spec.ts
+++ b/tests/e2e/public-deck/media-playback.spec.ts
@@ -1,21 +1,41 @@
 import { readFile } from 'node:fs/promises';
 import { PublicDeckPage } from '../pages/public-deck.page';
 import { createSharePayload } from '../support/share-payload';
-import { getBigBuckBunnyMp4Fixture } from '../support/test-assets';
+import { createTinyPngFixture, getBigBuckBunnyMp4Fixture } from '../support/test-assets';
 import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 
 const getServer = withIsolatedDevServer(test);
 
 test.describe('public deck media playback journey', () => {
-  test('renders and plays a shared deck video asset from the public viewer', async ({ page }) => {
+  test('renders and plays a shared deck video asset from the public viewer', async ({
+    page,
+  }, testInfo) => {
     const server = getServer();
     const payload = createSharePayload();
+    let releaseImagePreload!: () => void;
+    const imagePreloadReady = new Promise<void>((resolve) => {
+      releaseImagePreload = resolve;
+    });
+    payload.project.assets['asset-public-image'] = {
+      id: 'asset-public-image',
+      mimeType: 'image/png',
+      name: 'Public preload proof',
+      objectUrl: 'http://localhost/e2e-public-image.png',
+      type: 'image',
+    };
     payload.project.assets['asset-public-video'] = {
       id: 'asset-public-video',
       mimeType: 'video/mp4',
       name: 'Big Buck Bunny public fixture',
       objectUrl: 'http://localhost/e2e-public-video.mp4',
       type: 'video',
+    };
+    payload.project.assets['asset-public-gif'] = {
+      id: 'asset-public-gif',
+      mimeType: 'image/gif',
+      name: 'Public animated loop',
+      objectUrl: 'http://localhost/e2e-public-loop.png',
+      type: 'gif',
     };
     payload.project.elements['video-public'] = {
       assetId: 'asset-public-video',
@@ -42,10 +62,65 @@ test.describe('public deck media playback journey', () => {
       x: 600,
       y: 420,
     };
-    payload.project.pages[0].elementIds.push('video-public');
+    payload.project.elements['gif-public'] = {
+      assetId: 'asset-public-gif',
+      height: 180,
+      id: 'gif-public',
+      locked: false,
+      opacity: 1,
+      playing: true,
+      rotation: 0,
+      type: 'gif',
+      visible: true,
+      width: 240,
+      x: 240,
+      y: 420,
+    };
+    payload.project.elements['image-public'] = {
+      assetId: 'asset-public-image',
+      height: 180,
+      id: 'image-public',
+      locked: false,
+      opacity: 1,
+      rotation: 0,
+      type: 'image',
+      visible: true,
+      width: 240,
+      x: 120,
+      y: 120,
+    };
+    payload.project.fonts = {
+      preload: {
+        family: 'Public Preload Font',
+        fileName: 'public-preload.woff2',
+        fontStyle: 'normal',
+        fontWeight: 400,
+        id: 'public-preload-font',
+        mimeType: 'font/woff2',
+        objectUrl: 'http://localhost/e2e-public-font.woff2',
+        requestedFamily: 'Public Preload Font',
+        source: 'uploaded',
+        storage: 'remote',
+      },
+    };
+    payload.project.pages[0].elementIds.push('image-public');
+    payload.project.pages[1].elementIds.push('video-public', 'gif-public');
 
     await page.route('**/e2e-share-with-video.json', async (route) => {
       await route.fulfill({ contentType: 'application/json', json: payload });
+    });
+    await page.route('**/e2e-public-image.png', async (route) => {
+      await imagePreloadReady;
+      await route.fulfill({
+        body: await readFile(await createTinyPngFixture(testInfo)),
+        contentType: 'image/png',
+      });
+    });
+    await page.route('**/e2e-public-font.woff2', async (route) => {
+      await route.fulfill({
+        body: '',
+        contentType: 'font/woff2',
+      });
     });
     await page.route('**/e2e-public-video.mp4', async (route) => {
       await route.fulfill({
@@ -53,15 +128,32 @@ test.describe('public deck media playback journey', () => {
         contentType: 'video/mp4',
       });
     });
+    await page.route('**/e2e-public-loop.png', async (route) => {
+      await route.fulfill({
+        body: await readFile(await createTinyPngFixture(testInfo)),
+        contentType: 'image/png',
+      });
+    });
 
     const publicDeck = new PublicDeckPage(page, server.baseURL);
     const shareSrc = encodeURIComponent('http://localhost/e2e-share-with-video.json');
     await publicDeck.goto(`/editor/?share=e2e-share&src=${shareSrc}`);
+    await expect(page.getByRole('region', { name: 'Preparing shared deck' })).toBeVisible();
+    await expect(page.getByText('Loading deck...')).toHaveCount(0);
+    await expect(page.getByText(/assets ready$/)).toBeVisible();
+    releaseImagePreload();
     await publicDeck.expectReady(false);
+    await expect(page.getByText('1 / 2')).toBeVisible();
+    await page.getByRole('button', { name: 'Next slide' }).click();
+    await expect(page.getByText('2 / 2')).toBeVisible();
 
+    await expect(page.locator('canvas')).toBeVisible();
     const video = page.locator('video[aria-label="Big Buck Bunny public fixture"]');
     await expect(video).toBeVisible();
     await expect(video).toHaveAttribute('src', /e2e-public-video\.mp4/);
+    const gif = page.locator('img[aria-label="Public animated loop"]');
+    await expect(gif).toBeVisible();
+    await expect(gif).toHaveAttribute('src', /e2e-public-loop\.png/);
     await expect
       .poll(() =>
         video.evaluate((node: HTMLVideoElement) =>
@@ -72,7 +164,5 @@ test.describe('public deck media playback journey', () => {
         ),
       )
       .toBe(true);
-    await page.getByRole('button', { name: 'Next slide' }).click();
-    await expect(page.getByText('2 / 2')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Start public deck asset preloading immediately after the share payload loads, in parallel with project font loading, so media warming begins as early as possible during startup.
- Preload public deck images and GIFs through the shared canvas image cache, and keep hidden GIF/video elements mounted during preparation and presentation.
- Wait for every public deck asset preload attempt before starting playback.
- Wait for target-slide GIF and video readiness before changing slides, so navigating to media-heavy slides does not expose placeholders while the browser catches up.
- Keep read-only media placeholders visible for editor image export, while public deck playback opts into hiding them to avoid presenter placeholder flashes.
- Extend unit, public-deck E2E, and editor coverage E2E paths for image, GIF, video, font/request preloading, progress UI, next-slide media playback, and public presenter video rendering.

## Root Cause

Some media were still only being fetched or loaded on detached elements, which warmed network cache but did not always leave the browser with decoded GIF/image state or a ready video path when the slide mounted. Startup preload also ran after font loading, so media warming could be delayed before the progress UI finished.

The first placeholder fix reused the read-only canvas media behavior shared by public presenter playback and editor image export. That hid video placeholders in exported read-only canvases too, causing video-heavy sample slides to export as black images when animation images were disabled.

## Validation

- `npm run test --workspace @localstudio/editor -- tests/unit/ui/share/PublicDeckViewer.test.tsx tests/unit/ui/editor/ProjectVideoPreloader.test.tsx`
- `npm run test --workspace @localstudio/editor -- tests/unit/ui/editor/CanvasWorkspace.media.test.tsx tests/unit/ui/share/PublicDeckViewer.test.tsx`
- `E2E_COVERAGE=0 npm run test:e2e -- tests/e2e/editor/export-current-page-image.spec.ts --grep "exports readable final slide states"`
- `E2E_COVERAGE=0 npm run test:e2e -- tests/e2e/editor/generated-and-public-accessibility.spec.ts --grep "keeps public deck navigation"`
- `E2E_COVERAGE=0 npm run test:e2e -- tests/e2e/public-deck/media-playback.spec.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test:e2e:coverage:editor` (80.25% bytes)
- `npm run test:e2e:coverage:public-deck`
- Pre-commit hook reran lint, typecheck, and the full local test suite successfully.