### PR TITLE
Support inline text formatting

### DIFF
--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -26,7 +26,14 @@ const elementAnimationCommandConstructors = {
   SetElementAnimationBuildsCommand: elementAnimationCommands.SetElementAnimationBuildsCommand,
 };
 
-export type AlignMode = 'horizontal-center' | 'vertical-center' | 'page-center';
+export type AlignMode =
+  | 'horizontal-left'
+  | 'horizontal-center'
+  | 'horizontal-right'
+  | 'vertical-top'
+  | 'vertical-center'
+  | 'vertical-bottom'
+  | 'page-center';
 export type ZOrderMode = 'front' | 'back' | 'forward' | 'backward';
 export type ElementFramePatch = Partial<
   Pick<BaseElement, 'height' | 'rotation' | 'width' | 'x' | 'y'>
@@ -65,6 +72,8 @@ export type ElementStylePatch = Partial<{
   strokeWidth: number;
   startEndpoint: ShapeElement['startEndpoint'];
   endEndpoint: ShapeElement['endEndpoint'];
+  textColorRange: { start: number; end: number };
+  verticalAlign: 'bottom' | 'middle' | 'top';
 }>;
 export type ElementAnimationPatch = Omit<ElementAnimationBuild, 'elementId' | 'id'>;
 

--- a/apps/editor/src/domain/commands/elements/element-edit-commands.ts
+++ b/apps/editor/src/domain/commands/elements/element-edit-commands.ts
@@ -1,4 +1,5 @@
 import type { Asset, DesignElement, ProjectDocument } from '../../documents/model';
+import { textColorRanges } from '../../documents/textColorRanges';
 import { projectMutationUtils } from '../shared/projectMutationUtils';
 import type { EditorCommand } from '../shared/types';
 import type { ElementFramePatch, ElementStylePatch } from './basicCommands';
@@ -108,15 +109,19 @@ class UpdateTextContentCommand implements EditorCommand {
   execute(project: ProjectDocument): ProjectDocument {
     const element = project.elements[this.elementId];
     if (!element || element.type !== 'text' || element.locked) return project;
+    const colorRanges = textColorRanges.trimTextColorRanges(element.colorRanges, this.text.length);
+    const nextElement = {
+      ...element,
+      text: this.text,
+      ...(colorRanges ? { colorRanges } : {}),
+    };
+    if (!colorRanges) delete nextElement.colorRanges;
 
     return {
       ...project,
       elements: {
         ...project.elements,
-        [this.elementId]: {
-          ...element,
-          text: this.text,
-        },
+        [this.elementId]: nextElement,
       },
       updatedAt: projectMutationUtils.getProjectUpdatedAt(),
     };
@@ -142,17 +147,31 @@ class UpdateElementStyleCommand implements EditorCommand {
     let nextElement: DesignElement = { ...element, opacity };
 
     if (element.type === 'text') {
+      const nextColorRanges =
+        typeof this.patch.fill === 'string' && this.patch.textColorRange
+          ? textColorRanges.applyTextColorRange({
+              fill: this.patch.fill,
+              range: { ...this.patch.textColorRange, fill: this.patch.fill },
+              ranges: element.colorRanges,
+              textLength: element.text.length,
+            })
+          : textColorRanges.trimTextColorRanges(element.colorRanges, element.text.length);
       const nextTextElement = {
         ...element,
         opacity,
         ...(this.patch.align ? { align: this.patch.align } : {}),
-        ...(typeof this.patch.fill === 'string' ? { fill: this.patch.fill } : {}),
+        ...(typeof this.patch.fill === 'string' && !this.patch.textColorRange
+          ? { fill: this.patch.fill }
+          : {}),
         ...(this.patch.fontFamily ? { fontFamily: this.patch.fontFamily } : {}),
         ...(this.patch.fontSize !== undefined
           ? { fontSize: Math.max(1, this.patch.fontSize) }
           : {}),
         ...(this.patch.fontWeight !== undefined ? { fontWeight: this.patch.fontWeight } : {}),
+        ...(this.patch.verticalAlign ? { verticalAlign: this.patch.verticalAlign } : {}),
+        ...(nextColorRanges ? { colorRanges: nextColorRanges } : {}),
       };
+      if (!nextColorRanges) delete nextTextElement.colorRanges;
       if (typeof this.patch.hyperlink === 'string') {
         nextTextElement.hyperlink = this.patch.hyperlink;
       }

--- a/apps/editor/src/domain/commands/elements/element-structure-commands.ts
+++ b/apps/editor/src/domain/commands/elements/element-structure-commands.ts
@@ -20,11 +20,19 @@ class AlignElementCommand implements EditorCommand {
 
     const patch = {
       x:
-        this.mode === 'horizontal-center' || this.mode === 'page-center'
+        this.mode === 'horizontal-left'
+          ? 0
+          : this.mode === 'horizontal-right'
+            ? page.width - element.width
+            : this.mode === 'horizontal-center' || this.mode === 'page-center'
           ? (page.width - element.width) / 2
           : element.x,
       y:
-        this.mode === 'vertical-center' || this.mode === 'page-center'
+        this.mode === 'vertical-top'
+          ? 0
+          : this.mode === 'vertical-bottom'
+            ? page.height - element.height
+            : this.mode === 'vertical-center' || this.mode === 'page-center'
           ? (page.height - element.height) / 2
           : element.y,
     };

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -222,9 +222,16 @@ export interface TextElement extends BaseElement {
   fontWeight: number;
   fill: string;
   align: 'left' | 'center' | 'right';
+  colorRanges?: TextColorRange[];
   hyperlink?: string;
   lineHeight?: number;
   verticalAlign?: 'bottom' | 'middle' | 'top';
+}
+
+export interface TextColorRange {
+  start: number;
+  end: number;
+  fill: string;
 }
 
 export interface ImageElement extends BaseElement {

--- a/apps/editor/src/domain/documents/textColorRanges.ts
+++ b/apps/editor/src/domain/documents/textColorRanges.ts
@@ -1,0 +1,81 @@
+import type { TextColorRange } from './model';
+
+interface ApplyTextColorRangeInput {
+  fill: string;
+  range: TextColorRange;
+  ranges?: TextColorRange[] | undefined;
+  textLength: number;
+}
+
+function clampRange(range: TextColorRange, textLength: number) {
+  return {
+    ...range,
+    start: Math.max(0, Math.min(textLength, Math.floor(range.start))),
+    end: Math.max(0, Math.min(textLength, Math.floor(range.end))),
+  };
+}
+
+function rangesOverlap(left: TextColorRange, right: TextColorRange) {
+  return left.start < right.end && right.start < left.end;
+}
+
+function mergeAdjacentRanges(ranges: TextColorRange[]) {
+  return ranges.reduce<TextColorRange[]>((merged, range) => {
+    const previous = merged.at(-1);
+    if (previous && previous.end === range.start && previous.fill === range.fill) {
+      previous.end = range.end;
+      return merged;
+    }
+    merged.push({ ...range });
+    return merged;
+  }, []);
+}
+
+function applyTextColorRange({
+  fill,
+  range,
+  ranges = [],
+  textLength,
+}: ApplyTextColorRangeInput) {
+  const nextRange = clampRange({ ...range, fill }, textLength);
+  if (nextRange.start >= nextRange.end) return ranges;
+
+  const nextRanges = ranges.flatMap((existingRange) => {
+    const clampedExistingRange = clampRange(existingRange, textLength);
+    if (clampedExistingRange.start >= clampedExistingRange.end) return [];
+    if (!rangesOverlap(clampedExistingRange, nextRange)) return [clampedExistingRange];
+
+    const fragments: TextColorRange[] = [];
+    if (clampedExistingRange.start < nextRange.start) {
+      fragments.push({
+        ...clampedExistingRange,
+        end: nextRange.start,
+      });
+    }
+    if (clampedExistingRange.end > nextRange.end) {
+      fragments.push({
+        ...clampedExistingRange,
+        start: nextRange.end,
+      });
+    }
+    return fragments;
+  });
+
+  nextRanges.push(nextRange);
+  return mergeAdjacentRanges(nextRanges.sort((left, right) => left.start - right.start));
+}
+
+function trimTextColorRanges(ranges: TextColorRange[] | undefined, textLength: number) {
+  const trimmedRanges = mergeAdjacentRanges(
+    (ranges ?? [])
+      .map((range) => clampRange(range, textLength))
+      .filter((range) => range.start < range.end)
+      .sort((left, right) => left.start - right.start),
+  );
+  return trimmedRanges.length > 0 ? trimmedRanges : undefined;
+}
+
+export const textColorRanges = {
+  applyTextColorRange,
+  trimTextColorRanges,
+};

--- a/apps/editor/src/services/exporting/pptxExportService.ts
+++ b/apps/editor/src/services/exporting/pptxExportService.ts
@@ -172,8 +172,38 @@ function getShapeName(element: ShapeElement): PptxGenJS.SHAPE_NAME {
   return shapeMap[element.shape] ?? 'rect';
 }
 
+function getPptxTextRuns(element: Extract<DesignElement, { type: 'text' }>) {
+  if (!element.colorRanges?.length) return element.text;
+  const runs: Array<{ text: string; options: { color: string } }> = [];
+  let index = 0;
+  for (const range of element.colorRanges) {
+    const start = Math.max(0, Math.min(element.text.length, range.start));
+    const end = Math.max(start, Math.min(element.text.length, range.end));
+    if (index < start) {
+      runs.push({
+        text: element.text.slice(index, start),
+        options: { color: normalizeHexColor(element.fill, '111111') },
+      });
+    }
+    if (start < end) {
+      runs.push({
+        text: element.text.slice(start, end),
+        options: { color: normalizeHexColor(range.fill, '111111') },
+      });
+    }
+    index = end;
+  }
+  if (index < element.text.length) {
+    runs.push({
+      text: element.text.slice(index),
+      options: { color: normalizeHexColor(element.fill, '111111') },
+    });
+  }
+  return runs.length > 0 ? runs : element.text;
+}
+
 function addTextElement(slide: PptxGenJS.Slide, element: Extract<DesignElement, { type: 'text' }>) {
-  slide.addText(element.text, {
+  slide.addText(getPptxTextRuns(element), {
     ...toPosition(element),
     align: element.align,
     bold: element.fontWeight >= 600,

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -31,6 +31,7 @@ import type {
   ImageElement,
   ProjectDocument,
   SelectionState,
+  TextElement,
   VideoElement,
 } from '../../../domain/documents/model';
 import { getNormalizedElementPoint } from '../background-selection/backgroundSelection';
@@ -53,6 +54,9 @@ import { shapeLineDraw } from './shape-line-draw';
 import { textTranslationLayout } from '../state/text-translation-layout';
 
 const TEXT_FRAME_PADDING = 6;
+const textMeasureCanvas =
+  typeof document === 'undefined' ? undefined : document.createElement('canvas');
+const textMeasureContext = textMeasureCanvas?.getContext('2d');
 
 interface CanvasWorkspaceProps {
   project: ProjectDocument;
@@ -90,6 +94,8 @@ interface CanvasWorkspaceProps {
   canTranslateSelection?: boolean;
   isTranslating?: boolean;
   translationNotice?: string | undefined;
+  autoEditTextElementId?: string | undefined;
+  activeTextSelection?: { elementId: string; start: number; end: number } | undefined;
   onAlignSelectedElement?: (() => void) | undefined;
   onAnimationPreviewAdvance?: (() => void) | undefined;
   onBringSelectedElementForward?: (() => void) | undefined;
@@ -116,6 +122,9 @@ interface CanvasWorkspaceProps {
   onSelectElement?: ((elementId: string, options?: { additive?: boolean }) => void) | undefined;
   onSendSelectedElementBackward?: (() => void) | undefined;
   onTranslateSelectedText?: (() => void) | undefined;
+  onTextEditSelectionChange?:
+    | ((elementId: string, range: { start: number; end: number }) => void)
+    | undefined;
   onUpdateImageCrop?: ((elementId: string, patch: ImageCropPatch) => void) | undefined;
   onUpdateElementFrame?: ((elementId: string, patch: ElementFramePatch) => void) | undefined;
   onUpdateElementFrames?: ((patches: Record<string, ElementFramePatch>) => void) | undefined;
@@ -147,6 +156,111 @@ function getAnimationOpacity(baseOpacity: number, state: ElementAnimationRenderS
 function getTypedText(text: string, state: ElementAnimationRenderState) {
   if (state.activeBuild?.effect !== 'keyboard-typing') return text;
   return text.slice(0, Math.ceil(text.length * state.progress));
+}
+
+function measureTextSegmentWidth(input: {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: number;
+  text: string;
+}) {
+  if (!textMeasureContext) return input.text.length * input.fontSize * 0.55;
+  textMeasureContext.font = `${input.fontWeight} ${input.fontSize}px ${input.fontFamily}`;
+  return textMeasureContext.measureText(input.text).width;
+}
+
+function getFillForTextIndex(element: TextElement, index: number) {
+  return (
+    element.colorRanges?.find((range) => range.start <= index && index < range.end)?.fill ??
+    element.fill
+  );
+}
+
+function createTextRenderSegments(input: {
+  element: TextElement;
+  fontSize: number;
+  text: string;
+  width: number;
+}) {
+  const segments: Array<{ fill: string; text: string; x: number; y: number }> = [];
+  const lineHeight = input.element.lineHeight ?? 1.05;
+  const visualLines: Array<{
+    characters: Array<{ text: string; textIndex: number }>;
+    width: number;
+  }> = [];
+  let currentLine: Array<{ text: string; textIndex: number }> = [];
+  let currentLineWidth = 0;
+
+  for (let textIndex = 0; textIndex < input.text.length; textIndex += 1) {
+    const character = input.text[textIndex] ?? '';
+    if (character === '\n') {
+      visualLines.push({ characters: currentLine, width: currentLineWidth });
+      currentLine = [];
+      currentLineWidth = 0;
+      continue;
+    }
+
+    const characterWidth = measureTextSegmentWidth({
+      fontFamily: input.element.fontFamily,
+      fontSize: input.fontSize,
+      fontWeight: input.element.fontWeight,
+      text: character,
+    });
+    if (currentLine.length > 0 && currentLineWidth + characterWidth > input.width) {
+      visualLines.push({ characters: currentLine, width: currentLineWidth });
+      currentLine = [];
+      currentLineWidth = 0;
+    }
+    currentLine.push({ text: character, textIndex });
+    currentLineWidth += characterWidth;
+  }
+  visualLines.push({ characters: currentLine, width: currentLineWidth });
+
+  for (const [lineIndex, line] of visualLines.entries()) {
+    const lineX =
+      input.element.align === 'center'
+        ? Math.max(0, (input.width - line.width) / 2)
+        : input.element.align === 'right'
+          ? Math.max(0, input.width - line.width)
+          : 0;
+    let offsetX = lineX;
+    let segmentText = '';
+    let segmentFill = line.characters[0]
+      ? getFillForTextIndex(input.element, line.characters[0].textIndex)
+      : input.element.fill;
+
+    for (const character of line.characters) {
+      const fill = getFillForTextIndex(input.element, character.textIndex);
+      if (fill !== segmentFill && segmentText) {
+        segments.push({
+          fill: segmentFill,
+          text: segmentText,
+          x: offsetX,
+          y: lineIndex * input.fontSize * lineHeight,
+        });
+        offsetX += measureTextSegmentWidth({
+          fontFamily: input.element.fontFamily,
+          fontSize: input.fontSize,
+          fontWeight: input.element.fontWeight,
+          text: segmentText,
+        });
+        segmentText = '';
+      }
+      segmentFill = fill;
+      segmentText += character.text;
+    }
+
+    if (segmentText) {
+      segments.push({
+        fill: segmentFill,
+        text: segmentText,
+        x: offsetX,
+        y: lineIndex * input.fontSize * lineHeight,
+      });
+    }
+  }
+
+  return segments;
 }
 
 function getNormalizedStageRect(start: { x: number; y: number }, end: { x: number; y: number }) {
@@ -186,6 +300,7 @@ export function CanvasWorkspace({
   canTranslateSelection = false,
   isTranslating = false,
   translationNotice,
+  autoEditTextElementId,
   onAlignSelectedElement,
   onAnimationPreviewAdvance,
   onBackgroundPreviewPoint,
@@ -205,6 +320,7 @@ export function CanvasWorkspace({
   onSelectElement,
   onSendSelectedElementBackward,
   onTranslateSelectedText,
+  onTextEditSelectionChange,
   onUpdateImageCrop,
   onUpdateElementFrame,
   onUpdateElementFrames,
@@ -214,6 +330,7 @@ export function CanvasWorkspace({
   const nodeRefs = useRef<Record<string, Konva.Node | null>>({});
   const artboardRef = useRef<HTMLDivElement>(null);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
+  const consumedAutoEditTextElementIdRef = useRef<string | undefined>(undefined);
   const [stageSize, setStageSize] = useState({ width: 768, height: 432 });
   const [editingTextId, setEditingTextId] = useState<string | null>(null);
   const [editingTextValue, setEditingTextValue] = useState('');
@@ -382,6 +499,31 @@ export function CanvasWorkspace({
     textInputRef.current?.focus();
     textInputRef.current?.select();
   }, [editingTextId]);
+
+  useEffect(() => {
+    if (!autoEditTextElementId) return;
+    if (consumedAutoEditTextElementIdRef.current === autoEditTextElementId) return;
+    const element = project.elements[autoEditTextElementId];
+    if (!element || element.type !== 'text') return;
+    if (readOnly) return;
+    consumedAutoEditTextElementIdRef.current = autoEditTextElementId;
+    const timeoutId = window.setTimeout(() => {
+      onSelectElement?.(element.id);
+      setEditingTextId(element.id);
+      setEditingTextValue(element.text);
+      setEditingTextHeight(element.height);
+      onTextEditSelectionChange?.(element.id, { start: 0, end: element.text.length });
+    }, 0);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    autoEditTextElementId,
+    onSelectElement,
+    onTextEditSelectionChange,
+    project.elements,
+    readOnly,
+  ]);
 
   useEffect(() => {
     const fontSet = document.fonts;
@@ -640,6 +782,7 @@ export function CanvasWorkspace({
     setEditingTextId(element.id);
     setEditingTextValue(element.text);
     setEditingTextHeight(element.height);
+    onTextEditSelectionChange?.(element.id, { start: 0, end: element.text.length });
   }
 
   function commitTextEditing() {
@@ -650,6 +793,7 @@ export function CanvasWorkspace({
   }
 
   function cancelTextEditing() {
+    if (editingTextId) onTextEditSelectionChange?.(editingTextId, { start: 0, end: 0 });
     setEditingTextId(null);
     setEditingTextValue('');
     setEditingTextHeight(undefined);
@@ -668,6 +812,13 @@ export function CanvasWorkspace({
     if (nextHeight !== element.height) {
       onUpdateElementFrame?.(element.id, { height: nextHeight });
     }
+  }
+
+  function updateTextSelection(element: Extract<DesignElement, { type: 'text' }>, input: HTMLTextAreaElement) {
+    onTextEditSelectionChange?.(element.id, {
+      start: input.selectionStart,
+      end: input.selectionEnd,
+    });
   }
 
   function pickBackgroundSubject(
@@ -1127,11 +1278,70 @@ export function CanvasWorkspace({
                   );
                 }
 
+                const typedText = getTypedText(element.text, animationState);
+                if (element.colorRanges?.length) {
+                  const fontSize = element.fontSize * scaleY;
+                  const padding = TEXT_FRAME_PADDING * scaleY;
+                  const renderSegments = createTextRenderSegments({
+                    element,
+                    fontSize,
+                    text: typedText,
+                    width: element.width * scaleX - padding * 2,
+                  });
+                  const renderedLineCount =
+                    renderSegments.length > 0
+                      ? Math.max(
+                          ...renderSegments.map(
+                            (segment) => segment.y / (fontSize * (element.lineHeight ?? 1.05)),
+                          ),
+                        ) + 1
+                      : 1;
+                  const contentHeight =
+                    renderedLineCount * fontSize * (element.lineHeight ?? 1.05);
+                  const contentY =
+                    (element.verticalAlign ?? 'top') === 'middle'
+                      ? Math.max(0, (element.height * scaleY - contentHeight) / 2)
+                      : (element.verticalAlign ?? 'top') === 'bottom'
+                        ? Math.max(0, element.height * scaleY - contentHeight - padding)
+                        : 0;
+
+                  return (
+                    <Group
+                      {...commonProps}
+                      key={`${element.id}-font-${fontRenderVersion}`}
+                      ref={nodeRef}
+                      visible={editingTextId !== element.id}
+                    >
+                      <Rect
+                        height={element.height * scaleY}
+                        listening={false}
+                        width={element.width * scaleX}
+                        x={0}
+                        y={0}
+                      />
+                      {renderSegments.map((segment, index) => (
+                        <Text
+                          key={`${segment.x}-${segment.y}-${index}`}
+                          text={segment.text}
+                          fontFamily={element.fontFamily}
+                          fontSize={fontSize}
+                          fontStyle={element.fontWeight >= 700 ? 'bold' : 'normal'}
+                          fill={segment.fill}
+                          lineHeight={element.lineHeight ?? 1.05}
+                          x={padding + segment.x}
+                          y={padding + contentY + segment.y}
+                          {...(element.hyperlink ? { textDecoration: 'underline' } : {})}
+                        />
+                      ))}
+                    </Group>
+                  );
+                }
+
                 return (
                   <Text
                     {...commonProps}
                     key={`${element.id}-font-${fontRenderVersion}`}
-                    text={getTypedText(element.text, animationState)}
+                    text={typedText}
                     fontFamily={element.fontFamily}
                     fontSize={element.fontSize * scaleY}
                     fontStyle={element.fontWeight >= 700 ? 'bold' : 'normal'}
@@ -1282,17 +1492,25 @@ export function CanvasWorkspace({
                       transform: `rotate(${element.rotation}deg)`,
                       width: `${element.width * scaleX}px`,
                     }}
-                    onBlur={commitTextEditing}
+                    onBlur={(event) => {
+                      updateTextSelection(element, event.currentTarget);
+                      commitTextEditing();
+                    }}
                     onChange={(event) => {
                       updateTextEditing(element, event.currentTarget);
+                    }}
+                    onSelect={(event) => {
+                      updateTextSelection(element, event.currentTarget);
                     }}
                     onKeyDown={(event) => {
                       if (event.key === 'Escape') {
                         event.preventDefault();
+                        onTextEditSelectionChange?.(element.id, { start: 0, end: 0 });
                         cancelTextEditing();
                       }
                       if (event.key === 'Enter' && !event.shiftKey) {
                         event.preventDefault();
+                        onTextEditSelectionChange?.(element.id, { start: 0, end: 0 });
                         commitTextEditing();
                       }
                     }}

--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -63,15 +63,17 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
     const programmaticScrollRef = useRef(false);
     const scrollerRef = useRef<HTMLDivElement>(null);
     const selectedElement = project.elements[canvasProps.selection.elementIds[0] ?? ''];
+    const selectedTextElements = canvasProps.selection.elementIds
+      .map((elementId) => project.elements[elementId])
+      .filter((element) => element?.type === 'text');
     const showTextToolbar =
       !canvasProps.presentationMode &&
       selectedElement?.type === 'text' &&
-      canvasProps.selection.elementIds.length === 1;
+      selectedTextElements.length === canvasProps.selection.elementIds.length;
     const textToolbarDisabled =
       Boolean(canvasProps.isTranslating) ||
-      Boolean(
-        selectedElement?.type === 'text' &&
-        canvasProps.processingElementIds?.includes(selectedElement.id),
+      selectedTextElements.some((element) =>
+        canvasProps.processingElementIds?.includes(element.id),
       );
     const showPageControls = !canvasProps.presentationMode;
     const activePageIndex = project.pages.findIndex((page) => page.id === activePageId);
@@ -139,6 +141,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
           <div className="scrolling-text-toolbar-shell" data-testid="sticky-text-selection-toolbar">
             <TextSelectionToolbar
               element={selectedElement}
+              activeTextSelection={canvasProps.activeTextSelection}
               canTranslateSelection={Boolean(canvasProps.canTranslateSelection)}
               disabled={textToolbarDisabled}
               {...(canvasProps.onOpenAnimations

--- a/apps/editor/src/ui/editor/panels/ElementDesignInspector.tsx
+++ b/apps/editor/src/ui/editor/panels/ElementDesignInspector.tsx
@@ -254,8 +254,12 @@ export function ElementDesignInspector({
                 <option value="" disabled>
                   Align
                 </option>
+                <option value="horizontal-left">Left</option>
                 <option value="horizontal-center">Horizontal center</option>
+                <option value="horizontal-right">Right</option>
+                <option value="vertical-top">Top</option>
                 <option value="vertical-center">Vertical center</option>
+                <option value="vertical-bottom">Bottom</option>
                 <option value="page-center">Page center</option>
               </select>
               <button type="button" disabled>

--- a/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
+++ b/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
@@ -280,6 +280,38 @@ export function TextStyleInspector({
               </button>
             );
           })}
+          {([
+            { align: 'top' as const, icon: 'vertical_align_top', label: 'Align selected text top' },
+            {
+              align: 'middle' as const,
+              icon: 'vertical_align_center',
+              label: 'Align selected text middle',
+            },
+            {
+              align: 'bottom' as const,
+              icon: 'vertical_align_bottom',
+              label: 'Align selected text bottom',
+            },
+          ]).map((item) => (
+            <button
+              aria-label={item.label}
+              aria-pressed={(element.verticalAlign ?? 'top') === item.align}
+              className={
+                (element.verticalAlign ?? 'top') === item.align
+                  ? 'text-align-button active'
+                  : 'text-align-button'
+              }
+              key={item.align}
+              type="button"
+              onClick={() => {
+                onUpdateStyle({ verticalAlign: item.align });
+              }}
+            >
+              <span className="material-symbols-outlined" aria-hidden="true">
+                {item.icon}
+              </span>
+            </button>
+          ))}
         </div>
       </div>
     </section>

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1233,6 +1233,8 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             canTranslateSelection={vm.canTranslateSelection}
             isTranslating={vm.isTranslating}
             translationNotice={vm.translationNotice}
+            autoEditTextElementId={vm.autoEditTextElementId}
+            activeTextSelection={vm.activeTextSelection}
             onAlignSelectedElement={
               isHistoryReadOnly
                 ? undefined
@@ -1317,6 +1319,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
                 : () => {
                     void vm.translateSelectedText();
                   }
+            }
+            onTextEditSelectionChange={
+              isHistoryReadOnly ? undefined : vm.updateTextEditSelection
             }
             onUpdateImageCrop={isHistoryReadOnly ? undefined : vm.updateImageCrop}
             onUpdateElementFrame={isHistoryReadOnly ? undefined : vm.updateElementFrame}

--- a/apps/editor/src/ui/editor/state/editorViewModelText.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelText.ts
@@ -1,6 +1,6 @@
 import { basicCommands } from '../../../domain/commands/elements/basicCommands';
 import type { ElementFramePatch, ElementStylePatch } from '../../../domain/commands/elements/basicCommands';
-import type { ProjectDocument, ProjectFont } from '../../../domain/documents/model';
+import type { DesignElement, ProjectDocument, ProjectFont } from '../../../domain/documents/model';
 import { textTranslationLayout } from './text-translation-layout';
 
 function getFramePatchWithTextMinimum(
@@ -59,6 +59,60 @@ function updateElementStyle(
   return ensureTextElementMinimumHeight(nextProject, elementId);
 }
 
+function hasPatchValue(patch: ElementStylePatch) {
+  return Object.keys(patch).length > 0;
+}
+
+function getSupportedStylePatch(input: {
+  element: DesignElement | undefined;
+  patch: ElementStylePatch;
+  textSelection?: { start: number; end: number } | undefined;
+}) {
+  if (!input.element || input.element.locked) return undefined;
+  const sharedPatch: ElementStylePatch = {
+    ...(input.patch.opacity !== undefined ? { opacity: input.patch.opacity } : {}),
+  };
+
+  if (input.element.type === 'text') {
+    const textSelection =
+      input.textSelection && input.textSelection.start < input.textSelection.end
+        ? input.textSelection
+        : undefined;
+    const textPatch: ElementStylePatch = {
+      ...sharedPatch,
+      ...(input.patch.align !== undefined ? { align: input.patch.align } : {}),
+      ...(input.patch.fill !== undefined ? { fill: input.patch.fill } : {}),
+      ...(input.patch.fontFamily !== undefined ? { fontFamily: input.patch.fontFamily } : {}),
+      ...(input.patch.fontSize !== undefined ? { fontSize: input.patch.fontSize } : {}),
+      ...(input.patch.fontWeight !== undefined ? { fontWeight: input.patch.fontWeight } : {}),
+      ...(input.patch.hyperlink !== undefined ? { hyperlink: input.patch.hyperlink } : {}),
+      ...(input.patch.verticalAlign !== undefined
+        ? { verticalAlign: input.patch.verticalAlign }
+        : {}),
+      ...(textSelection && typeof input.patch.fill === 'string'
+        ? { textColorRange: textSelection }
+        : {}),
+    };
+    return hasPatchValue(textPatch) ? textPatch : undefined;
+  }
+
+  if (input.element.type === 'shape') {
+    const shapePatch: ElementStylePatch = {
+      ...sharedPatch,
+      ...(input.patch.fill !== undefined ? { fill: input.patch.fill } : {}),
+      ...(input.patch.stroke !== undefined ? { stroke: input.patch.stroke } : {}),
+      ...(input.patch.strokeWidth !== undefined ? { strokeWidth: input.patch.strokeWidth } : {}),
+      ...(input.patch.startEndpoint !== undefined
+        ? { startEndpoint: input.patch.startEndpoint }
+        : {}),
+      ...(input.patch.endEndpoint !== undefined ? { endEndpoint: input.patch.endEndpoint } : {}),
+    };
+    return hasPatchValue(shapePatch) ? shapePatch : undefined;
+  }
+
+  return hasPatchValue(sharedPatch) ? sharedPatch : undefined;
+}
+
 function applyFontFamilyWithFonts(input: {
   elementId: string;
   font: ProjectFont;
@@ -81,6 +135,7 @@ function applyFontFamilyWithFonts(input: {
 export const editorViewModelText = {
   applyFontFamilyWithFonts,
   ensureTextElementMinimumHeight,
+  getSupportedStylePatch,
   getFramePatchWithTextMinimum,
   updateElementStyle,
   updateTextContent,

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -196,6 +196,13 @@ export function useEditorViewModel(services: AppServices) {
   const activePageIdRef = useRef(activePageId);
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
   const selectedElementIdsRef = useRef(selectedElementIds);
+  const [autoEditTextElementId, setAutoEditTextElementId] = useState<string | undefined>();
+  const activeTextSelectionRef = useRef<
+    { elementId: string; start: number; end: number } | undefined
+  >(undefined);
+  const [activeTextSelection, setActiveTextSelection] = useState<
+    { elementId: string; start: number; end: number } | undefined
+  >(undefined);
   const [selectionTarget, setSelectionTarget] = useState<NonNullable<SelectionState['target']>>(
     'presentation',
   );
@@ -641,9 +648,11 @@ export function useEditorViewModel(services: AppServices) {
     projectRef.current = nextProject;
     activePageIdRef.current = nextActivePageId;
     selectedElementIdsRef.current = [];
+    activeTextSelectionRef.current = undefined;
     setProject(nextProject);
     setActivePageId(nextActivePageId);
     setSelectedElementIds([]);
+    setActiveTextSelection(undefined);
     setHistory({ past: [], future: [] });
     setPageLanguageCodes({});
     cancelBackgroundSelectionMode();
@@ -1217,7 +1226,9 @@ export function useEditorViewModel(services: AppServices) {
       }
       if (options?.selectedElementIds !== undefined) {
         selectedElementIdsRef.current = options.selectedElementIds;
+        activeTextSelectionRef.current = undefined;
         setSelectedElementIds(options.selectedElementIds);
+        setActiveTextSelection(undefined);
         setSelectionTarget(
           editorViewModelSelection.getSelectionTargetForElements(options.selectedElementIds),
         );
@@ -1229,6 +1240,8 @@ export function useEditorViewModel(services: AppServices) {
   function selectElement(elementId: string, options?: { additive?: boolean }) {
     if (processingElementIds.includes(elementId)) return;
     cancelBackgroundSelectionMode();
+    activeTextSelectionRef.current = undefined;
+    setActiveTextSelection(undefined);
     setSelectionTarget('elements');
     setSelectedElementIds((currentSelection) => {
       return editorViewModelSelection.getNextElementSelection({
@@ -1246,24 +1259,32 @@ export function useEditorViewModel(services: AppServices) {
       project,
     });
     cancelBackgroundSelectionMode();
+    activeTextSelectionRef.current = undefined;
+    setActiveTextSelection(undefined);
     setSelectionTarget('elements');
     setSelectedElementIds(selectableElementIds);
   }
 
   function clearSelection() {
     cancelBackgroundSelectionMode();
+    activeTextSelectionRef.current = undefined;
+    setActiveTextSelection(undefined);
     setSelectionTarget('presentation');
     setSelectedElementIds([]);
   }
 
   function selectSlideBackground() {
     cancelBackgroundSelectionMode();
+    activeTextSelectionRef.current = undefined;
+    setActiveTextSelection(undefined);
     setSelectionTarget('slide');
     setSelectedElementIds([]);
   }
 
   function selectPresentation() {
     cancelBackgroundSelectionMode();
+    activeTextSelectionRef.current = undefined;
+    setActiveTextSelection(undefined);
     setSelectionTarget('presentation');
     setSelectedElementIds([]);
   }
@@ -2151,9 +2172,44 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function updateElementStyle(elementId: string, patch: ElementStylePatch) {
-    commitProject((currentProject) =>
-      editorViewModelText.updateElementStyle(currentProject, elementId, patch),
-    );
+    const selectedIds = selectedElementIdsRef.current;
+    const targetIds =
+      selectedIds.length > 1 && selectedIds.includes(elementId) ? selectedIds : [elementId];
+    const capturedTextSelection =
+      targetIds.length === 1 && activeTextSelectionRef.current?.elementId === elementId
+        ? activeTextSelectionRef.current
+        : undefined;
+    if (capturedTextSelection && typeof patch.fill !== 'string') {
+      activeTextSelectionRef.current = undefined;
+      setActiveTextSelection(undefined);
+    }
+    commitProject((currentProject) => {
+      return targetIds.reduce((nextProject, targetId) => {
+        const element = nextProject.elements[targetId];
+        const textSelection =
+          capturedTextSelection?.elementId === targetId ? capturedTextSelection : undefined;
+        const targetPatch = editorViewModelText.getSupportedStylePatch({
+          element,
+          patch,
+          textSelection,
+        });
+        if (!targetPatch) return nextProject;
+        return editorViewModelText.updateElementStyle(nextProject, targetId, targetPatch);
+      }, currentProject);
+    });
+  }
+
+  function updateTextEditSelection(elementId: string, range: { start: number; end: number }) {
+    const nextSelection =
+      range.start === range.end
+        ? undefined
+        : {
+            elementId,
+            start: Math.min(range.start, range.end),
+            end: Math.max(range.start, range.end),
+          };
+    activeTextSelectionRef.current = nextSelection;
+    setActiveTextSelection(nextSelection);
   }
 
   async function downloadFontForSelection(family: string) {
@@ -2858,6 +2914,7 @@ export function useEditorViewModel(services: AppServices) {
         new basicCommands.AddElementsCommand(activePageId, [nextElement]).execute(currentProject),
       { selectedElementIds: [elementId] },
     );
+    setAutoEditTextElementId(elementId);
   }
 
   function insertShapeElement(shape: ShapeKind) {
@@ -2881,10 +2938,14 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function alignSelectedElement(mode: AlignMode) {
-    const elementId = selectedElementIds[0];
-    if (!elementId) return;
+    const elementIds = selectedElementIdsRef.current;
+    if (elementIds.length === 0) return;
     commitProject((currentProject) =>
-      new basicCommands.AlignElementCommand(activePageId, elementId, mode).execute(currentProject),
+      elementIds.reduce(
+        (nextProject, elementId) =>
+          new basicCommands.AlignElementCommand(activePageId, elementId, mode).execute(nextProject),
+        currentProject,
+      ),
     );
   }
 
@@ -3108,6 +3169,7 @@ export function useEditorViewModel(services: AppServices) {
     automation,
     activePageId,
     activePageFocusKey,
+    activeTextSelection,
     zoomPercent,
     pagesPanelOpen,
     isFullscreen,
@@ -3244,6 +3306,7 @@ export function useEditorViewModel(services: AppServices) {
     canTranslateCurrentSlide: !isTranslating && getTranslatableTextElementIds('slide').length > 0,
     canTranslateDeck: !isTranslating && getTranslatableTextElementIds('deck').length > 0,
     canPasteElements: elementClipboard.elements.length > 0,
+    autoEditTextElementId,
     translateSelectedText: () => requestTranslation('selection'),
     translateCurrentSlide: () => requestTranslation('slide'),
     translatePage: (pageId: string) => requestTranslation('slide', { pageId }),
@@ -3291,6 +3354,7 @@ export function useEditorViewModel(services: AppServices) {
     updateElementFrame,
     updateElementFrames,
     updateElementStyle,
+    updateTextEditSelection,
     downloadFontForSelection,
     importLocalFontForSelection,
     updateMediaPlayback,

--- a/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
@@ -4,6 +4,7 @@ import type { TextElement } from '../../../domain/documents/model';
 
 interface TextSelectionToolbarProps {
   disabled?: boolean;
+  activeTextSelection?: { elementId: string; start: number; end: number } | undefined;
   canTranslateSelection?: boolean;
   element: TextElement;
   onOpenAnimations?: () => void;
@@ -15,6 +16,20 @@ interface TextSelectionToolbarProps {
 const FONT_SIZE_STEP = 4;
 const REGULAR_WEIGHT = 600;
 const BOLD_WEIGHT = 800;
+const COLOR_INPUT_FALLBACK = '#000000';
+
+const horizontalAlignments = [
+  { align: 'left' as const, icon: 'format_align_left', label: 'Align text left' },
+  { align: 'center' as const, icon: 'format_align_center', label: 'Align text center' },
+  { align: 'right' as const, icon: 'format_align_right', label: 'Align text right' },
+  { align: 'justify' as const, icon: 'format_align_justify', label: 'Align text justify' },
+];
+
+const verticalAlignments = [
+  { align: 'top' as const, icon: 'vertical_align_top', label: 'Align text top' },
+  { align: 'middle' as const, icon: 'vertical_align_center', label: 'Align text middle' },
+  { align: 'bottom' as const, icon: 'vertical_align_bottom', label: 'Align text bottom' },
+];
 
 function normalizeHyperlink(value: string) {
   const trimmed = value.trim();
@@ -23,7 +38,43 @@ function normalizeHyperlink(value: string) {
   return `https://${trimmed}`;
 }
 
+function normalizeColorInputValue(fill: string) {
+  return /^#[\da-f]{6}$/i.test(fill) ? fill : COLOR_INPUT_FALLBACK;
+}
+
+function getTextColorAtIndex(element: TextElement, index: number) {
+  return (
+    element.colorRanges?.find((range) => range.start <= index && index < range.end)?.fill ??
+    element.fill
+  );
+}
+
+function getSelectedTextColor(
+  element: TextElement,
+  selection: TextSelectionToolbarProps['activeTextSelection'],
+) {
+  if (!selection || selection.elementId !== element.id || selection.start >= selection.end) {
+    return element.fill;
+  }
+  const clampedStart = Math.max(0, Math.min(element.text.length, selection.start));
+  const clampedEnd = Math.max(0, Math.min(element.text.length, selection.end));
+  if (clampedStart >= clampedEnd) return element.fill;
+  const firstColor = getTextColorAtIndex(element, clampedStart);
+  const hasMixedColor = Array.from({ length: clampedEnd - clampedStart }).some((_, offset) => {
+    return getTextColorAtIndex(element, clampedStart + offset) !== firstColor;
+  });
+  return hasMixedColor ? element.fill : firstColor;
+}
+
+function getCurrentAlignmentIcon(element: TextElement) {
+  return (
+    horizontalAlignments.find((item) => item.align === element.align)?.icon ??
+    'format_align_left'
+  );
+}
+
 export function TextSelectionToolbar({
+  activeTextSelection,
   disabled = false,
   canTranslateSelection = false,
   element,
@@ -33,8 +84,10 @@ export function TextSelectionToolbar({
   onUpdateElementStyle,
 }: TextSelectionToolbarProps) {
   const [showLinkEditor, setShowLinkEditor] = useState(false);
+  const [showAlignmentMenu, setShowAlignmentMenu] = useState(false);
   const [linkDraft, setLinkDraft] = useState({ elementId: element.id, value: element.hyperlink ?? '' });
   const linkValue = linkDraft.elementId === element.id ? linkDraft.value : (element.hyperlink ?? '');
+  const selectedTextColor = normalizeColorInputValue(getSelectedTextColor(element, activeTextSelection));
 
   function updateStyle(patch: ElementStylePatch) {
     if (disabled || element.locked) return;
@@ -101,7 +154,7 @@ export function TextSelectionToolbar({
           aria-label="Text color"
           disabled={disabled || element.locked}
           type="color"
-          value={element.fill}
+          value={selectedTextColor}
           onChange={(event) => {
             updateStyle({ fill: event.target.value });
           }}
@@ -123,32 +176,79 @@ export function TextSelectionToolbar({
         B
       </button>
 
-      <div className="text-toolbar-segment" aria-label="Text alignment">
-        {(['left', 'center', 'right'] as const).map((align) => (
-          <button
-            key={align}
-            aria-label={`Align text ${align}`}
-            aria-pressed={element.align === align}
-            className={
-              element.align === align
-                ? 'text-toolbar-button text-toolbar-button-active'
-                : 'text-toolbar-button'
-            }
-            disabled={disabled || element.locked}
-            type="button"
-            onClick={() => {
-              updateStyle({ align });
-            }}
-          >
-            <span className="material-symbols-outlined" aria-hidden="true">
-              {align === 'left'
-                ? 'format_align_left'
-                : align === 'center'
-                  ? 'format_align_center'
-                  : 'format_align_right'}
-            </span>
-          </button>
-        ))}
+      <div className="text-toolbar-alignment" aria-label="Text alignment">
+        <button
+          aria-expanded={showAlignmentMenu}
+          aria-haspopup="menu"
+          aria-label="Text alignment menu"
+          className="text-toolbar-button text-toolbar-alignment-trigger"
+          disabled={disabled || element.locked}
+          title="Text alignment"
+          type="button"
+          onClick={() => {
+            setShowAlignmentMenu((current) => !current);
+          }}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            {getCurrentAlignmentIcon(element)}
+          </span>
+          <span className="material-symbols-outlined text-toolbar-chevron" aria-hidden="true">
+            arrow_drop_down
+          </span>
+        </button>
+        {showAlignmentMenu ? (
+          <div className="text-toolbar-alignment-menu" role="menu" aria-label="Text alignment options">
+            <div className="text-toolbar-alignment-row">
+              {horizontalAlignments.map((item) => (
+                <button
+                  key={item.align}
+                  aria-label={item.label}
+                  aria-pressed={item.align !== 'justify' && element.align === item.align}
+                  className={
+                    element.align === item.align
+                      ? 'text-toolbar-button text-toolbar-button-active'
+                      : 'text-toolbar-button'
+                  }
+                  disabled={disabled || element.locked || item.align === 'justify'}
+                  type="button"
+                  onClick={() => {
+                    if (item.align === 'justify') return;
+                    updateStyle({ align: item.align });
+                    setShowAlignmentMenu(false);
+                  }}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                </button>
+              ))}
+            </div>
+            <div className="text-toolbar-alignment-row">
+              {verticalAlignments.map((item) => (
+                <button
+                  key={item.align}
+                  aria-label={item.label}
+                  aria-pressed={(element.verticalAlign ?? 'top') === item.align}
+                  className={
+                    (element.verticalAlign ?? 'top') === item.align
+                      ? 'text-toolbar-button text-toolbar-button-active'
+                      : 'text-toolbar-button'
+                  }
+                  disabled={disabled || element.locked}
+                  type="button"
+                  onClick={() => {
+                    updateStyle({ verticalAlign: item.align });
+                    setShowAlignmentMenu(false);
+                  }}
+                >
+                  <span className="material-symbols-outlined" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
       </div>
 
       <button

--- a/apps/editor/src/ui/styles/text-format-toolbar.css
+++ b/apps/editor/src/ui/styles/text-format-toolbar.css
@@ -163,6 +163,49 @@
   border-left: 1px solid rgba(55, 253, 118, 0.18);
 }
 
+.text-toolbar-alignment {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding-left: 5px;
+  border-left: 1px solid rgba(55, 253, 118, 0.18);
+}
+
+.text-toolbar-alignment-trigger {
+  gap: 2px;
+  padding: 0 4px 0 8px;
+}
+
+.text-toolbar-chevron {
+  margin-left: -3px;
+  font-size: 18px;
+}
+
+.text-toolbar-alignment-menu {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 7px);
+  left: 5px;
+  display: grid;
+  gap: 7px;
+  min-width: 142px;
+  padding: 8px;
+  border: 1px solid rgba(55, 253, 118, 0.18);
+  border-radius: 8px;
+  background: rgba(12, 22, 13, 0.98);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.36);
+}
+
+.text-toolbar-alignment-row {
+  display: grid;
+  grid-template-columns: repeat(4, 30px);
+  gap: 5px;
+}
+
+.text-toolbar-alignment-row + .text-toolbar-alignment-row {
+  grid-template-columns: repeat(3, 30px);
+}
+
 .text-selection-toolbar :disabled {
   cursor: not-allowed;
   opacity: 0.42;

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -130,6 +130,30 @@ describe('editor commands', () => {
     expect(project.elements['image-hero']?.x).toBe(55);
   });
 
+  it('aligns an element to page edges immutably', () => {
+    const project = sampleProject.createSampleProject();
+    const top = new basicCommands.AlignElementCommand(
+      'page-1',
+      'image-hero',
+      'vertical-top',
+    ).execute(project);
+    const right = new basicCommands.AlignElementCommand(
+      'page-1',
+      'image-hero',
+      'horizontal-right',
+    ).execute(project);
+    const bottom = new basicCommands.AlignElementCommand(
+      'page-1',
+      'image-hero',
+      'vertical-bottom',
+    ).execute(project);
+
+    expect(top.elements['image-hero']?.y).toBe(0);
+    expect(right.elements['image-hero']?.x).toBe(1920 - 980);
+    expect(bottom.elements['image-hero']?.y).toBe(1080 - 735);
+    expect(project.elements['image-hero']).toMatchObject({ x: 55, y: 200 });
+  });
+
   it('brings an element to front by moving its id to the end', () => {
     const project = sampleProject.createSampleProject();
     const command = new basicCommands.SetZOrderCommand('page-1', 'image-hero', 'front');
@@ -355,6 +379,37 @@ describe('editor commands', () => {
       fontSize: 96,
       opacity: 1,
     });
+  });
+
+  it('applies text color to selected character ranges without changing the whole text fill', () => {
+    const project = sampleProject.createSampleProject();
+    const first = new basicCommands.UpdateElementStyleCommand('text-title', {
+      fill: '#FF0000',
+      textColorRange: { start: 0, end: 2 },
+    }).execute(project);
+    const next = new basicCommands.UpdateElementStyleCommand('text-title', {
+      fill: '#0000FF',
+      textColorRange: { start: 1, end: 4 },
+    }).execute(first);
+
+    expect(next.elements['text-title']).toMatchObject({
+      fill: '#37FD76',
+      colorRanges: [
+        { start: 0, end: 1, fill: '#FF0000' },
+        { start: 1, end: 4, fill: '#0000FF' },
+      ],
+    });
+    expect(project.elements['text-title']).not.toHaveProperty('colorRanges');
+  });
+
+  it('updates text vertical alignment immutably', () => {
+    const project = sampleProject.createSampleProject();
+    const next = new basicCommands.UpdateElementStyleCommand('text-title', {
+      verticalAlign: 'bottom',
+    }).execute(project);
+
+    expect(next.elements['text-title']).toMatchObject({ verticalAlign: 'bottom' });
+    expect(project.elements['text-title']).not.toHaveProperty('verticalAlign');
   });
 
   it('clears shape fill and border style immutably', () => {

--- a/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
@@ -179,6 +179,7 @@ describe('ScrollingCanvasWorkspace', () => {
     );
     expect(onTranslateSelectedText).toHaveBeenCalledTimes(1);
 
+    await user.click(screen.getByRole('button', { name: 'Text alignment menu' }));
     await user.click(screen.getByRole('button', { name: 'Align text left' }));
     expect(onUpdateElementStyle).toHaveBeenCalledWith('text-subtitle', { align: 'left' });
 

--- a/tests/e2e/editor/command-contract-text-style-browser.ts
+++ b/tests/e2e/editor/command-contract-text-style-browser.ts
@@ -2,10 +2,20 @@
 import { type ProjectDocument } from '../../../apps/editor/src/domain/documents/model';
 
 export type CommandContractTextStyleResult = {
+  bottomY: number | undefined;
   elementCount: number;
+  rightX: number | undefined;
   shapeStroke: string | undefined;
   text: string | undefined;
+  textColorRanges:
+    | Array<{
+        end: number;
+        fill: string;
+        start: number;
+      }>
+    | undefined;
   textFontSize: number | undefined;
+  textVerticalAlign: string | undefined;
 };
 
 export async function evaluateCommandContractTextStyle(
@@ -28,6 +38,19 @@ export async function evaluateCommandContractTextStyle(
       fontSize: 52,
       fontWeight: 700,
       opacity: 0.75,
+      verticalAlign: 'middle',
+    }),
+  );
+  run(
+    new basicCommands.UpdateElementStyleCommand('text-1', {
+      fill: '#ff0000',
+      textColorRange: { start: 0, end: 4 },
+    }),
+  );
+  run(
+    new basicCommands.UpdateElementStyleCommand('text-1', {
+      fill: '#00ff00',
+      textColorRange: { start: 2, end: 7 },
     }),
   );
   run(
@@ -39,6 +62,8 @@ export async function evaluateCommandContractTextStyle(
       strokeWidth: 6,
     }),
   );
+  run(new basicCommands.AlignElementCommand('page-1', 'shape-1', 'horizontal-right'));
+  run(new basicCommands.AlignElementCommand('page-1', 'image-1', 'vertical-bottom'));
   run(new basicCommands.TranslateTextElementsCommand({ 'text-1': { fontSize: 46, text: 'Traduzido' } }));
 
   if (project.elements['text-1']?.text !== 'Traduzido') throw new Error('text should be translated');
@@ -47,9 +72,19 @@ export async function evaluateCommandContractTextStyle(
   }
 
   return {
+    bottomY: project.elements['image-1']?.y,
     elementCount: Object.keys(project.elements).length,
+    rightX: project.elements['shape-1']?.x,
     shapeStroke: project.elements['shape-1']?.stroke,
     text: project.elements['text-1']?.text,
+    textColorRanges:
+      project.elements['text-1']?.type === 'text'
+        ? project.elements['text-1'].colorRanges
+        : undefined,
     textFontSize: project.elements['text-1']?.fontSize,
+    textVerticalAlign:
+      project.elements['text-1']?.type === 'text'
+        ? project.elements['text-1'].verticalAlign
+        : undefined,
   };
 }

--- a/tests/e2e/editor/command-contracts.spec.ts
+++ b/tests/e2e/editor/command-contracts.spec.ts
@@ -47,10 +47,17 @@ test.describe('editor element command contracts', () => {
     );
 
     expect(result).toEqual({
+      bottomY: 840,
       elementCount: 4,
+      rightX: 1620,
       shapeStroke: '#ff00aa',
       text: 'Traduzido',
+      textColorRanges: [
+        { end: 2, fill: '#ff0000', start: 0 },
+        { end: 7, fill: '#00ff00', start: 2 },
+      ],
       textFontSize: 46,
+      textVerticalAlign: 'middle',
     });
   });
 });

--- a/tests/e2e/editor/multi-select-and-shape-styling.spec.ts
+++ b/tests/e2e/editor/multi-select-and-shape-styling.spec.ts
@@ -62,6 +62,16 @@ test.describe('editor multi-select and advanced shape styling journeys', () => {
     await page.getByLabel('Selected element height').fill('160');
     await page.getByRole('spinbutton', { name: 'Selected element rotation' }).fill('30');
     await page.getByLabel('Align selected element').selectOption('page-center');
+    await page.getByLabel('Align selected element').selectOption('horizontal-left');
+    await expect(page.getByLabel('Selected element x position')).toHaveValue('0');
+    await page.getByLabel('Align selected element').selectOption('vertical-top');
+    await expect(page.getByLabel('Selected element y position')).toHaveValue('0');
+    await page.getByLabel('Align selected element').selectOption('horizontal-right');
+    await expect.poll(async () => Number(await page.getByLabel('Selected element x position').inputValue()))
+      .toBeGreaterThan(1100);
+    await page.getByLabel('Align selected element').selectOption('vertical-bottom');
+    await expect.poll(async () => Number(await page.getByLabel('Selected element y position').inputValue()))
+      .toBeGreaterThan(800);
     await expect(page.getByLabel('Selected element width')).toHaveValue('720');
     await expect(page.getByLabel('Selected element height')).toHaveValue('160');
     await expect(page.getByRole('spinbutton', { name: 'Selected element rotation' })).toHaveValue('30');

--- a/tests/e2e/editor/text-theme-and-layout.spec.ts
+++ b/tests/e2e/editor/text-theme-and-layout.spec.ts
@@ -12,14 +12,29 @@ test.describe('editor text theme and layout journey', () => {
 
     await editor.openTool('Text');
     await page.getByRole('button', { name: 'Add a text box' }).click();
-    await editor.openTool('Layout');
-    await page.getByRole('button', { name: 'Add a little bit of body text', exact: true }).click();
+    const inlineTextEditor = page.getByRole('textbox', { name: 'Edit text' });
+    await expect(inlineTextEditor).toBeFocused();
+    await expect(inlineTextEditor).toHaveValue('Add a little bit of body text');
+    await page.keyboard.type('Overwritten body copy');
+    await expect(inlineTextEditor).toHaveValue('Overwritten body copy');
+    await inlineTextEditor.evaluate((element) => {
+      const input = element as HTMLTextAreaElement;
+      input.setSelectionRange(12, 16);
+      input.dispatchEvent(new Event('select', { bubbles: true }));
+    });
+    const textColorInput = page.getByRole('toolbar', { name: 'Text editing controls' }).getByLabel('Text color');
+    await textColorInput.fill('#ff0055');
+    await expect(textColorInput).toHaveValue('#ff0055');
+    await page.keyboard.press('Enter');
 
     const toolbar = page.getByRole('toolbar', { name: 'Text editing controls' });
     await expect(toolbar).toBeVisible();
     await toolbar.getByRole('spinbutton', { name: 'Text font size' }).fill('48');
     await toolbar.getByRole('button', { name: 'Bold text' }).click();
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
     await toolbar.getByRole('button', { name: 'Align text right' }).click();
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
+    await toolbar.getByRole('button', { name: 'Align text bottom' }).click();
     await toolbar.getByRole('button', { name: 'Edit text hyperlink' }).click();
     await toolbar.getByRole('textbox', { name: 'Text hyperlink URL' }).fill('localstudio.dev');
     await toolbar.getByRole('button', { name: 'Apply' }).click();
@@ -32,7 +47,12 @@ test.describe('editor text theme and layout journey', () => {
       'aria-pressed',
       'true',
     );
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
     await expect(toolbar.getByRole('button', { name: 'Align text right' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await expect(toolbar.getByRole('button', { name: 'Align text bottom' })).toHaveAttribute(
       'aria-pressed',
       'true',
     );
@@ -51,6 +71,72 @@ test.describe('editor text theme and layout journey', () => {
     await expect(page.getByRole('button', { name: 'Group', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ungroup' })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Distribute' })).toBeDisabled();
+  });
+
+  test('applies sticky toolbar formatting across multiple selected text elements', async ({
+    page,
+  }) => {
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await editor.gotoNewProject();
+
+    await editor.openTool('Text');
+    await page.getByRole('button', { name: 'Add a text box' }).click();
+    const inlineTextEditor = page.getByRole('textbox', { name: 'Edit text' });
+    await expect(inlineTextEditor).toBeFocused();
+    await page.keyboard.type('First multi text');
+    await page.keyboard.press('Enter');
+
+    await page.getByRole('button', { name: 'Add a text box' }).click();
+    await expect(inlineTextEditor).toBeFocused();
+    await page.keyboard.type('Second multi text');
+    await page.keyboard.press('Enter');
+
+    await editor.openTool('Layout');
+    const firstLayer = page.locator('.layer-list article[role="button"][aria-label="First multi text"]');
+    const secondLayer = page.locator('.layer-list article[role="button"][aria-label="Second multi text"]');
+    await secondLayer.click();
+    await firstLayer.click({ modifiers: ['Shift'] });
+    await expect(firstLayer).toHaveAttribute('aria-pressed', 'true');
+    await expect(secondLayer).toHaveAttribute('aria-pressed', 'true');
+
+    const toolbar = page.getByRole('toolbar', { name: 'Text editing controls' });
+    await expect(toolbar).toBeVisible();
+    await toolbar.getByRole('spinbutton', { name: 'Text font size' }).fill('64');
+    await toolbar.getByRole('button', { name: 'Bold text' }).click();
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
+    await toolbar.getByRole('button', { name: 'Align text center' }).click();
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
+    await toolbar.getByRole('button', { name: 'Align text middle' }).click();
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
+    await expect(toolbar.getByRole('button', { name: 'Align text middle' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    await firstLayer.click();
+    await editor.openTool('Design');
+    await expect(page.getByLabel('Selected text font size')).toHaveValue('64');
+    await expect(page.getByRole('button', { name: 'Align selected text center' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await expect(page.getByRole('button', { name: 'Align selected text middle' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    await editor.openTool('Layout');
+    await secondLayer.click();
+    await editor.openTool('Design');
+    await expect(page.getByLabel('Selected text font size')).toHaveValue('64');
+    await expect(page.getByRole('button', { name: 'Align selected text center' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await expect(page.getByRole('button', { name: 'Align selected text middle' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
   });
 
   test('changes presentation and slide design surfaces without selecting an element', async ({


### PR DESCRIPTION
## Summary
- Add inline text color ranges so selected words or letters can receive distinct colors while preserving whole-element text color.
- Auto-focus newly inserted text, select its placeholder text, and route immediate typing through the inline editor.
- Move sticky text alignment into a compact submenu with horizontal and vertical controls, extend object alignment to page edges, and apply text formatting changes across multi-selected text elements.
- Fix selected-word color editing so the toolbar reflects the selected range color and color changes target the selected characters instead of everything around them.
- Extend browser command contracts, unit coverage, and editor E2E coverage for inline text color, alignment submenu behavior, object alignment, and multi-select text formatting.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `E2E_COVERAGE=0 npm run test:e2e -- tests/e2e/editor/text-theme-and-layout.spec.ts`
- `E2E_COVERAGE=0 npm run test:e2e -- tests/e2e/editor/multi-select-and-shape-styling.spec.ts`
- `E2E_COVERAGE=0 npm run test:e2e -- tests/e2e/editor/command-contracts.spec.ts`
- `LOCALSTUDIO_E2E_WORKERS=2 node scripts/run-e2e-coverage.mjs editor` - passed with 59 editor tests plus the split export test, bytes coverage `80.06%` (`1,138,909 / 1,422,553`).