### PR TITLE
Fix public sharing progress and mirror-backed asset URLs

### DIFF
--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -298,6 +298,16 @@ export interface ShareMetadata {
   status: ShareStatus;
 }
 
+export interface SharePublishProgress {
+  current: number;
+  total: number;
+  label: string;
+}
+
+export interface SharePublishOptions {
+  onProgress?: (progress: SharePublishProgress) => void;
+}
+
 export interface ShareRecord {
   shareId: string;
   createdAt: string;
@@ -306,8 +316,8 @@ export interface ShareRecord {
 }
 
 export interface ShareService {
-  createShare(project: ProjectDocument): Promise<ShareMetadata>;
-  updateShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata>;
+  createShare(project: ProjectDocument, options?: SharePublishOptions): Promise<ShareMetadata>;
+  updateShare(shareId: string, project: ProjectDocument, options?: SharePublishOptions): Promise<ShareMetadata>;
   getShare(shareId: string): Promise<ShareRecord | null>;
   getProjectShareMetadata(project: ProjectDocument): ShareMetadata;
   getPublicUrl(shareId: string): string;

--- a/apps/editor/src/services/mirror/minioMirrorFiles.ts
+++ b/apps/editor/src/services/mirror/minioMirrorFiles.ts
@@ -1,5 +1,5 @@
 import { collectReferencedAssetIds } from '../../domain/assets/assetUsage';
-import type { Asset, ProjectDocument } from '../../domain/documents/model';
+import type { Asset, ProjectDocument, TranscriptRecordingAudio } from '../../domain/documents/model';
 import { assetFileUtils } from '../storage/assetFileUtils';
 import type { MirrorFile, ProjectRepository } from '../contracts/interfaces';
 import type { MinioMirrorConfig } from './minioMirrorService';
@@ -46,6 +46,20 @@ function cloneProjectWithoutObjectUrls(project: ProjectDocument): ProjectDocumen
               const nextFont = { ...font };
               delete nextFont.objectUrl;
               return [fontId, nextFont];
+            }),
+          ),
+        }
+      : {}),
+    ...(project.recordings
+      ? {
+          recordings: Object.fromEntries(
+            Object.entries(project.recordings).map(([recordingId, recording]) => {
+              const nextRecording = {
+                ...recording,
+                audio: { ...recording.audio },
+              };
+              delete nextRecording.audio.objectUrl;
+              return [recordingId, nextRecording];
             }),
           ),
         }
@@ -112,6 +126,28 @@ async function createMirrorFiles(
       files.push(await createFileEntry(`fonts/${font.fileName}`, blob));
     } else {
       projectForMirror.fonts![fontId] = { ...font };
+    }
+  }
+
+  for (const [recordingId, recording] of Object.entries(project.recordings ?? {})) {
+    const fileName =
+      recording.audio.fileName ??
+      `${recording.id}.${assetFileUtils.getAssetFileExtension(recording.audio.mimeType)}`;
+    const blob = await objectUrlToBlob(recording.audio, requestFetch);
+    if (blob) {
+      const audioForMirror: TranscriptRecordingAudio = {
+        ...recording.audio,
+        fileName,
+        storage: 'file',
+      };
+      delete audioForMirror.objectUrl;
+      projectForMirror.recordings![recordingId] = {
+        ...recording,
+        audio: audioForMirror,
+      };
+      files.push(await createFileEntry(`recordings/${fileName}`, blob));
+    } else {
+      projectForMirror.recordings![recordingId] = { ...recording };
     }
   }
 

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -72,6 +72,7 @@ const LEGACY_LOCAL_MINIO_CREDENTIALS = {
 } as const;
 
 const DELETE_BATCH_SIZE = 25;
+const MIRROR_UPLOAD_CONCURRENCY = 3;
 
 function getProjectMirrorKey(projectName: string) {
   return projectName.trim().replace(/[\\/]+/g, '-');
@@ -157,6 +158,24 @@ function chunkArray<T>(items: T[], size: number) {
   return chunks;
 }
 
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>,
+) {
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex];
+        nextIndex += 1;
+        if (item) await task(item);
+      }
+    }),
+  );
+}
+
 class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
   private readonly requestFetch: typeof fetch;
   private readonly now: () => Date;
@@ -202,7 +221,10 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
       total: totalFiles,
     });
 
-    for (const file of files) {
+    const manifestFile = files.find((file) => file.path === minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME);
+    const contentFiles = files.filter((file) => file.path !== minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME);
+
+    const syncFile = async (file: MirrorFile) => {
       options?.onProgress?.({
         current: completedFiles,
         label: `Mirroring ${file.path}`,
@@ -218,6 +240,12 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
         label: `Mirrored ${file.path}`,
         total: totalFiles,
       });
+    };
+
+    await runWithConcurrency(contentFiles, MIRROR_UPLOAD_CONCURRENCY, syncFile);
+
+    if (manifestFile) {
+      await syncFile(manifestFile);
     }
 
     return {

--- a/apps/editor/src/services/sharing/shareService.ts
+++ b/apps/editor/src/services/sharing/shareService.ts
@@ -1,14 +1,19 @@
 import { publicBasePath } from '../../app/routing/publicBasePath';
 import { collectReferencedAssetIds } from '../../domain/assets/assetUsage';
 import type { ProjectDocument } from '../../domain/documents/model';
-import type { ShareMetadata, ShareRecord, ShareService } from '../contracts/interfaces';
+import type {
+  ShareMetadata,
+  SharePublishOptions,
+  ShareRecord,
+  ShareService,
+} from '../contracts/interfaces';
 import { minioMirrorService } from '../mirror/minioMirrorService';
 import type { MinioMirrorConfig } from '../mirror/minioMirrorService';
 import { assetFileUtils } from '../storage/assetFileUtils';
 import { storageObjectUtils } from '../storage/storageObjectUtils';
 
 const PUBLIC_STORAGE_UNAVAILABLE_MESSAGE = 'Public sharing requires active external storage.';
-const SHARE_FILE_NAME = 'share.json';
+const SHARE_POINTER_FILE_EXTENSION = 'json';
 
 interface BrowserShareServiceOptions {
   basePath?: string;
@@ -19,6 +24,11 @@ interface BrowserShareServiceOptions {
 
 interface PublicSharePayload extends ShareRecord {
   schemaVersion: 1;
+}
+
+interface ShareProgressReporter {
+  active(label: string): void;
+  complete(label: string): void;
 }
 
 function getDefaultOrigin() {
@@ -44,16 +54,28 @@ function getProjectShareId(project: ProjectDocument) {
   return `project-${normalizedProjectId}`;
 }
 
+function getProjectMirrorKey(projectName: string) {
+  return projectName.trim().replace(/[\\/]+/g, '-');
+}
+
 function cloneProject(project: ProjectDocument): ProjectDocument {
   return JSON.parse(JSON.stringify(project)) as ProjectDocument;
 }
 
-function getShareRootKey(config: MinioMirrorConfig, shareId: string) {
-  return storageObjectUtils.joinObjectKey(storageObjectUtils.normalizeObjectKeyPart(config.prefix), 'public-shares', shareId);
+function getMirrorFileKey(config: MinioMirrorConfig, projectName: string, path: string) {
+  return storageObjectUtils.joinObjectKey(
+    storageObjectUtils.normalizeObjectKeyPart(config.prefix),
+    getProjectMirrorKey(projectName),
+    path,
+  );
 }
 
-function getShareFileKey(config: MinioMirrorConfig, shareId: string) {
-  return storageObjectUtils.joinObjectKey(getShareRootKey(config, shareId), SHARE_FILE_NAME);
+function getSharePointerFileKey(config: MinioMirrorConfig, shareId: string) {
+  return storageObjectUtils.joinObjectKey(
+    storageObjectUtils.normalizeObjectKeyPart(config.prefix),
+    'shares',
+    `${shareId}.${SHARE_POINTER_FILE_EXTENSION}`,
+  );
 }
 
 function publicViewerUrl(origin: string, basePath: string, route: 'share' | 'embed', shareId: string, shareUrl: string) {
@@ -71,6 +93,28 @@ function escapeHtmlAttribute(value: string) {
     .replaceAll('>', '&gt;');
 }
 
+function createShareProgressReporter(total: number, options?: SharePublishOptions): ShareProgressReporter {
+  let current = 0;
+  const safeTotal = Math.max(1, total);
+
+  function emit(label: string) {
+    options?.onProgress?.({ current, total: safeTotal, label });
+  }
+
+  return {
+    active: emit,
+    complete(label: string) {
+      current = Math.min(safeTotal, current + 1);
+      emit(label);
+    },
+  };
+}
+
+function shouldUseMirroredObjectUrl(storage: 'inline' | 'file' | 'remote' | undefined, objectUrl: string | undefined) {
+  if (storage === 'remote') return false;
+  return storage === 'file' || assetFileUtils.isReadableObjectUrl(objectUrl);
+}
+
 export class BrowserShareService implements ShareService {
   private readonly basePath: string;
   private readonly fetchImpl: typeof fetch | undefined;
@@ -84,12 +128,16 @@ export class BrowserShareService implements ShareService {
     this.origin = options.origin ?? getDefaultOrigin();
   }
 
-  async createShare(project: ProjectDocument): Promise<ShareMetadata> {
-    return this.publishShare(getProjectShareId(project), project);
+  async createShare(project: ProjectDocument, options?: SharePublishOptions): Promise<ShareMetadata> {
+    return this.publishShare(getProjectShareId(project), project, options);
   }
 
-  async updateShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata> {
-    return this.publishShare(shareId, project);
+  async updateShare(
+    shareId: string,
+    project: ProjectDocument,
+    options?: SharePublishOptions,
+  ): Promise<ShareMetadata> {
+    return this.publishShare(shareId, project, options);
   }
 
   async getShare(shareId: string): Promise<ShareRecord | null> {
@@ -117,14 +165,14 @@ export class BrowserShareService implements ShareService {
   getPublicUrl(shareId: string): string {
     const config = this.mirrorService.loadConfig();
     if (!config) return publicViewerUrl(this.origin, this.basePath, 'share', shareId, '');
-    const shareUrl = this.mirrorService.getPublicObjectUrl(getShareFileKey(config, shareId), config);
+    const shareUrl = this.mirrorService.getPublicObjectUrl(getSharePointerFileKey(config, shareId), config);
     return publicViewerUrl(this.origin, this.basePath, 'share', shareId, shareUrl);
   }
 
   getEmbedUrl(shareId: string): string {
     const config = this.mirrorService.loadConfig();
     if (!config) return publicViewerUrl(this.origin, this.basePath, 'embed', shareId, '');
-    const shareUrl = this.mirrorService.getPublicObjectUrl(getShareFileKey(config, shareId), config);
+    const shareUrl = this.mirrorService.getPublicObjectUrl(getSharePointerFileKey(config, shareId), config);
     return publicViewerUrl(this.origin, this.basePath, 'embed', shareId, shareUrl);
   }
 
@@ -149,12 +197,18 @@ export class BrowserShareService implements ShareService {
     return new URL(window.location.href).searchParams.get('src') ?? undefined;
   }
 
-  private async publishShare(shareId: string, project: ProjectDocument): Promise<ShareMetadata> {
+  private async publishShare(
+    shareId: string,
+    project: ProjectDocument,
+    options?: SharePublishOptions,
+  ): Promise<ShareMetadata> {
     const config = this.mirrorService.loadConfig();
     if (!config) throw new Error(PUBLIC_STORAGE_UNAVAILABLE_MESSAGE);
 
     const now = new Date().toISOString();
-    const projectForShare = await this.createPublicProject(project, config, shareId);
+    const progress = createShareProgressReporter(1, options);
+    progress.active('Preparing public share');
+    const projectForShare = this.createPublicProject(project, config);
     const payload: PublicSharePayload = {
       schemaVersion: 1,
       shareId,
@@ -162,68 +216,50 @@ export class BrowserShareService implements ShareService {
       updatedAt: now,
       project: projectForShare,
     };
-    await this.mirrorService.uploadPublicObject(getShareFileKey(config, shareId), storageObjectUtils.jsonBlob(payload), config);
+    progress.active('Publishing share link');
+    await this.mirrorService.uploadPublicObject(getSharePointerFileKey(config, shareId), storageObjectUtils.jsonBlob(payload), config);
+    progress.complete('Published share link');
     return this.toMetadata(payload, 'published');
   }
 
-  private async createPublicProject(
+  private createPublicProject(
     project: ProjectDocument,
     config: MinioMirrorConfig,
-    shareId: string,
-  ): Promise<ProjectDocument> {
+  ): ProjectDocument {
     const projectForShare = cloneProject(project);
     const referencedAssetIds = collectReferencedAssetIds(projectForShare);
 
-    await Promise.all(
-      Object.entries(projectForShare.assets).map(async ([assetId, asset]) => {
-        if (!referencedAssetIds.has(assetId)) return;
-        const blob = await assetFileUtils.objectUrlToBlobIfReadable(asset.objectUrl, this.fetchImpl);
-        if (!blob) return;
-
-        const fileName = asset.fileName ?? `${asset.id}.${assetFileUtils.getAssetFileExtension(asset.mimeType)}`;
-        const key = storageObjectUtils.joinObjectKey(getShareRootKey(config, shareId), 'assets', fileName);
-        await this.mirrorService.uploadPublicObject(key, blob, config);
+    for (const [assetId, asset] of Object.entries(projectForShare.assets)) {
+      if (!referencedAssetIds.has(assetId)) continue;
+      const fileName = asset.fileName ?? `${asset.id}.${assetFileUtils.getAssetFileExtension(asset.mimeType)}`;
+      if (shouldUseMirroredObjectUrl(asset.storage, asset.objectUrl)) {
+        const key = getMirrorFileKey(config, project.name, `assets/${fileName}`);
         projectForShare.assets[assetId] = {
           ...asset,
           objectUrl: this.mirrorService.getPublicObjectUrl(key, config),
           storage: 'remote',
           fileName,
         };
-      }),
-    );
+      }
+    }
 
-    await Promise.all(
-      Object.entries(projectForShare.fonts ?? {}).map(async ([fontId, font]) => {
-        const blob = await assetFileUtils.objectUrlToBlobIfReadable(font.objectUrl, this.fetchImpl);
-        if (!blob) return;
-
-        const key = storageObjectUtils.joinObjectKey(getShareRootKey(config, shareId), 'fonts', font.fileName);
-        await this.mirrorService.uploadPublicObject(key, blob, config);
+    for (const [fontId, font] of Object.entries(projectForShare.fonts ?? {})) {
+      if (shouldUseMirroredObjectUrl(font.storage, font.objectUrl)) {
+        const key = getMirrorFileKey(config, project.name, `fonts/${font.fileName}`);
         projectForShare.fonts![fontId] = {
           ...font,
           objectUrl: this.mirrorService.getPublicObjectUrl(key, config),
           storage: 'remote',
         };
-      }),
-    );
+      }
+    }
 
-    await Promise.all(
-      Object.entries(projectForShare.recordings ?? {}).map(async ([recordingId, recording]) => {
-        const blob = await assetFileUtils.objectUrlToBlobIfReadable(
-          recording.audio.objectUrl,
-          this.fetchImpl,
-        );
-        if (!blob) return;
-
-        const fileName =
-          recording.audio.fileName ??
-          `${recording.id}.${assetFileUtils.getAssetFileExtension(recording.audio.mimeType)}`;
-        const key = storageObjectUtils.joinObjectKey(
-          getShareRootKey(config, shareId),
-          'recordings',
-          fileName,
-        );
-        await this.mirrorService.uploadPublicObject(key, blob, config);
+    for (const [recordingId, recording] of Object.entries(projectForShare.recordings ?? {})) {
+      const fileName =
+        recording.audio.fileName ??
+        `${recording.id}.${assetFileUtils.getAssetFileExtension(recording.audio.mimeType)}`;
+      if (shouldUseMirroredObjectUrl(recording.audio.storage, recording.audio.objectUrl)) {
+        const key = getMirrorFileKey(config, project.name, `recordings/${fileName}`);
         projectForShare.recordings![recordingId] = {
           ...recording,
           audio: {
@@ -233,8 +269,8 @@ export class BrowserShareService implements ShareService {
             storage: 'remote',
           },
         };
-      }),
-    );
+      }
+    }
 
     return projectForShare;
   }

--- a/apps/editor/src/ui/e2e/E2ECoverageDiagnosticsPage.tsx
+++ b/apps/editor/src/ui/e2e/E2ECoverageDiagnosticsPage.tsx
@@ -348,7 +348,11 @@ function E2EDiagnosticsComponentGallery() {
                 status: 'syncing',
               }
         }
-        shareProgressLabel={shareCopyMode === 'ready' ? undefined : 'Preparing public link'}
+        shareProgress={
+          shareCopyMode === 'ready'
+            ? undefined
+            : { current: 1, total: 3, label: 'Preparing public link' }
+        }
         onClose={() => setShellDiagnostics('share-close')}
         onConfigurePublicLink={() => setShareCopyMode('ready')}
         onCopyLink={async (recordingId) => ({

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type Konva from 'konva';
 import type { AppServices } from '../../../app/composition';
+import type { ProjectDocument } from '../../../domain/documents/model';
 import { pageVisibility } from '../../../domain/documents/pageVisibility';
-import type { ShareMetadata } from '../../../services/contracts/interfaces';
+import type {
+  ShareMetadata,
+  SharePublishProgress,
+} from '../../../services/contracts/interfaces';
 import { editorAutomationController } from '../../../services/automation/editorAutomationController';
 import type { EditorAutomationDelegate } from '../../../services/automation/editorAutomationController';
 import {
@@ -59,6 +63,10 @@ function isMobileEditorViewport() {
   if (typeof window === 'undefined' || !window.matchMedia) return false;
   if (editorShellBrowserUtils.isWebMcpEnabled()) return false;
   return window.matchMedia(editorMobileViewportQuery).matches;
+}
+
+function getProjectPublishSignature(project: ProjectDocument) {
+  return `${project.id}:${project.updatedAt}`;
 }
 
 export function EditorShell({ services }: EditorShellProps) {
@@ -125,6 +133,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const [isExportingImages, setIsExportingImages] = useState(false);
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
   const [shareMetadata, setShareMetadata] = useState<ShareMetadata | undefined>();
+  const [sharePublishProgress, setSharePublishProgress] = useState<SharePublishProgress | undefined>();
   const stageRef = useRef<Konva.Stage>(null);
   const imageExportStageRef = useRef<Konva.Stage>(null);
   const workspaceRef = useRef<HTMLElement>(null);
@@ -135,6 +144,11 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const imageExportNoticeTimeoutRef = useRef<number | undefined>(undefined);
   const presenterFullscreenEnteredRef = useRef(false);
   const pendingShareAfterLocalSaveRef = useRef(false);
+  const lastPublishedShareSelectionRef = useRef<{
+    projectSignature: string;
+    selectedRecordingId?: string | undefined;
+    shareId: string;
+  } | undefined>(undefined);
   const sharePublishPromiseRef = useRef<{
     promise: Promise<ShareMetadata>;
     selectedRecordingId?: string | undefined;
@@ -189,11 +203,19 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       return services.shareService.updateShare(
         shareId,
         createProjectForSelectedShareRecording(fontResult.project, selectedRecordingId),
+        {
+          onProgress: setSharePublishProgress,
+        },
       );
     })();
     sharePublishPromiseRef.current = { promise: publishPromise, selectedRecordingId };
     try {
       const nextShare = await publishPromise;
+      lastPublishedShareSelectionRef.current = {
+        projectSignature: getProjectPublishSignature(vm.project),
+        selectedRecordingId,
+        shareId: nextShare.shareId,
+      };
       setShareMetadata(nextShare);
       return nextShare;
     } catch (error) {
@@ -203,8 +225,38 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       if (sharePublishPromiseRef.current?.promise === publishPromise) {
         sharePublishPromiseRef.current = undefined;
       }
+      setSharePublishProgress(undefined);
     }
   }, [services.shareService, shareMetadata?.shareId, vm.project]);
+
+  function getReusablePublishedShare(
+    share: ShareMetadata | undefined,
+    selectedRecordingId: string | undefined,
+  ): ShareMetadata | undefined {
+    if (!share || (share.status !== 'published' && share.status !== 'copied')) return undefined;
+    const lastPublishedShareSelection = lastPublishedShareSelectionRef.current;
+    if (
+      lastPublishedShareSelection?.shareId === share.shareId &&
+      lastPublishedShareSelection.selectedRecordingId === selectedRecordingId
+    ) {
+      return share;
+    }
+    return undefined;
+  }
+
+  const hasPublishedCurrentProjectShare = useCallback((
+    share: ShareMetadata | undefined,
+    selectedRecordingId: string | undefined,
+    project: ProjectDocument,
+  ) => {
+    if (!share || (share.status !== 'published' && share.status !== 'copied')) return false;
+    const lastPublishedShareSelection = lastPublishedShareSelectionRef.current;
+    return (
+      lastPublishedShareSelection?.shareId === share.shareId &&
+      lastPublishedShareSelection.selectedRecordingId === selectedRecordingId &&
+      lastPublishedShareSelection.projectSignature === getProjectPublishSignature(project)
+    );
+  }, []);
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -308,7 +360,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   }
 
   async function copyPublicShareLink(selectedRecordingId?: string) {
-    const preparedShare = await publishCurrentProjectShare(selectedRecordingId);
+    const preparedShare =
+      getReusablePublishedShare(shareMetadata, selectedRecordingId) ??
+      (await publishCurrentProjectShare(selectedRecordingId));
     const copiedShare: ShareMetadata = { ...preparedShare, status: 'copied' };
     setShareMetadata(copiedShare);
     copyShareText(copiedShare.publicUrl);
@@ -1169,13 +1223,17 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         window.clearTimeout(timeoutId);
       };
     }
+    if (!shareMetadata?.shareId) return undefined;
+    if (hasPublishedCurrentProjectShare(shareMetadata, undefined, vm.project)) return undefined;
     void publishCurrentProjectShare().catch(() => undefined);
     return undefined;
   }, [
+    hasPublishedCurrentProjectShare,
     publishCurrentProjectShare,
     publicSharingAvailable,
-    shareMetadata?.shareId,
+    shareMetadata,
     vm.mirrorState.status,
+    vm.project,
   ]);
 
   return (
@@ -1488,6 +1546,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           projectName={vm.project.name}
           recordingOptions={shareRecordingOptions}
           share={shareMetadata}
+          shareProgress={sharePublishProgress}
           onClose={() => {
             setSharePanelOpen(false);
           }}

--- a/apps/editor/src/ui/share/SharePanel.tsx
+++ b/apps/editor/src/ui/share/SharePanel.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
-import type { ShareMetadata } from '../../services/contracts/interfaces';
+import type {
+  ShareMetadata,
+  SharePublishProgress,
+} from '../../services/contracts/interfaces';
 import { copyShareText } from './shareClipboard';
 
 export interface ShareRecordingOption {
@@ -13,7 +16,7 @@ interface SharePanelProps {
   recordingOptions?: ShareRecordingOption[] | undefined;
   share?: ShareMetadata | undefined;
   publicLinkUnavailableReason?: string | undefined;
-  shareProgressLabel?: string | undefined;
+  shareProgress?: SharePublishProgress | undefined;
   onClose: () => void;
   onConfigurePublicLink?: () => void;
   onCopyLink: (selectedRecordingId?: string) => Promise<ShareMetadata>;
@@ -35,7 +38,7 @@ export function SharePanel({
   recordingOptions = [],
   share,
   publicLinkUnavailableReason,
-  shareProgressLabel,
+  shareProgress,
   onClose,
   onConfigurePublicLink,
   onCopyLink,
@@ -50,9 +53,12 @@ export function SharePanel({
   const currentShare = share ?? lastCopiedShare;
   const publicLinkUnavailable = Boolean(publicLinkUnavailableReason);
   const statusLabel = getStatusLabel(currentShare, isCopying);
+  const progressPercent = shareProgress
+    ? Math.round((shareProgress.current / shareProgress.total) * 100)
+    : 0;
   const shareAccessDescription =
     copyError ??
-    shareProgressLabel ??
+    shareProgress?.label ??
     publicLinkUnavailableReason ??
     (currentShare
       ? 'Unlisted: anyone with the link can view.'
@@ -102,6 +108,18 @@ export function SharePanel({
       <section className="share-access-block" aria-label="Share access">
         <span className="share-status-pill">{copyError ? 'Share failed' : statusLabel}</span>
         <p>{shareAccessDescription}</p>
+        {shareProgress ? (
+          <div
+            className="share-publish-progress"
+            role="progressbar"
+            aria-label="Share publish progress"
+            aria-valuemin={0}
+            aria-valuemax={shareProgress.total}
+            aria-valuenow={shareProgress.current}
+          >
+            <span style={{ width: `${progressPercent}%` }} />
+          </div>
+        ) : null}
         <p className="share-access-note">
           Public links should use a read-only storage key so viewers cannot write or modify
           presentations.

--- a/apps/editor/src/ui/styles/share-panel.css
+++ b/apps/editor/src/ui/styles/share-panel.css
@@ -49,6 +49,22 @@
   font-weight: 700;
 }
 
+.share-publish-progress {
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+  background: #d9dee7;
+  border-radius: 999px;
+}
+
+.share-publish-progress span {
+  display: block;
+  height: 100%;
+  background: var(--ew-green);
+  border-radius: inherit;
+  transition: width 160ms ease;
+}
+
 .share-copy-link-button {
   min-height: 42px;
   display: inline-flex;

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -154,6 +154,60 @@ describe('minioMirrorService.createMirrorFiles', () => {
       storage: 'file',
     });
   });
+
+  it('includes presenter recording audio files in mirror payloads', async () => {
+    const project: ProjectDocument = {
+      ...sampleProject.createSampleProject(),
+      recordings: {
+        recording1: {
+          id: 'recording1',
+          name: 'Presenter recording',
+          createdAt: '2026-07-18T12:00:00.000Z',
+          updatedAt: '2026-07-18T12:00:00.000Z',
+          durationMs: 2400,
+          language: 'en',
+          modelPresetId: 'web-speech-api',
+          audio: {
+            mimeType: 'audio/webm;codecs=opus',
+            objectUrl: 'data:audio/webm;base64,YXVkaW8=',
+            storage: 'inline',
+          },
+          segments: [
+            {
+              id: 'segment1',
+              text: 'Mirrored transcript audio.',
+              startMs: 0,
+              endMs: 2400,
+              final: true,
+            },
+          ],
+        },
+      },
+    };
+
+    const files = await minioMirrorService.createMirrorFiles(
+      project,
+      new VersionedRepository([], project),
+      config,
+    );
+
+    expect(files.map((file) => file.path)).toContain('recordings/recording1.webm');
+    const projectJson = JSON.parse(
+      await files.find((file) => file.path === 'project.json')!.blob.text(),
+    ) as ProjectDocument;
+    expect(projectJson.recordings?.recording1).toMatchObject({
+      audio: {
+        fileName: 'recording1.webm',
+        storage: 'file',
+      },
+      segments: [
+        {
+          text: 'Mirrored transcript audio.',
+        },
+      ],
+    });
+    expect(projectJson.recordings?.recording1?.audio.objectUrl).toBeUndefined();
+  });
 });
 
 describe('minioMirrorService.MinioMirrorService', () => {

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -66,6 +66,39 @@ function getAuthorizationCredential(init: RequestInit | undefined) {
   return headers?.authorization?.match(/Credential=([^/]+)/)?.[1];
 }
 
+function createProjectWithInlineMirrorAssets(assetCount: number): ProjectDocument {
+  const project = sampleProject.createSampleProject();
+  const firstPage = project.pages[0];
+  if (!firstPage) throw new Error('Sample project must contain a page.');
+  for (let index = 0; index < assetCount; index += 1) {
+    const assetId = `parallel-asset-${index}`;
+    project.assets[assetId] = {
+      id: assetId,
+      type: 'image',
+      mimeType: 'image/png',
+      name: `Parallel asset ${index}`,
+      objectUrl: 'data:image/png;base64,aW1hZ2U=',
+      storage: 'inline',
+    };
+    const elementId = `parallel-image-${index}`;
+    project.elements[elementId] = {
+      id: elementId,
+      type: 'image',
+      assetId,
+      x: 40 + index,
+      y: 60 + index,
+      width: 120,
+      height: 80,
+      rotation: 0,
+      opacity: 1,
+      locked: false,
+      visible: true,
+    };
+    firstPage.elementIds.push(elementId);
+  }
+  return project;
+}
+
 describe('minioMirrorService.createMirrorFiles', () => {
   it('creates a complete portable project mirror payload', async () => {
     const project = sampleProject.createSampleProject();
@@ -403,6 +436,40 @@ describe('minioMirrorService.MinioMirrorService', () => {
     if (!finalProgress) throw new Error('Expected mirror progress updates.');
     expect(finalProgress.current).toBe(finalProgress.total);
     expect(finalProgress.label).toContain('Mirrored ');
+  });
+
+  it('uploads changed mirror content files in bounded parallel and commits the manifest last', async () => {
+    const project = createProjectWithInlineMirrorAssets(5);
+    let activePuts = 0;
+    let maxActivePuts = 0;
+    const putOrder: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return new Response('', { status: 404 });
+      }
+      if (init?.method === 'PUT') {
+        activePuts += 1;
+        maxActivePuts = Math.max(maxActivePuts, activePuts);
+        await new Promise((resolve) => {
+          setTimeout(resolve, url.endsWith('localstudio-mirror.json') ? 0 : 10);
+        });
+        activePuts -= 1;
+        putOrder.push(url);
+        return new Response('', { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+    const service = new minioMirrorService.MinioMirrorService({
+      fetch: fetchMock,
+      now: () => new Date('2026-06-30T10:00:00.000Z'),
+    });
+
+    await service.syncProject(project, new VersionedRepository([], project), config);
+
+    expect(maxActivePuts).toBeGreaterThan(1);
+    expect(maxActivePuts).toBeLessThanOrEqual(3);
+    expect(putOrder.at(-1)).toContain('localstudio-mirror.json');
   });
 
   it('uses writer credentials when sync checks and uploads mirror files', async () => {

--- a/apps/editor/tests/unit/services/shareService.test.ts
+++ b/apps/editor/tests/unit/services/shareService.test.ts
@@ -109,8 +109,9 @@ describe('BrowserShareService', () => {
     window.localStorage.clear();
   });
 
-  it('publishes a public share payload and local assets to MinIO', async () => {
+  it('publishes a mirror-backed public share payload without re-uploading assets', async () => {
     const uploadedBodies = new Map<string, Blob>();
+    const progressEvents: Array<{ current: number; total: number; label: string }> = [];
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = getRequestUrl(input);
       if (init?.method === 'GET') {
@@ -129,31 +130,28 @@ describe('BrowserShareService', () => {
       origin: 'https://localstudio.test',
     });
 
-    const share = await service.createShare(createProjectWithInlineAsset());
+    const share = await service.createShare(createProjectWithInlineAsset(), {
+      onProgress: (progress) => progressEvents.push(progress),
+    });
 
     expect(share.shareId).toBe('project-project-1');
     const publicUrl = new URL(share.publicUrl);
     expect(publicUrl.pathname).toBe('/editor/');
     expect(publicUrl.searchParams.get('share')).toBe('project-project-1');
     expect(publicUrl.searchParams.get('src')).toBe(
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
+      'http://localhost:9000/localstudio/mirrors/shares/project-project-1.json',
     );
     expect(share.embedHtml).toContain('/editor/?embed=project-project-1');
     expect(share.embedHtml).toContain('src=');
 
     const putUrls = Array.from(uploadedBodies.keys());
-    expect(putUrls).toContain(
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/assets/asset-inline.png',
-    );
-    expect(putUrls).toContain(
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
-    );
+    expect(putUrls).toEqual([
+      'http://localhost:9000/localstudio/mirrors/shares/project-project-1.json',
+    ]);
 
     const sharePayload = JSON.parse(
       await uploadedBodies
-        .get(
-          'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
-        )!
+        .get('http://localhost:9000/localstudio/mirrors/shares/project-project-1.json')!
         .text(),
     ) as unknown as PublicSharePayloadFixture;
     expect(sharePayload).toMatchObject({
@@ -164,15 +162,20 @@ describe('BrowserShareService', () => {
         assets: {
           'asset-inline': {
             objectUrl:
-              'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/assets/asset-inline.png',
+              'http://localhost:9000/localstudio/mirrors/Untitled%20AI%20Deck/assets/asset-inline.png',
             storage: 'remote',
           },
         },
       },
     });
+    expect(progressEvents).toEqual([
+      { current: 0, total: 1, label: 'Preparing public share' },
+      { current: 0, total: 1, label: 'Publishing share link' },
+      { current: 1, total: 1, label: 'Published share link' },
+    ]);
   });
 
-  it('publishes project fonts as public remote font files', async () => {
+  it('maps public font URLs to existing mirror files', async () => {
     const uploadedBodies = new Map<string, Blob>();
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'PUT') {
@@ -191,10 +194,9 @@ describe('BrowserShareService', () => {
     await service.createShare(createProjectWithInlineFont());
 
     const fontUrl =
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/fonts/acme-sans.woff2';
-    const shareUrl =
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json';
-    expect(Array.from(uploadedBodies.keys())).toContain(fontUrl);
+      'http://localhost:9000/localstudio/mirrors/Untitled%20AI%20Deck/fonts/acme-sans.woff2';
+    const shareUrl = 'http://localhost:9000/localstudio/mirrors/shares/project-project-1.json';
+    expect(Array.from(uploadedBodies.keys())).toEqual([shareUrl]);
     const sharePayload = JSON.parse(await uploadedBodies.get(shareUrl)!.text()) as PublicSharePayloadFixture;
     expect(sharePayload.project.fonts?.acme).toMatchObject({
       objectUrl: fontUrl,
@@ -202,7 +204,7 @@ describe('BrowserShareService', () => {
     });
   });
 
-  it('publishes presenter recording audio and transcript data with public shares', async () => {
+  it('maps public recording audio URLs to existing mirror files with transcript data', async () => {
     const uploadedBodies = new Map<string, Blob>();
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.method === 'PUT') {
@@ -221,11 +223,9 @@ describe('BrowserShareService', () => {
     await service.createShare(createProjectWithRecording());
 
     const recordingUrl =
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/recordings/recording1.webm';
-    const shareUrl =
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json';
-    expect(Array.from(uploadedBodies.keys())).toContain(recordingUrl);
-    expect(await uploadedBodies.get(recordingUrl)!.text()).toBe('audio');
+      'http://localhost:9000/localstudio/mirrors/Untitled%20AI%20Deck/recordings/recording1.webm';
+    const shareUrl = 'http://localhost:9000/localstudio/mirrors/shares/project-project-1.json';
+    expect(Array.from(uploadedBodies.keys())).toEqual([shareUrl]);
     const sharePayload = JSON.parse(await uploadedBodies.get(shareUrl)!.text()) as PublicSharePayloadFixture;
     expect(sharePayload.project.recordings?.recording1).toMatchObject({
       audio: {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.export-share.test.tsx
@@ -384,13 +384,47 @@ describe('EditorShell export and share workflows', () => {
     const expectedPublicUrl = `${
       window.location.origin
     }/editor/s/project-project-1?src=${encodeURIComponent(
-      'http://localhost:9000/localstudio/mirrors/public-shares/project-project-1/share.json',
+      'http://localhost:9000/localstudio/mirrors/shares/project-project-1.json',
     )}`;
     expect(
       await screen.findByDisplayValue(expectedPublicUrl, undefined, { timeout: 3_000 }),
     ).toBeInTheDocument();
     expect(execCommand).toHaveBeenCalledWith('copy');
     expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('copies an already published public link without uploading the project again', async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+    const services = createAppServices();
+    const shareService = new RecordingShareService();
+    services.mirrorService = new RecordingMirrorService();
+    services.shareService = shareService;
+    services.projectRepository = new LoadingProjectRepository(sampleProject.createSampleProject());
+    services.persistenceAvailable = true;
+    services.skipStoredProjectLoad = false;
+
+    render(<EditorShell services={services} />);
+
+    await waitForShareButtonReady();
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Copied')).toBeInTheDocument();
+    });
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(shareService.updateShare).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledTimes(2);
+    });
+    expect(shareService.updateShare).toHaveBeenCalledTimes(1);
   });
 
   it('publishes only the selected presenter recording from the share panel', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
@@ -192,13 +192,13 @@ class RecordingShareService implements ShareService {
 
   getPublicUrl(shareId: string): string {
     return `${this.origin}/editor/s/${shareId}?src=${encodeURIComponent(
-      `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`,
+      `http://localhost:9000/localstudio/mirrors/shares/${shareId}.json`,
     )}`;
   }
 
   getEmbedUrl(shareId: string): string {
     return `${this.origin}/editor/embed/${shareId}?src=${encodeURIComponent(
-      `http://localhost:9000/localstudio/mirrors/public-shares/${shareId}/share.json`,
+      `http://localhost:9000/localstudio/mirrors/shares/${shareId}.json`,
     )}`;
   }
 

--- a/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
+++ b/apps/editor/tests/unit/ui/share/SharePanel.test.tsx
@@ -121,6 +121,25 @@ describe('SharePanel', () => {
     expect(screen.getByText('Copied')).toBeInTheDocument();
   });
 
+  it('shows publish progress while the public link is syncing', () => {
+    render(
+      <SharePanel
+        projectName="Untitled AI Deck"
+        share={createShareMetadata({ status: 'syncing' })}
+        shareProgress={{ current: 2, total: 5, label: 'Uploading media5.mp4' }}
+        onClose={vi.fn()}
+        onCopyLink={vi.fn()}
+        onDownload={vi.fn()}
+        onPresent={vi.fn()}
+      />,
+    );
+
+    const progress = screen.getByRole('progressbar', { name: 'Share publish progress' });
+    expect(screen.getByText('Uploading media5.mp4')).toBeInTheDocument();
+    expect(progress).toHaveAttribute('aria-valuenow', '2');
+    expect(progress).toHaveAttribute('aria-valuemax', '5');
+  });
+
   it('lets speakers choose which saved recording is published with the public link', async () => {
     const user = userEvent.setup();
     const onCopyLink = vi.fn().mockResolvedValue(createShareMetadata({ status: 'copied' }));

--- a/tests/e2e/editor/local-font-mirror-settings.spec.ts
+++ b/tests/e2e/editor/local-font-mirror-settings.spec.ts
@@ -79,12 +79,12 @@ test.describe('local font mirror settings', () => {
 
     const storedKeys = Array.from(storedObjects.keys());
     const mirroredFontKey = storedKeys.find(
-      (key) => key.includes('/public-shares/') && key.includes('/fonts/font-acme-sans-'),
+      (key) => key.includes('/fonts/font-acme-sans-'),
     );
-    expect(mirroredFontKey).toMatch(/public-shares\/.+\/fonts\/font-acme-sans-\d+-acmesans-regular-woff2\.woff2$/);
+    expect(mirroredFontKey).toMatch(/mirrors\/.+\/fonts\/font-acme-sans-\d+-acmesans-regular-woff2\.woff2$/);
     expect(storedKeys.some((key) => key.includes('/fonts/uploaded-font-'))).toBe(false);
 
-    const shareKey = storedKeys.find((key) => key.endsWith('/share.json'));
+    const shareKey = storedKeys.find((key) => key.match(/\/shares\/.+\.json$/));
     expect(shareKey).toBeTruthy();
     const sharePayload = JSON.parse(storedObjects.get(shareKey!)!.body.toString()) as {
       project: { fonts?: Record<string, { fileName: string; objectUrl: string; storage: string }> };


### PR DESCRIPTION
## Summary
- Add share publishing progress callbacks and a visual progress bar.
- Reuse project mirror assets instead of re-uploading them during share creation.
- Mirror presenter recording audio and publish share pointer files under stable project-based paths.
- Avoid unnecessary republishing when the current project share is already up to date.
- Update unit coverage for recording mirroring, progress events, and share URLs.

## Testing
- Updated unit tests for mirror file generation and browser share publishing.