### PR TITLE
Enable WebMCP by default with safe registration cleanup

### DIFF
--- a/apps/editor/src/services/webmcp/webMcpToolAdapter.ts
+++ b/apps/editor/src/services/webmcp/webMcpToolAdapter.ts
@@ -66,6 +66,19 @@ function translateInput(input: ToolInput): TranslateTextAutomationInput {
   };
 }
 
+function isCleanupCallback(value: unknown): value is () => void {
+  return typeof value === 'function';
+}
+
+function isDuplicateToolNameError(error: unknown) {
+  if (!(error instanceof DOMException || error instanceof Error)) return false;
+  return error.name === 'InvalidStateError' && error.message.includes('Duplicate tool name');
+}
+
+function collectCleanup(cleanups: Array<() => void>, value: unknown) {
+  if (isCleanupCallback(value)) cleanups.push(value);
+}
+
 export class WebMcpToolAdapter {
   constructor(private readonly controller: ControllerLike) {}
 
@@ -137,12 +150,25 @@ export class WebMcpToolAdapter {
 
   register(modelContext: WebMcpModelContext): () => void {
     const tools = this.createTools();
+    const cleanups: Array<() => void> = [];
     if (modelContext.registerTools) {
-      modelContext.registerTools(tools);
+      try {
+        collectCleanup(cleanups, modelContext.registerTools(tools));
+      } catch (error) {
+        if (!isDuplicateToolNameError(error)) throw error;
+      }
     } else {
-      tools.forEach((tool) => modelContext.registerTool?.(tool));
+      tools.forEach((tool) => {
+        try {
+          collectCleanup(cleanups, modelContext.registerTool?.(tool));
+        } catch (error) {
+          if (!isDuplicateToolNameError(error)) throw error;
+        }
+      });
     }
 
-    return () => undefined;
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
   }
 }

--- a/apps/editor/src/ui/editor/browser/editorShellBrowserUtils.ts
+++ b/apps/editor/src/ui/editor/browser/editorShellBrowserUtils.ts
@@ -55,6 +55,11 @@ function isWebMcpEnabled() {
   return new URL(window.location.href).searchParams.get('webmcp') === '1';
 }
 
+function isWebMcpProtocolEnabled() {
+  if (typeof window === 'undefined') return false;
+  return new URL(window.location.href).searchParams.get('webmcp') !== '0';
+}
+
 function getWebMcpModelContext() {
   if (typeof document === 'undefined') return undefined;
   return (document as Document & { modelContext?: WebMcpModelContext }).modelContext;
@@ -67,5 +72,6 @@ export const editorShellBrowserUtils = {
   hasEditorObjectClipboardMarker,
   writeEditorObjectClipboardMarker,
   isWebMcpEnabled,
+  isWebMcpProtocolEnabled,
   getWebMcpModelContext,
 };

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1128,7 +1128,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   }, [hasSelection, isHistoryReadOnly, vm]);
 
   useEffect(() => {
-    if (!editorShellBrowserUtils.isWebMcpEnabled()) return undefined;
+    if (!editorShellBrowserUtils.isWebMcpProtocolEnabled()) return undefined;
     const delegate: EditorAutomationDelegate = {
       createProject: (input) => automationDelegateRef.current.createProject(input),
       generateSlides: (input) => automationDelegateRef.current.generateSlides(input),

--- a/apps/editor/tests/unit/services/webMcpToolAdapter.test.ts
+++ b/apps/editor/tests/unit/services/webMcpToolAdapter.test.ts
@@ -2,15 +2,19 @@ import { promptRecipes } from '../../../src/ui/editor/prompting/promptRecipes';
 import { WebMcpToolAdapter, type WebMcpTool } from '../../../src/services/webmcp/webMcpToolAdapter';
 
 describe('WebMcpToolAdapter', () => {
-  it('registers discoverable WebMCP tools with prompt examples in metadata', () => {
-    const registerTools = vi.fn<(tools: WebMcpTool[]) => void>();
-    const adapter = new WebMcpToolAdapter({
+  function createAdapter() {
+    return new WebMcpToolAdapter({
       createProject: vi.fn(),
       generateSlides: vi.fn(),
       generateImage: vi.fn(),
       translateText: vi.fn(),
       getProjectSnapshot: vi.fn(),
     });
+  }
+
+  it('registers discoverable WebMCP tools with prompt examples in metadata', () => {
+    const registerTools = vi.fn<(tools: WebMcpTool[]) => void>();
+    const adapter = createAdapter();
 
     adapter.register({ registerTools });
 
@@ -27,6 +31,28 @@ describe('WebMcpToolAdapter', () => {
     const generateImageTool = tools.find((tool) => tool.name === 'generate_image');
     expect(generateSlidesTool?.description).toContain(promptRecipes.slidePromptExamples[0]);
     expect(generateImageTool?.description).toContain(promptRecipes.imagePromptExamples[0]);
+  });
+
+  it('runs WebMCP cleanup callbacks returned by the browser runtime', () => {
+    const cleanup = vi.fn();
+    const adapter = createAdapter();
+    const unregister = adapter.register({
+      registerTools: vi.fn(() => cleanup),
+    });
+
+    unregister();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores duplicate WebMCP tool registration errors from an existing runtime registration', () => {
+    const adapter = createAdapter();
+    const registerTool = vi.fn(() => {
+      throw new DOMException('Duplicate tool name', 'InvalidStateError');
+    });
+
+    expect(() => adapter.register({ registerTool })).not.toThrow();
+    expect(registerTool).toHaveBeenCalledTimes(5);
   });
 
   it('forwards tool calls to the automation controller', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test.tsx
@@ -40,9 +40,9 @@ describe('EditorShell', () => {
     vi.restoreAllMocks();
   });
 
-  it('registers WebMCP tools when explicitly enabled', async () => {
+  it('registers WebMCP tools by default', async () => {
     const registerTools = vi.fn<(tools: WebMcpTool[]) => void>();
-    window.history.pushState({}, '', '/editor/?webmcp=1');
+    window.history.pushState({}, '', '/editor/');
     Object.defineProperty(document, 'modelContext', {
       configurable: true,
       value: { registerTools },
@@ -63,8 +63,25 @@ describe('EditorShell', () => {
     ]);
   });
 
+  it('can disable WebMCP protocol registration from the editor URL', async () => {
+    const registerTools = vi.fn<(tools: WebMcpTool[]) => void>();
+    window.history.pushState({}, '', '/editor/?webmcp=0');
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: { registerTools },
+    });
+
+    render(<EditorShell services={createAppServices()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'LocalStudio.dev' })).toBeInTheDocument();
+    });
+    expect(registerTools).not.toHaveBeenCalled();
+    expect((window as WebMcpDemoWindow).localStudioWebMcpTools).toBeUndefined();
+  });
+
   it('exposes same-origin demo tools when WebMCP runtime is unavailable', async () => {
-    window.history.pushState({}, '', '/editor/?webmcp=1');
+    window.history.pushState({}, '', '/editor/');
 
     render(<EditorShell services={createAppServices()} />);
 


### PR DESCRIPTION
## Summary
- Enable WebMCP protocol registration by default, with `webmcp=0` opt-out.
- Handle duplicate tool registrations from existing browser runtimes.
- Run cleanup callbacks returned by WebMCP registration APIs.
- Add unit coverage for default enablement, opt-out, cleanup, and duplicates.

## Testing
- Added and updated unit tests for WebMCP adapter and editor shell behavior.