### PR TITLE
Add prompt model controls across editor and transcript experiences

### DIFF
--- a/apps/editor/src/services/presenter/presenterSessionTypes.ts
+++ b/apps/editor/src/services/presenter/presenterSessionTypes.ts
@@ -1,4 +1,8 @@
 import type { ProjectDocument, TranscriptRecording } from '../../domain/documents/model';
+import type {
+  ModelDownloadProgressDetails,
+  ModelStatus,
+} from '../contracts/interfaces';
 import type { AnimationPreviewState } from '../../ui/editor/animation/useAnimationPreviewController';
 import type {
   PresenterRemotePeerSession,
@@ -15,6 +19,23 @@ export type PresenterRemoteSessionMetadata = PresenterRemoteSession & {
 export interface PresenterStatePayload {
   activePageId: string;
   animationPreview: AnimationPreviewState | undefined;
+  promptModel?:
+    | {
+        options: Array<{
+          compatibility: 'compatible' | 'incompatible' | 'unknown';
+          id: string;
+          label: string;
+          modelId?: string | undefined;
+          readiness: ModelStatus;
+          selected: boolean;
+        }>;
+        preparation: ModelDownloadProgressDetails & {
+          availability: string;
+          progress: number;
+          status: 'idle' | 'downloading' | 'ready' | 'failed';
+        };
+      }
+    | undefined;
   project: ProjectDocument;
   presenterMode?: 'presenting' | 'ready' | undefined;
   remoteSession?: PresenterRemoteSessionMetadata | undefined;
@@ -24,14 +45,17 @@ export interface PresenterStatePayload {
 }
 
 export type PresenterWindowCommand =
+  | { command: 'cancel-prompt-model-download'; modelId: string }
   | { command: 'close' }
   | { command: 'go-to-page'; pageId: string }
   | { command: 'next' }
   | { command: 'pause-timer' }
   | { command: 'previous' }
+  | { command: 'prepare-prompt-api' }
   | { command: 'request-state' }
   | { command: 'reset-timer' }
   | { command: 'resume-timer' }
+  | { command: 'set-prompt-provider'; providerId: string }
   | { audioBlob?: Blob | undefined; command: 'save-recording'; recording: TranscriptRecording }
   | { command: 'start-presenting' }
   | { command: 'update-timer'; timer: PresenterRemoteTimerState }

--- a/apps/editor/src/services/prompting/browserPromptService.ts
+++ b/apps/editor/src/services/prompting/browserPromptService.ts
@@ -19,7 +19,11 @@ import { buildSlideElementPrompt } from './slideElementPrompt';
 import { slideLayoutPresets } from './slideLayoutPresets';
 import { slideTaskPrompt } from './slideTaskPrompt';
 import { webGpuTextGenerationRuntime } from './webGpuTextGenerationRuntime';
-import type { TextGenerationInput, TextGenerationRuntime } from './webGpuTextGenerationRuntime';
+import type {
+  TextGenerationInput,
+  TextGenerationOptions,
+  TextGenerationRuntime,
+} from './webGpuTextGenerationRuntime';
 
 const CHROME_PROMPT_PROVIDER_ID = 'chrome-prompt-api';
 const GEMMA_PROMPT_PROVIDER_ID = 'gemma-4-webgpu';
@@ -49,6 +53,18 @@ interface PromptProvider {
       existingElements: GeneratedSlideElement[];
     },
   ): Promise<GeneratedSlideElement>;
+  generateText(prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string>;
+}
+
+function formatChromePromptInput(prompt: TextGenerationInput) {
+  if (typeof prompt === 'string') return prompt;
+  return prompt
+    .map((message) => {
+      const content =
+        typeof message.content === 'string' ? message.content : JSON.stringify(message.content);
+      return `${message.role}: ${content}`;
+    })
+    .join('\n\n');
 }
 
 class ChromePromptProvider implements PromptProvider {
@@ -87,6 +103,10 @@ class ChromePromptProvider implements PromptProvider {
     },
   ): Promise<GeneratedSlideElement> {
     return this.chromePromptService.generateSlideElementFromTask(task, context);
+  }
+
+  generateText(prompt: TextGenerationInput): Promise<string> {
+    return this.chromePromptService.generateText(formatChromePromptInput(prompt));
   }
 }
 
@@ -238,6 +258,14 @@ class GemmaPromptProvider implements PromptProvider {
     });
   }
 
+  generateText(prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string> {
+    return this.runtimeClient.generate(
+      aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+      prompt,
+      options,
+    );
+  }
+
   private async generateStructuredJson<T>(options: GemmaStructuredJsonOptions<T>) {
     const response = await this.runtimeClient.generate(
       aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
@@ -366,6 +394,10 @@ class BrowserPromptService implements PromptService {
     },
   ): Promise<GeneratedSlideElement> {
     return this.getSelectedProvider().generateSlideElementFromTask(task, context);
+  }
+
+  generateText(prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string> {
+    return this.getSelectedProvider().generateText(prompt, options);
   }
 
   private getSelectedProvider() {

--- a/apps/editor/src/services/prompting/chromePromptService.ts
+++ b/apps/editor/src/services/prompting/chromePromptService.ts
@@ -131,14 +131,22 @@ export class ChromePromptService implements PromptService {
     );
   }
 
+  generateText(prompt: string): Promise<string> {
+    return this.promptText(prompt);
+  }
+
   private async promptWithStructuredOutput(prompt: string, responseConstraint: unknown) {
+    return this.promptText(prompt, { responseConstraint });
+  }
+
+  private async promptText(prompt: string, options?: { responseConstraint?: unknown }) {
     const languageModel = getLanguageModelApi();
     if (!languageModel?.create) throw new Error('Chrome Prompt API is unavailable.');
 
     const session = await languageModel.create();
     try {
       if (!session.prompt) throw new Error('Chrome Prompt API session cannot generate text.');
-      return await session.prompt(prompt, { responseConstraint });
+      return await session.prompt(prompt, options);
     } finally {
       session.destroy?.();
     }

--- a/apps/editor/src/services/transcription/transcriptQuestionAnsweringService.ts
+++ b/apps/editor/src/services/transcription/transcriptQuestionAnsweringService.ts
@@ -1,5 +1,8 @@
 import type { TranscriptRecording, TranscriptSegment } from '../../domain/documents/model';
-import type { TextGenerationRuntime } from '../prompting/webGpuTextGenerationRuntime';
+import type {
+  TextGenerationInput,
+  TextGenerationOptions,
+} from '../prompting/webGpuTextGenerationRuntime';
 import { TranscriptEmbeddingRuntimeClient } from './transcriptEmbeddingRuntimeClient';
 import type { TranscriptEmbeddingPreset } from './transcriptionModelCatalog';
 import { transcriptionModelCatalog } from './transcriptionModelCatalog';
@@ -28,8 +31,9 @@ interface TranscriptIndexEntry {
 interface TranscriptQuestionAnsweringServiceOptions {
   embeddingClient?: TranscriptEmbeddingRuntimeClient;
   embeddingPreset?: TranscriptEmbeddingPreset;
-  modelId?: string;
-  textGenerationRuntime: TextGenerationRuntime;
+  textGenerator: {
+    generate(prompt: TextGenerationInput, options?: TextGenerationOptions): Promise<string>;
+  };
 }
 
 function normalizeSegments(recordings: TranscriptRecording[]) {
@@ -70,7 +74,6 @@ function createPrompt(question: string, citations: TranscriptAnswerCitation[]) {
 export class TranscriptQuestionAnsweringService {
   private readonly embeddingClient: TranscriptEmbeddingRuntimeClient;
   private readonly embeddingPreset: TranscriptEmbeddingPreset;
-  private readonly modelId: string;
   private index: TranscriptIndexEntry[] = [];
   private indexedRecordingIds = '';
 
@@ -78,7 +81,6 @@ export class TranscriptQuestionAnsweringService {
     this.embeddingClient = options.embeddingClient ?? new TranscriptEmbeddingRuntimeClient();
     this.embeddingPreset =
       options.embeddingPreset ?? transcriptionModelCatalog.getEmbeddingPreset(undefined);
-    this.modelId = options.modelId ?? transcriptionModelCatalog.transcriptQuestionAnsweringModelId;
   }
 
   async answer(question: string, recordings: TranscriptRecording[]): Promise<TranscriptAnswer> {
@@ -105,8 +107,7 @@ export class TranscriptQuestionAnsweringService {
       startMs: match.segment.startMs,
       text: match.segment.text,
     }));
-    const text = await this.options.textGenerationRuntime.generate(
-      this.modelId,
+    const text = await this.options.textGenerator.generate(
       createPrompt(trimmedQuestion, citations),
       {
         do_sample: false,

--- a/apps/editor/src/services/transcription/transcriptQuestionAnsweringService.ts
+++ b/apps/editor/src/services/transcription/transcriptQuestionAnsweringService.ts
@@ -20,6 +20,17 @@ export interface TranscriptAnswer {
   text: string;
 }
 
+export interface TranscriptQuestionContext {
+  currentSlide: {
+    id: string;
+    index: number;
+    name: string;
+    speakerNotes?: string;
+    text: string[];
+    totalSlides: number;
+  };
+}
+
 interface TranscriptIndexEntry {
   embedding: number[];
   id: string;
@@ -42,6 +53,7 @@ function normalizeSegments(recordings: TranscriptRecording[]) {
       .filter((segment) => segment.final && segment.text.trim())
       .map((segment) => ({
         id: `${recording.id}:${segment.id}`,
+        recordingName: recording.name,
         recordingId: recording.id,
         segment,
         text: segment.text.trim(),
@@ -49,24 +61,55 @@ function normalizeSegments(recordings: TranscriptRecording[]) {
   );
 }
 
-function createPrompt(question: string, citations: TranscriptAnswerCitation[]) {
-  const context = citations
+function formatSegmentTimestamp(milliseconds: number) {
+  return `${Math.round(milliseconds / 1000)}s`;
+}
+
+function createPrompt(
+  question: string,
+  transcript: ReturnType<typeof normalizeSegments>,
+  citations: TranscriptAnswerCitation[],
+  context?: TranscriptQuestionContext,
+) {
+  const currentSlide = context?.currentSlide;
+  const slideContext = currentSlide
+    ? [
+        `Slide ${currentSlide.index + 1} of ${currentSlide.totalSlides}`,
+        `Name: ${currentSlide.name}`,
+        `ID: ${currentSlide.id}`,
+        `Visible text:\n${currentSlide.text.length > 0 ? currentSlide.text.join('\n') : '(none)'}`,
+        `Speaker notes: ${currentSlide.speakerNotes?.trim() || '(none)'}`,
+      ].join('\n')
+    : 'Current slide information is unavailable.';
+  const fullTranscript = transcript
+    .map((entry, index) => {
+      const pageLabel =
+        entry.segment.pageName ??
+        (typeof entry.segment.pageIndex === 'number'
+          ? `Slide ${entry.segment.pageIndex + 1}`
+          : (entry.segment.pageId ?? 'Unassigned slide'));
+      return `[${index + 1}] ${entry.recordingName} | ${pageLabel} | ${formatSegmentTimestamp(
+        entry.segment.startMs,
+      )}-${formatSegmentTimestamp(entry.segment.endMs)}: ${entry.text}`;
+    })
+    .join('\n');
+  const relevantCitations = citations
     .map(
       (citation, index) =>
-        `[${index + 1}] ${Math.round(citation.startMs / 1000)}s-${Math.round(
-          citation.endMs / 1000,
-        )}s: ${citation.text}`,
+        `[${index + 1}] ${formatSegmentTimestamp(citation.startMs)}-${formatSegmentTimestamp(
+          citation.endMs,
+        )}: ${citation.text}`,
     )
     .join('\n');
   return [
     {
       role: 'system',
       content:
-        'Answer only from the transcript context. If the answer is not in the transcript, say you cannot find it in the transcript. Keep the answer concise and mention the cited timestamps.',
+        'Answer only from the current slide context and full presentation transcript. If the answer is not available there, say you cannot find it in the presentation. Keep the answer concise and mention timestamps when relevant.',
     },
     {
       role: 'user',
-      content: `Transcript context:\n${context}\n\nQuestion: ${question}`,
+      content: `Current slide context:\n${slideContext}\n\nFull presentation transcript:\n${fullTranscript}\n\nMost relevant timestamp citations:\n${relevantCitations}\n\nQuestion: ${question}`,
     },
   ];
 }
@@ -83,7 +126,11 @@ export class TranscriptQuestionAnsweringService {
       options.embeddingPreset ?? transcriptionModelCatalog.getEmbeddingPreset(undefined);
   }
 
-  async answer(question: string, recordings: TranscriptRecording[]): Promise<TranscriptAnswer> {
+  async answer(
+    question: string,
+    recordings: TranscriptRecording[],
+    context?: TranscriptQuestionContext,
+  ): Promise<TranscriptAnswer> {
     const trimmedQuestion = question.trim();
     if (!trimmedQuestion) return { citations: [], text: '' };
     await this.ensureIndex(recordings);
@@ -108,7 +155,7 @@ export class TranscriptQuestionAnsweringService {
       text: match.segment.text,
     }));
     const text = await this.options.textGenerator.generate(
-      createPrompt(trimmedQuestion, citations),
+      createPrompt(trimmedQuestion, normalizeSegments(recordings), citations, context),
       {
         do_sample: false,
         max_new_tokens: 220,

--- a/apps/editor/src/services/transcription/transcriptionModelCatalog.ts
+++ b/apps/editor/src/services/transcription/transcriptionModelCatalog.ts
@@ -14,8 +14,6 @@ const embeddingPresets: TranscriptEmbeddingPreset[] = [
   },
 ];
 
-const transcriptQuestionAnsweringModelId = 'onnx-community/gemma-3-270m-ONNX';
-
 function getEmbeddingPreset(id: string | undefined): TranscriptEmbeddingPreset {
   return embeddingPresets.find((preset) => preset.id === id) ?? embeddingPresets[0]!;
 }
@@ -23,5 +21,4 @@ function getEmbeddingPreset(id: string | undefined): TranscriptEmbeddingPreset {
 export const transcriptionModelCatalog = {
   embeddingPresets,
   getEmbeddingPreset,
-  transcriptQuestionAnsweringModelId,
 };

--- a/apps/editor/src/ui/editor/prompting/PromptBar.tsx
+++ b/apps/editor/src/ui/editor/prompting/PromptBar.tsx
@@ -2,6 +2,10 @@ import { ImagePlus, Mic, Plus, SendHorizontal, Square, X } from 'lucide-react';
 import { useLayoutEffect, useRef, useState } from 'react';
 import { IconButton } from '../../components/IconButton';
 import type { CreateImagePromptOptions } from '../media/imagePromptOptions';
+import {
+  PromptModelControl,
+  type PromptModelControlState,
+} from './PromptModelControl';
 import { promptRecipes } from './promptRecipes';
 
 interface PromptBarProps {
@@ -11,10 +15,17 @@ interface PromptBarProps {
   generationStatus?: string | undefined;
   isGeneratingImage?: boolean;
   isGeneratingSlide?: boolean;
+  createImageModelControlState?: PromptModelControlState | undefined;
+  slideModelControlState?: PromptModelControlState | undefined;
   selectedImageElementId?: string | undefined;
   createImageOptions: CreateImagePromptOptions;
   onCreateImagePromptIntent?: () => boolean | Promise<boolean>;
   onCreateImageSubmit?: (prompt: string, options: CreateImagePromptOptions) => Promise<void>;
+  onCancelCreateImageModelDownload?: ((modelId: string) => Promise<void>) | undefined;
+  onCancelPromptModelDownload?: ((modelId: string) => Promise<void>) | undefined;
+  onPrepareCreateImageModel?: (() => Promise<void>) | undefined;
+  onPreparePromptApi?: (() => Promise<void>) | undefined;
+  onPromptProviderChange?: ((providerId: string) => void) | undefined;
   onSlidePromptSubmit?: (prompt: string) => Promise<void>;
   onStopGeneration?: () => void;
 }
@@ -26,10 +37,17 @@ export function PromptBar({
   generationStatus,
   isGeneratingImage = false,
   isGeneratingSlide,
+  createImageModelControlState,
+  slideModelControlState,
   selectedImageElementId,
   createImageOptions,
   onCreateImagePromptIntent,
   onCreateImageSubmit,
+  onCancelCreateImageModelDownload,
+  onCancelPromptModelDownload,
+  onPrepareCreateImageModel,
+  onPreparePromptApi,
+  onPromptProviderChange,
   onSlidePromptSubmit,
   onStopGeneration,
 }: PromptBarProps) {
@@ -44,6 +62,8 @@ export function PromptBar({
       ? promptRecipes.imagePromptExamples
       : promptRecipes.slidePromptExamples;
   const isProcessing = isGeneratingSlide || isGeneratingImage || localSubmissionActive;
+  const activeModelControlState =
+    activeMode === 'create-image' ? createImageModelControlState : slideModelControlState;
 
   useLayoutEffect(() => {
     const input = inputRef.current;
@@ -225,6 +245,19 @@ export function PromptBar({
           />
         </div>
         <div className="prompt-submit-actions" data-tour-id="prompt-submit-actions">
+          {activeModelControlState ? (
+            <PromptModelControl
+              disabled={isProcessing}
+              state={activeModelControlState}
+              onCancelDownload={
+                activeMode === 'create-image'
+                  ? onCancelCreateImageModelDownload
+                  : onCancelPromptModelDownload
+              }
+              onPrepare={activeMode === 'create-image' ? onPrepareCreateImageModel : onPreparePromptApi}
+              onProviderChange={activeMode === 'create-image' ? undefined : onPromptProviderChange}
+            />
+          ) : null}
           <IconButton disabled={isProcessing} label="Record voice prompt">
             <Mic size={16} />
           </IconButton>

--- a/apps/editor/src/ui/editor/prompting/PromptModelControl.tsx
+++ b/apps/editor/src/ui/editor/prompting/PromptModelControl.tsx
@@ -1,0 +1,162 @@
+import { ChevronDown, Download, X } from 'lucide-react';
+import type {
+  ModelDownloadProgressDetails,
+  ModelStatus,
+} from '../../../services/contracts/interfaces';
+import { AiToolsDownloadProgress } from '../panels/AiToolsDownloadProgress';
+
+type PromptPreparationStatus = 'idle' | 'downloading' | 'ready' | 'failed';
+
+export interface PromptModelControlOption {
+  compatibility: 'compatible' | 'incompatible' | 'unknown';
+  id: string;
+  label: string;
+  modelId?: string | undefined;
+  readiness: ModelStatus;
+  selected: boolean;
+}
+
+export interface PromptModelControlState {
+  label?: string | undefined;
+  preparation: ModelDownloadProgressDetails & {
+    availability: string;
+    progress: number;
+    status: PromptPreparationStatus;
+  };
+  options: PromptModelControlOption[];
+}
+
+function getSelectedOption(options: PromptModelControlOption[]) {
+  return options.find((option) => option.selected) ?? options[0];
+}
+
+function getPreparationStatus(
+  option: PromptModelControlOption | undefined,
+  preparationStatus: PromptPreparationStatus,
+): PromptPreparationStatus {
+  if (preparationStatus === 'downloading' || preparationStatus === 'failed') {
+    return preparationStatus;
+  }
+  if (option?.readiness === 'ready') return 'ready';
+  return 'idle';
+}
+
+function getProgressValue(status: PromptPreparationStatus, progress: number) {
+  if (status === 'ready') return 100;
+  return Math.max(0, Math.min(100, Math.round(progress)));
+}
+
+export function PromptModelControl({
+  compact = false,
+  disabled = false,
+  state,
+  onCancelDownload,
+  onPrepare,
+  onProviderChange,
+}: {
+  compact?: boolean;
+  disabled?: boolean;
+  state: PromptModelControlState;
+  onCancelDownload?: ((modelId: string) => Promise<void>) | undefined;
+  onPrepare?: (() => Promise<void>) | undefined;
+  onProviderChange?: ((providerId: string) => void) | undefined;
+}) {
+  const selectedOption = getSelectedOption(state.options);
+  if (!selectedOption) return null;
+
+  const status = getPreparationStatus(selectedOption, state.preparation.status);
+  const progress = getProgressValue(status, state.preparation.progress);
+  const isDownloading = status === 'downloading';
+  const needsDownload =
+    selectedOption.readiness === 'needs-download' || selectedOption.readiness === 'failed';
+  const isIncompatible = selectedOption.compatibility === 'incompatible';
+  const canUseSelect =
+    !disabled && !isDownloading && (state.options.length === 1 || Boolean(onProviderChange));
+  const canCancelDownload =
+    Boolean(onCancelDownload) && !disabled && isDownloading && Boolean(selectedOption.modelId);
+  const canPrepare = Boolean(onPrepare) && !disabled && !isDownloading && !isIncompatible;
+
+  return (
+    <div
+      className={compact ? 'prompt-model-control prompt-model-control-compact' : 'prompt-model-control'}
+      aria-label={state.label ?? 'Prompt model'}
+    >
+      <label className="prompt-model-select-shell">
+        <span className="visually-hidden-input">{state.label ?? 'Prompt model'}</span>
+        <select
+          aria-label={state.label ?? 'Prompt model'}
+          disabled={!canUseSelect}
+          value={selectedOption.id}
+          onChange={(event) => onProviderChange?.(event.target.value)}
+        >
+          {state.options.map((option) => (
+            <option
+              disabled={option.compatibility === 'incompatible'}
+              key={option.id}
+              value={option.id}
+            >
+              {option.label}
+              {option.compatibility === 'incompatible' ? ' - unavailable' : ''}
+            </option>
+          ))}
+        </select>
+        <ChevronDown size={14} aria-hidden="true" />
+      </label>
+      {needsDownload || isDownloading ? (
+        <button
+          aria-label={
+            isDownloading
+              ? `Downloading ${selectedOption.label}`
+              : `Download ${selectedOption.label}`
+          }
+          className="prompt-model-download-button"
+          disabled={!canPrepare}
+          title={
+            isDownloading
+              ? `Downloading ${selectedOption.label}`
+              : `Download ${selectedOption.label}`
+          }
+          type="button"
+          onClick={() => {
+            void onPrepare?.();
+          }}
+        >
+          <Download size={14} aria-hidden="true" />
+        </button>
+      ) : null}
+      {isDownloading ? (
+        <div className="prompt-model-progress" aria-label="Prompt model download progress">
+          {selectedOption.modelId ? (
+            <button
+              aria-label={`Cancel ${selectedOption.label} download`}
+              className="prompt-model-cancel-button"
+              disabled={!canCancelDownload}
+              title={`Cancel ${selectedOption.label} download`}
+              type="button"
+              onClick={() => {
+                if (!selectedOption.modelId) return;
+                void onCancelDownload?.(selectedOption.modelId);
+              }}
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          ) : null}
+          <div
+            aria-label={`${selectedOption.label} download progress`}
+            aria-valuemax={100}
+            aria-valuemin={0}
+            aria-valuenow={progress}
+            className="model-progress"
+            role="progressbar"
+          >
+            <span style={{ width: `${progress}%` }} />
+          </div>
+          <AiToolsDownloadProgress
+            details={{ ...state.preparation, progress }}
+            status="downloading"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -5,6 +5,7 @@ import { pageVisibility } from '../../../domain/documents/pageVisibility';
 import type { ShareMetadata } from '../../../services/contracts/interfaces';
 import { editorAutomationController } from '../../../services/automation/editorAutomationController';
 import type { EditorAutomationDelegate } from '../../../services/automation/editorAutomationController';
+import { imageGenerationModel } from '../../../services/image-generation/imageGenerationModel';
 import {
   WebMcpToolAdapter,
   type WebMcpDemoWindow,
@@ -22,6 +23,7 @@ import { ProjectVideoPreloader } from '../media/ProjectVideoPreloader';
 import { localMediaImportConfig } from '../media/localMediaImportConfig';
 import { movieStartPlayback } from '../media/movieStartPlayback';
 import { PromptBar } from '../prompting/PromptBar';
+import type { PromptModelControlState } from '../prompting/PromptModelControl';
 import { RemoteImportPanel } from '../panels/RemoteImportPanel';
 import { CanvasWorkspace } from '../canvas/CanvasWorkspace';
 import { ScrollingCanvasWorkspace } from '../canvas/ScrollingCanvasWorkspace';
@@ -34,7 +36,10 @@ import { copyShareText } from '../../share/shareClipboard';
 import { KeyboardShortcutsDialog, type KeyboardShortcutAction } from '../../components/KeyboardShortcutsDialog';
 import { editorShellBrowserUtils } from '../browser/editorShellBrowserUtils';
 import { BrowserPresenterSessionService } from '../../../services/presenter/presenterSessionService';
-import type { PresenterRemoteSessionMetadata } from '../../../services/presenter/presenterSessionTypes';
+import type {
+  PresenterRemoteSessionMetadata,
+  PresenterStatePayload,
+} from '../../../services/presenter/presenterSessionTypes';
 import { PresenterRemotePanel } from '../../presenter/PresenterRemotePanel';
 import { EditorAiWorkflowTour } from '../tour/EditorAiWorkflowTour';
 import type { EditorAiWorkflowTourHandle } from '../tour/editorAiWorkflowTourTypes';
@@ -54,6 +59,19 @@ interface EditorShellProps {
 }
 
 const editorMobileViewportQuery = '(max-width: 760px)';
+
+function getModelControlPreparation(status: string | undefined, progress: number | undefined) {
+  if (status === 'downloading') {
+    return { availability: 'downloading', progress: progress ?? 0, status: 'downloading' as const };
+  }
+  if (status === 'ready') {
+    return { availability: 'ready', progress: 100, status: 'ready' as const };
+  }
+  if (status === 'failed') {
+    return { availability: 'downloadable', progress: progress ?? 0, status: 'failed' as const };
+  }
+  return { availability: 'downloadable', progress: 0, status: 'idle' as const };
+}
 
 function isMobileEditorViewport() {
   if (typeof window === 'undefined' || !window.matchMedia) return false;
@@ -167,6 +185,60 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       label: recording.name,
       segmentCount: recording.segments.length,
     }));
+  const imageGenerationState = vm.modelStates.find(
+    (model) => model.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
+  );
+  const imageGenerationModelControlState: PromptModelControlState = {
+    label: 'Image generation model',
+    preparation: {
+      ...getModelControlPreparation(imageGenerationState?.status, imageGenerationState?.progress),
+      estimatedRemainingMs: imageGenerationState?.estimatedRemainingMs,
+      loadedBytes: imageGenerationState?.loadedBytes,
+      totalBytes: imageGenerationState?.totalBytes,
+    },
+    options: [
+      {
+        compatibility: imageGenerationState?.status === 'unavailable' ? 'incompatible' : 'compatible',
+        id: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
+        label: imageGenerationModel.IMAGE_GENERATION_DISPLAY_NAME,
+        modelId: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
+        readiness: imageGenerationState?.status ?? 'needs-download',
+        selected: true,
+      },
+    ],
+  };
+  const promptModelControlState: PromptModelControlState = {
+    label: 'Prompt model',
+    preparation: vm.promptPreparation,
+    options: vm.promptProviderStates,
+  };
+
+  const createPresenterStatePayload = useCallback(
+    (overrides?: Partial<PresenterStatePayload>): PresenterStatePayload => ({
+      activePageId: vm.activePageId,
+      animationPreview: vm.animationPreview,
+      presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
+      project: vm.project,
+      promptModel: {
+        options: vm.promptProviderStates,
+        preparation: vm.promptPreparation,
+      },
+      streamPeerId: presenterRemoteStreamPeerId,
+      transcriptionLanguage: presenterTranscriptionLanguage,
+      ...overrides,
+    }),
+    [
+      presenterRemoteStreamPeerId,
+      presenterSessionId,
+      presenterTranscriptionLanguage,
+      remotePresenterActive,
+      vm.activePageId,
+      vm.animationPreview,
+      vm.project,
+      vm.promptPreparation,
+      vm.promptProviderStates,
+    ],
+  );
 
   const publishCurrentProjectShare = useCallback(async (selectedRecordingId?: string) => {
     const inFlightSharePublish = sharePublishPromiseRef.current;
@@ -392,14 +464,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       })
       .then((remoteSession) => {
         setPresenterRemoteSession(remoteSession);
-        service.publishState({
-          activePageId: pageId,
-          animationPreview: vm.animationPreview,
-          presenterMode: 'presenting',
-          project: vm.project,
-          streamPeerId: presenterRemoteStreamPeerId,
-          transcriptionLanguage: presenterTranscriptionLanguage,
-        });
+        service.publishState(
+          createPresenterStatePayload({ activePageId: pageId, presenterMode: 'presenting' }),
+        );
       })
       .catch(() => {
         setPresenterRemoteUnavailable(true);
@@ -412,16 +479,11 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     setAudienceFullscreenPromptOpen(true);
     vm.playPresentationPreview(pageId);
     window.setTimeout(() => {
-      service.publishState({
-        activePageId: pageId,
-        animationPreview: vm.animationPreview,
-        presenterMode: 'presenting',
-        project: vm.project,
-        streamPeerId: presenterRemoteStreamPeerId,
-        transcriptionLanguage: presenterTranscriptionLanguage,
-      });
+      service.publishState(
+        createPresenterStatePayload({ activePageId: pageId, presenterMode: 'presenting' }),
+      );
     }, 0);
-  }, [presenterRemoteStreamPeerId, presenterSessionId, presenterTranscriptionLanguage, vm]);
+  }, [createPresenterStatePayload, presenterSessionId, vm]);
 
   function enterAudienceFullscreen() {
     setAudienceFullscreenPromptOpen(false);
@@ -889,14 +951,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       .then((remoteSession) => {
         if (cancelled) return;
         setPresenterRemoteSession(remoteSession);
-        service.publishState({
-          activePageId: pageId,
-          animationPreview: vm.animationPreview,
-          presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
-          project: vm.project,
-          streamPeerId: presenterRemoteStreamPeerId,
-          transcriptionLanguage: presenterTranscriptionLanguage,
-        });
+        service.publishState(createPresenterStatePayload({ activePageId: pageId }));
       })
       .catch(() => {
         if (cancelled) return;
@@ -907,14 +962,11 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       cancelled = true;
     };
   }, [
-    presenterRemoteStreamPeerId,
+    createPresenterStatePayload,
     presenterRemoteUnavailable,
     presenterSessionId,
     remotePresenterActive,
-    presenterTranscriptionLanguage,
     vm.activePageId,
-    vm.animationPreview,
-    vm.project,
   ]);
 
   useEffect(() => {
@@ -930,14 +982,21 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           vm.playPresentationPreview(firstPageId);
           void vm.toggleFullscreen(workspaceRef.current);
         }
-        getPresenterSessionService().publishState({
-          activePageId: firstPageId,
-          animationPreview: vm.animationPreview,
-          presenterMode: 'presenting',
-          project: vm.project,
-          streamPeerId: presenterRemoteStreamPeerId,
-          transcriptionLanguage: presenterTranscriptionLanguage,
-        });
+        getPresenterSessionService().publishState(
+          createPresenterStatePayload({ activePageId: firstPageId, presenterMode: 'presenting' }),
+        );
+        return;
+      }
+      if (message.command === 'prepare-prompt-api') {
+        void vm.preparePromptApi();
+        return;
+      }
+      if (message.command === 'set-prompt-provider') {
+        void vm.setPromptProvider(message.providerId);
+        return;
+      }
+      if (message.command === 'cancel-prompt-model-download') {
+        void vm.cancelPromptModelDownload(message.modelId);
         return;
       }
       if (message.command === 'next') {
@@ -978,14 +1037,12 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           updatedAt: new Date().toISOString(),
         };
         vm.addTranscriptRecording(editorOwnedRecording);
-        getPresenterSessionService().publishState({
+        getPresenterSessionService().publishState(createPresenterStatePayload({
           activePageId: vm.activePageId,
           animationPreview: vm.animationPreview,
           presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
           project: projectWithRecording,
-          streamPeerId: presenterRemoteStreamPeerId,
-          transcriptionLanguage: presenterTranscriptionLanguage,
-        });
+        }));
         return;
       }
       if (message.command === 'update-stream-peer') {
@@ -993,14 +1050,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         return;
       }
       if (message.command === 'request-state') {
-        getPresenterSessionService().publishState({
-          activePageId: vm.activePageId,
-          animationPreview: vm.animationPreview,
-          presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
-          project: vm.project,
-          streamPeerId: presenterRemoteStreamPeerId,
-          transcriptionLanguage: presenterTranscriptionLanguage,
-        });
+        getPresenterSessionService().publishState(createPresenterStatePayload());
         return;
       }
       if (message.command === 'close') {
@@ -1009,10 +1059,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     });
   }, [
     advancePresentationPreviewFromUserAction,
+    createPresenterStatePayload,
     presenterRemoteSession,
-    presenterRemoteStreamPeerId,
     presenterSessionId,
-    presenterTranscriptionLanguage,
     remotePresenterActive,
     closePresenterViewSession,
     vm,
@@ -1036,24 +1085,8 @@ function EditorDesktopShell({ services }: EditorShellProps) {
 
   useEffect(() => {
     if (!presenterRemoteSession) return;
-    getPresenterSessionService().publishState({
-      activePageId: vm.activePageId,
-      animationPreview: vm.animationPreview,
-      presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
-      project: vm.project,
-      streamPeerId: presenterRemoteStreamPeerId,
-      transcriptionLanguage: presenterTranscriptionLanguage,
-    });
-  }, [
-    presenterRemoteSession,
-    presenterRemoteStreamPeerId,
-    presenterSessionId,
-    remotePresenterActive,
-    presenterTranscriptionLanguage,
-    vm.activePageId,
-    vm.animationPreview,
-    vm.project,
-  ]);
+    getPresenterSessionService().publishState(createPresenterStatePayload());
+  }, [createPresenterStatePayload, presenterRemoteSession]);
 
   useEffect(() => {
     if (!presenterRemotePanelOpen) return;
@@ -1433,6 +1466,8 @@ function EditorDesktopShell({ services }: EditorShellProps) {
               createImageNotice={vm.createImageNotice}
               createImageStatus={vm.createImageStatus}
               createImageOptions={vm.createImageOptions}
+              createImageModelControlState={imageGenerationModelControlState}
+              slideModelControlState={promptModelControlState}
               generationNotice={vm.promptGenerationNotice}
               generationStatus={vm.promptGenerationStatus}
               isGeneratingImage={vm.isGeneratingImage}
@@ -1440,6 +1475,15 @@ function EditorDesktopShell({ services }: EditorShellProps) {
               selectedImageElementId={vm.selectedImagePromptElementId}
               onCreateImagePromptIntent={() => vm.ensureImageGenerationReadyForPrompt()}
               onCreateImageSubmit={(prompt, options) => vm.generateImageFromPrompt(prompt, options)}
+              onCancelCreateImageModelDownload={vm.cancelModelDownload}
+              onCancelPromptModelDownload={vm.cancelPromptModelDownload}
+              onPrepareCreateImageModel={() =>
+                vm.downloadModel(imageGenerationModel.IMAGE_GENERATION_MODEL_ID)
+              }
+              onPreparePromptApi={vm.preparePromptApi}
+              onPromptProviderChange={(providerId) => {
+                void vm.setPromptProvider(providerId);
+              }}
               onSlidePromptSubmit={(prompt) => vm.generateSlideFromPrompt(prompt)}
               onStopGeneration={vm.stopPromptGeneration}
             />

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -244,6 +244,8 @@ export function useEditorViewModel(services: AppServices) {
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
   const [aiToolsAttentionModelId, setAiToolsAttentionModelId] = useState<string | undefined>();
   const [pageLanguageCodes, setPageLanguageCodes] = useState<Record<string, string>>({});
+  const modelDownloadRunIdsRef = useRef<Record<string, number>>({});
+  const promptPreparationRunIdRef = useRef(0);
   const promptGenerationRunIdRef = useRef(0);
   const [elementClipboard, setElementClipboard] = useState<ElementClipboardState>({
     assets: {},
@@ -691,6 +693,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   async function downloadModel(id: string) {
+    const runId = (modelDownloadRunIdsRef.current[id] ?? 0) + 1;
+    modelDownloadRunIdsRef.current = { ...modelDownloadRunIdsRef.current, [id]: runId };
+    const isCurrentRun = () => modelDownloadRunIdsRef.current[id] === runId;
     setModelStates((currentStates) =>
       currentStates.map((state) =>
         state.id === id && state.status !== 'ready'
@@ -700,6 +705,7 @@ export function useEditorViewModel(services: AppServices) {
     );
     const next = await services.modelSetupService.downloadModel(id, {
       onProgress: (progress, details) => {
+        if (!isCurrentRun()) return;
         setModelStates((currentStates) =>
           currentStates.map((state) =>
             state.id === id
@@ -709,6 +715,7 @@ export function useEditorViewModel(services: AppServices) {
         );
       },
     });
+    if (!isCurrentRun()) return;
     setModelStates((currentStates) =>
       currentStates.map((state) => (state.id === id ? next : state)),
     );
@@ -727,6 +734,14 @@ export function useEditorViewModel(services: AppServices) {
       setCreateImageNotice(undefined);
       setAiToolsAttentionModelId(undefined);
     }
+  }
+
+  async function cancelModelDownload(id: string) {
+    modelDownloadRunIdsRef.current = {
+      ...modelDownloadRunIdsRef.current,
+      [id]: (modelDownloadRunIdsRef.current[id] ?? 0) + 1,
+    };
+    await removeModel(id);
   }
 
   async function removeModel(id: string) {
@@ -816,6 +831,9 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   async function preparePromptApi() {
+    const runId = promptPreparationRunIdRef.current + 1;
+    promptPreparationRunIdRef.current = runId;
+    const isCurrentRun = () => promptPreparationRunIdRef.current === runId;
     setPromptApiNotice(undefined);
     setPromptApiAttention(false);
     setPromptPreparation((current) => ({
@@ -826,6 +844,7 @@ export function useEditorViewModel(services: AppServices) {
     try {
       await services.promptService.preparePromptApi({
         onProgress: (progress, details) => {
+          if (!isCurrentRun()) return;
           setPromptPreparation((current) => ({
             ...current,
             availability: progress >= 100 ? 'ready' : current.availability,
@@ -837,6 +856,7 @@ export function useEditorViewModel(services: AppServices) {
           }));
         },
       });
+      if (!isCurrentRun()) return;
       setPromptPreparation({ availability: 'ready', progress: 100, status: 'ready' });
       setModelStates(await services.modelSetupService.getModelStates());
       if (services.promptService.getProviderStates) {
@@ -844,6 +864,7 @@ export function useEditorViewModel(services: AppServices) {
       }
       setPromptApiNotice('Prompt API ready');
     } catch (error: unknown) {
+      if (!isCurrentRun()) return;
       const selectedProvider = promptProviderStates.find((provider) => provider.selected);
       if (selectedProvider?.modelId) {
         await services.modelSetupService.removeModel?.(selectedProvider.modelId);
@@ -858,6 +879,14 @@ export function useEditorViewModel(services: AppServices) {
         error instanceof Error ? error.message : 'Chrome Prompt API could not be prepared.',
       );
     }
+  }
+
+  async function cancelPromptModelDownload(modelId: string) {
+    promptPreparationRunIdRef.current += 1;
+    setPromptApiNotice(undefined);
+    setPromptApiAttention(false);
+    setPromptPreparation({ availability: 'downloadable', progress: 0, status: 'idle' });
+    await cancelModelDownload(modelId);
   }
 
   async function setPromptProvider(providerId: string) {
@@ -3256,6 +3285,7 @@ export function useEditorViewModel(services: AppServices) {
     generateSlideFromPrompt,
     generateImageFromPrompt,
     stopPromptGeneration,
+    cancelPromptModelDownload,
     setCreateImageOptions,
     setPromptProvider,
     setTranslationProvider,
@@ -3273,6 +3303,7 @@ export function useEditorViewModel(services: AppServices) {
     translateDeck: () => requestTranslation('deck'),
     downloadRequiredModels,
     downloadModel,
+    cancelModelDownload,
     removeModel,
     selectElement,
     selectAllElementsOnActivePage,

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -37,6 +37,7 @@ import { PresenterAudioRecorder } from '../../services/transcription/presenterAu
 import { PresenterSpeechTranscriber } from '../../services/transcription/presenterSpeechTranscriber';
 import { TRANSLATION_LANGUAGE_OPTIONS } from '../editor/translation/translationLanguages';
 import { presenterRemoteTimerFormat } from '@localstudio/presenter-remote/timer-format';
+import { PromptModelControl } from '../editor/prompting/PromptModelControl';
 
 interface PresenterViewProps {
   sessionId?: string;
@@ -1183,6 +1184,24 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
                 </select>
               </label>
             </div>
+            {snapshot.promptModel ? (
+              <PromptModelControl
+                compact
+                disabled={recordingStatus === 'downloading' || recordingStatus === 'transcribing'}
+                state={snapshot.promptModel}
+                onCancelDownload={(modelId) => {
+                  postCommand({ command: 'cancel-prompt-model-download', modelId });
+                  return Promise.resolve();
+                }}
+                onPrepare={() => {
+                  postCommand({ command: 'prepare-prompt-api' });
+                  return Promise.resolve();
+                }}
+                onProviderChange={(providerId) => {
+                  postCommand({ command: 'set-prompt-provider', providerId });
+                }}
+              />
+            ) : null}
             <button
               className="stitch-icon-button presenter-control-button"
               type="button"

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -28,7 +28,10 @@ import { modelSetupService } from '../../services/model-setup/modelSetupService'
 import { browserPromptService } from '../../services/prompting/browserPromptService';
 import { webGpuTextGenerationRuntime } from '../../services/prompting/webGpuTextGenerationRuntime';
 import { TranscriptQuestionAnsweringService } from '../../services/transcription/transcriptQuestionAnsweringService';
-import type { TranscriptAnswer } from '../../services/transcription/transcriptQuestionAnsweringService';
+import type {
+  TranscriptAnswer,
+  TranscriptQuestionContext,
+} from '../../services/transcription/transcriptQuestionAnsweringService';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
 import { ProjectVideoPreloader } from '../editor/media/ProjectVideoPreloader';
 import { MiniPagePreview } from '../editor/panels/PageMiniPreview';
@@ -88,6 +91,28 @@ function formatTranscriptTimestamp(milliseconds: number) {
 
 function getTranscriptRecordings(project: ProjectDocument): TranscriptRecording[] {
   return Object.values(project.recordings ?? {}).filter((recording) => recording.segments.length > 0);
+}
+
+function getTranscriptQuestionContext(
+  project: ProjectDocument,
+  page: Page,
+  pageIndex: number,
+): TranscriptQuestionContext {
+  const text = page.elementIds.flatMap((elementId) => {
+    const element = project.elements[elementId];
+    if (element?.type !== 'text' || element.visible === false || !element.text.trim()) return [];
+    return [element.text.trim()];
+  });
+  return {
+    currentSlide: {
+      id: page.id,
+      index: pageIndex,
+      name: page.name,
+      ...(page.speakerNotes ? { speakerNotes: page.speakerNotes } : {}),
+      text,
+      totalSlides: project.pages.length,
+    },
+  };
 }
 
 function getRecordingTimePercent(currentMs: number, durationMs: number) {
@@ -1744,6 +1769,11 @@ export function PublicDeckViewer({
   const canGoPrevious = activePageIndex > 0;
   const canGoNext = activePageIndex < project.pages.length - 1;
   const transcriptRecordings = getTranscriptRecordings(project);
+  const transcriptQuestionContext = getTranscriptQuestionContext(
+    project,
+    activePage,
+    activePageIndex,
+  );
   const hasTranscriptRecordings = transcriptRecordings.length > 0;
   const showPlaybackOverlay = hasTranscriptRecordings && !embed;
   const readyViewerClassName = [
@@ -1867,9 +1897,11 @@ export function PublicDeckViewer({
       const answer = await transcriptQaServiceRef.current.answer(
         trimmedQuestion,
         transcriptRecordings,
+        transcriptQuestionContext,
       );
       if (transcriptAnswerRunIdRef.current !== runId) return;
       setTranscriptAnswer(answer);
+      setTranscriptQuestion('');
       setTranscriptAnswerStatus('idle');
     } catch (error) {
       if (transcriptAnswerRunIdRef.current !== runId) return;

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -1,6 +1,16 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
-import { Captions, ListMusic, Maximize2, Pause, Play, SendHorizontal, Square, X } from 'lucide-react';
+import {
+  Captions,
+  ListMusic,
+  Maximize2,
+  Pause,
+  Play,
+  SendHorizontal,
+  Sparkles,
+  Square,
+  X,
+} from 'lucide-react';
 import type {
   ElementAnimationBuild,
   Page,
@@ -8,13 +18,24 @@ import type {
   SelectionState,
   TranscriptRecording,
 } from '../../domain/documents/model';
-import type { FontImportService, ShareService } from '../../services/contracts/interfaces';
+import type {
+  AiProviderState,
+  FontImportService,
+  ModelDownloadProgressDetails,
+  ShareService,
+} from '../../services/contracts/interfaces';
+import { modelSetupService } from '../../services/model-setup/modelSetupService';
+import { browserPromptService } from '../../services/prompting/browserPromptService';
+import { webGpuTextGenerationRuntime } from '../../services/prompting/webGpuTextGenerationRuntime';
 import { TranscriptQuestionAnsweringService } from '../../services/transcription/transcriptQuestionAnsweringService';
 import type { TranscriptAnswer } from '../../services/transcription/transcriptQuestionAnsweringService';
-import { webGpuTextGenerationRuntime } from '../../services/prompting/webGpuTextGenerationRuntime';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
 import { ProjectVideoPreloader } from '../editor/media/ProjectVideoPreloader';
 import { MiniPagePreview } from '../editor/panels/PageMiniPreview';
+import {
+  PromptModelControl,
+  type PromptModelControlState,
+} from '../editor/prompting/PromptModelControl';
 import { preloadPublicDeckAssets } from './publicDeckAssetPreloader';
 
 interface PublicDeckViewerProps {
@@ -72,6 +93,25 @@ function getTranscriptRecordings(project: ProjectDocument): TranscriptRecording[
 function getRecordingTimePercent(currentMs: number, durationMs: number) {
   if (durationMs <= 0) return 0;
   return Math.min(100, Math.max(0, (currentMs / durationMs) * 100));
+}
+
+function getTranscriptModelPreparation(
+  provider: AiProviderState | undefined,
+): PromptModelControlState['preparation'] {
+  if (provider?.readiness === 'ready') {
+    return { availability: 'ready', progress: 100, status: 'ready' };
+  }
+  if (provider?.readiness === 'downloading') {
+    return { availability: 'downloading', progress: 4, status: 'downloading' };
+  }
+  return {
+    availability:
+      provider?.compatibility === 'incompatible' || provider?.readiness === 'unavailable'
+        ? 'unavailable'
+        : 'downloadable',
+    progress: 0,
+    status: 'idle',
+  };
 }
 
 function getSlidePositionPercent(pageIndex: number, pageCount: number) {
@@ -289,7 +329,11 @@ function PublicTranscriptPromptComposer({
   answer,
   error,
   isAnswering,
+  modelControlState,
   question,
+  onCancelModelDownload,
+  onPrepareModel,
+  onProviderChange,
   onQuestionChange,
   onStop,
   onSubmit,
@@ -297,7 +341,11 @@ function PublicTranscriptPromptComposer({
   answer: TranscriptAnswer | undefined;
   error: string | undefined;
   isAnswering: boolean;
+  modelControlState: PromptModelControlState;
   question: string;
+  onCancelModelDownload: (modelId: string) => Promise<void>;
+  onPrepareModel: () => Promise<void>;
+  onProviderChange: (providerId: string) => void;
   onQuestionChange: (question: string) => void;
   onStop: () => void;
   onSubmit: (question: string) => void;
@@ -382,6 +430,13 @@ function PublicTranscriptPromptComposer({
           />
         </div>
         <div className="prompt-submit-actions" data-tour-id="prompt-submit-actions">
+          <PromptModelControl
+            disabled={isAnswering}
+            state={modelControlState}
+            onCancelDownload={onCancelModelDownload}
+            onPrepare={onPrepareModel}
+            onProviderChange={onProviderChange}
+          />
           {isAnswering ? (
             <button
               className="icon-button icon-button-danger"
@@ -1201,6 +1256,15 @@ function PublicDeckPlaybackOverlay({
           <button
             className="public-deck-playback-button"
             type="button"
+            aria-label="Open presentation AI"
+            title="Open presentation AI"
+            onClick={onOpenTranscript}
+          >
+            <Sparkles size={18} aria-hidden="true" />
+          </button>
+          <button
+            className="public-deck-playback-button"
+            type="button"
             aria-label="Present slide fullscreen"
             onClick={onEnterSlideFullscreen}
           >
@@ -1230,8 +1294,19 @@ export function PublicDeckViewer({
   const animationFrameRef = useRef<number | undefined>(undefined);
   const pagePreloadAbortRef = useRef<AbortController | undefined>(undefined);
   const runNextAnimationBuildRef = useRef<() => void>(() => undefined);
+  const transcriptTextGenerationRuntimeRef = useRef<
+    | InstanceType<typeof webGpuTextGenerationRuntime.TransformersTextGenerationRuntime>
+    | undefined
+  >(undefined);
+  const transcriptModelSetupServiceRef = useRef<
+    InstanceType<typeof modelSetupService.BrowserModelSetupService> | undefined
+  >(undefined);
+  const transcriptPromptServiceRef = useRef<
+    InstanceType<typeof browserPromptService.BrowserPromptService> | undefined
+  >(undefined);
   const transcriptQaServiceRef = useRef<TranscriptQuestionAnsweringService | undefined>(undefined);
   const transcriptAnswerRunIdRef = useRef(0);
+  const transcriptModelPreparationRunIdRef = useRef(0);
   const emptySelection = useMemo<SelectionState>(() => ({ pageId: '', elementIds: [] }), []);
   const [transcriptPanelOpen, setTranscriptPanelOpen] = useState(false);
   const [publicPlaybackSync, setPublicPlaybackSync] = useState<PublicPlaybackSync | undefined>();
@@ -1243,6 +1318,55 @@ export function PublicDeckViewer({
     'answering' | 'failed' | 'idle'
   >('idle');
   const [transcriptAnswerError, setTranscriptAnswerError] = useState<string | undefined>();
+  const [transcriptPromptProviderStates, setTranscriptPromptProviderStates] = useState<
+    AiProviderState[]
+  >([]);
+  const [transcriptModelPreparation, setTranscriptModelPreparation] = useState<
+    PromptModelControlState['preparation']
+  >({
+    availability: 'downloadable',
+    progress: 0,
+    status: 'idle',
+  });
+
+  const getTranscriptPromptServices = useCallback(() => {
+    transcriptTextGenerationRuntimeRef.current ??=
+      new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime();
+    transcriptModelSetupServiceRef.current ??=
+      new modelSetupService.BrowserModelSetupService(
+        undefined,
+        undefined,
+        undefined,
+        transcriptTextGenerationRuntimeRef.current,
+      );
+    transcriptPromptServiceRef.current ??= new browserPromptService.BrowserPromptService(
+      transcriptModelSetupServiceRef.current,
+      undefined,
+      undefined,
+      transcriptTextGenerationRuntimeRef.current,
+    );
+    return {
+      modelSetup: transcriptModelSetupServiceRef.current,
+      promptService: transcriptPromptServiceRef.current,
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    void getTranscriptPromptServices()
+      .promptService.getProviderStates()
+      .then((providers) => {
+        if (!active) return;
+        setTranscriptPromptProviderStates(providers);
+        setTranscriptModelPreparation(
+          getTranscriptModelPreparation(providers.find((provider) => provider.selected)),
+        );
+      });
+    return () => {
+      active = false;
+    };
+  }, [getTranscriptPromptServices]);
+
   const viewerClassName = embed
     ? 'public-deck-viewer public-deck-viewer-embed'
     : 'public-deck-viewer public-deck-viewer-present';
@@ -1630,6 +1754,90 @@ export function PublicDeckViewer({
   ]
     .filter(Boolean)
     .join(' ');
+  const transcriptModelControlState: PromptModelControlState = {
+    label: 'Transcript answer model',
+    preparation: transcriptModelPreparation,
+    options: transcriptPromptProviderStates,
+  };
+
+  async function prepareTranscriptAnswerModel() {
+    const selectedProvider = transcriptPromptProviderStates.find((provider) => provider.selected);
+    if (selectedProvider?.readiness === 'ready') return true;
+    if (selectedProvider?.compatibility === 'incompatible') {
+      throw new Error(selectedProvider.disabledReason ?? `${selectedProvider.label} is unavailable.`);
+    }
+    const runId = transcriptModelPreparationRunIdRef.current + 1;
+    transcriptModelPreparationRunIdRef.current = runId;
+    const isCurrentRun = () => transcriptModelPreparationRunIdRef.current === runId;
+    setTranscriptModelPreparation((current) => ({
+      ...current,
+      availability: 'downloading',
+      progress: Math.max(current.progress, 4),
+      status: 'downloading',
+    }));
+    try {
+      const { promptService } = getTranscriptPromptServices();
+      await promptService.preparePromptApi({
+        onProgress: (progress: number, details?: ModelDownloadProgressDetails) => {
+          if (!isCurrentRun()) return;
+          setTranscriptModelPreparation({
+            availability: progress >= 100 ? 'ready' : 'downloading',
+            progress: Math.max(4, Math.min(100, Math.round(progress))),
+            status: progress >= 100 ? 'ready' : 'downloading',
+            ...details,
+          });
+        },
+      });
+      if (!isCurrentRun()) return false;
+      const providers = await promptService.getProviderStates();
+      if (!isCurrentRun()) return false;
+      const preparedProvider = providers.find((provider) => provider.selected);
+      if (preparedProvider?.readiness !== 'ready') {
+        throw new Error(`${preparedProvider?.label ?? 'Transcript answer model'} could not be prepared.`);
+      }
+      setTranscriptPromptProviderStates(providers);
+      setTranscriptModelPreparation({
+        availability: 'ready',
+        progress: 100,
+        status: 'ready',
+      });
+      return true;
+    } catch (error) {
+      if (!isCurrentRun()) return false;
+      setTranscriptModelPreparation({
+        availability: 'downloadable',
+        progress: 0,
+        status: 'failed',
+      });
+      setTranscriptAnswerError(
+        error instanceof Error ? error.message : 'Transcript answer model could not be prepared.',
+      );
+      throw error;
+    }
+  }
+
+  async function cancelTranscriptAnswerModelDownload(modelId: string) {
+    transcriptModelPreparationRunIdRef.current += 1;
+    const { modelSetup, promptService } = getTranscriptPromptServices();
+    await modelSetup.removeModel(modelId);
+    const providers = await promptService.getProviderStates();
+    setTranscriptPromptProviderStates(providers);
+    setTranscriptModelPreparation(
+      getTranscriptModelPreparation(providers.find((provider) => provider.selected)),
+    );
+  }
+
+  async function setTranscriptPromptProvider(providerId: string) {
+    transcriptModelPreparationRunIdRef.current += 1;
+    const providers = await getTranscriptPromptServices().promptService.setSelectedProvider(
+      providerId,
+    );
+    setTranscriptPromptProviderStates(providers);
+    setTranscriptModelPreparation(
+      getTranscriptModelPreparation(providers.find((provider) => provider.selected)),
+    );
+    setTranscriptAnswerError(undefined);
+  }
 
   async function answerTranscriptQuestion(question = transcriptQuestion) {
     const trimmedQuestion = question.trim();
@@ -1638,9 +1846,23 @@ export function PublicDeckViewer({
     transcriptAnswerRunIdRef.current = runId;
     setTranscriptAnswerStatus('answering');
     setTranscriptAnswerError(undefined);
+    if (transcriptRecordings.length === 0) {
+      setTranscriptAnswer({
+        citations: [],
+        text: 'No transcript text is available for this presentation.',
+      });
+      setTranscriptAnswerStatus('idle');
+      return;
+    }
     try {
+      const isModelReady = await prepareTranscriptAnswerModel();
+      if (!isModelReady) return;
+      if (transcriptAnswerRunIdRef.current !== runId) return;
       transcriptQaServiceRef.current ??= new TranscriptQuestionAnsweringService({
-        textGenerationRuntime: new webGpuTextGenerationRuntime.TransformersTextGenerationRuntime(),
+        textGenerator: {
+          generate: (prompt, options) =>
+            getTranscriptPromptServices().promptService.generateText(prompt, options),
+        },
       });
       const answer = await transcriptQaServiceRef.current.answer(
         trimmedQuestion,
@@ -1713,7 +1935,7 @@ export function PublicDeckViewer({
           recordings={transcriptRecordings}
           project={project}
           onEnterSlideFullscreen={enterSlideOnlyFullscreen}
-          onOpenTranscript={() => setTranscriptPanelOpen((current) => !current)}
+          onOpenTranscript={() => setTranscriptPanelOpen(true)}
           onPlaybackSync={setPublicPlaybackSync}
           onSelectPage={(pageIndex) => playPresentationPage(project, pageIndex)}
         />
@@ -1757,6 +1979,16 @@ export function PublicDeckViewer({
           >
             <ListMusic size={18} aria-hidden="true" />
           </button>
+          <button
+            className="stitch-icon-button"
+            type="button"
+            aria-label="Open presentation AI"
+            aria-expanded={transcriptPanelOpen}
+            title="Open presentation AI"
+            onClick={() => setTranscriptPanelOpen(true)}
+          >
+            <Sparkles size={18} aria-hidden="true" />
+          </button>
         </nav>
       ) : null}
       {transcriptPanelOpen && !slideOnlyFullscreen ? (
@@ -1792,7 +2024,15 @@ export function PublicDeckViewer({
             answer={transcriptAnswer}
             error={transcriptAnswerError}
             isAnswering={transcriptAnswerStatus === 'answering'}
+            modelControlState={transcriptModelControlState}
             question={transcriptQuestion}
+            onCancelModelDownload={cancelTranscriptAnswerModelDownload}
+            onPrepareModel={async () => {
+              await prepareTranscriptAnswerModel();
+            }}
+            onProviderChange={(providerId) => {
+              void setTranscriptPromptProvider(providerId);
+            }}
             onQuestionChange={setTranscriptQuestion}
             onStop={stopTranscriptAnswer}
             onSubmit={(question) => void answerTranscriptQuestion(question)}

--- a/apps/editor/src/ui/styles/prompt-composer.css
+++ b/apps/editor/src/ui/styles/prompt-composer.css
@@ -224,6 +224,140 @@
   min-width: 0;
 }
 
+.prompt-model-control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.prompt-model-select-shell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 116px;
+  max-width: 170px;
+  height: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--ew-text);
+}
+
+.prompt-model-select-shell select {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  border: 0;
+  outline: 0;
+  appearance: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  padding: 0 26px 0 11px;
+}
+
+.prompt-model-select-shell select:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.prompt-model-select-shell svg {
+  position: absolute;
+  right: 8px;
+  pointer-events: none;
+  color: var(--ew-muted);
+}
+
+.prompt-model-download-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(55, 253, 118, 0.42);
+  border-radius: 999px;
+  background: rgba(55, 253, 118, 0.12);
+  color: var(--ew-green);
+  cursor: pointer;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease;
+}
+
+.prompt-model-download-button:hover:not(:disabled),
+.prompt-model-download-button:focus-visible {
+  border-color: rgba(55, 253, 118, 0.72);
+  background: rgba(55, 253, 118, 0.2);
+  outline: 0;
+  transform: translateY(-1px);
+}
+
+.prompt-model-download-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.66;
+}
+
+.prompt-model-progress {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: 12;
+  display: grid;
+  gap: 7px;
+  min-width: 190px;
+  border: 1px solid rgba(55, 253, 118, 0.28);
+  border-radius: 8px;
+  background: #111;
+  padding: 9px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.48);
+}
+
+.prompt-model-cancel-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.38);
+  color: var(--ew-text);
+  cursor: pointer;
+}
+
+.prompt-model-cancel-button:hover:not(:disabled),
+.prompt-model-cancel-button:focus-visible {
+  border-color: rgba(255, 122, 122, 0.6);
+  color: #ff9a9a;
+  outline: 0;
+}
+
+.prompt-model-cancel-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.prompt-model-progress .download-progress-copy {
+  padding-right: 28px;
+  font-size: 11px;
+}
+
+.prompt-model-control-compact .prompt-model-select-shell {
+  min-width: 132px;
+  max-width: 176px;
+  height: 40px;
+}
+
 .prompt-bar textarea:disabled {
   color: rgba(236, 255, 233, 0.72);
   opacity: 1;

--- a/apps/editor/tests/unit/services/browserPromptService.gemma.test.ts
+++ b/apps/editor/tests/unit/services/browserPromptService.gemma.test.ts
@@ -111,6 +111,21 @@ describe('browserPromptService.GemmaPromptProvider structured JSON generation', 
     expect(progress.at(-1)).toBe(100);
   });
 
+  it('generates general text with the supported Gemma model', async () => {
+    const runtime = new TestTextGenerationRuntime();
+    runtime.generate.mockResolvedValue('Transcript answer');
+    const provider = new browserPromptService.GemmaPromptProvider(runtime);
+
+    await expect(provider.generateText('Summarize this transcript')).resolves.toBe(
+      'Transcript answer',
+    );
+    expect(runtime.generate).toHaveBeenCalledWith(
+      aiModelCatalog.GEMMA_LLM_TRANSFORMERS_MODEL_ID,
+      'Summarize this transcript',
+      undefined,
+    );
+  });
+
   it('normalizes left-image hero layout geometry after Gemma output', async () => {
     const modelSetupService: ModelSetupService = {
       getModelStates: vi.fn().mockResolvedValue([]),

--- a/apps/editor/tests/unit/services/chromePromptService.slides.test.ts
+++ b/apps/editor/tests/unit/services/chromePromptService.slides.test.ts
@@ -42,6 +42,24 @@ describe('ChromePromptService slide generation', () => {
     expect(destroy).toHaveBeenCalled();
   });
 
+  it('generates general text without a structured response constraint', async () => {
+    const prompt = vi.fn().mockResolvedValue('Transcript answer');
+    Object.defineProperty(window, 'LanguageModel', {
+      configurable: true,
+      value: {
+        availability: vi.fn().mockResolvedValue('available'),
+        create: vi.fn().mockResolvedValue({ prompt, destroy: vi.fn() }),
+      },
+    });
+
+    const service = new ChromePromptService();
+
+    await expect(service.generateText('Summarize this transcript')).resolves.toBe(
+      'Transcript answer',
+    );
+    expect(prompt).toHaveBeenCalledWith('Summarize this transcript', undefined);
+  });
+
   it('generates one validated element for a task', async () => {
     const prompt = vi.fn().mockResolvedValue(JSON.stringify({
       type: 'text',

--- a/apps/editor/tests/unit/ui/editor/PromptBar.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/PromptBar.test.tsx
@@ -1,10 +1,38 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import { imageGenerationModel } from '../../../../src/services/image-generation/imageGenerationModel';
 import { imagePromptOptions } from '../../../../src/ui/editor/media/imagePromptOptions';
+import type { PromptModelControlOption } from '../../../../src/ui/editor/prompting/PromptModelControl';
 import { PromptBar } from '../../../../src/ui/editor/prompting/PromptBar';
 
 describe('PromptBar', () => {
+  const promptOptions: PromptModelControlOption[] = [
+    {
+      compatibility: 'compatible',
+      id: 'gemma-webgpu',
+      label: 'Gemma WebGPU',
+      modelId: 'gemma-4-webgpu-llm',
+      readiness: 'needs-download',
+      selected: true,
+    },
+    {
+      compatibility: 'compatible',
+      id: 'chrome-built-in',
+      label: 'Chrome Prompt',
+      readiness: 'ready',
+      selected: false,
+    },
+  ];
+  const imageGenerationOption: PromptModelControlOption = {
+    compatibility: 'compatible',
+    id: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
+    label: imageGenerationModel.IMAGE_GENERATION_DISPLAY_NAME,
+    modelId: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
+    readiness: 'downloading',
+    selected: true,
+  };
+
   it('uses a multiline prompt field so long image prompts can wrap', () => {
     render(<PromptBar createImageOptions={imagePromptOptions.defaultCreateImagePromptOptions} />);
 
@@ -51,5 +79,97 @@ describe('PromptBar', () => {
         imagePromptOptions.defaultCreateImagePromptOptions,
       );
     });
+  });
+
+  it('shows the selected prompt model and download action', async () => {
+    const user = userEvent.setup();
+    const onPreparePromptApi = vi.fn();
+    const onPromptProviderChange = vi.fn();
+
+    render(
+      <PromptBar
+        createImageOptions={imagePromptOptions.defaultCreateImagePromptOptions}
+        slideModelControlState={{
+          preparation: { availability: 'downloadable', progress: 0, status: 'idle' },
+          options: promptOptions,
+        }}
+        onPreparePromptApi={onPreparePromptApi}
+        onPromptProviderChange={onPromptProviderChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Remove Create image mode' }));
+    expect(screen.getByRole('combobox', { name: 'Prompt model' })).toHaveValue('gemma-webgpu');
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Prompt model' }), 'chrome-built-in');
+    expect(onPromptProviderChange).toHaveBeenCalledWith('chrome-built-in');
+
+    await user.click(screen.getByRole('button', { name: 'Download Gemma WebGPU' }));
+    expect(onPreparePromptApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows prompt model download progress and cancel action while preparation runs', async () => {
+    const user = userEvent.setup();
+    const onCancelPromptModelDownload = vi.fn();
+
+    render(
+      <PromptBar
+        createImageOptions={imagePromptOptions.defaultCreateImagePromptOptions}
+        slideModelControlState={{
+          preparation: {
+            availability: 'downloading',
+            estimatedRemainingMs: 61_000,
+            progress: 48,
+            status: 'downloading',
+          },
+          options: promptOptions,
+        }}
+        onCancelPromptModelDownload={onCancelPromptModelDownload}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Remove Create image mode' }));
+    expect(screen.getByRole('button', { name: 'Downloading Gemma WebGPU' })).toBeDisabled();
+    expect(
+      screen.getByRole('progressbar', { name: 'Gemma WebGPU download progress' }),
+    ).toHaveAttribute('aria-valuenow', '48');
+    expect(screen.getByText('48%')).toBeInTheDocument();
+    expect(screen.getByText('About 2 min remaining')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel Gemma WebGPU download' }));
+    expect(onCancelPromptModelDownload).toHaveBeenCalledWith('gemma-4-webgpu-llm');
+  });
+
+  it('uses the Bonsai image model control while create image mode is active', () => {
+    render(
+      <PromptBar
+        createImageOptions={imagePromptOptions.defaultCreateImagePromptOptions}
+        createImageModelControlState={{
+          label: 'Image generation model',
+          preparation: {
+            availability: 'downloading',
+            loadedBytes: 900_000_000,
+            progress: 27,
+            status: 'downloading',
+            totalBytes: 3_600_000_000,
+          },
+          options: [imageGenerationOption],
+        }}
+        slideModelControlState={{
+          preparation: { availability: 'downloadable', progress: 0, status: 'idle' },
+          options: promptOptions,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Image generation model' })).toHaveValue(
+      imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
+    );
+    expect(
+      screen.getByRole('progressbar', {
+        name: `${imageGenerationModel.IMAGE_GENERATION_DISPLAY_NAME} download progress`,
+      }),
+    ).toHaveAttribute('aria-valuenow', '27');
+    expect(screen.queryByRole('combobox', { name: 'Prompt model' })).not.toBeInTheDocument();
   });
 });

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -7,6 +7,8 @@ import type {
   FontImportService,
   ShareRecord,
 } from '../../../../src/services/contracts/interfaces';
+import { aiModelCatalog } from '../../../../src/services/model-setup/aiModelCatalog';
+import { browserPromptService } from '../../../../src/services/prompting/browserPromptService';
 import { BrowserShareService } from '../../../../src/services/sharing/shareService';
 import { canvasWorkspaceUtils } from '../../../../src/ui/editor/canvas/canvasWorkspaceUtils';
 import { PublicDeckViewer } from '../../../../src/ui/share/PublicDeckViewer';
@@ -50,6 +52,17 @@ describe('PublicDeckViewer', () => {
     window.history.replaceState({}, '', '/');
     vi.stubGlobal('Image', MockPreloadImage);
     vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(null, { status: 204 }))));
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: {},
+    });
+    Object.defineProperty(window, 'LanguageModel', {
+      configurable: true,
+      value: {
+        availability: vi.fn().mockResolvedValue('available'),
+        create: vi.fn().mockResolvedValue({ destroy: vi.fn(), prompt: vi.fn() }),
+      },
+    });
     vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(function loadMedia(
       this: HTMLMediaElement,
     ) {
@@ -98,6 +111,14 @@ describe('PublicDeckViewer', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(window, 'LanguageModel', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(navigator, 'gpu', {
+      configurable: true,
+      value: undefined,
+    });
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -142,6 +163,7 @@ describe('PublicDeckViewer', () => {
 
   it('renders a shared deck in read-only mode', async () => {
     const { share, shareService } = createRemoteShare('00000000-0000-4000-8000-000000000201');
+    const user = userEvent.setup();
     render(
       <PublicDeckViewer
         shareId={share.shareId}
@@ -156,6 +178,9 @@ describe('PublicDeckViewer', () => {
     expect(screen.getByRole('button', { name: 'Previous slide' })).toBeDisabled();
     expect(screen.queryByRole('region', { name: 'Presentation playback' })).not.toBeInTheDocument();
     expect(screen.getByText('1 / 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open transcript chat' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Open presentation AI' }));
+    expect(screen.getByRole('complementary', { name: 'Transcript chat' })).toBeInTheDocument();
   });
 
   it('opens transcript panel with public recording audio and segments', async () => {
@@ -268,7 +293,8 @@ describe('PublicDeckViewer', () => {
     await user.click(screen.getByRole('button', { name: 'Jump to slide 3: Slide 3' }));
     expect(screen.queryByText('The second slide has synced audio.')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Jump to slide 2: Slide 2' }));
-    await user.click(screen.getByRole('button', { name: 'Open transcript chat' }));
+    expect(screen.getByRole('button', { name: 'Open transcript chat' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Open presentation AI' }));
 
     expect(screen.getByRole('complementary', { name: 'Transcript chat' })).toBeInTheDocument();
     expect(screen.getByRole('region', { name: 'Podcast playback' })).toBeInTheDocument();
@@ -285,6 +311,30 @@ describe('PublicDeckViewer', () => {
     expect(screen.queryByRole('tab', { name: 'Ask' })).not.toBeInTheDocument();
     expect(screen.getByRole('form', { name: 'Transcript question prompt' })).toHaveClass('prompt-bar');
     expect(screen.getByRole('textbox', { name: 'Question for transcript chat' }).tagName).toBe('TEXTAREA');
+    const transcriptModelSelect = await screen.findByRole('combobox', {
+      name: 'Transcript answer model',
+    });
+    expect(transcriptModelSelect).toHaveValue(browserPromptService.CHROME_PROMPT_PROVIDER_ID);
+    expect(Array.from((transcriptModelSelect as HTMLSelectElement).options)).toEqual([
+      expect.objectContaining({
+        text: 'Chrome Built-in Prompt API',
+        value: browserPromptService.CHROME_PROMPT_PROVIDER_ID,
+      }),
+      expect.objectContaining({
+        text: aiModelCatalog.GEMMA_LLM_DISPLAY_NAME,
+        value: browserPromptService.GEMMA_PROMPT_PROVIDER_ID,
+      }),
+    ]);
+    await user.selectOptions(
+      transcriptModelSelect,
+      browserPromptService.GEMMA_PROMPT_PROVIDER_ID,
+    );
+    await waitFor(() => {
+      expect(transcriptModelSelect).toHaveValue(browserPromptService.GEMMA_PROMPT_PROVIDER_ID);
+    });
+    expect(
+      screen.getByRole('button', { name: `Download ${aiModelCatalog.GEMMA_LLM_DISPLAY_NAME}` }),
+    ).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Summarize this presentation in 3 bullets' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Presenter recording' })).toBeInTheDocument();
     expect(screen.getByText('The roadmap includes transcript chat.')).toBeInTheDocument();

--- a/tests/e2e/editor/ai-webgpu-gemma-providers-flow.ts
+++ b/tests/e2e/editor/ai-webgpu-gemma-providers-flow.ts
@@ -18,6 +18,9 @@ export const aiWebGpuGemmaProvidersFlow = {
     await expect(page.getByRole('button', { name: 'Remove LLM Model' })).toBeVisible({
       timeout: 30_000,
     });
+    await expect(
+      page.getByRole('combobox', { exact: true, name: 'Image generation model' }),
+    ).toHaveValue('image-generation-models');
     await page.getByRole('combobox', { name: 'Language Detection Model' }).selectOption('language-detection-webgpu');
     await expect(page.getByRole('button', { name: 'Remove Language Detection Model' })).toBeVisible({
       timeout: 30_000,
@@ -28,6 +31,9 @@ export const aiWebGpuGemmaProvidersFlow = {
     });
 
     await page.getByRole('button', { name: 'Remove Create image mode' }).click();
+    await expect(page.getByRole('combobox', { name: 'Prompt model' })).toHaveValue(
+      'gemma-4-webgpu',
+    );
     await page
       .getByRole('textbox', { name: 'Slide structure prompt' })
       .fill('Create a title and subtitle slide about WebGPU model QA');

--- a/tests/e2e/editor/image-export-journey-page.ts
+++ b/tests/e2e/editor/image-export-journey-page.ts
@@ -26,8 +26,9 @@ export const imageExportJourneyPage = {
     if (await localSave.isVisible({ timeout: 1_000 }).catch(() => false)) {
       await localSave.getByRole('button', { name: 'Choose folder' }).click();
     }
-    await expect(page.getByRole('complementary', { name: 'Share design panel' })).toBeVisible();
-    await page.getByRole('button', { name: 'Download' }).click();
+    const sharePanel = page.getByRole('complementary', { name: 'Share design panel' });
+    await expect(sharePanel).toBeVisible();
+    await sharePanel.getByRole('button', { exact: true, name: 'Download' }).click();
     return downloadPromise;
   },
 

--- a/tests/e2e/editor/public-transcript-chat.spec.ts
+++ b/tests/e2e/editor/public-transcript-chat.spec.ts
@@ -173,10 +173,12 @@ test.describe('editor public transcript chat journey', () => {
           create: () =>
             Promise.resolve({
               destroy() {},
-              prompt: () =>
-                Promise.resolve(
+              prompt: (prompt: string) => {
+                Object.assign(window, { __lastTranscriptPrompt: prompt });
+                return Promise.resolve(
                   'The transcript says podcast mode uses slide chapters so viewers can jump to the right section.',
-                ),
+                );
+              },
             }),
         },
       });
@@ -329,7 +331,35 @@ test.describe('editor public transcript chat journey', () => {
     await expect(page.getByText('The transcript says podcast mode uses slide chapters')).toBeVisible({
       timeout: 10_000,
     });
+    await expect(page.getByRole('textbox', { name: 'Question for transcript chat' })).toBeEmpty();
     await expect(page.locator('.public-transcript-answer span').first()).toHaveText('0:00');
+
+    await page.getByRole('button', { name: 'What was explained on the current slide?' }).click();
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (window as typeof window & { __lastTranscriptPrompt?: string })
+                .__lastTranscriptPrompt,
+          ),
+        { timeout: 10_000 },
+      )
+      .toContain('Question: What was explained on the current slide?');
+    const currentSlidePrompt = await page.evaluate(
+      () =>
+        (window as typeof window & { __lastTranscriptPrompt?: string }).__lastTranscriptPrompt ?? '',
+    );
+    expect(currentSlidePrompt).toContain('Slide 2 of 2');
+    expect(currentSlidePrompt).toContain('Name: Closing');
+    expect(currentSlidePrompt).toContain('Shared deck closing');
+    expect(currentSlidePrompt).toContain(
+      'Podcast mode uses slide chapters so viewers can jump to the right section.',
+    );
+    expect(currentSlidePrompt).toContain(
+      'The public deck keeps the transcript searchable alongside playback.',
+    );
+    expect(currentSlidePrompt).toContain('Question: What was explained on the current slide?');
 
     await page
       .getByRole('textbox', { name: 'Question for transcript chat' })

--- a/tests/e2e/editor/public-transcript-chat.spec.ts
+++ b/tests/e2e/editor/public-transcript-chat.spec.ts
@@ -44,8 +44,10 @@ test.describe('editor public transcript chat journey', () => {
     await publicDeck.expectReady(false);
 
     const transcriptButton = page.getByRole('button', { name: 'Open transcript chat' });
+    const presentationAiButton = page.getByRole('button', { name: 'Open presentation AI' });
     await expect(transcriptButton).toBeEnabled();
-    await transcriptButton.click();
+    await expect(presentationAiButton).toBeEnabled();
+    await presentationAiButton.click();
     await expect(page.getByRole('complementary', { name: 'Transcript chat' })).toBeVisible();
     await expect(
       page.getByText('No presenter recording has been published with this deck.'),
@@ -59,21 +61,41 @@ test.describe('editor public transcript chat journey', () => {
 
   test('surfaces transcript chat model failures in the public viewer', async ({ page }) => {
     await page.addInitScript(() => {
+      Object.defineProperty(window, 'LanguageModel', {
+        configurable: true,
+        value: {
+          availability: () => Promise.resolve('available'),
+          create: () =>
+            Promise.resolve({
+              destroy() {},
+              prompt: () => Promise.reject(new Error('Transcript answer generation failed.')),
+            }),
+        },
+      });
       class FailingWorker {
         onerror: ((event: ErrorEvent) => void) | null = null;
         onmessage: ((event: MessageEvent) => void) | null = null;
 
-        postMessage(message: { id?: string; type?: string }) {
+        postMessage(message: { id?: string; texts?: string[]; type?: string }) {
           const id = message.id ?? 'missing-id';
           window.setTimeout(() => {
+            if (message.type === 'embed') {
+              this.onmessage?.(
+                new MessageEvent('message', {
+                  data: {
+                    embeddings: (message.texts ?? []).map(() => [1, 0, 0]),
+                    id,
+                    type: 'result',
+                  },
+                }),
+              );
+              return;
+            }
             this.onmessage?.(
               new MessageEvent('message', {
                 data: {
                   id,
-                  message:
-                    message.type === 'embed'
-                      ? 'Transcript embeddings are unavailable in this browser.'
-                      : 'Transcript answer generation failed.',
+                  message: 'Transcript answer generation failed.',
                   type: 'error',
                 },
               }),
@@ -135,7 +157,7 @@ test.describe('editor public transcript chat journey', () => {
       .fill('Why did setup fail?');
     await page.getByRole('button', { name: 'Ask transcript' }).click();
 
-    await expect(page.getByText('Transcript embeddings are unavailable in this browser.')).toBeVisible({
+    await expect(page.getByText('Transcript answer generation failed.')).toBeVisible({
       timeout: 10_000,
     });
   });
@@ -144,6 +166,20 @@ test.describe('editor public transcript chat journey', () => {
     page,
   }) => {
     await page.addInitScript(() => {
+      Object.defineProperty(window, 'LanguageModel', {
+        configurable: true,
+        value: {
+          availability: () => Promise.resolve('available'),
+          create: () =>
+            Promise.resolve({
+              destroy() {},
+              prompt: () =>
+                Promise.resolve(
+                  'The transcript says podcast mode uses slide chapters so viewers can jump to the right section.',
+                ),
+            }),
+        },
+      });
       Object.defineProperty(HTMLMediaElement.prototype, 'duration', {
         configurable: true,
         get() {
@@ -265,6 +301,12 @@ test.describe('editor public transcript chat journey', () => {
 
     await page.getByRole('button', { name: 'Open transcript chat' }).click();
     await expect(page.getByRole('complementary', { name: 'Transcript chat' })).toBeVisible();
+    const transcriptModelSelect = page.getByRole('combobox', { name: 'Transcript answer model' });
+    await expect(transcriptModelSelect).toHaveValue('chrome-prompt-api');
+    await expect(transcriptModelSelect.getByRole('option')).toHaveText([
+      'Chrome Built-in Prompt API',
+      'Gemma 4 E2B',
+    ]);
     const podcastPlayer = page.getByRole('region', { name: 'Podcast playback' });
     await expect(podcastPlayer).toBeVisible();
     await expect(


### PR DESCRIPTION
## Summary

- Add configurable prompt-model controls to editor AI workflows.
- Support model selection across browser, Chrome, presenter, and public transcript experiences.
- Update prompting UI and styling with coverage for model controls and provider flows.

## Testing

- Added and updated unit tests for prompt services, PromptBar, and PublicDeckViewer.
- Added end-to-end coverage for Gemma WebGPU providers and public transcript chat.