### PR TITLE
Add keyboard shortcuts to public deck views

### DIFF
--- a/apps/editor/src/ui/components/KeyboardShortcutsDialog.tsx
+++ b/apps/editor/src/ui/components/KeyboardShortcutsDialog.tsx
@@ -1,6 +1,7 @@
 interface KeyboardShortcutsDialogProps {
   onShortcutAction?: (action: KeyboardShortcutAction) => void;
   onClose: () => void;
+  shortcutGroups?: readonly KeyboardShortcutGroup[];
   supportedActions?: readonly KeyboardShortcutAction[];
   title?: string;
   variant?: 'dialog' | 'popover';
@@ -36,7 +37,12 @@ export type KeyboardShortcutAction =
   | 'scroll-notes-up'
   | 'scroll-notes-down';
 
-const shortcutGroups = [
+export interface KeyboardShortcutGroup {
+  title: string;
+  items: { action: KeyboardShortcutAction; keys: string[]; label: string }[];
+}
+
+const defaultShortcutGroups = [
   {
     title: 'Navigation',
     items: [
@@ -91,14 +97,12 @@ const shortcutGroups = [
       { action: 'jump-movie-end', keys: ['O'], label: 'Jump to end of movie' },
     ],
   },
-] satisfies {
-  title: string;
-  items: { action: KeyboardShortcutAction; keys: string[]; label: string }[];
-}[];
+] satisfies KeyboardShortcutGroup[];
 
 export function KeyboardShortcutsDialog({
   onShortcutAction,
   onClose,
+  shortcutGroups = defaultShortcutGroups,
   supportedActions,
   title = 'Keyboard Shortcuts',
   variant = 'dialog',

--- a/apps/editor/src/ui/components/isKeyboardShortcutEditableTarget.ts
+++ b/apps/editor/src/ui/components/isKeyboardShortcutEditableTarget.ts
@@ -1,0 +1,9 @@
+export function isKeyboardShortcutEditableTarget(target: EventTarget | null) {
+  const isEditableElement = (value: Element | EventTarget | null) =>
+    value instanceof HTMLInputElement ||
+    value instanceof HTMLTextAreaElement ||
+    value instanceof HTMLSelectElement ||
+    (value instanceof HTMLElement && value.isContentEditable);
+
+  return isEditableElement(target) || isEditableElement(document.activeElement);
+}

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -19,6 +19,7 @@ import {
   KeyboardShortcutsDialog,
   type KeyboardShortcutAction,
 } from '../components/KeyboardShortcutsDialog';
+import { isKeyboardShortcutEditableTarget } from '../components/isKeyboardShortcutEditableTarget';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
 import {
   presentationMovieControls,
@@ -127,15 +128,6 @@ function getPresenterOpener() {
   if (!candidate || typeof candidate !== 'object') return null;
   if (!('postMessage' in candidate)) return null;
   return candidate as Window;
-}
-
-function isEditablePresenterTarget(target: EventTarget | null) {
-  const isEditableElement = (value: Element | EventTarget | null) =>
-    value instanceof HTMLInputElement ||
-    value instanceof HTMLTextAreaElement ||
-    value instanceof HTMLSelectElement ||
-    (value instanceof HTMLElement && value.isContentEditable);
-  return isEditableElement(target) || isEditableElement(document.activeElement);
 }
 
 function getActivePage(project: ProjectDocument, activePageId: string) {
@@ -919,7 +911,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (isEditablePresenterTarget(event.target)) return;
+      if (isKeyboardShortcutEditableTarget(event.target)) return;
 
       if (keyboardShortcutsMode && event.key === 'Escape') {
         event.preventDefault();

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -61,6 +61,23 @@ interface PublicPodcastChapter {
 
 type PublicPlaybackSource = 'overlay' | 'podcast';
 
+const nativeControlActivationKeys = new Set([' ', 'Enter', 'Spacebar']);
+
+function isKeyboardShortcutControlActivation(event: KeyboardEvent) {
+  if (!nativeControlActivationKeys.has(event.key)) return false;
+  return (
+    isKeyboardShortcutInteractiveTarget(event.target) ||
+    isKeyboardShortcutInteractiveTarget(document.activeElement)
+  );
+}
+
+function isKeyboardShortcutInteractiveTarget(target: EventTarget | null) {
+  return (
+    target instanceof Element &&
+    Boolean(target.closest('button, a[href], [role="button"], [role="link"]'))
+  );
+}
+
 const publicDeckShortcutActions = [
   'black-screen',
   'cursor-toggle',
@@ -1726,6 +1743,7 @@ export function PublicDeckViewer({
     function handleKeyDown(event: KeyboardEvent) {
       if (viewerState.status !== 'ready') return;
       if (isKeyboardShortcutEditableTarget(event.target)) return;
+      if (isKeyboardShortcutControlActivation(event)) return;
       if (keyboardShortcutsOpen && event.key === 'Escape') {
         event.preventDefault();
         setKeyboardShortcutsOpen(false);

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -63,7 +63,6 @@ type PublicPlaybackSource = 'overlay' | 'podcast';
 
 const publicDeckShortcutActions = [
   'black-screen',
-  'close-slide-navigator',
   'cursor-toggle',
   'decrease-notes',
   'fast-forward-movie',
@@ -81,7 +80,6 @@ const publicDeckShortcutActions = [
   'play-pause-movie',
   'previous-build',
   'previous-navigator-slide',
-  'quit-presentation',
   'reset-timer',
   'rewind-movie',
   'select-navigator-slide',
@@ -108,7 +106,6 @@ const publicDeckShortcutGroups = [
   {
     title: 'Other',
     items: [
-      { action: 'quit-presentation', keys: ['Esc'], label: 'Quit presentation mode' },
       { action: 'shortcut-toggle', keys: ['?'], label: 'Show or hide Keyboard Shortcuts window' },
       { action: 'pause-presentation', keys: ['F'], label: 'Pause presentation; press any key to resume' },
       { action: 'black-screen', keys: ['B'], label: 'Pause presentation and show black screen' },
@@ -124,7 +121,6 @@ const publicDeckShortcutGroups = [
       { action: 'next-navigator-slide', keys: ['+'], label: 'Go to the next slide in the slide navigator' },
       { action: 'previous-navigator-slide', keys: ['-'], label: 'Go to the previous slide in the slide navigator' },
       { action: 'select-navigator-slide', keys: ['Return'], label: 'Go to the current slide in the slide navigator' },
-      { action: 'close-slide-navigator', keys: ['Esc'], label: 'Close the slide navigator' },
     ],
   },
   {
@@ -1412,7 +1408,9 @@ export function PublicDeckViewer({
   const getPublicDeckVideos = useCallback(() => {
     const viewerElement = publicViewerRef.current;
     if (!viewerElement) return [];
-    return Array.from(viewerElement.querySelectorAll<HTMLVideoElement>('video'));
+    return Array.from(
+      viewerElement.querySelectorAll<HTMLVideoElement>('.public-deck-stage-shell video'),
+    );
   }, []);
 
   const controlPublicDeckMovies = useCallback((action: 'end' | 'play-toggle' | 'start') => {
@@ -1938,7 +1936,6 @@ export function PublicDeckViewer({
     if (action === 'fast-forward-movie') pulsePublicDeckMovieHold('fast-forward');
     if (action === 'jump-movie-start') controlPublicDeckMovies('start');
     if (action === 'jump-movie-end') controlPublicDeckMovies('end');
-    if (action === 'quit-presentation') window.close();
   }
 
   return (

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -12,8 +12,18 @@ import type { FontImportService, ShareService } from '../../services/contracts/i
 import { TranscriptQuestionAnsweringService } from '../../services/transcription/transcriptQuestionAnsweringService';
 import type { TranscriptAnswer } from '../../services/transcription/transcriptQuestionAnsweringService';
 import { webGpuTextGenerationRuntime } from '../../services/prompting/webGpuTextGenerationRuntime';
+import {
+  KeyboardShortcutsDialog,
+  type KeyboardShortcutAction,
+  type KeyboardShortcutGroup,
+} from '../components/KeyboardShortcutsDialog';
+import { isKeyboardShortcutEditableTarget } from '../components/isKeyboardShortcutEditableTarget';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
 import { ProjectVideoPreloader } from '../editor/media/ProjectVideoPreloader';
+import {
+  presentationMovieControls,
+  type MovieHoldState,
+} from '../editor/media/presentationMovieControls';
 import { MiniPagePreview } from '../editor/panels/PageMiniPreview';
 import { preloadPublicDeckAssets } from './publicDeckAssetPreloader';
 
@@ -50,6 +60,94 @@ interface PublicPodcastChapter {
 }
 
 type PublicPlaybackSource = 'overlay' | 'podcast';
+
+const publicDeckShortcutActions = [
+  'black-screen',
+  'close-slide-navigator',
+  'cursor-toggle',
+  'decrease-notes',
+  'fast-forward-movie',
+  'previous-slide',
+  'first-slide',
+  'increase-notes',
+  'jump-movie-end',
+  'jump-movie-start',
+  'last-slide',
+  'next-build',
+  'next-navigator-slide',
+  'next-slide',
+  'open-slide-navigator',
+  'pause-presentation',
+  'play-pause-movie',
+  'previous-build',
+  'previous-navigator-slide',
+  'quit-presentation',
+  'reset-timer',
+  'rewind-movie',
+  'select-navigator-slide',
+  'shortcut-toggle',
+  'show-slide-number',
+  'white-screen',
+  'scroll-notes-up',
+  'scroll-notes-down',
+] satisfies KeyboardShortcutAction[];
+
+const publicDeckShortcutGroups = [
+  {
+    title: 'Navigation',
+    items: [
+      { action: 'next-build', keys: ['→', '↓'], label: 'Advance to next build' },
+      { action: 'previous-build', keys: ['['], label: 'Go back to previous build' },
+      { action: 'next-build', keys: [']'], label: 'Advance and skip build' },
+      { action: 'next-slide', keys: ['Shift', '↓'], label: 'Advance to next slide' },
+      { action: 'previous-slide', keys: ['←', '↑'], label: 'Go back to previous slide' },
+      { action: 'first-slide', keys: ['Home'], label: 'Go to first slide' },
+      { action: 'last-slide', keys: ['End'], label: 'Go to last slide' },
+    ],
+  },
+  {
+    title: 'Other',
+    items: [
+      { action: 'quit-presentation', keys: ['Esc'], label: 'Quit presentation mode' },
+      { action: 'shortcut-toggle', keys: ['?'], label: 'Show or hide Keyboard Shortcuts window' },
+      { action: 'pause-presentation', keys: ['F'], label: 'Pause presentation; press any key to resume' },
+      { action: 'black-screen', keys: ['B'], label: 'Pause presentation and show black screen' },
+      { action: 'white-screen', keys: ['W'], label: 'Pause presentation and show white screen' },
+      { action: 'cursor-toggle', keys: ['C'], label: 'Show or hide the pointer cursor' },
+      { action: 'show-slide-number', keys: ['S'], label: 'Display the current slide number' },
+    ],
+  },
+  {
+    title: 'Slide Navigator',
+    items: [
+      { action: 'open-slide-navigator', keys: ['#'], label: 'Open the slide navigator' },
+      { action: 'next-navigator-slide', keys: ['+'], label: 'Go to the next slide in the slide navigator' },
+      { action: 'previous-navigator-slide', keys: ['-'], label: 'Go to the previous slide in the slide navigator' },
+      { action: 'select-navigator-slide', keys: ['Return'], label: 'Go to the current slide in the slide navigator' },
+      { action: 'close-slide-navigator', keys: ['Esc'], label: 'Close the slide navigator' },
+    ],
+  },
+  {
+    title: 'Presenter Display',
+    items: [
+      { action: 'reset-timer', keys: ['R'], label: 'Reset timer' },
+      { action: 'scroll-notes-up', keys: ['U'], label: 'Scroll notes up' },
+      { action: 'scroll-notes-down', keys: ['D'], label: 'Scroll notes down' },
+      { action: 'increase-notes', keys: ['⌘', '+'], label: 'Increase note font size' },
+      { action: 'decrease-notes', keys: ['⌘', '-'], label: 'Decrease note font size' },
+    ],
+  },
+  {
+    title: 'Movies',
+    items: [
+      { action: 'play-pause-movie', keys: ['K'], label: 'Pause/Play movie' },
+      { action: 'rewind-movie', keys: ['J'], label: 'Hold to rewind movie' },
+      { action: 'fast-forward-movie', keys: ['L'], label: 'Hold to fast forward movie' },
+      { action: 'jump-movie-start', keys: ['I'], label: 'Jump to beginning of movie' },
+      { action: 'jump-movie-end', keys: ['O'], label: 'Jump to end of movie' },
+    ],
+  },
+] satisfies KeyboardShortcutGroup[];
 
 interface PublicPlaybackSync {
   currentTimeMs: number;
@@ -407,6 +505,90 @@ function PublicTranscriptPromptComposer({
   );
 }
 
+function PublicDeckSlideList({
+  activeChapter,
+  activePageIndex,
+  chaptersByPageIndex,
+  onSelectPage,
+  onToggleChapterPlayback,
+  pages,
+  playing = false,
+  project,
+}: {
+  activeChapter?: PublicPodcastChapter | undefined;
+  activePageIndex: number;
+  chaptersByPageIndex?: ReadonlyMap<number, PublicPodcastChapter>;
+  onSelectPage: (pageIndex: number) => void;
+  onToggleChapterPlayback?: (chapter: PublicPodcastChapter) => void;
+  pages: Page[];
+  playing?: boolean;
+  project: ProjectDocument;
+}) {
+  return (
+    <div className="public-podcast-chapters" aria-label="Presentation slides">
+      <div className="public-podcast-chapters-heading">
+        <span>Slides</span>
+        <strong>{pages.length}</strong>
+      </div>
+      {pages.map((page, pageIndex) => {
+        const chapter = chaptersByPageIndex?.get(pageIndex);
+        const isActiveSlide = pageIndex === activePageIndex;
+        return (
+          <article
+            className={
+              isActiveSlide
+                ? 'public-podcast-slide public-podcast-chapter-active page-card page-card-active'
+                : 'public-podcast-slide page-card'
+            }
+            key={page.id}
+            aria-label={`Slide ${pageIndex + 1}: ${page.name}`}
+          >
+            <span className="page-card-number">{pageIndex + 1}</span>
+            <button
+              className="page-card-preview"
+              style={{ aspectRatio: `${page.width} / ${page.height}` }}
+              type="button"
+              aria-label={`Open slide ${pageIndex + 1}: ${page.name}`}
+              onClick={() => onSelectPage(pageIndex)}
+            >
+              <MiniPagePreview page={page} project={project} visible={page.visible ?? true} />
+            </button>
+            <span className="public-podcast-slide-body page-card-body">
+              {chaptersByPageIndex ? (
+                chapter ? (
+                  <span className="public-podcast-chapter-time">
+                    {formatTranscriptTimestamp(chapter.startMs)}
+                  </span>
+                ) : (
+                  <span className="public-podcast-chapter-time public-podcast-chapter-time-empty">
+                    No audio
+                  </span>
+                )
+              ) : null}
+              <strong>Slide {pageIndex + 1}</strong>
+              <em>{page.name}</em>
+            </span>
+            {chapter && onToggleChapterPlayback ? (
+              <button
+                className="public-podcast-chapter-icon"
+                type="button"
+                aria-label={`${chapter.id === activeChapter?.id && playing ? 'Pause' : 'Play'} slide ${pageIndex + 1}`}
+                onClick={() => onToggleChapterPlayback(chapter)}
+              >
+                {chapter.id === activeChapter?.id && playing ? (
+                  <Pause size={14} aria-hidden="true" />
+                ) : (
+                  <Play size={14} aria-hidden="true" />
+                )}
+              </button>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
 function PublicTranscriptPodcastPlayer({
   activePageIndex,
   onSelectPage,
@@ -742,65 +924,16 @@ function PublicTranscriptPodcastPlayer({
           }}
         />
       </div>
-      <div className="public-podcast-chapters" aria-label="Presentation slides">
-        <div className="public-podcast-chapters-heading">
-          <span>Slides</span>
-          <strong>{pages.length}</strong>
-        </div>
-        {pages.map((page, pageIndex) => {
-          const chapter = chaptersByPageIndex.get(pageIndex);
-          const isActiveSlide = pageIndex === activePageIndex;
-          return (
-            <article
-              className={
-                isActiveSlide
-                  ? 'public-podcast-slide public-podcast-chapter-active page-card page-card-active'
-                  : 'public-podcast-slide page-card'
-              }
-              key={page.id}
-              aria-label={`Slide ${pageIndex + 1}: ${page.name}`}
-            >
-              <span className="page-card-number">{pageIndex + 1}</span>
-              <button
-                className="page-card-preview"
-                style={{ aspectRatio: `${page.width} / ${page.height}` }}
-                type="button"
-                aria-label={`Open slide ${pageIndex + 1}: ${page.name}`}
-                onClick={() => selectSlide(pageIndex)}
-              >
-                <MiniPagePreview page={page} project={project} visible={page.visible ?? true} />
-              </button>
-              <span className="public-podcast-slide-body page-card-body">
-                {chapter ? (
-                  <span className="public-podcast-chapter-time">
-                    {formatTranscriptTimestamp(chapter.startMs)}
-                  </span>
-                ) : (
-                  <span className="public-podcast-chapter-time public-podcast-chapter-time-empty">
-                    No audio
-                  </span>
-                )}
-                <strong>Slide {pageIndex + 1}</strong>
-                <em>{page.name}</em>
-              </span>
-              {chapter ? (
-                <button
-                  className="public-podcast-chapter-icon"
-                  type="button"
-                  aria-label={`${chapter.id === activeChapter?.id && playing ? 'Pause' : 'Play'} slide ${pageIndex + 1}`}
-                  onClick={() => toggleChapterPlayback(chapter)}
-                >
-                  {chapter.id === activeChapter?.id && playing ? (
-                    <Pause size={14} aria-hidden="true" />
-                  ) : (
-                    <Play size={14} aria-hidden="true" />
-                  )}
-                </button>
-              ) : null}
-            </article>
-          );
-        })}
-      </div>
+      <PublicDeckSlideList
+        activeChapter={activeChapter}
+        activePageIndex={activePageIndex}
+        chaptersByPageIndex={chaptersByPageIndex}
+        pages={pages}
+        playing={playing}
+        project={project}
+        onSelectPage={selectSlide}
+        onToggleChapterPlayback={toggleChapterPlayback}
+      />
       <section className="public-transcript-list public-podcast-transcript-list" aria-label="Transcript">
         <article>
           <h3>{selectedRecording.name}</h3>
@@ -848,10 +981,12 @@ function PublicDeckPlaybackOverlay({
   activePageIndex,
   canGoNext,
   canGoPrevious,
+  keyboardShortcutsOpen,
   onEnterSlideFullscreen,
   onOpenTranscript,
   onPlaybackSync,
   onSelectPage,
+  onToggleKeyboardShortcuts,
   playbackSync,
   project,
   recordings,
@@ -859,10 +994,12 @@ function PublicDeckPlaybackOverlay({
   activePageIndex: number;
   canGoNext: boolean;
   canGoPrevious: boolean;
+  keyboardShortcutsOpen: boolean;
   onEnterSlideFullscreen: () => void;
   onOpenTranscript: () => void;
   onPlaybackSync: (sync: PublicPlaybackSync) => void;
   onSelectPage: (pageIndex: number) => void;
+  onToggleKeyboardShortcuts: () => void;
   playbackSync: PublicPlaybackSync | undefined;
   project: ProjectDocument;
   recordings: TranscriptRecording[];
@@ -1201,6 +1338,17 @@ function PublicDeckPlaybackOverlay({
           <button
             className="public-deck-playback-button"
             type="button"
+            aria-label="Show keyboard shortcuts"
+            aria-expanded={keyboardShortcutsOpen}
+            onClick={onToggleKeyboardShortcuts}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              keyboard
+            </span>
+          </button>
+          <button
+            className="public-deck-playback-button"
+            type="button"
             aria-label="Present slide fullscreen"
             onClick={onEnterSlideFullscreen}
           >
@@ -1230,12 +1378,15 @@ export function PublicDeckViewer({
   const animationFrameRef = useRef<number | undefined>(undefined);
   const pagePreloadAbortRef = useRef<AbortController | undefined>(undefined);
   const runNextAnimationBuildRef = useRef<() => void>(() => undefined);
+  const movieHoldStateRef = useRef<MovieHoldState | undefined>(undefined);
   const transcriptQaServiceRef = useRef<TranscriptQuestionAnsweringService | undefined>(undefined);
   const transcriptAnswerRunIdRef = useRef(0);
   const emptySelection = useMemo<SelectionState>(() => ({ pageId: '', elementIds: [] }), []);
   const [transcriptPanelOpen, setTranscriptPanelOpen] = useState(false);
+  const [slideListOpen, setSlideListOpen] = useState(false);
   const [publicPlaybackSync, setPublicPlaybackSync] = useState<PublicPlaybackSync | undefined>();
   const [slideOnlyFullscreen, setSlideOnlyFullscreen] = useState(false);
+  const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
   const publicViewerRef = useRef<HTMLElement | null>(null);
   const [transcriptQuestion, setTranscriptQuestion] = useState('');
   const [transcriptAnswer, setTranscriptAnswer] = useState<TranscriptAnswer | undefined>();
@@ -1249,12 +1400,43 @@ export function PublicDeckViewer({
 
   const enterSlideOnlyFullscreen = useCallback(() => {
     setTranscriptPanelOpen(false);
+    setSlideListOpen(false);
     setSlideOnlyFullscreen(true);
     const viewerElement = publicViewerRef.current;
     if (!viewerElement?.requestFullscreen) return;
     void viewerElement.requestFullscreen().catch(() => {
       setSlideOnlyFullscreen(false);
     });
+  }, []);
+
+  const getPublicDeckVideos = useCallback(() => {
+    const viewerElement = publicViewerRef.current;
+    if (!viewerElement) return [];
+    return Array.from(viewerElement.querySelectorAll<HTMLVideoElement>('video'));
+  }, []);
+
+  const controlPublicDeckMovies = useCallback((action: 'end' | 'play-toggle' | 'start') => {
+    return presentationMovieControls.control(getPublicDeckVideos(), action);
+  }, [getPublicDeckVideos]);
+
+  const pulsePublicDeckMovieHold = useCallback((action: 'fast-forward' | 'rewind') => {
+    movieHoldStateRef.current = presentationMovieControls.pulse(
+      getPublicDeckVideos(),
+      action,
+      movieHoldStateRef.current,
+    );
+  }, [getPublicDeckVideos]);
+
+  const startPublicDeckMovieHold = useCallback((action: 'fast-forward' | 'rewind') => {
+    movieHoldStateRef.current = presentationMovieControls.startHold(
+      getPublicDeckVideos(),
+      action,
+      movieHoldStateRef.current,
+    );
+  }, [getPublicDeckVideos]);
+
+  const stopPublicDeckMovieHold = useCallback(() => {
+    movieHoldStateRef.current = presentationMovieControls.stopHold(movieHoldStateRef.current);
   }, []);
 
   const clearAnimationTimers = useCallback(() => {
@@ -1538,27 +1720,105 @@ export function PublicDeckViewer({
     return () => {
       pagePreloadAbortRef.current?.abort();
       clearAnimationTimers();
+      movieHoldStateRef.current = presentationMovieControls.stopHold(movieHoldStateRef.current);
     };
   }, [clearAnimationTimers]);
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (viewerState.status !== 'ready') return;
-      if (event.key === 'ArrowLeft') {
+      if (isKeyboardShortcutEditableTarget(event.target)) return;
+      if (keyboardShortcutsOpen && event.key === 'Escape') {
         event.preventDefault();
-        rewindPresentation();
+        setKeyboardShortcutsOpen(false);
+        return;
       }
-      if (event.key === 'ArrowRight') {
+      if (event.key === '?' || (event.key === '/' && event.shiftKey)) {
+        event.preventDefault();
+        setKeyboardShortcutsOpen((current) => !current);
+        return;
+      }
+      const lowerKey = event.key.toLowerCase();
+      if (event.key === 'Home') {
+        event.preventDefault();
+        playPresentationPage(viewerState.project, 0);
+        return;
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        playPresentationPage(viewerState.project, viewerState.project.pages.length - 1);
+        return;
+      }
+      if (event.key === 'ArrowDown' && event.shiftKey) {
+        event.preventDefault();
+        playPresentationPage(viewerState.project, activePageIndex + 1);
+        return;
+      }
+      if (
+        event.key === 'ArrowRight' ||
+        event.key === 'ArrowDown' ||
+        event.key === 'PageDown' ||
+        event.key === ' ' ||
+        event.key === 'Enter' ||
+        event.key === ']'
+      ) {
         event.preventDefault();
         advancePresentation();
+        return;
+      }
+      if (event.key === '[' || event.key === 'ArrowLeft' || event.key === 'ArrowUp' || event.key === 'PageUp') {
+        event.preventDefault();
+        rewindPresentation();
+        return;
+      }
+      if (lowerKey === 'k') {
+        event.preventDefault();
+        controlPublicDeckMovies('play-toggle');
+        return;
+      }
+      if (lowerKey === 'j') {
+        event.preventDefault();
+        if (!event.repeat) startPublicDeckMovieHold('rewind');
+        return;
+      }
+      if (lowerKey === 'l') {
+        event.preventDefault();
+        if (!event.repeat) startPublicDeckMovieHold('fast-forward');
+        return;
+      }
+      if (lowerKey === 'i') {
+        event.preventDefault();
+        controlPublicDeckMovies('start');
+        return;
+      }
+      if (lowerKey === 'o') {
+        event.preventDefault();
+        controlPublicDeckMovies('end');
       }
     }
 
+    function handleKeyUp(event: KeyboardEvent) {
+      if (event.key.toLowerCase() !== 'j' && event.key.toLowerCase() !== 'l') return;
+      stopPublicDeckMovieHold();
+    }
+
     window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [advancePresentation, rewindPresentation, viewerState.status]);
+  }, [
+    activePageIndex,
+    advancePresentation,
+    controlPublicDeckMovies,
+    keyboardShortcutsOpen,
+    playPresentationPage,
+    rewindPresentation,
+    startPublicDeckMovieHold,
+    stopPublicDeckMovieHold,
+    viewerState,
+  ]);
 
   useEffect(() => {
     function handleFullscreenChange() {
@@ -1666,6 +1926,21 @@ export function PublicDeckViewer({
     setTranscriptAnswerError('Transcript answer stopped.');
   }
 
+  function executePublicDeckShortcut(action: KeyboardShortcutAction) {
+    if (action === 'shortcut-toggle') setKeyboardShortcutsOpen((current) => !current);
+    if (action === 'previous-slide' || action === 'previous-build') rewindPresentation();
+    if (action === 'next-slide') advancePresentation();
+    if (action === 'next-build') advancePresentation();
+    if (action === 'first-slide') playPresentationPage(project, 0);
+    if (action === 'last-slide') playPresentationPage(project, project.pages.length - 1);
+    if (action === 'play-pause-movie') controlPublicDeckMovies('play-toggle');
+    if (action === 'rewind-movie') pulsePublicDeckMovieHold('rewind');
+    if (action === 'fast-forward-movie') pulsePublicDeckMovieHold('fast-forward');
+    if (action === 'jump-movie-start') controlPublicDeckMovies('start');
+    if (action === 'jump-movie-end') controlPublicDeckMovies('end');
+    if (action === 'quit-presentation') window.close();
+  }
+
   return (
     <main
       ref={publicViewerRef}
@@ -1709,6 +1984,7 @@ export function PublicDeckViewer({
           activePageIndex={activePageIndex}
           canGoNext={canGoNext}
           canGoPrevious={canGoPrevious}
+          keyboardShortcutsOpen={keyboardShortcutsOpen}
           playbackSync={publicPlaybackSync}
           recordings={transcriptRecordings}
           project={project}
@@ -1716,6 +1992,7 @@ export function PublicDeckViewer({
           onOpenTranscript={() => setTranscriptPanelOpen((current) => !current)}
           onPlaybackSync={setPublicPlaybackSync}
           onSelectPage={(pageIndex) => playPresentationPage(project, pageIndex)}
+          onToggleKeyboardShortcuts={() => setKeyboardShortcutsOpen((current) => !current)}
         />
       ) : !slideOnlyFullscreen ? (
         <nav className="public-deck-controls" aria-label="Slide navigation">
@@ -1751,15 +2028,56 @@ export function PublicDeckViewer({
           <button
             className="stitch-icon-button"
             type="button"
-            aria-label="Open transcript chat"
-            aria-expanded={transcriptPanelOpen}
-            onClick={() => setTranscriptPanelOpen((current) => !current)}
+            aria-label={hasTranscriptRecordings ? 'Open transcript chat' : 'Open slide list'}
+            aria-expanded={hasTranscriptRecordings ? transcriptPanelOpen : slideListOpen}
+            onClick={() => {
+              if (hasTranscriptRecordings) {
+                setTranscriptPanelOpen((current) => !current);
+                return;
+              }
+              setSlideListOpen((current) => !current);
+            }}
           >
             <ListMusic size={18} aria-hidden="true" />
           </button>
+          <button
+            className="stitch-icon-button"
+            type="button"
+            aria-label="Show keyboard shortcuts"
+            aria-expanded={keyboardShortcutsOpen}
+            onClick={() => setKeyboardShortcutsOpen((current) => !current)}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              keyboard
+            </span>
+          </button>
         </nav>
       ) : null}
-      {transcriptPanelOpen && !slideOnlyFullscreen ? (
+      {slideListOpen && !hasTranscriptRecordings && !slideOnlyFullscreen ? (
+        <aside className="public-slide-list-popover" aria-label="Slide list">
+          <header>
+            <h2>Slides</h2>
+            <button
+              className="stitch-icon-button"
+              type="button"
+              aria-label="Close slide list"
+              onClick={() => setSlideListOpen(false)}
+            >
+              <X size={18} aria-hidden="true" />
+            </button>
+          </header>
+          <PublicDeckSlideList
+            activePageIndex={activePageIndex}
+            pages={project.pages}
+            project={project}
+            onSelectPage={(pageIndex) => {
+              playPresentationPage(project, pageIndex);
+              setSlideListOpen(false);
+            }}
+          />
+        </aside>
+      ) : null}
+      {transcriptPanelOpen && hasTranscriptRecordings && !slideOnlyFullscreen ? (
         <aside className="public-transcript-panel" aria-label="Transcript chat">
           <header>
             <div>
@@ -1775,19 +2093,15 @@ export function PublicDeckViewer({
               <X size={18} aria-hidden="true" />
             </button>
           </header>
-          {hasTranscriptRecordings ? (
-            <PublicTranscriptPodcastPlayer
-              activePageIndex={activePageIndex}
-              playbackSync={publicPlaybackSync}
-              recordings={transcriptRecordings}
-              project={project}
-              pages={project.pages}
-              onPlaybackSync={setPublicPlaybackSync}
-              onSelectPage={(pageIndex) => playPresentationPage(project, pageIndex)}
-            />
-          ) : (
-            <p className="public-deck-status">No presenter recording has been published with this deck.</p>
-          )}
+          <PublicTranscriptPodcastPlayer
+            activePageIndex={activePageIndex}
+            playbackSync={publicPlaybackSync}
+            recordings={transcriptRecordings}
+            project={project}
+            pages={project.pages}
+            onPlaybackSync={setPublicPlaybackSync}
+            onSelectPage={(pageIndex) => playPresentationPage(project, pageIndex)}
+          />
           <PublicTranscriptPromptComposer
             answer={transcriptAnswer}
             error={transcriptAnswerError}
@@ -1798,6 +2112,16 @@ export function PublicDeckViewer({
             onSubmit={(question) => void answerTranscriptQuestion(question)}
           />
         </aside>
+      ) : null}
+      {keyboardShortcutsOpen ? (
+        <KeyboardShortcutsDialog
+          title="Keyboard Shortcuts"
+          variant="popover"
+          onClose={() => setKeyboardShortcutsOpen(false)}
+          onShortcutAction={executePublicDeckShortcut}
+          shortcutGroups={publicDeckShortcutGroups}
+          supportedActions={publicDeckShortcutActions}
+        />
       ) : null}
     </main>
   );

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -2309,16 +2309,18 @@ export function PublicDeckViewer({
           >
             <ListMusic size={18} aria-hidden="true" />
           </button>
-          <button
-            className="stitch-icon-button"
-            type="button"
-            aria-label="Open presentation AI"
-            aria-expanded={transcriptPanelOpen}
-            title="Open presentation AI"
-            onClick={() => setTranscriptPanelOpen(true)}
-          >
-            <Sparkles size={18} aria-hidden="true" />
-          </button>
+          {hasTranscriptRecordings ? (
+            <button
+              className="stitch-icon-button"
+              type="button"
+              aria-label="Open presentation AI"
+              aria-expanded={transcriptPanelOpen}
+              title="Open presentation AI"
+              onClick={() => setTranscriptPanelOpen(true)}
+            >
+              <Sparkles size={18} aria-hidden="true" />
+            </button>
+          ) : null}
           <button
             className="stitch-icon-button"
             type="button"

--- a/apps/editor/src/ui/styles.css
+++ b/apps/editor/src/ui/styles.css
@@ -57,6 +57,7 @@
 @import './styles/mirror-settings-details.css';
 @import './styles/remote-import.css';
 @import './styles/public-deck-viewer.css';
+@import './styles/public-deck-slide-list.css';
 @import './styles/public-deck-playback-overlay.css';
 @import './styles/public-podcast-player.css';
 @import './styles/share-panel.css';

--- a/apps/editor/src/ui/styles/public-deck-slide-list.css
+++ b/apps/editor/src/ui/styles/public-deck-slide-list.css
@@ -1,0 +1,37 @@
+.public-slide-list-popover {
+  position: fixed;
+  right: 18px;
+  bottom: 76px;
+  z-index: 8;
+  width: min(390px, calc(100vw - 36px));
+  max-height: min(620px, calc(100vh - 112px));
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--ew-text);
+  background: rgba(5, 8, 10, 0.94);
+  box-shadow: 0 18px 54px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(12px);
+}
+
+.public-slide-list-popover header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.public-slide-list-popover h2 {
+  margin: 0;
+  font-family: var(--ls-font-display);
+  font-size: 16px;
+  letter-spacing: 0;
+}
+
+.public-slide-list-popover .public-podcast-chapters {
+  min-height: 0;
+  max-height: none;
+}

--- a/apps/editor/src/ui/styles/public-deck-viewer.css
+++ b/apps/editor/src/ui/styles/public-deck-viewer.css
@@ -110,6 +110,7 @@
 .public-deck-viewer-slide-fullscreen .public-deck-playback-overlay,
 .public-deck-viewer-slide-fullscreen .public-deck-controls,
 .public-deck-viewer-slide-fullscreen .public-deck-slide-dots,
+.public-deck-viewer-slide-fullscreen .public-slide-list-popover,
 .public-deck-viewer-slide-fullscreen .public-transcript-panel,
 .public-deck-viewer-slide-fullscreen .public-deck-caption-overlay {
   display: none;

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
@@ -554,6 +554,37 @@ describe('PublicDeckViewer', () => {
       'aria-current',
       'page',
     );
+
+    await user.click(screen.getByRole('button', { name: 'Show keyboard shortcuts' }));
+    expect(screen.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Advance to next build/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Go to first slide/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Pause\/Play movie/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Jump to end of movie/ })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Go to first slide/ }));
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'End' });
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Home' });
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.queryByRole('dialog', { name: 'Keyboard Shortcuts' })).not.toBeInTheDocument();
+    fireEvent.keyDown(window, { key: '?' });
+    expect(screen.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('dialog', { name: 'Keyboard Shortcuts' })).not.toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { name: 'Open transcript chat' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Open slide list' }));
+    const slideList = screen.getByRole('complementary', { name: 'Slide list' });
+    expect(slideList).toBeInTheDocument();
+    expect(slideList).toContainElement(
+      screen.getByRole('button', { name: 'Open slide 2: Slide 2' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Open slide 2: Slide 2' }));
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
+    expect(screen.queryByRole('complementary', { name: 'Slide list' })).not.toBeInTheDocument();
   });
 
   it('waits for target slide videos and GIFs before changing public deck slides', async () => {

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -179,7 +179,7 @@ describe('PublicDeckViewer', () => {
     expect(screen.getByText('1 / 1')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Open transcript chat' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Open slide list' })).toBeEnabled();
-    expect(screen.getByRole('button', { name: 'Open presentation AI' })).toBeEnabled();
+    expect(screen.queryByRole('button', { name: 'Open presentation AI' })).not.toBeInTheDocument();
   });
 
   it('opens transcript panel with public recording audio and segments', async () => {

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -555,6 +555,12 @@ describe('PublicDeckViewer', () => {
       'page',
     );
 
+    const previousButton = screen.getByRole('button', { name: 'Previous slide' });
+    previousButton.focus();
+    expect(previousButton).toHaveFocus();
+    await user.keyboard(' ');
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+
     await user.click(screen.getByRole('button', { name: 'Show keyboard shortcuts' }));
     expect(screen.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Advance to next build/ })).toBeInTheDocument();

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -714,6 +714,50 @@ describe('PublicDeckViewer', () => {
     });
 
     expect(await screen.findByText('2 / 2')).toBeInTheDocument();
+
+    const presentedVideo = screen.getByLabelText<HTMLVideoElement>('Slide video');
+    const preloadedVideo = document.querySelector<HTMLVideoElement>(
+      '.project-video-preloader video',
+    );
+    expect(preloadedVideo).not.toBeNull();
+    let presentedVideoPaused = true;
+    const playPresentedVideo = vi.fn(() => {
+      presentedVideoPaused = false;
+      return Promise.resolve();
+    });
+    const pausePresentedVideo = vi.fn(() => {
+      presentedVideoPaused = true;
+    });
+    const playPreloadedVideo = vi.fn(() => Promise.resolve());
+    Object.defineProperty(presentedVideo, 'paused', {
+      configurable: true,
+      get: () => presentedVideoPaused,
+    });
+    Object.defineProperty(presentedVideo, 'play', {
+      configurable: true,
+      value: playPresentedVideo,
+    });
+    Object.defineProperty(presentedVideo, 'pause', {
+      configurable: true,
+      value: pausePresentedVideo,
+    });
+    Object.defineProperty(preloadedVideo, 'play', {
+      configurable: true,
+      value: playPreloadedVideo,
+    });
+
+    fireEvent.keyDown(window, { key: 'k' });
+    expect(playPresentedVideo).toHaveBeenCalledOnce();
+    expect(playPreloadedVideo).not.toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'k' });
+    expect(pausePresentedVideo).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole('button', { name: 'Show keyboard shortcuts' }));
+    expect(screen.queryByRole('button', { name: /Quit presentation mode/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Close the slide navigator/ })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Pause\/Play movie/ }));
+    expect(playPresentedVideo).toHaveBeenCalledTimes(2);
+    expect(playPreloadedVideo).not.toHaveBeenCalled();
   });
 
   it('rewinds shared deck slides with the left arrow key after advancing', async () => {

--- a/tests/e2e/editor/e2e-coverage-diagnostics.spec.ts
+++ b/tests/e2e/editor/e2e-coverage-diagnostics.spec.ts
@@ -83,7 +83,11 @@ test.describe('editor bundled runtime diagnostics coverage', () => {
     await noRecordingViewer.getByRole('button', { name: /Jump to slide 2: Public Slide 2/ }).click();
     await expect(noRecordingViewer.getByText('2 / 3')).toBeVisible();
     await noRecordingViewer.getByRole('button', { name: 'Previous slide' }).click();
-    await noRecordingViewer.getByRole('button', { name: 'Open transcript chat' }).click();
+    await noRecordingViewer.getByRole('button', { name: 'Open slide list' }).click();
+    const slideList = page.getByRole('complementary', { name: 'Slide list' });
+    await expect(slideList).toBeVisible();
+    await slideList.getByRole('button', { name: /Open slide 2: Public Slide 2/ }).click();
+    await expect(noRecordingViewer.getByText('2 / 3')).toBeVisible();
     await expect(page.getByText('Deck not found')).toBeVisible();
     await expect(page.getByText('Deck could not be loaded')).toBeVisible();
     await expect(page.getByLabel('Sequential view model diagnostics')).toContainText('"pages"', {

--- a/tests/e2e/editor/public-transcript-chat.spec.ts
+++ b/tests/e2e/editor/public-transcript-chat.spec.ts
@@ -43,20 +43,16 @@ test.describe('editor public transcript chat journey', () => {
     await publicDeck.goto(`/editor/?share=e2e-share&src=${shareSrc}`);
     await publicDeck.expectReady(false);
 
-    const transcriptButton = page.getByRole('button', { name: 'Open transcript chat' });
-    const presentationAiButton = page.getByRole('button', { name: 'Open presentation AI' });
-    await expect(transcriptButton).toBeEnabled();
-    await expect(presentationAiButton).toBeEnabled();
-    await presentationAiButton.click();
-    await expect(page.getByRole('complementary', { name: 'Transcript chat' })).toBeVisible();
-    await expect(
-      page.getByText('No presenter recording has been published with this deck.'),
-    ).toBeVisible();
-    await page
-      .getByRole('textbox', { name: 'Question for transcript chat' })
-      .fill('Is there a recording?');
-    await page.getByRole('button', { name: 'Ask transcript' }).click();
-    await expect(page.getByText('No transcript text is available for this presentation.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open transcript chat' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open presentation AI' })).not.toBeVisible();
+
+    const slideListButton = page.getByRole('button', { name: 'Open slide list' });
+    await expect(slideListButton).toBeEnabled();
+    await slideListButton.click();
+    const slideList = page.getByRole('complementary', { name: 'Slide list' });
+    await expect(slideList).toBeVisible();
+    await slideList.getByRole('button', { name: 'Open slide 2: Closing' }).click();
+    await expect(page.getByText('2 / 2')).toBeVisible();
   });
 
   test('surfaces transcript chat model failures in the public viewer', async ({ page }) => {

--- a/tests/e2e/public-deck/view-shared-deck.spec.ts
+++ b/tests/e2e/public-deck/view-shared-deck.spec.ts
@@ -105,8 +105,14 @@ test.describe('public deck view journey', () => {
         ],
       },
     };
+    const noTranscriptPayload = structuredClone(payload);
+    noTranscriptPayload.shareId = 'e2e-no-transcript';
+    noTranscriptPayload.project.recordings = {};
     await page.route('**/e2e-share.json', async (route) => {
       await route.fulfill({ contentType: 'application/json', json: payload });
+    });
+    await page.route('**/e2e-no-transcript-share.json', async (route) => {
+      await route.fulfill({ contentType: 'application/json', json: noTranscriptPayload });
     });
     await page.route('**/missing-share.json', async (route) => {
       await route.fulfill({ contentType: 'application/json', json: { shareId: 'other' } });
@@ -114,6 +120,9 @@ test.describe('public deck view journey', () => {
 
     const publicDeck = new PublicDeckPage(page, server.baseURL);
     const shareSrc = encodeURIComponent('http://localhost/e2e-share.json');
+    const noTranscriptShareSrc = encodeURIComponent(
+      'http://localhost/e2e-no-transcript-share.json',
+    );
     const missingShareSrc = encodeURIComponent('http://localhost/missing-share.json');
     await publicDeck.goto(`/editor/?share=e2e-share&src=${shareSrc}`);
     await publicDeck.expectReady(false);
@@ -121,6 +130,27 @@ test.describe('public deck view journey', () => {
     await page.getByRole('button', { name: 'Next slide' }).click();
     await expect(page.getByText('2 / 3')).toBeVisible();
     await page.keyboard.press('ArrowLeft');
+    await expect(page.getByText('1 / 3')).toBeVisible();
+    await page.getByRole('button', { name: 'Show keyboard shortcuts' }).click();
+    const shortcuts = page.getByRole('dialog', { name: 'Keyboard Shortcuts' });
+    await expect(shortcuts).toBeVisible();
+    await expect(shortcuts.getByRole('button', { name: /Advance to next build/ })).toBeVisible();
+    await expect(shortcuts.getByRole('button', { name: /Go to first slide/ })).toBeVisible();
+    await expect(shortcuts.getByRole('button', { name: /Pause\/Play movie/ })).toBeVisible();
+    await expect(shortcuts.getByRole('button', { name: /Jump to end of movie/ })).toBeVisible();
+    await shortcuts.getByRole('button', { name: /Go to last slide/ }).click();
+    await expect(page.getByText('3 / 3')).toBeVisible();
+    await page.keyboard.press('Home');
+    await expect(page.getByText('1 / 3')).toBeVisible();
+    await page.keyboard.press('End');
+    await expect(page.getByText('3 / 3')).toBeVisible();
+    await page.keyboard.press('?');
+    await expect(shortcuts).toBeHidden();
+    await page.keyboard.press('?');
+    await expect(shortcuts).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(shortcuts).toBeHidden();
+    await page.keyboard.press('Home');
     await expect(page.getByText('1 / 3')).toBeVisible();
     await expect(page.getByRole('region', { name: 'Presentation playback' })).toBeVisible();
     await expect(page.getByRole('navigation', { name: 'Jump to slide' })).toBeHidden();
@@ -189,6 +219,18 @@ test.describe('public deck view journey', () => {
 
     await publicDeck.goto(`/editor/?embed=e2e-share&src=${shareSrc}`);
     await publicDeck.expectReady(true);
+
+    await publicDeck.goto(
+      `/editor/?share=e2e-no-transcript&src=${noTranscriptShareSrc}`,
+    );
+    await publicDeck.expectReady(false);
+    await expect(page.getByRole('button', { name: 'Open transcript chat' })).toHaveCount(0);
+    await page.getByRole('button', { name: 'Open slide list' }).click();
+    const slideList = page.getByRole('complementary', { name: 'Slide list' });
+    await expect(slideList).toBeVisible();
+    await slideList.getByRole('button', { name: 'Open slide 3: Appendix' }).click();
+    await expect(page.getByText('3 / 3')).toBeVisible();
+    await expect(slideList).toBeHidden();
 
     await publicDeck.goto(`/editor/?share=e2e-share&src=${missingShareSrc}`);
     await expect(page.getByRole('heading', { name: 'Deck not found' })).toBeVisible();

--- a/tests/e2e/public-deck/view-shared-deck.spec.ts
+++ b/tests/e2e/public-deck/view-shared-deck.spec.ts
@@ -138,6 +138,49 @@ test.describe('public deck view journey', () => {
     await expect(shortcuts.getByRole('button', { name: /Go to first slide/ })).toBeVisible();
     await expect(shortcuts.getByRole('button', { name: /Pause\/Play movie/ })).toBeVisible();
     await expect(shortcuts.getByRole('button', { name: /Jump to end of movie/ })).toBeVisible();
+    await expect(shortcuts.getByRole('button', { name: /Quit presentation mode/ })).toHaveCount(0);
+    await expect(shortcuts.getByRole('button', { name: /Close the slide navigator/ })).toHaveCount(0);
+    await page.evaluate(() => {
+      function addInstrumentedVideo(parent: Element, testId: string) {
+        const video = document.createElement('video');
+        let paused = true;
+        video.dataset.testid = testId;
+        video.dataset.shortcutState = 'idle';
+        Object.defineProperty(video, 'paused', {
+          configurable: true,
+          get: () => paused,
+        });
+        video.play = () => {
+          paused = false;
+          video.dataset.shortcutState = 'playing';
+          return Promise.resolve();
+        };
+        video.pause = () => {
+          paused = true;
+          video.dataset.shortcutState = 'paused';
+        };
+        parent.append(video);
+      }
+
+      const viewer = document.querySelector('[aria-label="Public presentation"]');
+      const stage = viewer?.querySelector('.public-deck-stage-shell');
+      if (!viewer || !stage) throw new Error('Public deck stage was not rendered.');
+      const preloader = document.createElement('div');
+      preloader.className = 'project-video-preloader';
+      viewer.prepend(preloader);
+      addInstrumentedVideo(preloader, 'preloaded-shortcut-video');
+      addInstrumentedVideo(stage, 'presented-shortcut-video');
+    });
+    const presentedVideo = page.getByTestId('presented-shortcut-video');
+    const preloadedVideo = page.getByTestId('preloaded-shortcut-video');
+    await page.keyboard.press('k');
+    await expect(presentedVideo).toHaveAttribute('data-shortcut-state', 'playing');
+    await expect(preloadedVideo).toHaveAttribute('data-shortcut-state', 'idle');
+    await page.keyboard.press('k');
+    await expect(presentedVideo).toHaveAttribute('data-shortcut-state', 'paused');
+    await shortcuts.getByRole('button', { name: /Pause\/Play movie/ }).click();
+    await expect(presentedVideo).toHaveAttribute('data-shortcut-state', 'playing');
+    await expect(preloadedVideo).toHaveAttribute('data-shortcut-state', 'idle');
     await shortcuts.getByRole('button', { name: /Go to last slide/ }).click();
     await expect(page.getByText('3 / 3')).toBeVisible();
     await page.keyboard.press('Home');


### PR DESCRIPTION
## Summary

- Add shared keyboard shortcut handling for presenter and public deck views
- Add shortcut guidance dialog and styling for public deck navigation
- Cover shared-deck shortcut behavior with unit and Playwright tests

## Testing

- Added unit coverage for `PublicDeckViewer`
- Added Playwright coverage for viewing shared decks