### PR TITLE
Add pricing section and waitlist flow to the landing page

### DIFF
--- a/apps/landing/src/LandingPage.tsx
+++ b/apps/landing/src/LandingPage.tsx
@@ -7,11 +7,11 @@ import { ClosingSection } from './sections/ClosingSection';
 import { DemoSection } from './sections/DemoSection';
 import { FeaturesSection } from './sections/FeaturesSection';
 import { HeroSection } from './sections/HeroSection';
+import { PricingSection } from './sections/PricingSection';
 import { RequirementsSection } from './sections/RequirementsSection';
 import { ShowcaseSection } from './sections/ShowcaseSection';
 import { ThanksSection } from './sections/ThanksSection';
 import { WebAiSection } from './sections/WebAiSection';
-import { WebMcpSection } from './sections/WebMcpSection';
 
 export function LandingPage() {
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -25,8 +25,8 @@ export function LandingPage() {
       <ShowcaseSection />
       <DemoSection />
       <WebAiSection />
-      <WebMcpSection />
       <FeaturesSection />
+      <PricingSection />
       <RequirementsSection />
       <ThanksSection />
       <ClosingSection />

--- a/apps/landing/src/components/LandingHeader.tsx
+++ b/apps/landing/src/components/LandingHeader.tsx
@@ -6,9 +6,9 @@ import { GitHubStarButton } from './GitHubStarButton';
 const navItems = [
   { href: '#top', label: 'About it', sectionId: 'top' },
   { href: '#features', label: 'Features', sectionId: 'features' },
-  { href: '#webmcp', label: 'WebMCP Showcase', sectionId: 'webmcp' },
   { href: '#requirements', label: 'Requirements', sectionId: 'requirements' },
   { href: localStudioAppRoutes.docs.gettingStartedAnchor, label: 'Docs', sectionId: 'docs' },
+  { href: '#pricing', label: 'Pricing', sectionId: 'pricing' },
 ] as const;
 
 export function LandingHeader({

--- a/apps/landing/src/hooks/useActiveSection.ts
+++ b/apps/landing/src/hooks/useActiveSection.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const landingSectionIds = ['top', 'features', 'webmcp', 'requirements'];
+const landingSectionIds = ['top', 'features', 'pricing', 'requirements'];
 const sectionObserverThresholds = [0, 0.18, 0.34, 0.5, 0.66, 0.82, 1];
 
 export function useActiveSection() {

--- a/apps/landing/src/sections/FeaturesSection.tsx
+++ b/apps/landing/src/sections/FeaturesSection.tsx
@@ -1,6 +1,7 @@
 import { Layers3 } from 'lucide-react';
 import { Reveal } from '../components/Reveal';
 import { editorProof } from '../content/editorProof';
+import { WebMcpSection } from './WebMcpSection';
 
 export function FeaturesSection() {
   return (
@@ -22,6 +23,7 @@ export function FeaturesSection() {
           ))}
         </ul>
       </div>
+      <WebMcpSection />
     </section>
   );
 }

--- a/apps/landing/src/sections/PricingSection.tsx
+++ b/apps/landing/src/sections/PricingSection.tsx
@@ -1,0 +1,221 @@
+import {
+  ArrowRight,
+  CheckCircle2,
+  Cloud,
+  Database,
+  LockKeyhole,
+  Mail,
+  Mic2,
+  Server,
+  ShieldCheck,
+} from 'lucide-react';
+import { useEffect } from 'react';
+import { Reveal } from '../components/Reveal';
+
+declare global {
+  interface Window {
+    MauticDomain?: string;
+    MauticLang?: {
+      submittingMessage: string;
+    };
+    MauticSDK?: {
+      onLoad: () => void;
+    };
+    MauticSDKLoaded?: boolean;
+  }
+}
+
+const mauticWaitlistConfig = {
+  action: 'https://mautic.erickwendel.com.br/form/submit?formId=6',
+  domain: 'https://mautic.erickwendel.com.br',
+  formId: '6',
+  formName: 'localstudiowaitlist',
+  scriptId: 'mautic-form-sdk',
+  scriptSrc: 'https://mautic.erickwendel.com.br/media/js/mautic-form.js?ve96f9e9b',
+} as const;
+
+const speakerFeatures = [
+  'Full editor with LocalStack or your own S3-compatible setup',
+  'Projects, assets, browser AI models, and exports stay on infrastructure you control',
+  'Presenter mode, public share payloads, imports, exports, and WebMCP from the open product',
+  'Free forever for builders, speakers, educators, and self-hosted teams',
+];
+
+const keynoteFeatures = [
+  'Premium models for sharper image generation, slide drafting, and transcription',
+  'Managed private cloud for backups, history, assets, public links, and transcripts',
+  'Better results when local browser models are too small, slow, or inaccurate',
+  'Private-by-default workspaces with recovery when a machine changes',
+  'Early access to hosted conveniences as the cloud plan launches',
+];
+
+export function PricingSection() {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.MauticDomain = mauticWaitlistConfig.domain;
+    window.MauticLang = {
+      submittingMessage: 'Please wait...',
+    };
+
+    if (window.MauticSDKLoaded) {
+      window.MauticSDK?.onLoad();
+      return;
+    }
+
+    window.MauticSDKLoaded = true;
+
+    const script = document.createElement('script');
+    script.id = mauticWaitlistConfig.scriptId;
+    script.src = mauticWaitlistConfig.scriptSrc;
+    script.type = 'text/javascript';
+    script.onload = () => {
+      window.MauticSDK?.onLoad();
+    };
+    document.head.appendChild(script);
+  }, []);
+
+  return (
+    <section id="pricing" className="pricing-section" aria-labelledby="pricing-title">
+      <div className="section-heading pricing-heading">
+        <p className="eyebrow">Pricing</p>
+        <h2 id="pricing-title">Free forever locally. Cheap when convenience matters.</h2>
+        <p>
+          LocalStudio stays open and self-hostable. The paid plan is for speakers who want the practical parts handled:
+          private cloud backups, project history, hosted assets, share links, and transcriptions without running the
+          storage stack themselves.
+        </p>
+      </div>
+
+      <div className="pricing-grid" aria-label="LocalStudio plans">
+        <Reveal as="article" className="pricing-card pricing-card--speaker" reveal="pricing-speaker">
+          <div className="pricing-card-header">
+            <span className="pricing-badge">Free forever</span>
+            <Mic2 size={34} aria-hidden="true" />
+          </div>
+          <h3>Speaker</h3>
+          <p className="pricing-price">
+            $0
+            <span>/forever</span>
+          </p>
+          <p className="pricing-card-copy">
+            Everything you need to build, import, present, export, and share from your own browser and local stack.
+          </p>
+          <ul className="pricing-feature-list">
+            {speakerFeatures.map((feature) => (
+              <li key={feature}>
+                <CheckCircle2 size={18} aria-hidden="true" />
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+          <a className="secondary-action pricing-card-action" href="/editor/">
+            Start free
+            <ArrowRight size={17} aria-hidden="true" />
+          </a>
+        </Reveal>
+
+        <Reveal as="article" className="pricing-card pricing-card--keynote" delay={80} reveal="pricing-keynote">
+          <div className="pricing-card-header">
+            <span className="pricing-badge pricing-badge--highlight">Waitlist</span>
+            <Cloud size={34} aria-hidden="true" />
+          </div>
+          <h3>Keynote Speaker</h3>
+          <p className="pricing-price">
+            Cheap
+            <span>/managed cloud</span>
+          </p>
+          <p className="pricing-card-copy">
+            For people who want LocalStudio to feel portable and more capable: private backups, premium models, history,
+            assets, transcriptions, and recovery handled by our cloud.
+          </p>
+          <ul className="pricing-feature-list">
+            {keynoteFeatures.map((feature) => (
+              <li key={feature}>
+                <CheckCircle2 size={18} aria-hidden="true" />
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+          <div id="mauticform_wrapper_localstudiowaitlist" className="mauticform_wrapper">
+            <form
+              action={mauticWaitlistConfig.action}
+              autoComplete="off"
+              className="pricing-waitlist-form"
+              data-mautic-form={mauticWaitlistConfig.formName}
+              encType="multipart/form-data"
+              id="mauticform_localstudiowaitlist"
+              method="post"
+              role="form"
+            >
+              <div className="mauticform-error" id="mauticform_localstudiowaitlist_error" />
+              <div className="mauticform-message" id="mauticform_localstudiowaitlist_message" />
+              <label htmlFor="mauticform_input_localstudiowaitlist_email">Email</label>
+              <div className="pricing-waitlist-row">
+                <input
+                  autoComplete="email"
+                  className="mauticform-input"
+                  id="mauticform_input_localstudiowaitlist_email"
+                  name="mauticform[email]"
+                  placeholder="you@company.com"
+                  required
+                  type="email"
+                />
+                <button
+                  className="mauticform-button"
+                  id="mauticform_input_localstudiowaitlist_submit"
+                  name="mauticform[submit]"
+                  type="submit"
+                  value="1"
+                >
+                  <Mail size={17} aria-hidden="true" />
+                  Join waitlist
+                </button>
+              </div>
+              <p>Join the list with your email.</p>
+              <input
+                id="mauticform_localstudiowaitlist_id"
+                type="hidden"
+                name="mauticform[formId]"
+                value={mauticWaitlistConfig.formId}
+              />
+              <input
+                id="mauticform_localstudiowaitlist_return"
+                type="hidden"
+                name="mauticform[return]"
+                value=""
+              />
+              <input
+                id="mauticform_localstudiowaitlist_name"
+                type="hidden"
+                name="mauticform[formName]"
+                value={mauticWaitlistConfig.formName}
+              />
+            </form>
+          </div>
+        </Reveal>
+      </div>
+
+      <Reveal as="div" className="pricing-trust-row" delay={120} reveal="pricing-trust">
+        <span>
+          <Server size={18} aria-hidden="true" />
+          Self-hostable core
+        </span>
+        <span>
+          <Database size={18} aria-hidden="true" />
+          Managed storage option
+        </span>
+        <span>
+          <LockKeyhole size={18} aria-hidden="true" />
+          Private assets
+        </span>
+        <span>
+          <ShieldCheck size={18} aria-hidden="true" />
+          Controlled by design
+        </span>
+      </Reveal>
+    </section>
+  );
+}

--- a/apps/landing/src/sections/WebMcpSection.tsx
+++ b/apps/landing/src/sections/WebMcpSection.tsx
@@ -16,7 +16,7 @@ function getWebMcpDesktopSrcSet() {
 
 export function WebMcpSection() {
   return (
-    <section id="webmcp" className="webmcp-section" aria-labelledby="webmcp-title">
+    <div id="webmcp" className="webmcp-section" aria-labelledby="webmcp-title">
       <div className="showcase-row">
         <Reveal as="div" className="showcase-copy" reveal="webmcp-copy">
           <p className="eyebrow">WebMCP showcase</p>
@@ -61,6 +61,6 @@ export function WebMcpSection() {
           <span className="webmcp-cursor-path" aria-hidden="true" />
         </Reveal>
       </div>
-    </section>
+    </div>
   );
 }

--- a/apps/landing/src/styles/base.css
+++ b/apps/landing/src/styles/base.css
@@ -34,8 +34,8 @@ a {
 .demo-section,
 .showcase-section,
 .web-ai-section,
-.webmcp-section,
 .features-section,
+.pricing-section,
 .requirements-section,
 .thanks-section,
 .closing-section {
@@ -146,8 +146,8 @@ h3 {
 .showcase-section,
 .demo-section,
 .web-ai-section,
-.webmcp-section,
 .features-section,
+.pricing-section,
 .requirements-section,
 .thanks-section,
 .closing-section {

--- a/apps/landing/src/styles/responsive.css
+++ b/apps/landing/src/styles/responsive.css
@@ -4,6 +4,8 @@
   .web-ai-section,
   .webmcp-section .showcase-row,
   .feature-details,
+  .pricing-grid,
+  .pricing-trust-row,
   .requirements-grid,
   .thanks-section,
   .closing-section {
@@ -53,8 +55,17 @@
   .web-ai-section,
   .webmcp-section .showcase-row,
   .feature-details,
+  .pricing-grid,
   .thanks-section {
     grid-template-columns: 1fr;
+  }
+
+  .pricing-card {
+    min-height: auto;
+  }
+
+  .pricing-trust-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .landing-header {
@@ -202,6 +213,15 @@
 
   .requirements-grid {
     grid-template-columns: 1fr;
+  }
+
+  .pricing-waitlist-row,
+  .pricing-trust-row {
+    grid-template-columns: 1fr;
+  }
+
+  .pricing-waitlist-row button {
+    width: 100%;
   }
 
   .landing-footer {

--- a/apps/landing/src/styles/sections.css
+++ b/apps/landing/src/styles/sections.css
@@ -224,6 +224,9 @@
 }
 
 .webmcp-section {
+  margin-top: clamp(38px, 6vw, 76px);
+  padding-top: clamp(34px, 5vw, 64px);
+  border-top: 1px solid rgba(105, 255, 137, 0.18);
   background:
     linear-gradient(180deg, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.42)),
     rgba(4, 17, 12, 0.36);
@@ -292,6 +295,268 @@
   color: var(--ls-text);
   font-size: 18px;
   font-weight: 900;
+}
+
+.pricing-section {
+  background:
+    radial-gradient(circle at 18% 18%, rgba(54, 215, 255, 0.12), transparent 34%),
+    linear-gradient(180deg, rgba(55, 253, 118, 0.04), rgba(0, 0, 0, 0.26)),
+    rgba(0, 0, 0, 0.24);
+}
+
+.pricing-heading {
+  max-width: 920px;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(18px, 3vw, 30px);
+}
+
+.pricing-card {
+  position: relative;
+  display: grid;
+  gap: 14px;
+  align-content: start;
+  min-height: 640px;
+  border: 1px solid rgba(105, 255, 137, 0.26);
+  border-radius: 8px;
+  padding: clamp(24px, 3.2vw, 40px);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.065), transparent 34%),
+    rgba(0, 0, 0, 0.68);
+  box-shadow: 0 34px 90px rgba(0, 0, 0, 0.32);
+}
+
+.pricing-card--keynote {
+  border-color: rgba(54, 215, 255, 0.58);
+  background:
+    linear-gradient(140deg, rgba(54, 215, 255, 0.14), transparent 36%),
+    linear-gradient(320deg, rgba(55, 253, 118, 0.11), transparent 34%),
+    rgba(0, 0, 0, 0.72);
+  box-shadow:
+    0 34px 100px rgba(0, 0, 0, 0.38),
+    0 0 0 1px rgba(54, 215, 255, 0.16);
+}
+
+.pricing-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  color: var(--ls-green-fixed);
+}
+
+.pricing-card--keynote .pricing-card-header {
+  color: var(--ls-cyan);
+}
+
+.pricing-badge {
+  display: inline-flex;
+  width: fit-content;
+  border: 1px solid rgba(55, 253, 118, 0.4);
+  border-radius: 999px;
+  padding: 7px 10px;
+  background: rgba(55, 253, 118, 0.1);
+  color: var(--ls-green-fixed);
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pricing-badge--highlight {
+  border-color: rgba(54, 215, 255, 0.46);
+  background: rgba(54, 215, 255, 0.1);
+  color: var(--ls-cyan);
+}
+
+.pricing-card h3 {
+  margin: 0;
+  font-size: clamp(30px, 3vw, 44px);
+}
+
+.pricing-price {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  align-items: end;
+  margin: 0;
+  color: var(--ls-text);
+  font-family: var(--ls-font-display);
+  font-size: clamp(42px, 4.6vw, 64px);
+  font-weight: 900;
+  line-height: 0.9;
+}
+
+.pricing-price span {
+  padding-bottom: 7px;
+  color: var(--ls-muted);
+  font-family: var(--ls-font-body);
+  font-size: 16px;
+  font-weight: 900;
+  line-height: 1.2;
+}
+
+.pricing-card-copy {
+  max-width: 620px;
+  margin: 0;
+  color: var(--ls-muted);
+  font-size: 17px;
+  line-height: 1.58;
+}
+
+.pricing-feature-list {
+  display: grid;
+  gap: 11px;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pricing-feature-list li {
+  display: grid;
+  grid-template-columns: 20px 1fr;
+  gap: 11px;
+  align-items: start;
+  color: var(--ls-text);
+  font-size: 15px;
+  font-weight: 850;
+  line-height: 1.45;
+}
+
+.pricing-feature-list svg {
+  margin-top: 2px;
+  color: var(--ls-green-fixed);
+}
+
+.pricing-card--keynote .pricing-feature-list svg {
+  color: var(--ls-cyan);
+}
+
+.pricing-card-action {
+  align-self: end;
+  width: fit-content;
+  margin-top: auto;
+}
+
+.pricing-card .mauticform_wrapper {
+  display: contents;
+}
+
+.pricing-waitlist-form {
+  display: grid;
+  gap: 10px;
+  align-self: end;
+  margin-top: auto;
+  border-top: 1px solid rgba(105, 255, 137, 0.16);
+  padding-top: 20px;
+}
+
+.pricing-waitlist-form label {
+  color: var(--ls-text);
+  font-size: 13px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pricing-waitlist-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.pricing-waitlist-row input,
+.pricing-waitlist-row button {
+  min-height: 50px;
+  border-radius: 6px;
+  font: inherit;
+}
+
+.pricing-waitlist-row input {
+  min-width: 0;
+  border: 1px solid rgba(105, 255, 137, 0.24);
+  padding: 0 14px;
+  background: rgba(0, 0, 0, 0.56);
+  color: var(--ls-text);
+  outline: none;
+}
+
+.pricing-waitlist-row input:focus {
+  border-color: rgba(54, 215, 255, 0.78);
+  box-shadow: 0 0 0 3px rgba(54, 215, 255, 0.12);
+}
+
+.pricing-waitlist-row button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid rgba(55, 253, 118, 0.64);
+  padding: 0 16px;
+  background: var(--ls-green);
+  color: var(--ls-on-primary);
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.pricing-waitlist-form p {
+  min-height: 22px;
+  margin: 0;
+  color: var(--ls-muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.mauticform-field-hidden {
+  display: none;
+}
+
+.mauticform-error,
+.mauticform-message {
+  min-height: 0;
+  color: var(--ls-muted);
+  font-size: 13px;
+  font-weight: 900;
+  line-height: 1.4;
+}
+
+.mauticform-error:not(:empty) {
+  color: #ff756f;
+}
+
+.mauticform-message:not(:empty) {
+  color: var(--ls-green-fixed);
+}
+
+.pricing-trust-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.pricing-trust-row span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  min-height: 54px;
+  border: 1px solid rgba(105, 255, 137, 0.2);
+  border-radius: 8px;
+  padding: 0 14px;
+  background: rgba(0, 0, 0, 0.5);
+  color: var(--ls-muted);
+  font-size: 14px;
+  font-weight: 900;
+  text-align: center;
+}
+
+.pricing-trust-row svg {
+  flex: 0 0 auto;
+  color: var(--ls-green-fixed);
 }
 
 .requirements-section {

--- a/apps/landing/src/styles/sections.css
+++ b/apps/landing/src/styles/sections.css
@@ -298,6 +298,8 @@
 }
 
 .pricing-section {
+  scroll-margin-top: 0;
+  padding-top: 0;
   background:
     radial-gradient(circle at 18% 18%, rgba(54, 215, 255, 0.12), transparent 34%),
     linear-gradient(180deg, rgba(55, 253, 118, 0.04), rgba(0, 0, 0, 0.26)),
@@ -306,23 +308,36 @@
 
 .pricing-heading {
   max-width: 920px;
+  margin-bottom: 20px;
+}
+
+.pricing-heading h2 {
+  max-width: 860px;
+  font-size: clamp(30px, 3vw, 44px);
+  line-height: 1.03;
+}
+
+.pricing-heading p:not(.eyebrow) {
+  max-width: 860px;
+  font-size: clamp(15px, 1.1vw, 17px);
+  line-height: 1.42;
 }
 
 .pricing-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: clamp(18px, 3vw, 30px);
+  align-items: start;
 }
 
 .pricing-card {
   position: relative;
   display: grid;
-  gap: 14px;
+  gap: 12px;
   align-content: start;
-  min-height: 640px;
   border: 1px solid rgba(105, 255, 137, 0.26);
   border-radius: 8px;
-  padding: clamp(24px, 3.2vw, 40px);
+  padding: clamp(22px, 2.4vw, 32px);
   background:
     linear-gradient(145deg, rgba(255, 255, 255, 0.065), transparent 34%),
     rgba(0, 0, 0, 0.68);
@@ -374,7 +389,7 @@
 
 .pricing-card h3 {
   margin: 0;
-  font-size: clamp(30px, 3vw, 44px);
+  font-size: clamp(28px, 2.5vw, 38px);
 }
 
 .pricing-price {
@@ -385,16 +400,16 @@
   margin: 0;
   color: var(--ls-text);
   font-family: var(--ls-font-display);
-  font-size: clamp(42px, 4.6vw, 64px);
+  font-size: clamp(38px, 4vw, 56px);
   font-weight: 900;
   line-height: 0.9;
 }
 
 .pricing-price span {
-  padding-bottom: 7px;
+  padding-bottom: 5px;
   color: var(--ls-muted);
   font-family: var(--ls-font-body);
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 900;
   line-height: 1.2;
 }
@@ -403,14 +418,14 @@
   max-width: 620px;
   margin: 0;
   color: var(--ls-muted);
-  font-size: 17px;
-  line-height: 1.58;
+  font-size: 16px;
+  line-height: 1.45;
 }
 
 .pricing-feature-list {
   display: grid;
-  gap: 11px;
-  margin: 4px 0 0;
+  gap: 8px;
+  margin: 2px 0 0;
   padding: 0;
   list-style: none;
 }
@@ -421,9 +436,9 @@
   gap: 11px;
   align-items: start;
   color: var(--ls-text);
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 850;
-  line-height: 1.45;
+  line-height: 1.34;
 }
 
 .pricing-feature-list svg {
@@ -447,11 +462,11 @@
 
 .pricing-waitlist-form {
   display: grid;
-  gap: 10px;
+  gap: 8px;
   align-self: end;
   margin-top: auto;
   border-top: 1px solid rgba(105, 255, 137, 0.16);
-  padding-top: 20px;
+  padding-top: 14px;
 }
 
 .pricing-waitlist-form label {
@@ -470,7 +485,7 @@
 
 .pricing-waitlist-row input,
 .pricing-waitlist-row button {
-  min-height: 50px;
+  min-height: 44px;
   border-radius: 6px;
   font: inherit;
 }

--- a/apps/landing/tests/unit/LandingPage.test.tsx
+++ b/apps/landing/tests/unit/LandingPage.test.tsx
@@ -53,12 +53,19 @@ describe('LandingPage', () => {
     expect(screen.queryByLabelText('LocalStudio workflow path')).not.toBeInTheDocument();
     expect(screen.queryByText('Live editor')).not.toBeInTheDocument();
     expect(screen.queryByText('Browser API')).not.toBeInTheDocument();
+    const navigationLinks = within(
+      screen.getByRole('navigation', { name: 'Landing sections' }),
+    ).getAllByRole('link');
+    expect(navigationLinks.map((link) => link.textContent)).toEqual([
+      'About it',
+      'Features',
+      'Requirements',
+      'Docs',
+      'Pricing',
+    ]);
     expect(screen.getByRole('link', { name: 'About it' })).toHaveAttribute('href', '#top');
     expect(screen.getByRole('link', { name: 'Features' })).toHaveAttribute('href', '#features');
-    expect(screen.getByRole('link', { name: 'WebMCP Showcase' })).toHaveAttribute(
-      'href',
-      '#webmcp',
-    );
+    expect(screen.queryByRole('link', { name: 'WebMCP Showcase' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Requirements' })).toHaveAttribute(
       'href',
       '#requirements',
@@ -67,6 +74,7 @@ describe('LandingPage', () => {
       'href',
       localStudioAppRoutes.docs.gettingStartedAnchor,
     );
+    expect(screen.getByRole('link', { name: 'Pricing' })).toHaveAttribute('href', '#pricing');
     expect(screen.queryByRole('link', { name: 'Workflow' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'S3 Mirror' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Showcase' })).not.toBeInTheDocument();
@@ -87,6 +95,7 @@ describe('LandingPage', () => {
     expect(screen.getByRole('link', { name: 'About it' })).toHaveAttribute('aria-current', 'page');
     expect(screen.getByRole('link', { name: 'About it' })).toHaveAttribute('href', '#top');
     expect(screen.getByRole('link', { name: 'Features' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Pricing' })).not.toHaveAttribute('aria-current');
   });
 
   it('adds scroll reveal contracts to hero, media, cards, and calls to action', () => {

--- a/tests/e2e/landing/public-funnel.spec.ts
+++ b/tests/e2e/landing/public-funnel.spec.ts
@@ -55,6 +55,33 @@ test.describe('landing public funnel journey', () => {
     await expect(
       page.getByRole('heading', { name: 'Every AI action returns to the editor.' }),
     ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: 'A host page can drive the editor through browser tools.',
+      }),
+    ).toBeVisible();
+
+    await page.getByRole('link', { name: 'Pricing' }).click();
+    await expect(
+      page.getByRole('heading', { name: 'Free forever locally. Cheap when convenience matters.' }),
+    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Speaker', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Keynote Speaker' })).toBeVisible();
+    await page.getByLabel('Email').fill('speaker@example.com');
+    await expect(page.locator('#mauticform_localstudiowaitlist')).toHaveAttribute(
+      'action',
+      'https://mautic.erickwendel.com.br/form/submit?formId=6',
+    );
+    await expect(page.getByLabel('Email')).toHaveAttribute('name', 'mauticform[email]');
+    await expect(page.locator('#mauticform_localstudiowaitlist_id')).toHaveValue('6');
+    await expect(page.locator('#mauticform_localstudiowaitlist_return')).toHaveAttribute(
+      'name',
+      'mauticform[return]',
+    );
+    await expect(page.locator('#mauticform_localstudiowaitlist_name')).toHaveValue(
+      'localstudiowaitlist',
+    );
+    await expect(page.getByRole('button', { name: 'Join waitlist' })).toBeVisible();
 
     await expect(
       page.getByRole('link', { name: /Star LocalStudio.dev on GitHub/i }),


### PR DESCRIPTION
## Summary

- Add Speaker and Keynote Speaker pricing cards with self-hosting and managed-cloud positioning
- Integrate the Mautic waitlist form and responsive pricing layouts
- Move the WebMCP showcase into the Features section and update navigation
- Expand unit and public funnel E2E coverage for pricing and waitlist contracts

## Testing

- Updated LandingPage unit tests
- Updated landing public funnel Playwright coverage