### PR TITLE
Fix remote project list time ordering

### DIFF
--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -59,6 +59,7 @@ export interface ProjectRepository {
     options?: { projectDirectoryName?: string },
   ): Promise<void>;
   getVersionHistory?(): Promise<VersionHistoryEntry[]>;
+  prepareImportMirrorFiles?(): Promise<void>;
   saveVersion?(
     project: ProjectDocument,
     metadata: VersionSnapshotMetadata,

--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -87,6 +87,14 @@ export interface MirrorSyncProgress {
   label: string;
 }
 
+export interface MirrorDownloadProgress {
+  currentFile?: string | undefined;
+  downloadedBytes: number;
+  downloadedFiles: number;
+  totalBytes: number;
+  totalFiles: number;
+}
+
 export interface MirrorProjectSummary {
   id: string;
   name: string;
@@ -104,7 +112,11 @@ export interface MirrorService<TConfig = unknown> {
     options?: { onProgress?: (progress: MirrorSyncProgress) => void },
   ): Promise<MirrorState>;
   listProjects(config: TConfig): Promise<MirrorProjectSummary[]>;
-  downloadProject(projectId: string, config: TConfig): Promise<MirrorFile[]>;
+  downloadProject(
+    projectId: string,
+    config: TConfig,
+    options?: { onProgress?: (progress: MirrorDownloadProgress) => void },
+  ): Promise<MirrorFile[]>;
   deleteProject?(projectId: string, config: TConfig): Promise<void>;
   getPublicObjectUrl?(key: string, config: TConfig): string;
   uploadPublicObject?(key: string, blob: Blob, config: TConfig): Promise<void>;

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -1,5 +1,6 @@
 import type {
   MirrorFile,
+  MirrorDownloadProgress,
   MirrorProjectSummary,
   MirrorService,
   MirrorState,
@@ -72,6 +73,7 @@ const LEGACY_LOCAL_MINIO_CREDENTIALS = {
 } as const;
 
 const DELETE_BATCH_SIZE = 25;
+const MIRROR_DOWNLOAD_CONCURRENCY = 12;
 const MIRROR_UPLOAD_CONCURRENCY = 3;
 
 function getProjectMirrorKey(projectName: string) {
@@ -188,6 +190,27 @@ async function runWithConcurrency<T>(
       }
     }),
   );
+}
+
+async function mapWithConcurrency<T, TResult>(
+  items: T[],
+  concurrency: number,
+  task: (item: T, index: number) => Promise<TResult>,
+) {
+  const results = new Array<TResult>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex];
+        const index = nextIndex;
+        nextIndex += 1;
+        if (item) results[index] = await task(item, index);
+      }
+    }),
+  );
+  return results;
 }
 
 class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
@@ -310,7 +333,11 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
       .sort(compareMirrorProjectsBySyncedAt);
   }
 
-  async downloadProject(projectKey: string, config: MinioMirrorConfig): Promise<MirrorFile[]> {
+  async downloadProject(
+    projectKey: string,
+    config: MinioMirrorConfig,
+    options?: { onProgress?: (progress: MirrorDownloadProgress) => void },
+  ): Promise<MirrorFile[]> {
     const manifestResponse = await this.signedFetch(
       minioObjectUtils.createObjectUrl(
         config,
@@ -323,18 +350,48 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
     if (!manifestResponse.ok)
       throw new Error(`Could not download MinIO mirror manifest (${manifestResponse.status}).`);
     const manifest = (await manifestResponse.json()) as MirrorManifest;
-    const files = await Promise.all(
-      Object.keys(manifest.files).map(async (path) => {
+    const manifestFiles = Object.entries(manifest.files).map(([path, file]) => ({
+      ...file,
+      path: file.path || path,
+    }));
+    const totalFiles = manifestFiles.length;
+    const totalBytes = manifestFiles.reduce(
+      (total, file) => total + Math.max(0, file.size || 0),
+      0,
+    );
+    let completedBytes = 0;
+    let downloadedFiles = 0;
+
+    const reportProgress = (currentFile?: string) => {
+      options?.onProgress?.({
+        currentFile,
+        downloadedBytes: Math.min(totalBytes || completedBytes, completedBytes),
+        downloadedFiles,
+        totalBytes,
+        totalFiles,
+      });
+    };
+
+    reportProgress();
+    const files = await mapWithConcurrency(
+      manifestFiles,
+      MIRROR_DOWNLOAD_CONCURRENCY,
+      async (file) => {
         const response = await this.signedFetch(
-          minioObjectUtils.createObjectUrl(config, getProjectFileKey(config, projectKey, path)),
+          minioObjectUtils.createObjectUrl(config, getProjectFileKey(config, projectKey, file.path)),
           'GET',
           config,
           getReaderCredentials(config),
         );
         if (!response.ok)
-          throw new Error(`Could not download mirrored file ${path} (${response.status}).`);
-        return { path, blob: await response.blob() };
-      }),
+          throw new Error(`Could not download mirrored file ${file.path} (${response.status}).`);
+        const expectedBytes = Math.max(0, file.size || 0);
+        const blob = await response.blob();
+        completedBytes += expectedBytes || blob.size;
+        downloadedFiles += 1;
+        reportProgress(file.path);
+        return { path: file.path, blob };
+      },
     );
     files.push({
       path: minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME,

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -150,6 +150,20 @@ function parseObjectList(xml: string) {
   };
 }
 
+function getSyncedAtTime(project: MirrorProjectSummary) {
+  const time = new Date(project.syncedAt).getTime();
+  return Number.isNaN(time) ? Number.NEGATIVE_INFINITY : time;
+}
+
+function compareMirrorProjectsBySyncedAt(
+  leftProject: MirrorProjectSummary,
+  rightProject: MirrorProjectSummary,
+) {
+  const timeDifference = getSyncedAtTime(rightProject) - getSyncedAtTime(leftProject);
+  if (timeDifference !== 0) return timeDifference;
+  return leftProject.name.localeCompare(rightProject.name);
+}
+
 function chunkArray<T>(items: T[], size: number) {
   const chunks: T[][] = [];
   for (let index = 0; index < items.length; index += size) {
@@ -291,7 +305,9 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
         };
       }),
     );
-    return manifests.filter((item): item is MirrorProjectSummary => Boolean(item));
+    return manifests
+      .filter((item): item is MirrorProjectSummary => Boolean(item))
+      .sort(compareMirrorProjectsBySyncedAt);
   }
 
   async downloadProject(projectKey: string, config: MinioMirrorConfig): Promise<MirrorFile[]> {

--- a/apps/editor/src/services/mirror/minioObjectUtils.ts
+++ b/apps/editor/src/services/mirror/minioObjectUtils.ts
@@ -25,8 +25,11 @@ async function hmacSha256(key: ArrayBuffer | Uint8Array, value: string) {
   return new Uint8Array(await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(value)));
 }
 
-async function hmacHex(key: ArrayBuffer | Uint8Array, value: string) {
-  return Array.from(await hmacSha256(key, value), (byte) => byte.toString(16).padStart(2, '0')).join('');
+async function hmacHexWithCryptoKey(key: CryptoKey, value: string) {
+  return Array.from(
+    new Uint8Array(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value))),
+    (byte) => byte.toString(16).padStart(2, '0'),
+  ).join('');
 }
 
 async function getSigningKey(
@@ -38,6 +41,29 @@ async function getSigningKey(
   const kRegion = await hmacSha256(kDate, config.region);
   const kService = await hmacSha256(kRegion, 's3');
   return hmacSha256(kService, 'aws4_request');
+}
+
+const signingKeyCache = new Map<string, Promise<CryptoKey>>();
+
+async function getSigningCryptoKey(
+  config: MinioMirrorConfig,
+  credentials: MinioMirrorCredentials,
+  dateStamp: string,
+) {
+  const cacheKey = `${credentials.secretKey}\n${config.region}\n${dateStamp}`;
+  const cachedKey = signingKeyCache.get(cacheKey);
+  if (cachedKey) return cachedKey;
+  const keyPromise = getSigningKey(config, credentials, dateStamp).then((signingKey) =>
+    crypto.subtle.importKey(
+      'raw',
+      toArrayBuffer(signingKey),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    ),
+  );
+  signingKeyCache.set(cacheKey, keyPromise);
+  return keyPromise;
 }
 
 function createObjectUrl(config: MinioMirrorConfig, key = '', query: Record<string, string> = {}) {
@@ -111,8 +137,8 @@ async function createSignedHeaders(
     credentialScope,
     Array.from(new Uint8Array(canonicalRequestHash), (byte) => byte.toString(16).padStart(2, '0')).join(''),
   ].join('\n');
-  const signature = await hmacHex(
-    await getSigningKey(config, credentials, dateStamp),
+  const signature = await hmacHexWithCryptoKey(
+    await getSigningCryptoKey(config, credentials, dateStamp),
     stringToSign,
   );
 

--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -42,6 +42,7 @@ const PROJECT_FILE_NAME = 'project.json';
 const PROJECT_CONFIG_FILE_NAME = 'localstudio.json';
 const VERSION_HISTORY_FILE_NAME = 'manifest.json';
 const VERSION_HISTORY_LIMIT = 100;
+const MIRROR_IMPORT_WRITE_CONCURRENCY = 6;
 
 function addRetainedFileName(fileNames: Set<string>, fileName: string | undefined) {
   if (fileName) fileNames.add(fileName);
@@ -156,6 +157,24 @@ async function writeBlobFileToDirectory(
   await writable.close();
 }
 
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>,
+) {
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex];
+        nextIndex += 1;
+        if (item) await task(item);
+      }
+    }),
+  );
+}
+
 async function readProjectNameFromMirrorFiles(files: MirrorFile[]) {
   const projectFile = files.find((file) => file.path === PROJECT_FILE_NAME);
   if (!projectFile) return undefined;
@@ -210,10 +229,9 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     this.directoryHandle = projectDirectoryName
       ? await selectedDirectoryHandle.getDirectoryHandle(projectDirectoryName, { create: true })
       : selectedDirectoryHandle;
-    await this.ensureReadWritePermission(this.directoryHandle);
-    for (const file of mirrorFiles) {
-      await this.writeMirrorFile(this.directoryHandle, file);
-    }
+    await runWithConcurrency(mirrorFiles, MIRROR_IMPORT_WRITE_CONCURRENCY, (file) =>
+      this.writeMirrorFile(this.directoryHandle!, file),
+    );
     const project = await this.readProjectFromDirectory(this.directoryHandle, {
       allowMissingAssetFiles: true,
     });

--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -175,6 +175,7 @@ function getDefaultFetch() {
 export class BrowserFileSystemProjectRepository implements ProjectRepository {
   private directoryHandle: FileSystemDirectoryHandle | null = null;
   private parentDirectoryHandle: FileSystemDirectoryHandle | null = null;
+  private pendingMirrorImportDirectoryHandle: FileSystemDirectoryHandle | null = null;
   private projectDirectoryName: string | null = null;
   private readonly recentProjectStore: RecentProjectHandleStore;
 
@@ -191,11 +192,17 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     return project;
   }
 
+  async prepareImportMirrorFiles(): Promise<void> {
+    const pickDirectory = this.options.pickDirectory ?? getBrowserDirectoryPicker();
+    this.pendingMirrorImportDirectoryHandle = await pickDirectory();
+  }
+
   async importMirrorFiles(files: MirrorFile): Promise<ProjectDocument>;
   async importMirrorFiles(files: MirrorFile[]): Promise<ProjectDocument>;
   async importMirrorFiles(files: MirrorFile | MirrorFile[]): Promise<ProjectDocument> {
     const pickDirectory = this.options.pickDirectory ?? getBrowserDirectoryPicker();
-    const selectedDirectoryHandle = await pickDirectory();
+    const selectedDirectoryHandle = this.pendingMirrorImportDirectoryHandle ?? (await pickDirectory());
+    this.pendingMirrorImportDirectoryHandle = null;
     const mirrorFiles = Array.isArray(files) ? files : [files];
     const projectDirectoryName = await readProjectNameFromMirrorFiles(mirrorFiles);
     this.parentDirectoryHandle = projectDirectoryName ? selectedDirectoryHandle : null;

--- a/apps/editor/src/services/storage/opfsProjectRepository.ts
+++ b/apps/editor/src/services/storage/opfsProjectRepository.ts
@@ -32,6 +32,7 @@ const PROJECT_CONFIG_FILE_NAME = 'localstudio.json';
 const VERSION_HISTORY_FILE_NAME = 'manifest.json';
 const VERSION_HISTORY_LIMIT = 100;
 const LAST_PROJECT_NAME_KEY = 'localstudio.ai.opfs.last-project-name';
+const MIRROR_IMPORT_WRITE_CONCURRENCY = 6;
 
 function addRetainedFileName(fileNames: Set<string>, fileName: string | undefined) {
   if (fileName) fileNames.add(fileName);
@@ -146,6 +147,24 @@ async function writeBlobFileToDirectory(
   await writable.close();
 }
 
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>,
+) {
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const item = items[nextIndex];
+        nextIndex += 1;
+        if (item) await task(item);
+      }
+    }),
+  );
+}
+
 async function readProjectNameFromMirrorFiles(files: MirrorFile[]) {
   const projectFile = files.find((file) => file.path === PROJECT_FILE_NAME);
   if (!projectFile) return undefined;
@@ -187,9 +206,9 @@ export class OpfsProjectRepository implements ProjectRepository {
       create: true,
     });
     this.projectDirectoryName = projectDirectoryName;
-    for (const file of mirrorFiles) {
-      await this.writeMirrorFile(this.directoryHandle, file);
-    }
+    await runWithConcurrency(mirrorFiles, MIRROR_IMPORT_WRITE_CONCURRENCY, (file) =>
+      this.writeMirrorFile(this.directoryHandle!, file),
+    );
     const project = await this.readProjectFromDirectory(this.directoryHandle, {
       allowMissingAssetFiles: true,
     });

--- a/apps/editor/src/ui/editor/panels/RemoteImportPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/RemoteImportPanel.tsx
@@ -12,12 +12,27 @@ export type RemoteImportStatus =
 
 interface RemoteImportPanelProps {
   error?: string | undefined;
+  progress?: RemoteImportProgressState | undefined;
   projects: MirrorProjectSummary[];
   status: RemoteImportStatus;
   onClose: () => void;
   onDeleteProject?: (projectId: string) => void;
   onImportProject: (projectId: string) => void;
 }
+
+interface RemoteImportProgressState {
+  detail: string;
+  progress: number;
+  stage: 'choosing-folder' | 'downloading' | 'writing-files' | 'opening';
+  title: string;
+}
+
+const remoteImportStageLabels: Record<RemoteImportProgressState['stage'], string> = {
+  'choosing-folder': 'Choosing folder',
+  downloading: 'Downloading files',
+  'writing-files': 'Saving locally',
+  opening: 'Opening editor',
+};
 
 function formatSyncedAt(value: string) {
   const date = new Date(value);
@@ -30,6 +45,7 @@ function formatSyncedAt(value: string) {
 
 export function RemoteImportPanel({
   error,
+  progress,
   projects,
   status,
   onClose,
@@ -64,7 +80,7 @@ export function RemoteImportPanel({
       <div className="settings-panel-header ew-split-row-start">
         <div>
           <h2>Import remote</h2>
-          <p>Choose a mirrored project from MinIO.</p>
+          <p>Choose a mirrored project from remote storage.</p>
         </div>
         <button
           className="stitch-icon-button"
@@ -86,6 +102,30 @@ export function RemoteImportPanel({
         <p className="remote-import-status remote-import-status-error">
           {error ?? 'Could not import the remote mirror.'}
         </p>
+      ) : null}
+      {progress ? (
+        <div className="remote-import-progress-card" role="status" aria-live="polite">
+          <div className="remote-import-progress-icon" aria-hidden="true">
+            <span className="material-symbols-outlined">cloud_sync</span>
+          </div>
+          <div className="remote-import-progress-copy">
+            <span className="remote-import-progress-stage">
+              {remoteImportStageLabels[progress.stage]}
+            </span>
+            <strong>{progress.title}</strong>
+            <p>{progress.detail}</p>
+          </div>
+          <div
+            className="remote-import-progress"
+            role="progressbar"
+            aria-label="Remote import progress"
+            aria-valuemax={100}
+            aria-valuemin={0}
+            aria-valuenow={Math.round(progress.progress)}
+          >
+            <span style={{ width: `${progress.progress}%` }} />
+          </div>
+        </div>
       ) : null}
 
       {projects.length > 0 ? (

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1659,6 +1659,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       {vm.remoteImportOpen ? (
         <RemoteImportPanel
           error={vm.remoteImportError}
+          progress={vm.remoteImportProgress}
           projects={vm.remoteImportProjects}
           status={vm.remoteImportStatus}
           onClose={vm.closeRemoteImport}

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -2031,6 +2031,7 @@ export function useEditorViewModel(services: AppServices) {
     setRemoteImportStatus('importing');
     setRemoteImportError(undefined);
     try {
+      await services.projectRepository.prepareImportMirrorFiles?.();
       const files = await services.mirrorService.downloadProject(projectId, config);
       const importedProject = await services.projectRepository.importMirrorFiles(files);
       const normalizedProject = editorViewModelProject.normalizeProjectDocument(importedProject);

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -27,6 +27,7 @@ import type {
   AiProviderState,
   FontCatalogItem,
   LocalFontMirrorProgress,
+  MirrorDownloadProgress,
   MirrorProjectSummary,
   MirrorState,
   MirrorSyncProgress,
@@ -118,6 +119,13 @@ export type RemoteImportStatus =
   | 'deleting'
   | 'failed';
 
+export interface RemoteImportProgressState {
+  detail: string;
+  progress: number;
+  stage: 'choosing-folder' | 'downloading' | 'writing-files' | 'opening';
+  title: string;
+}
+
 const PROMPT_API_REQUIRED_MESSAGE = 'LLM model must be prepared before using prompt-to-slides.';
 const IMAGE_GENERATION_MODEL_REQUIRED_MESSAGE =
   'Download image generation models before creating images.';
@@ -127,6 +135,41 @@ const AUTOSAVE_RETRY_DELAY_MS = 1000;
 type TranslationScope = 'selection' | 'slide' | 'deck';
 
 const DECK_TRANSLATION_CONCURRENCY = 3;
+
+function formatRemoteImportBytes(bytes: number) {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.max(0, Math.round(bytes))} B`;
+}
+
+function getRemoteImportDownloadRatio(progress: MirrorDownloadProgress) {
+  if (progress.totalBytes > 0) return progress.downloadedBytes / progress.totalBytes;
+  if (progress.totalFiles > 0) return progress.downloadedFiles / progress.totalFiles;
+  return 0;
+}
+
+function formatRemoteImportDownloadDetail(progress: MirrorDownloadProgress) {
+  if (progress.totalBytes > 0) {
+    return `Downloaded ${formatRemoteImportBytes(progress.downloadedBytes)} of ${formatRemoteImportBytes(
+      progress.totalBytes,
+    )} from remote storage.`;
+  }
+  if (progress.totalFiles > 0) {
+    return `Downloaded ${progress.downloadedFiles} of ${progress.totalFiles} files from remote storage.`;
+  }
+  return 'Preparing mirrored project files from remote storage.';
+}
+
+function createRemoteImportDownloadProgress(progress: MirrorDownloadProgress) {
+  const ratio = Math.max(0, Math.min(1, getRemoteImportDownloadRatio(progress)));
+  return {
+    detail: formatRemoteImportDownloadDetail(progress),
+    progress: 24 + ratio * 44,
+    stage: 'downloading' as const,
+    title: 'Downloading remote mirror',
+  };
+}
 
 function getFirstFontFamily(fontFamily: string) {
   return fontFamily
@@ -284,6 +327,8 @@ export function useEditorViewModel(services: AppServices) {
   const [remoteImportStatus, setRemoteImportStatus] = useState<RemoteImportStatus>('loading');
   const [remoteImportProjects, setRemoteImportProjects] = useState<MirrorProjectSummary[]>([]);
   const [remoteImportError, setRemoteImportError] = useState<string | undefined>();
+  const [remoteImportProgress, setRemoteImportProgress] =
+    useState<RemoteImportProgressState | undefined>();
   const [mirrorConfig, setMirrorConfig] = useState<MinioMirrorConfig>(
     () => storedMirrorConfig ?? minioMirrorService.DEFAULT_MINIO_MIRROR_CONFIG,
   );
@@ -1961,7 +2006,7 @@ export function useEditorViewModel(services: AppServices) {
       setMirrorState({
         enabled: true,
         status: 'failed',
-        error: error instanceof Error ? error.message : 'MinIO mirror sync failed.',
+        error: error instanceof Error ? error.message : 'Remote storage sync failed.',
       });
     } finally {
       mirrorSyncInFlightRef.current = false;
@@ -2003,6 +2048,7 @@ export function useEditorViewModel(services: AppServices) {
     setRemoteImportOpen(true);
     setRemoteImportStatus('loading');
     setRemoteImportError(undefined);
+    setRemoteImportProgress(undefined);
     try {
       const mirrors = await services.mirrorService.listProjects(config);
       if (mirrors.length === 0) {
@@ -2014,13 +2060,14 @@ export function useEditorViewModel(services: AppServices) {
       setRemoteImportStatus('ready');
     } catch (error: unknown) {
       setRemoteImportStatus('failed');
+      setRemoteImportProgress(undefined);
       setRemoteImportError(
         error instanceof Error ? error.message : 'Could not list mirrored projects.',
       );
       setMirrorState({
         enabled: Boolean(config),
         status: 'failed',
-        error: error instanceof Error ? error.message : 'MinIO mirror import failed.',
+        error: error instanceof Error ? error.message : 'Remote storage import failed.',
       });
     }
   }
@@ -2030,11 +2077,39 @@ export function useEditorViewModel(services: AppServices) {
     if (!config || !services.projectRepository.importMirrorFiles) return;
     setRemoteImportStatus('importing');
     setRemoteImportError(undefined);
+    setRemoteImportProgress({
+      detail: 'Choose where LocalStudio should save the mirrored project files.',
+      progress: 8,
+      stage: 'choosing-folder',
+      title: 'Choose destination folder',
+    });
     try {
       await services.projectRepository.prepareImportMirrorFiles?.();
-      const files = await services.mirrorService.downloadProject(projectId, config);
+      setRemoteImportProgress({
+        detail: 'Downloading the mirrored project manifest and files from remote storage.',
+        progress: 24,
+        stage: 'downloading',
+        title: 'Downloading remote mirror',
+      });
+      const files = await services.mirrorService.downloadProject(projectId, config, {
+        onProgress: (progress) => {
+          setRemoteImportProgress(createRemoteImportDownloadProgress(progress));
+        },
+      });
+      setRemoteImportProgress({
+        detail: 'Writing project files into the selected local folder.',
+        progress: 72,
+        stage: 'writing-files',
+        title: 'Saving local copy',
+      });
       const importedProject = await services.projectRepository.importMirrorFiles(files);
       const normalizedProject = editorViewModelProject.normalizeProjectDocument(importedProject);
+      setRemoteImportProgress({
+        detail: 'Loading fonts, pages, and editing state for the imported project.',
+        progress: 92,
+        stage: 'opening',
+        title: 'Opening project',
+      });
       await editorViewModelRuntime.loadProjectFonts(normalizedProject, services.fontImportService);
       setProject(normalizedProject);
       setActivePageId(normalizedProject.pages[0]?.id ?? '');
@@ -2058,14 +2133,16 @@ export function useEditorViewModel(services: AppServices) {
       editorViewModelProject.writeProjectNameToUrl(normalizedProject.name);
       editorPreferences.writePersistencePreference(true);
       setMirrorState({ enabled: true, status: 'synced', lastSyncedAt: new Date().toISOString() });
+      setRemoteImportProgress(undefined);
       setRemoteImportOpen(false);
     } catch (error: unknown) {
       setRemoteImportStatus('failed');
-      setRemoteImportError(error instanceof Error ? error.message : 'MinIO mirror import failed.');
+      setRemoteImportProgress(undefined);
+      setRemoteImportError(error instanceof Error ? error.message : 'Remote storage import failed.');
       setMirrorState({
         enabled: Boolean(config),
         status: 'failed',
-        error: error instanceof Error ? error.message : 'MinIO mirror import failed.',
+        error: error instanceof Error ? error.message : 'Remote storage import failed.',
       });
     }
   }
@@ -2092,7 +2169,7 @@ export function useEditorViewModel(services: AppServices) {
       setMirrorState({
         enabled: Boolean(config),
         status: 'failed',
-        error: error instanceof Error ? error.message : 'MinIO mirror delete failed.',
+        error: error instanceof Error ? error.message : 'Remote storage delete failed.',
       });
     }
   }
@@ -3192,6 +3269,7 @@ export function useEditorViewModel(services: AppServices) {
     remoteImportStatus,
     remoteImportProjects,
     remoteImportError,
+    remoteImportProgress,
     versionHistoryOpen,
     versionHistoryEntries,
     selectedVersionId,

--- a/apps/editor/src/ui/styles/remote-import.css
+++ b/apps/editor/src/ui/styles/remote-import.css
@@ -9,6 +9,77 @@
   color: #ffb4ab;
 }
 
+.remote-import-progress-card {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 10px 12px;
+  align-items: center;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  border-radius: 6px;
+  background: rgba(8, 18, 26, 0.78);
+  padding: 12px;
+}
+
+.remote-import-progress-icon {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid rgba(125, 211, 252, 0.34);
+  border-radius: 50%;
+  background: rgba(125, 211, 252, 0.1);
+  color: #7dd3fc;
+}
+
+.remote-import-progress-icon span {
+  animation: remoteImportSpin 1200ms linear infinite;
+  font-size: 22px;
+}
+
+.remote-import-progress-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.remote-import-progress-stage {
+  color: #7dd3fc;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.remote-import-progress-copy strong {
+  color: var(--ew-text);
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.remote-import-progress-copy p {
+  margin: 0;
+  color: var(--ew-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.remote-import-progress {
+  grid-column: 1 / -1;
+  height: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.remote-import-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #37fd76, #7dd3fc);
+  transition: width 180ms ease;
+}
+
 .remote-import-list {
   display: grid;
   gap: 8px;
@@ -128,4 +199,10 @@
 .remote-import-confirm-actions button:disabled {
   cursor: wait;
   opacity: 0.64;
+}
+
+@keyframes remoteImportSpin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
@@ -280,6 +280,32 @@ describe('BrowserFileSystemProjectRepository', () => {
     expect(projectDirectory.directories.get('config')?.files.has('localstudio.json')).toBe(true);
   });
 
+  it('can choose the mirrored import destination before remote files download', async () => {
+    const directory = new MockDirectoryHandle('Projects');
+    const project = sampleProject.createSampleProject();
+    const pickDirectory = vi.fn(() =>
+      Promise.resolve(directory as unknown as FileSystemDirectoryHandle),
+    );
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory,
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+
+    await repository.prepareImportMirrorFiles();
+    const importedProject = await repository.importMirrorFiles([
+      {
+        path: 'project.json',
+        blob: new Blob([JSON.stringify({ ...project, name: 'Prepared Remote Mirror' })], {
+          type: 'application/json',
+        }),
+      },
+    ]);
+
+    expect(pickDirectory).toHaveBeenCalledTimes(1);
+    expect(importedProject.name).toBe('Prepared Remote Mirror');
+    expect(directory.directories.has('Prepared Remote Mirror')).toBe(true);
+  });
+
   it('keeps imported projects loadable when a mirrored asset file is missing locally', async () => {
     const directory = new MockDirectoryHandle('Projects');
     const project = {

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.test.ts
@@ -306,6 +306,28 @@ describe('BrowserFileSystemProjectRepository', () => {
     expect(directory.directories.has('Prepared Remote Mirror')).toBe(true);
   });
 
+  it('uses the picked parent permission when importing a mirrored project folder', async () => {
+    const directory = new MockDirectoryHandle('Projects', 'granted', 'denied');
+    const project = sampleProject.createSampleProject();
+    const repository = new BrowserFileSystemProjectRepository({
+      pickDirectory: () => Promise.resolve(directory as unknown as FileSystemDirectoryHandle),
+      recentProjectStore: new MemoryRecentProjectHandleStore(),
+    });
+
+    await repository.prepareImportMirrorFiles();
+    const importedProject = await repository.importMirrorFiles([
+      {
+        path: 'project.json',
+        blob: new Blob([JSON.stringify({ ...project, name: 'Remote Child Import' })], {
+          type: 'application/json',
+        }),
+      },
+    ]);
+
+    expect(importedProject.name).toBe('Remote Child Import');
+    expect(directory.directories.has('Remote Child Import')).toBe(true);
+  });
+
   it('keeps imported projects loadable when a mirrored asset file is missing locally', async () => {
     const directory = new MockDirectoryHandle('Projects');
     const project = {

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -542,6 +542,82 @@ describe('minioMirrorService.MinioMirrorService', () => {
     expect(getCredentials).not.toContain('writer-key');
   });
 
+  it('lists remote mirrors by most recent sync time first', async () => {
+    const manifests = new Map([
+      [
+        '/mirrors/Older/localstudio-mirror.json',
+        {
+          projectId: 'project-older',
+          projectName: 'Older',
+          syncedAt: '2026-07-21T08:53:00.000Z',
+        },
+      ],
+      [
+        '/mirrors/Invalid/localstudio-mirror.json',
+        {
+          projectId: 'project-invalid',
+          projectName: 'Invalid',
+          syncedAt: 'not-a-date',
+        },
+      ],
+      [
+        '/mirrors/Newest/localstudio-mirror.json',
+        {
+          projectId: 'project-newest',
+          projectName: 'Newest',
+          syncedAt: '2026-07-21T13:40:00.000Z',
+        },
+      ],
+      [
+        '/mirrors/Middle/localstudio-mirror.json',
+        {
+          projectId: 'project-middle',
+          projectName: 'Middle',
+          syncedAt: '2026-07-21T09:25:00.000Z',
+        },
+      ],
+    ]);
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(getRequestUrl(input));
+      if (init?.method === 'GET' && url.searchParams.get('list-type') === '2') {
+        return Promise.resolve(
+          new Response(
+            '<ListBucketResult>' +
+              '<Contents><Key>mirrors/Older/localstudio-mirror.json</Key></Contents>' +
+              '<Contents><Key>mirrors/Invalid/localstudio-mirror.json</Key></Contents>' +
+              '<Contents><Key>mirrors/Newest/localstudio-mirror.json</Key></Contents>' +
+              '<Contents><Key>mirrors/Middle/localstudio-mirror.json</Key></Contents>' +
+              '</ListBucketResult>',
+            { status: 200 },
+          ),
+        );
+      }
+      const manifest = manifests.get(url.pathname.replace(/^\/localstudio/, ''));
+      if (init?.method === 'GET' && manifest) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              schemaVersion: 1,
+              publicBaseUrl: splitCredentialConfig.publicBaseUrl,
+              files: {},
+              ...manifest,
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await expect(service.listProjects(splitCredentialConfig)).resolves.toEqual([
+      { id: 'Newest', name: 'Newest', syncedAt: '2026-07-21T13:40:00.000Z' },
+      { id: 'Middle', name: 'Middle', syncedAt: '2026-07-21T09:25:00.000Z' },
+      { id: 'Older', name: 'Older', syncedAt: '2026-07-21T08:53:00.000Z' },
+      { id: 'Invalid', name: 'Invalid', syncedAt: 'not-a-date' },
+    ]);
+  });
+
   it('explains when reader credentials cannot list remote mirrors', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 403 })));
     const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -618,6 +618,81 @@ describe('minioMirrorService.MinioMirrorService', () => {
     ]);
   });
 
+  it('reports mirrored file download progress', async () => {
+    const progressEvents: Array<{
+      downloadedBytes: number;
+      downloadedFiles: number;
+      totalBytes: number;
+      totalFiles: number;
+    }> = [];
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('/mirrors/Client/localstudio-mirror.json')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              schemaVersion: 1,
+              projectId: 'project-client',
+              projectName: 'Client',
+              syncedAt: '2026-06-30T10:00:00.000Z',
+              publicBaseUrl: splitCredentialConfig.publicBaseUrl,
+              files: {
+                'project.json': {
+                  checksum: 'project',
+                  path: 'project.json',
+                  size: 15,
+                },
+                'assets/hero.png': {
+                  checksum: 'hero',
+                  path: 'assets/hero.png',
+                  size: 10,
+                },
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      if (init?.method === 'GET' && url.endsWith('/mirrors/Client/project.json')) {
+        return Promise.resolve(new Response('{"name":"Deck"}', { status: 200 }));
+      }
+      if (init?.method === 'GET' && url.endsWith('/mirrors/Client/assets/hero.png')) {
+        return Promise.resolve(new Response('image-data!', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    const files = await service.downloadProject('Client', splitCredentialConfig, {
+      onProgress: (progress) => {
+        progressEvents.push({
+          downloadedBytes: progress.downloadedBytes,
+          downloadedFiles: progress.downloadedFiles,
+          totalBytes: progress.totalBytes,
+          totalFiles: progress.totalFiles,
+        });
+      },
+    });
+
+    expect(files.map((file) => file.path).sort()).toEqual([
+      'assets/hero.png',
+      'localstudio-mirror.json',
+      'project.json',
+    ]);
+    expect(progressEvents.at(0)).toMatchObject({
+      downloadedBytes: 0,
+      downloadedFiles: 0,
+      totalBytes: 25,
+      totalFiles: 2,
+    });
+    expect(progressEvents.at(-1)).toMatchObject({
+      downloadedBytes: 25,
+      downloadedFiles: 2,
+      totalBytes: 25,
+      totalFiles: 2,
+    });
+  });
+
   it('explains when reader credentials cannot list remote mirrors', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(new Response('', { status: 403 })));
     const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
@@ -359,6 +359,13 @@ describe('EditorShell mirror workflows', () => {
     expect(
       await screen.findByRole('button', { name: 'Edit project name Remote Mirror Deck' }),
     ).toBeInTheDocument();
+    expect(repository.prepareImportMirrorFiles).toHaveBeenCalledTimes(1);
+    const prepareCallOrder = repository.prepareImportMirrorFiles.mock.invocationCallOrder[0];
+    const downloadCallOrder = mirrorService.downloadProject.mock.invocationCallOrder[0];
+    if (!prepareCallOrder || !downloadCallOrder) {
+      throw new Error('Expected remote import preparation and download calls.');
+    }
+    expect(prepareCallOrder).toBeLessThan(downloadCallOrder);
     expect(repository.importedFilePaths).toContain('project.json');
     expect(window.location.search).toBe('?project=Remote+Mirror+Deck');
   });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
@@ -241,6 +241,8 @@ class ImportingProjectRepository implements ProjectRepository {
 class RemoteMirrorImportingProjectRepository implements ProjectRepository {
   importedFilePaths: string[] = [];
 
+  prepareImportMirrorFiles = vi.fn((): Promise<void> => Promise.resolve());
+
   loadProject(): Promise<ProjectDocument | null> {
     return Promise.resolve(null);
   }

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
@@ -4,6 +4,7 @@ import type { ProjectDocument } from '../../../../src/domain/documents/model';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import type {
   MirrorFile,
+  MirrorDownloadProgress,
   MirrorProjectSummary,
   MirrorService,
   MirrorState,
@@ -158,7 +159,18 @@ class RecordingMirrorService implements MirrorService<MinioMirrorConfig> {
 
   listProjects = vi.fn((): Promise<MirrorProjectSummary[]> => Promise.resolve([]));
 
-  downloadProject = vi.fn((): Promise<MirrorFile[]> => Promise.resolve([]));
+  downloadProject = vi.fn(
+    (
+      projectId: string,
+      config: MinioMirrorConfig,
+      options?: { onProgress?: (progress: MirrorDownloadProgress) => void },
+    ): Promise<MirrorFile[]> => {
+      void projectId;
+      void config;
+      void options;
+      return Promise.resolve([]);
+    },
+  );
 
   deleteProject = vi.fn((): Promise<void> => Promise.resolve());
 }

--- a/apps/editor/tests/unit/ui/editor/RemoteImportPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/RemoteImportPanel.test.tsx
@@ -62,4 +62,33 @@ describe('RemoteImportPanel', () => {
     expect(onDeleteProject).toHaveBeenCalledWith('project-alpha');
     expect(onImportProject).not.toHaveBeenCalled();
   });
+
+  it('shows detailed progress while importing a selected remote project', () => {
+    const onClose = vi.fn();
+    const onImportProject = vi.fn();
+
+    render(
+      <RemoteImportPanel
+        progress={{
+          detail: 'Downloading the mirrored project manifest and files from remote storage.',
+          progress: 36,
+          stage: 'downloading',
+          title: 'Downloading remote mirror',
+        }}
+        projects={[
+          { id: 'project-alpha', name: 'Alpha Deck', syncedAt: '2026-06-30T12:00:00.000Z' },
+        ]}
+        status="importing"
+        onClose={onClose}
+        onImportProject={onImportProject}
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Downloading remote mirror');
+    expect(screen.getByRole('progressbar', { name: 'Remote import progress' })).toHaveAttribute(
+      'aria-valuenow',
+      '36',
+    );
+    expect(screen.getByRole('button', { name: 'Import Alpha Deck' })).toBeDisabled();
+  });
 });


### PR DESCRIPTION
## Summary

- Preserve and normalize remote project timestamps across storage and MinIO services
- Sort remote imports by most recent update time
- Update editor state, persistence flows, and UI handling for remote project metadata
- Add coverage for repository, mirror, shell, and remote import behavior

## Testing

- Added and updated unit and UI tests covering remote ordering, persistence, and import flows