### PR TITLE
Add magnet guides for element alignment and selection workflows

### DIFF
--- a/apps/editor/src/domain/commands/elements/basicCommands.ts
+++ b/apps/editor/src/domain/commands/elements/basicCommands.ts
@@ -26,7 +26,18 @@ const elementAnimationCommandConstructors = {
   SetElementAnimationBuildsCommand: elementAnimationCommands.SetElementAnimationBuildsCommand,
 };
 
-export type AlignMode = 'horizontal-center' | 'vertical-center' | 'page-center';
+export type AlignMode =
+  | 'horizontal-center'
+  | 'page-bottom'
+  | 'page-bottom-center'
+  | 'page-center'
+  | 'page-left'
+  | 'page-left-center'
+  | 'page-right'
+  | 'page-right-center'
+  | 'page-top'
+  | 'page-top-center'
+  | 'vertical-center';
 export type ZOrderMode = 'front' | 'back' | 'forward' | 'backward';
 export type ElementFramePatch = Partial<
   Pick<BaseElement, 'height' | 'rotation' | 'width' | 'x' | 'y'>

--- a/apps/editor/src/domain/commands/elements/element-structure-commands.ts
+++ b/apps/editor/src/domain/commands/elements/element-structure-commands.ts
@@ -19,14 +19,8 @@ class AlignElementCommand implements EditorCommand {
     if (!page || !element || element.locked) return project;
 
     const patch = {
-      x:
-        this.mode === 'horizontal-center' || this.mode === 'page-center'
-          ? (page.width - element.width) / 2
-          : element.x,
-      y:
-        this.mode === 'vertical-center' || this.mode === 'page-center'
-          ? (page.height - element.height) / 2
-          : element.y,
+      x: getAlignedX({ element, mode: this.mode, pageWidth: page.width }),
+      y: getAlignedY({ element, mode: this.mode, pageHeight: page.height }),
     };
 
     return {
@@ -37,6 +31,38 @@ class AlignElementCommand implements EditorCommand {
       },
     };
   }
+}
+
+function getAlignedX(input: { element: DesignElement; mode: AlignMode; pageWidth: number }) {
+  if (input.mode === 'page-left' || input.mode === 'page-left-center') return 0;
+  if (input.mode === 'page-right' || input.mode === 'page-right-center') {
+    return input.pageWidth - input.element.width;
+  }
+  if (
+    input.mode === 'horizontal-center' ||
+    input.mode === 'page-center' ||
+    input.mode === 'page-top-center' ||
+    input.mode === 'page-bottom-center'
+  ) {
+    return (input.pageWidth - input.element.width) / 2;
+  }
+  return input.element.x;
+}
+
+function getAlignedY(input: { element: DesignElement; mode: AlignMode; pageHeight: number }) {
+  if (input.mode === 'page-top' || input.mode === 'page-top-center') return 0;
+  if (input.mode === 'page-bottom' || input.mode === 'page-bottom-center') {
+    return input.pageHeight - input.element.height;
+  }
+  if (
+    input.mode === 'vertical-center' ||
+    input.mode === 'page-center' ||
+    input.mode === 'page-left-center' ||
+    input.mode === 'page-right-center'
+  ) {
+    return (input.pageHeight - input.element.height) / 2;
+  }
+  return input.element.y;
 }
 
 class SetZOrderCommand implements EditorCommand {

--- a/apps/editor/src/domain/commands/elements/media-element-commands.ts
+++ b/apps/editor/src/domain/commands/elements/media-element-commands.ts
@@ -183,6 +183,33 @@ class ReplaceVideoAssetCommand implements EditorCommand {
   }
 }
 
+class ReplaceElementWithMediaCommand implements EditorCommand {
+  readonly description = 'Replace element with media';
+
+  constructor(
+    private readonly elementId: string,
+    private readonly payload: { asset: Asset; element: ImageElement | GifElement | VideoElement },
+  ) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    const element = project.elements[this.elementId];
+    if (!element || element.locked || this.payload.element.id !== this.elementId) return project;
+
+    return {
+      ...project,
+      assets: {
+        ...project.assets,
+        [this.payload.asset.id]: this.payload.asset,
+      },
+      elements: {
+        ...project.elements,
+        [this.elementId]: this.payload.element,
+      },
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
 class ToggleImageFlipCommand implements EditorCommand {
   readonly description = 'Flip image';
 
@@ -237,6 +264,7 @@ class UpdateImageCropCommand implements EditorCommand {
 export const mediaElementCommands = {
   AddImageElementCommand,
   AddMediaElementCommand,
+  ReplaceElementWithMediaCommand,
   ReplaceImageAssetCommand,
   ReplaceVideoAssetCommand,
   ToggleImageFlipCommand,

--- a/apps/editor/src/ui/editor/canvas/CanvasDragGuide.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasDragGuide.tsx
@@ -1,34 +1,43 @@
 import { Line } from 'react-konva';
+import type { CanvasMagnetGuide } from './canvasMagnetGuides';
 
 interface CanvasDragGuideProps {
-  guide: { x: number; y: number };
-  stageHeight: number;
-  stageWidth: number;
+  guides: CanvasMagnetGuide[];
 }
 
-export function CanvasDragGuide({ guide, stageHeight, stageWidth }: CanvasDragGuideProps) {
+export function CanvasDragGuide({ guides }: CanvasDragGuideProps) {
   return (
     <>
-      <Line
-        listening={false}
-        points={[guide.x, 0, guide.x, stageHeight]}
-        stroke="#37FD76"
-        strokeWidth={1}
-        opacity={0.78}
-        dash={[2, 7]}
-        shadowBlur={10}
-        shadowColor="#37FD76"
-      />
-      <Line
-        listening={false}
-        points={[0, guide.y, stageWidth, guide.y]}
-        stroke="#37FD76"
-        strokeWidth={1}
-        opacity={0.78}
-        dash={[2, 7]}
-        shadowBlur={10}
-        shadowColor="#37FD76"
-      />
+      {guides.map((guide) => (
+        <Line
+          dash={guide.kind === 'line' ? [2, 7] : [6, 4]}
+          key={`${guide.id}-primary`}
+          listening={false}
+          name={`magnet-guide-${guide.kind}-${guide.orientation}`}
+          opacity={0.78}
+          points={[guide.x1, guide.y1, guide.x2, guide.y2]}
+          shadowBlur={10}
+          shadowColor="#37FD76"
+          stroke="#37FD76"
+          strokeWidth={guide.kind === 'line' ? 1 : 2}
+        />
+      ))}
+      {guides.map((guide) =>
+        guide.kind === 'size' ? (
+          <Line
+            dash={[6, 4]}
+            key={`${guide.id}-cap`}
+            listening={false}
+            name={`magnet-guide-size-cap-${guide.orientation}`}
+            opacity={0.78}
+            points={[guide.capX1, guide.capY1, guide.capX2, guide.capY2]}
+            shadowBlur={10}
+            shadowColor="#37FD76"
+            stroke="#37FD76"
+            strokeWidth={2}
+          />
+        ) : null,
+      )}
     </>
   );
 }

--- a/apps/editor/src/ui/editor/canvas/CanvasImageElement.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasImageElement.tsx
@@ -1,5 +1,6 @@
 import type Konva from 'konva';
 import { Image as KonvaImage, Rect } from 'react-konva';
+import { placeholderImage } from '../../../domain/assets/placeholderImage';
 import type { DesignElement } from '../../../domain/documents/model';
 import { canvasWorkspaceUtils } from './canvasWorkspaceUtils';
 import type { CommonElementProps } from './canvas-element-props';
@@ -46,6 +47,29 @@ export function CanvasImageElement({
     );
   }
 
+  if (element.assetId === placeholderImage.PLACEHOLDER_IMAGE_ASSET_ID) {
+    const placeholderFrame = fitPlaceholderVisualFrame({
+      height: commonProps.height,
+      imageHeight: image.naturalHeight,
+      imageWidth: image.naturalWidth,
+      width: commonProps.width,
+    });
+    return (
+      <>
+        <Rect {...imageProps} fill="#F4F4F5" cornerRadius={6} ref={nodeRef} />
+        <KonvaImage
+          image={image}
+          x={commonProps.x + placeholderFrame.x}
+          y={commonProps.y + placeholderFrame.y}
+          width={placeholderFrame.width}
+          height={placeholderFrame.height}
+          opacity={0.36}
+          listening={false}
+        />
+      </>
+    );
+  }
+
   return (
     <KonvaImage
       {...imageProps}
@@ -55,4 +79,24 @@ export function CanvasImageElement({
       ref={nodeRef}
     />
   );
+}
+
+function fitPlaceholderVisualFrame(input: {
+  height: number;
+  imageHeight: number;
+  imageWidth: number;
+  width: number;
+}) {
+  const imageAspectRatio =
+    input.imageWidth > 0 && input.imageHeight > 0 ? input.imageWidth / input.imageHeight : 1;
+  const maxWidth = Math.max(1, input.width * 0.46);
+  const maxHeight = Math.max(1, input.height * 0.46);
+  const width = Math.min(maxWidth, maxHeight * imageAspectRatio);
+  const height = width / imageAspectRatio;
+  return {
+    height,
+    width,
+    x: (input.width - width) / 2,
+    y: (input.height - height) / 2,
+  };
 }

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -5,20 +5,14 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
 } from 'react';
 import type Konva from 'konva';
-import {
-  Circle,
-  Group,
-  Layer,
-  Rect,
-  Stage,
-  Text,
-  Transformer,
-} from 'react-konva';
+import { Circle, Group, Layer, Rect, Stage, Text, Transformer } from 'react-konva';
 import type {
+  AlignMode,
   ElementFramePatch,
   ImageCropPatch,
 } from '../../../domain/commands/elements/basicCommands';
@@ -47,6 +41,11 @@ import { CanvasReadOnlyMediaElement } from './CanvasReadOnlyMediaElement';
 import { CanvasShapeElement } from './CanvasShapeElement';
 import { CanvasStatusHint } from './CanvasStatusHint';
 import { CanvasDragGuide } from './CanvasDragGuide';
+import {
+  canvasMagnetGuides,
+  type CanvasMagnetGuide,
+  type CanvasMagnetRect,
+} from './canvasMagnetGuides';
 import { CropFrameOverlay } from './CropFrameOverlay';
 import type { CommonElementProps, ElementAnimationRenderState } from './canvas-element-props';
 import { shapeLineDraw } from './shape-line-draw';
@@ -91,9 +90,10 @@ interface CanvasWorkspaceProps {
   canTranslateSelection?: boolean;
   isTranslating?: boolean;
   translationNotice?: string | undefined;
-  onAlignSelectedElement?: (() => void) | undefined;
+  onAlignSelectedElement?: ((mode: AlignMode) => void) | undefined;
   onAnimationPreviewAdvance?: (() => void) | undefined;
   onBringSelectedElementForward?: (() => void) | undefined;
+  onCanvasBackgroundDoubleClick?: (() => void) | undefined;
   onBackgroundPreviewPoint?:
     | ((elementId: string, point: { x: number; y: number }) => void)
     | undefined;
@@ -117,6 +117,7 @@ interface CanvasWorkspaceProps {
   onSelectElement?: ((elementId: string, options?: { additive?: boolean }) => void) | undefined;
   onSendSelectedElementBackward?: (() => void) | undefined;
   onTranslateSelectedText?: (() => void) | undefined;
+  onEditSelectionGrid?: (() => void) | undefined;
   onUpdateImageCrop?: ((elementId: string, patch: ImageCropPatch) => void) | undefined;
   onUpdateElementFrame?: ((elementId: string, patch: ElementFramePatch) => void) | undefined;
   onUpdateElementFrames?: ((patches: Record<string, ElementFramePatch>) => void) | undefined;
@@ -195,6 +196,7 @@ export function CanvasWorkspace({
   onBackgroundSelectionToggle,
   onBackgroundSubjectPick,
   onBringSelectedElementForward,
+  onCanvasBackgroundDoubleClick,
   onCancelBackgroundSelection,
   onDeleteSelectedElement,
   onDuplicateSelectedElement,
@@ -207,6 +209,7 @@ export function CanvasWorkspace({
   onSelectElement,
   onSendSelectedElementBackward,
   onTranslateSelectedText,
+  onEditSelectionGrid,
   onUpdateImageCrop,
   onUpdateElementFrame,
   onUpdateElementFrames,
@@ -215,6 +218,7 @@ export function CanvasWorkspace({
   const transformerRef = useRef<Konva.Transformer>(null);
   const nodeRefs = useRef<Record<string, Konva.Node | null>>({});
   const artboardRef = useRef<HTMLDivElement>(null);
+  const suppressNextBackgroundDoubleClickRef = useRef(false);
   const textInputRef = useRef<HTMLTextAreaElement>(null);
   const [stageSize, setStageSize] = useState({ width: 768, height: 432 });
   const [editingTextId, setEditingTextId] = useState<string | null>(null);
@@ -226,7 +230,7 @@ export function CanvasWorkspace({
     x: number;
     y: number;
   } | null>(null);
-  const [dragGuide, setDragGuide] = useState<{ x: number; y: number } | null>(null);
+  const [magnetGuides, setMagnetGuides] = useState<CanvasMagnetGuide[]>([]);
   const [marqueeSelection, setMarqueeSelection] = useState<MarqueeSelection | null>(null);
   const [cropModeElementId, setCropModeElementId] = useState<string | null>(null);
   const [cropDraft, setCropDraft] = useState<
@@ -265,7 +269,9 @@ export function CanvasWorkspace({
   const projectFontSignature = useMemo(
     () =>
       Object.values(project.fonts ?? {})
-        .map((font) => `${font.family}:${font.fontStyle}:${font.fontWeight}:${font.objectUrl ?? ''}`)
+        .map(
+          (font) => `${font.family}:${font.fontStyle}:${font.fontWeight}:${font.objectUrl ?? ''}`,
+        )
         .sort()
         .join('|'),
     [project.fonts],
@@ -467,6 +473,69 @@ export function CanvasWorkspace({
     };
   }
 
+  function getElementFrameStageRect(element: DesignElement): CanvasMagnetRect {
+    return {
+      height: element.height * scaleY,
+      id: element.id,
+      width: element.width * scaleX,
+      x: element.x * scaleX,
+      y: element.y * scaleY,
+    };
+  }
+
+  function getMagnetTargetRects(movingElementIds: string[]) {
+    const movingElementIdSet = new Set(movingElementIds);
+    return visibleElements
+      .filter((element) => !movingElementIdSet.has(element.id))
+      .map((element) => ({ ...getElementStageRect(element), id: element.id }));
+  }
+
+  function getSelectedMovingElementIds(elementId: string) {
+    if (!selection.elementIds.includes(elementId)) return [elementId];
+    return selection.elementIds.filter((selectedElementId) => {
+      const selected = project.elements[selectedElementId];
+      return selected && !selected.locked;
+    });
+  }
+
+  function getMovingStageRect(elementId: string, currentRect: CanvasMagnetRect) {
+    const movingElementIds = getSelectedMovingElementIds(elementId);
+    if (movingElementIds.length <= 1) return currentRect;
+    const activeElement = project.elements[elementId];
+    if (!activeElement) return currentRect;
+    const activeOriginalRect = getElementFrameStageRect(activeElement);
+    const originalMovingRects = movingElementIds
+      .map((movingElementId) => project.elements[movingElementId])
+      .filter((element): element is DesignElement => Boolean(element))
+      .map((element) => getElementFrameStageRect(element));
+    const groupRect = canvasMagnetGuides.getRectBounds(originalMovingRects);
+    if (!groupRect) return currentRect;
+    return canvasMagnetGuides.translateRect(groupRect, {
+      x: currentRect.x - activeOriginalRect.x,
+      y: currentRect.y - activeOriginalRect.y,
+    });
+  }
+
+  function applyDragSnapToNode(elementId: string, node: Konva.Node) {
+    const currentRect = {
+      ...node.getClientRect({ skipShadow: true, skipStroke: true }),
+      id: elementId,
+    };
+    const movingElementIds = getSelectedMovingElementIds(elementId);
+    const snap = canvasMagnetGuides.getDragSnap({
+      movingRect: getMovingStageRect(elementId, currentRect),
+      stageHeight,
+      stageWidth,
+      targetRects: getMagnetTargetRects(movingElementIds),
+      threshold: canvasMagnetGuides.SNAP_THRESHOLD_STAGE,
+    });
+    if (snap.deltaX !== 0 || snap.deltaY !== 0) {
+      node.x(node.x() + snap.deltaX);
+      node.y(node.y() + snap.deltaY);
+    }
+    return snap;
+  }
+
   function selectElementsInMarquee(rect: StageRect) {
     const selectedElementIds = pageVisibleElements
       .filter((element) => stageRectsIntersect(rect, getElementStageRect(element)))
@@ -481,7 +550,8 @@ export function CanvasWorkspace({
   }
 
   function handleDragEnd(elementId: string, event: Konva.KonvaEventObject<DragEvent>) {
-    setDragGuide(null);
+    applyDragSnapToNode(elementId, event.target);
+    setMagnetGuides([]);
     const element = project.elements[elementId];
     if (!element) return;
     const nextX =
@@ -518,15 +588,18 @@ export function CanvasWorkspace({
   }
 
   function handleDragMove(event: Konva.KonvaEventObject<DragEvent>) {
-    const node = event.target;
-    const rect = node.getClientRect({ skipShadow: true, skipStroke: true });
-    setDragGuide({
-      x: rect.x + rect.width / 2,
-      y: rect.y + rect.height / 2,
-    });
+    const elementId = Object.entries(nodeRefs.current).find(
+      ([, node]) => node === event.target,
+    )?.[0];
+    if (!elementId) return;
+    const snap = applyDragSnapToNode(elementId, event.target);
+    setMagnetGuides(snap.guides);
   }
 
-  function getTransformFramePatch(elementId: string, node: Konva.Node): ElementFramePatch | undefined {
+  function getTransformFramePatch(
+    elementId: string,
+    node: Konva.Node,
+  ): ElementFramePatch | undefined {
     const element = project.elements[elementId];
     if (!element) return undefined;
     const scaleXValue = Math.abs(node.scaleX());
@@ -568,7 +641,7 @@ export function CanvasWorkspace({
 
   function handleTransform(elementId: string, event: Konva.KonvaEventObject<Event>) {
     const node = event.target;
-    const frame = getTransformFramePatch(elementId, node);
+    const frame = getSnappedTransformFramePatch(elementId, node);
     if (!frame) return;
 
     applyTransformPatchToNode(elementId, node, frame);
@@ -576,11 +649,36 @@ export function CanvasWorkspace({
 
   function handleTransformEnd(elementId: string, event: Konva.KonvaEventObject<Event>) {
     const node = event.target;
-    const draft = getTransformFramePatch(elementId, node);
+    const draft = getSnappedTransformFramePatch(elementId, node);
     if (!draft) return;
 
     applyTransformPatchToNode(elementId, node, draft);
+    setMagnetGuides([]);
     onUpdateElementFrame?.(elementId, draft);
+  }
+
+  function getSnappedTransformFramePatch(elementId: string, node: Konva.Node) {
+    const frame = getTransformFramePatch(elementId, node);
+    const element = project.elements[elementId];
+    if (!frame || !element) return frame;
+    const resizedRect = {
+      height: (frame.height ?? element.height) * scaleY,
+      id: elementId,
+      width: (frame.width ?? element.width) * scaleX,
+      x: (frame.x ?? element.x) * scaleX,
+      y: (frame.y ?? element.y) * scaleY,
+    };
+    const snap = canvasMagnetGuides.getResizeSnap({
+      resizedRect,
+      targetRects: getMagnetTargetRects([elementId]),
+      threshold: canvasMagnetGuides.SNAP_THRESHOLD_STAGE,
+    });
+    setMagnetGuides(snap.guides);
+    return {
+      ...frame,
+      height: toDocumentY(snap.height),
+      width: toDocumentX(snap.width),
+    };
   }
 
   function toggleCropMode() {
@@ -657,7 +755,10 @@ export function CanvasWorkspace({
     setEditingTextHeight(undefined);
   }
 
-  function updateTextEditing(element: Extract<DesignElement, { type: 'text' }>, input: HTMLTextAreaElement) {
+  function updateTextEditing(
+    element: Extract<DesignElement, { type: 'text' }>,
+    input: HTMLTextAreaElement,
+  ) {
     const nextValue = input.value;
     const nextHeight = textTranslationLayout.getMinimumTextFrameHeight({
       ...element,
@@ -728,7 +829,10 @@ export function CanvasWorkspace({
     return element.type === 'text' && Boolean(element.hyperlink) && (presentationMode || readOnly);
   }
 
-  function getCommonElementProps(element: DesignElement, options: { interactive?: boolean } = {}): CommonElementProps {
+  function getCommonElementProps(
+    element: DesignElement,
+    options: { interactive?: boolean } = {},
+  ): CommonElementProps {
     const isInteractive = options.interactive ?? true;
     const isBackgroundSelectionTarget = element.id === backgroundSelectionTargetId;
     const isProcessing = processingElementIds.includes(element.id);
@@ -736,7 +840,8 @@ export function CanvasWorkspace({
     const animationTransform = animationState.preset?.transform;
 
     return {
-      draggable: isInteractive && !readOnly && !element.locked && !backgroundSelectionMode && !isProcessing,
+      draggable:
+        isInteractive && !readOnly && !element.locked && !backgroundSelectionMode && !isProcessing,
       height: element.height * scaleY,
       ...(!isInteractive ? { listening: false } : {}),
       ...(animationState.activeBuild ? { name: `animated-element-${element.id}` } : {}),
@@ -790,11 +895,13 @@ export function CanvasWorkspace({
       onDblClick: () => {
         if (!isInteractive) return;
         if (readOnly) return;
+        suppressNextBackgroundDoubleClickRef.current = true;
         startTextEditing(element);
       },
       onDblTap: () => {
         if (!isInteractive) return;
         if (readOnly) return;
+        suppressNextBackgroundDoubleClickRef.current = true;
         startTextEditing(element);
       },
       onDragEnd: (event: Konva.KonvaEventObject<DragEvent>) => {
@@ -993,6 +1100,22 @@ export function CanvasWorkspace({
     window.addEventListener('mouseup', handleMouseUp);
   }
 
+  function handleStageDoubleClick(event: Konva.KonvaEventObject<MouseEvent>) {
+    if (readOnly || backgroundSelectionMode || editingTextId) return;
+    if (event.target !== event.target.getStage()) return;
+    onCanvasBackgroundDoubleClick?.();
+  }
+
+  function handleArtboardDoubleClick(event: ReactMouseEvent<HTMLDivElement>) {
+    if (suppressNextBackgroundDoubleClickRef.current) {
+      suppressNextBackgroundDoubleClickRef.current = false;
+      return;
+    }
+    if (readOnly || backgroundSelectionMode || editingTextId) return;
+    if (!(event.target instanceof HTMLCanvasElement)) return;
+    onCanvasBackgroundDoubleClick?.();
+  }
+
   const marqueeRect = marqueeSelection
     ? getNormalizedStageRect(marqueeSelection.anchor, marqueeSelection.current)
     : undefined;
@@ -1017,7 +1140,7 @@ export function CanvasWorkspace({
           ? { 'data-background-selection-target': backgroundSelectionTargetId }
           : {})}
         data-selected-elements={selection.elementIds.join(',')}
-        data-drag-guide={dragGuide ? 'active' : 'idle'}
+        data-drag-guide={magnetGuides.length > 0 ? 'active' : 'idle'}
         data-marquee-selection={marqueeSelection ? 'active' : 'idle'}
         data-animation-preview={
           animationPreview?.playing && animationPreview.pageId === activePageId ? 'playing' : 'idle'
@@ -1032,7 +1155,12 @@ export function CanvasWorkspace({
         data-testid="slide-canvas-frame"
         style={{ '--canvas-zoom': `${zoomPercent / 100}` } as CSSProperties}
       >
-        <div className="canvas-artboard" ref={artboardRef} style={{ background: pageBackground }}>
+        <div
+          className="canvas-artboard"
+          ref={artboardRef}
+          style={{ background: pageBackground }}
+          onDoubleClick={handleArtboardDoubleClick}
+        >
           {showEditorOverlays &&
           (backgroundSelectionMode ||
             backgroundSelectionNotice ||
@@ -1055,6 +1183,7 @@ export function CanvasWorkspace({
             height={stageHeight}
             width={stageWidth}
             onMouseDown={handleStagePointerDown}
+            onDblClick={handleStageDoubleClick}
             onTouchStart={handleStagePointerDown}
           >
             <Layer>
@@ -1112,7 +1241,10 @@ export function CanvasWorkspace({
                         element={element}
                         hidePlaceholder={hideReadOnlyMediaPlaceholder}
                         key={element.id}
-                        label={asset?.name ?? (element.type === 'video' ? 'Imported video' : 'Imported GIF')}
+                        label={
+                          asset?.name ??
+                          (element.type === 'video' ? 'Imported video' : 'Imported GIF')
+                        }
                         nodeRef={nodeRef}
                       />
                     );
@@ -1185,12 +1317,8 @@ export function CanvasWorkspace({
                 </>
               ) : null}
               {showEditorOverlays && !backgroundSelectionMode && !processingSelectedImageId ? (
-                dragGuide ? (
-                  <CanvasDragGuide
-                    guide={dragGuide}
-                    stageHeight={stageHeight}
-                    stageWidth={stageWidth}
-                  />
+                magnetGuides.length > 0 ? (
+                  <CanvasDragGuide guides={magnetGuides} />
                 ) : null
               ) : null}
               {showEditorOverlays &&
@@ -1369,7 +1497,7 @@ export function CanvasWorkspace({
         selectedElement.type !== 'text' ? (
           <FloatingSelectionToolbar
             elementType={selectedElement.type}
-            onAlignCenter={onAlignSelectedElement}
+            onAlign={onAlignSelectedElement}
             onBringForward={onBringSelectedElementForward}
             onDelete={onDeleteSelectedElement}
             onDuplicate={onDuplicateSelectedElement}
@@ -1378,8 +1506,10 @@ export function CanvasWorkspace({
             onBackgroundSelectionToggle={onBackgroundSelectionToggle}
             onOpenAnimations={onOpenAnimations}
             onSendBackward={onSendSelectedElementBackward}
+            onEditAsGrid={onEditSelectionGrid}
             onTranslateSelectedText={onTranslateSelectedText}
             backgroundSelectionActive={backgroundSelectionMode}
+            selectionCount={selection.elementIds.length}
             cropActive={isCropModeActive}
             canTranslateSelection={canTranslateSelection}
             disabled={Boolean(processingSelectedImageId) || isTranslating}

--- a/apps/editor/src/ui/editor/canvas/canvasMagnetGuides.ts
+++ b/apps/editor/src/ui/editor/canvas/canvasMagnetGuides.ts
@@ -1,0 +1,260 @@
+export interface CanvasMagnetRect {
+  height: number;
+  id?: string;
+  width: number;
+  x: number;
+  y: number;
+}
+
+export interface CanvasMagnetLineGuide {
+  id: string;
+  kind: 'line';
+  orientation: 'horizontal' | 'vertical';
+  source: 'object' | 'page';
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+}
+
+export interface CanvasMagnetSizeGuide {
+  id: string;
+  capX1: number;
+  capX2: number;
+  capY1: number;
+  capY2: number;
+  kind: 'size';
+  orientation: 'horizontal' | 'vertical';
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+}
+
+export type CanvasMagnetGuide = CanvasMagnetLineGuide | CanvasMagnetSizeGuide;
+
+interface DragSnapInput {
+  movingRect: CanvasMagnetRect;
+  stageHeight: number;
+  stageWidth: number;
+  targetRects: CanvasMagnetRect[];
+  threshold: number;
+}
+
+interface ResizeSnapInput {
+  resizedRect: CanvasMagnetRect;
+  targetRects: CanvasMagnetRect[];
+  threshold: number;
+}
+
+const OBJECT_GUIDE_MARGIN = 18;
+const SIZE_GUIDE_CAP = 18;
+
+function getRectBounds(rects: CanvasMagnetRect[]) {
+  if (rects.length === 0) return undefined;
+  const left = Math.min(...rects.map((rect) => rect.x));
+  const top = Math.min(...rects.map((rect) => rect.y));
+  const right = Math.max(...rects.map((rect) => rect.x + rect.width));
+  const bottom = Math.max(...rects.map((rect) => rect.y + rect.height));
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+function translateRect(rect: CanvasMagnetRect, delta: { x: number; y: number }) {
+  return { ...rect, x: rect.x + delta.x, y: rect.y + delta.y };
+}
+
+function getObjectGuideSpan(first: CanvasMagnetRect, second: CanvasMagnetRect) {
+  return {
+    x1: Math.min(first.x, second.x) - OBJECT_GUIDE_MARGIN,
+    x2: Math.max(first.x + first.width, second.x + second.width) + OBJECT_GUIDE_MARGIN,
+    y1: Math.min(first.y, second.y) - OBJECT_GUIDE_MARGIN,
+    y2: Math.max(first.y + first.height, second.y + second.height) + OBJECT_GUIDE_MARGIN,
+  };
+}
+
+function getBestMatch(
+  candidates: Array<{ delta: number; guide: CanvasMagnetLineGuide }>,
+  threshold: number,
+) {
+  return candidates
+    .filter((candidate) => Math.abs(candidate.delta) <= threshold)
+    .sort((first, second) => Math.abs(first.delta) - Math.abs(second.delta))[0];
+}
+
+function getDragSnap(input: DragSnapInput) {
+  const { movingRect, stageHeight, stageWidth, targetRects, threshold } = input;
+  const movingXAnchors = [
+    { name: 'left', value: movingRect.x },
+    { name: 'center', value: movingRect.x + movingRect.width / 2 },
+    { name: 'right', value: movingRect.x + movingRect.width },
+  ];
+  const movingYAnchors = [
+    { name: 'top', value: movingRect.y },
+    { name: 'center', value: movingRect.y + movingRect.height / 2 },
+    { name: 'bottom', value: movingRect.y + movingRect.height },
+  ];
+  const pageVerticalCenter = stageWidth / 2;
+  const pageHorizontalCenter = stageHeight / 2;
+  const verticalCandidates: Array<{ delta: number; guide: CanvasMagnetLineGuide }> = [
+    {
+      delta: pageVerticalCenter - (movingRect.x + movingRect.width / 2),
+      guide: {
+        id: 'page-vertical-center',
+        kind: 'line',
+        orientation: 'vertical',
+        source: 'page',
+        x1: pageVerticalCenter,
+        x2: pageVerticalCenter,
+        y1: 0,
+        y2: stageHeight,
+      } satisfies CanvasMagnetLineGuide,
+    },
+  ];
+  const horizontalCandidates: Array<{ delta: number; guide: CanvasMagnetLineGuide }> = [
+    {
+      delta: pageHorizontalCenter - (movingRect.y + movingRect.height / 2),
+      guide: {
+        id: 'page-horizontal-center',
+        kind: 'line',
+        orientation: 'horizontal',
+        source: 'page',
+        x1: 0,
+        x2: stageWidth,
+        y1: pageHorizontalCenter,
+        y2: pageHorizontalCenter,
+      } satisfies CanvasMagnetLineGuide,
+    },
+  ];
+
+  for (const targetRect of targetRects) {
+    const span = getObjectGuideSpan(movingRect, targetRect);
+    const targetXAnchors = [
+      { name: 'left', value: targetRect.x },
+      { name: 'center', value: targetRect.x + targetRect.width / 2 },
+      { name: 'right', value: targetRect.x + targetRect.width },
+    ];
+    const targetYAnchors = [
+      { name: 'top', value: targetRect.y },
+      { name: 'center', value: targetRect.y + targetRect.height / 2 },
+      { name: 'bottom', value: targetRect.y + targetRect.height },
+    ];
+    for (const movingAnchor of movingXAnchors) {
+      for (const targetAnchor of targetXAnchors) {
+        verticalCandidates.push({
+          delta: targetAnchor.value - movingAnchor.value,
+          guide: {
+            id: `object-vertical-${targetRect.id ?? 'target'}-${movingAnchor.name}-${targetAnchor.name}`,
+            kind: 'line',
+            orientation: 'vertical',
+            source: 'object',
+            x1: targetAnchor.value,
+            x2: targetAnchor.value,
+            y1: span.y1,
+            y2: span.y2,
+          },
+        });
+      }
+    }
+    for (const movingAnchor of movingYAnchors) {
+      for (const targetAnchor of targetYAnchors) {
+        horizontalCandidates.push({
+          delta: targetAnchor.value - movingAnchor.value,
+          guide: {
+            id: `object-horizontal-${targetRect.id ?? 'target'}-${movingAnchor.name}-${targetAnchor.name}`,
+            kind: 'line',
+            orientation: 'horizontal',
+            source: 'object',
+            x1: span.x1,
+            x2: span.x2,
+            y1: targetAnchor.value,
+            y2: targetAnchor.value,
+          },
+        });
+      }
+    }
+  }
+
+  const verticalMatch = getBestMatch(verticalCandidates, threshold);
+  const horizontalMatch = getBestMatch(horizontalCandidates, threshold);
+  return {
+    deltaX: verticalMatch?.delta ?? 0,
+    deltaY: horizontalMatch?.delta ?? 0,
+    guides: [verticalMatch?.guide, horizontalMatch?.guide].filter(
+      (guide): guide is CanvasMagnetLineGuide => Boolean(guide),
+    ),
+  };
+}
+
+function getResizeSnap(input: ResizeSnapInput) {
+  const { resizedRect, targetRects, threshold } = input;
+  let widthMatch: { guide: CanvasMagnetSizeGuide; width: number } | undefined;
+  let heightMatch: { guide: CanvasMagnetSizeGuide; height: number } | undefined;
+
+  for (const targetRect of targetRects) {
+    const widthDelta = targetRect.width - resizedRect.width;
+    if (
+      Math.abs(widthDelta) <= threshold &&
+      (!widthMatch || Math.abs(widthDelta) < Math.abs(widthMatch.width - resizedRect.width))
+    ) {
+      const y = resizedRect.y + resizedRect.height;
+      const capX = resizedRect.x + targetRect.width;
+      widthMatch = {
+        width: targetRect.width,
+        guide: {
+          id: `size-width-${targetRect.id ?? 'target'}`,
+          capX1: capX,
+          capX2: capX,
+          capY1: y - SIZE_GUIDE_CAP,
+          capY2: y + SIZE_GUIDE_CAP,
+          kind: 'size',
+          orientation: 'horizontal',
+          x1: resizedRect.x,
+          x2: resizedRect.x + targetRect.width,
+          y1: y,
+          y2: y,
+        },
+      };
+    }
+
+    const heightDelta = targetRect.height - resizedRect.height;
+    if (
+      Math.abs(heightDelta) <= threshold &&
+      (!heightMatch || Math.abs(heightDelta) < Math.abs(heightMatch.height - resizedRect.height))
+    ) {
+      const x = resizedRect.x + resizedRect.width;
+      const capY = resizedRect.y + targetRect.height;
+      heightMatch = {
+        height: targetRect.height,
+        guide: {
+          id: `size-height-${targetRect.id ?? 'target'}`,
+          capX1: x - SIZE_GUIDE_CAP,
+          capX2: x + SIZE_GUIDE_CAP,
+          capY1: capY,
+          capY2: capY,
+          kind: 'size',
+          orientation: 'vertical',
+          x1: x,
+          x2: x,
+          y1: resizedRect.y,
+          y2: resizedRect.y + targetRect.height,
+        },
+      };
+    }
+  }
+
+  return {
+    height: heightMatch?.height ?? resizedRect.height,
+    guides: [widthMatch?.guide, heightMatch?.guide].filter(
+      (guide): guide is CanvasMagnetSizeGuide => Boolean(guide),
+    ),
+    width: widthMatch?.width ?? resizedRect.width,
+  };
+}
+
+export const canvasMagnetGuides = {
+  SNAP_THRESHOLD_STAGE: 6,
+  getDragSnap,
+  getRectBounds,
+  getResizeSnap,
+  translateRect,
+};

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -52,6 +52,7 @@ interface DesignPanelProps {
     visible: boolean,
   ) => void;
   onAlignSelectedElement?: (mode: AlignMode) => void;
+  onEditSelectionGrid?: () => void;
   onSetElementLock?: (elementId: string, locked: boolean) => void;
   onSetSelectedElementZOrder?: (mode: ZOrderMode) => void;
   onReplaceVideoAsset?: (elementId: string, file: File) => void;
@@ -100,6 +101,7 @@ export function DesignPanel({
   onEditSlideLayout,
   onToggleSlideLayoutPlaceholder,
   onAlignSelectedElement,
+  onEditSelectionGrid,
   onSetElementLock,
   onSetSelectedElementZOrder,
   availableFonts = [],
@@ -132,9 +134,9 @@ export function DesignPanel({
   );
   const fontFamilyOptions = useMemo(
     () =>
-      Array.from(
-        new Set([...textStyleOptions.TEXT_FONT_FAMILIES, ...projectFontFamilies]),
-      ).sort((left, right) => left.localeCompare(right)),
+      Array.from(new Set([...textStyleOptions.TEXT_FONT_FAMILIES, ...projectFontFamilies])).sort(
+        (left, right) => left.localeCompare(right),
+      ),
     [projectFontFamilies],
   );
   const localFontFamilyOptions = useMemo(() => {
@@ -146,9 +148,7 @@ export function DesignPanel({
   }, [fontFamilyOptions, localFonts]);
   const filteredDownloadableFonts = useMemo(() => {
     const query = fontSearchQuery.trim();
-    return availableFonts
-      .filter((font) => fontMatchesQuery(font, query))
-      .slice(0, 12);
+    return availableFonts.filter((font) => fontMatchesQuery(font, query)).slice(0, 12);
   }, [availableFonts, fontSearchQuery]);
 
   useEffect(() => {
@@ -275,7 +275,26 @@ export function DesignPanel({
         </div>
       </PanelSection>
 
-      {selectedElement ? (
+      {selection.elementIds.length > 1 ? (
+        <PanelSection title="Selection">
+          <div className="compact-action design-selection-summary ew-surface ew-surface-hover ew-compact-row">
+            <CaseSensitive size={16} />
+            <span>{selection.elementIds.length} elements selected</span>
+          </div>
+          <section className="movie-panel-section" aria-label="Arrange selected elements">
+            <h3>Arrange</h3>
+            <div className="movie-arrange-grid">
+              <button
+                type="button"
+                disabled={!onEditSelectionGrid}
+                onClick={onEditSelectionGrid}
+              >
+                Edit as grid
+              </button>
+            </div>
+          </section>
+        </PanelSection>
+      ) : selectedElement ? (
         <ElementDesignInspector
           key={selectedElement.id}
           assetName={

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -281,6 +281,11 @@ export function DesignPanel({
             <CaseSensitive size={16} />
             <span>{selection.elementIds.length} elements selected</span>
           </div>
+          <div className="movie-inspector-tabs" role="tablist" aria-label="Movie inspector sections">
+            <button type="button" role="tab" aria-selected="true">
+              Arrange
+            </button>
+          </div>
           <section className="movie-panel-section" aria-label="Arrange selected elements">
             <h3>Arrange</h3>
             <div className="movie-arrange-grid">
@@ -290,6 +295,15 @@ export function DesignPanel({
                 onClick={onEditSelectionGrid}
               >
                 Edit as grid
+              </button>
+              <button type="button" disabled>
+                Group
+              </button>
+              <button type="button" disabled>
+                Ungroup
+              </button>
+              <button type="button" disabled>
+                Distribute
               </button>
             </div>
           </section>

--- a/apps/editor/src/ui/editor/panels/ElementDesignInspector.tsx
+++ b/apps/editor/src/ui/editor/panels/ElementDesignInspector.tsx
@@ -254,8 +254,12 @@ export function ElementDesignInspector({
                 <option value="" disabled>
                   Align
                 </option>
+                <option value="page-left-center">Center left</option>
                 <option value="horizontal-center">Horizontal center</option>
+                <option value="page-right-center">Center right</option>
+                <option value="page-top-center">Center top</option>
                 <option value="vertical-center">Vertical center</option>
+                <option value="page-bottom-center">Center bottom</option>
                 <option value="page-center">Page center</option>
               </select>
               <button type="button" disabled>

--- a/apps/editor/src/ui/editor/panels/LayersPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LayersPanel.tsx
@@ -1,6 +1,31 @@
-import { Eye, EyeOff, Film, GripVertical, Image, Lock, Search, Square, Trash2, Type, Unlock, Video } from 'lucide-react';
-import { useState, type DragEvent } from 'react';
-import type { DesignElement, ProjectDocument, SelectionState } from '../../../domain/documents/model';
+import {
+  Eye,
+  EyeOff,
+  Film,
+  GripVertical,
+  Image,
+  LayoutGrid,
+  Lock,
+  Search,
+  Square,
+  Trash2,
+  Type,
+  Unlock,
+  Video,
+} from 'lucide-react';
+import { useState, type CSSProperties, type DragEvent, type FormEvent } from 'react';
+import type {
+  DesignElement,
+  ProjectDocument,
+  SelectionState,
+} from '../../../domain/documents/model';
+import type {
+  ImageGridFit,
+  ImageGridMediaPosition,
+  ImageGridPreset,
+  ImageGridRequest,
+  SelectionGridRequest,
+} from '../state/editorViewModelElements';
 import { IconButton } from '../../components/IconButton';
 import { PanelSection } from '../../components/PanelSection';
 
@@ -14,8 +39,24 @@ interface LayersPanelProps {
   onSetElementVisibility?: (elementId: string, visible: boolean) => void;
   onSetElementLock?: (elementId: string, locked: boolean) => void;
   onDeleteElement?: (elementId: string) => void;
+  onApplyGridToSelection?: (request: SelectionGridRequest) => void;
+  onInsertImageGrid?: (request: ImageGridRequest) => void;
   onReorderElement?: (elementId: string, targetElementId: string, position?: DropPosition) => void;
 }
+
+const CUSTOM_IMAGE_GRID_LIMIT = 6;
+const CUSTOM_TEXT_PLACEHOLDER_LIMIT = 6;
+
+const imageGridPresets: Array<{
+  label: string;
+  preset: ImageGridPreset;
+  preview: number[];
+}> = [
+  { label: '1 image', preset: 'one', preview: [1] },
+  { label: '2 images', preset: 'two-columns', preview: [2] },
+  { label: '3 images', preset: 'three-two-one', preview: [2, 1] },
+  { label: '4 images', preset: 'four-square', preview: [2, 2] },
+];
 
 function isDesignElement(element: DesignElement | undefined): element is DesignElement {
   return Boolean(element);
@@ -51,6 +92,13 @@ function getDropPosition(event: DragEvent<HTMLElement>): DropPosition {
   return event.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
 }
 
+function parseBoundedInteger(value: string, max: number) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return undefined;
+  if (parsed < 0 || parsed > max) return undefined;
+  return parsed;
+}
+
 export function LayersPanel({
   project,
   activePageId,
@@ -59,9 +107,19 @@ export function LayersPanel({
   onSetElementVisibility,
   onSetElementLock,
   onDeleteElement,
+  onApplyGridToSelection,
+  onInsertImageGrid,
   onReorderElement,
 }: LayersPanelProps) {
-  const [dropIndicator, setDropIndicator] = useState<{ layerId: string; position: DropPosition } | undefined>();
+  const [dropIndicator, setDropIndicator] = useState<
+    { layerId: string; position: DropPosition } | undefined
+  >();
+  const [customColumns, setCustomColumns] = useState('1');
+  const [customRows, setCustomRows] = useState('1');
+  const [customTextCount, setCustomTextCount] = useState('1');
+  const [customMediaPosition, setCustomMediaPosition] =
+    useState<ImageGridMediaPosition>('left');
+  const [customImageFit, setCustomImageFit] = useState<ImageGridFit>('cover');
   const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
   const selectedElementId = selection.elementIds[0];
   const layers =
@@ -79,6 +137,49 @@ export function LayersPanel({
         locked: element.locked,
       })) ?? [];
   const selectedLayer = layers.find((layer) => layer.selected);
+  const gridEditMode = selection.elementIds.length > 1;
+  const selectedTextCount = layers.filter(
+    (layer) => layer.selected && layer.type === 'text',
+  ).length;
+  const balancedSelectionColumns = Math.max(1, Math.ceil(Math.sqrt(selection.elementIds.length)));
+  const balancedSelectionRows = Math.max(
+    1,
+    Math.ceil(selection.elementIds.length / balancedSelectionColumns),
+  );
+  const customColumnsControlValue =
+    gridEditMode && customColumns === '1' && customRows === '1'
+      ? String(balancedSelectionColumns)
+      : customColumns;
+  const customRowsControlValue =
+    gridEditMode && customColumns === '1' && customRows === '1'
+      ? String(balancedSelectionRows)
+      : customRows;
+  const customColumnsValue = parseBoundedInteger(
+    customColumnsControlValue,
+    CUSTOM_IMAGE_GRID_LIMIT,
+  );
+  const customRowsValue = parseBoundedInteger(customRowsControlValue, CUSTOM_IMAGE_GRID_LIMIT);
+  const customTextCountValue = parseBoundedInteger(customTextCount, CUSTOM_TEXT_PLACEHOLDER_LIMIT);
+  const customGrid =
+    customColumnsValue && customRowsValue && customTextCountValue !== undefined
+      ? {
+          columns: customColumnsValue,
+          imageFit: customImageFit,
+          mediaPosition: customMediaPosition,
+          rows: customRowsValue,
+          textCount: gridEditMode ? selectedTextCount : customTextCountValue,
+        }
+      : undefined;
+  const customGridInvalid = !customGrid;
+  const submitCustomGrid = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!customGrid) return;
+    if (gridEditMode) {
+      onApplyGridToSelection?.(customGrid);
+      return;
+    }
+    onInsertImageGrid?.(customGrid);
+  };
 
   return (
     <div className="panel-stack">
@@ -86,12 +187,136 @@ export function LayersPanel({
         <Search size={15} />
         <input aria-label="Search layers" placeholder="Search layers" type="search" />
       </div>
+      <PanelSection title={gridEditMode ? 'Edit selected grid' : 'Image grids'}>
+        {gridEditMode ? (
+          <p className="panel-muted">{selection.elementIds.length} selected elements</p>
+        ) : (
+          <div className="layout-image-grid-options">
+            {imageGridPresets.map((preset) => (
+              <button
+                aria-label={`Insert ${preset.label} grid`}
+                className="layout-image-grid-option ew-surface ew-surface-hover"
+                disabled={!onInsertImageGrid}
+                key={preset.preset}
+                type="button"
+                onClick={() => onInsertImageGrid?.(preset.preset)}
+              >
+                <LayoutGrid size={15} />
+                <GridPresetPreview rows={preset.preview} />
+                <span>{preset.label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+        <form className="layout-custom-grid-form" onSubmit={submitCustomGrid}>
+          <span className="layout-custom-grid-label">Custom grid</span>
+          <div className="layout-custom-grid-fields">
+            <label className="layout-custom-grid-field">
+              <span>Columns</span>
+              <input
+                aria-label="Grid columns"
+                inputMode="numeric"
+                min={1}
+                max={CUSTOM_IMAGE_GRID_LIMIT}
+                type="number"
+                value={customColumnsControlValue}
+                onChange={(event) => {
+                  setCustomColumns(event.currentTarget.value);
+                }}
+              />
+            </label>
+            <label className="layout-custom-grid-field">
+              <span>Rows</span>
+              <input
+                aria-label="Grid rows"
+                inputMode="numeric"
+                min={1}
+                max={CUSTOM_IMAGE_GRID_LIMIT}
+                type="number"
+                value={customRowsControlValue}
+                onChange={(event) => {
+                  setCustomRows(event.currentTarget.value);
+                }}
+              />
+            </label>
+            <label className="layout-custom-grid-field">
+              <span>Text</span>
+              <input
+                aria-label="Text placeholders"
+                disabled={gridEditMode}
+                inputMode="numeric"
+                min={0}
+                max={CUSTOM_TEXT_PLACEHOLDER_LIMIT}
+                type="number"
+                value={gridEditMode ? String(selectedTextCount) : customTextCount}
+                onChange={(event) => {
+                  setCustomTextCount(event.currentTarget.value);
+                }}
+              />
+            </label>
+          </div>
+          <span className="layout-custom-grid-label">Arrangement</span>
+          <div className="layout-custom-grid-row">
+            <select
+              aria-label="Media position"
+              value={customMediaPosition}
+              onChange={(event) => {
+                setCustomMediaPosition(event.currentTarget.value as ImageGridMediaPosition);
+              }}
+            >
+              <option value="left">Images left, text right</option>
+              <option value="right">Text left, images right</option>
+              <option value="top">Images top, text bottom</option>
+              <option value="bottom">Text top, images bottom</option>
+            </select>
+          </div>
+          <span className="layout-custom-grid-label">Image behavior</span>
+          <div className="layout-custom-grid-row">
+            <select
+              aria-label="Image fit"
+              value={customImageFit}
+              onChange={(event) => {
+                setCustomImageFit(event.currentTarget.value as ImageGridFit);
+              }}
+            >
+              <option value="cover">object-fit: cover</option>
+              <option value="contain">object-fit: contain</option>
+              <option value="stretch">object-fit: fill</option>
+            </select>
+            <button
+              className="layout-custom-grid-submit ew-surface ew-surface-hover"
+              disabled={
+                gridEditMode
+                  ? !onApplyGridToSelection || !customGrid
+                  : !onInsertImageGrid || !customGrid
+              }
+              type="submit"
+            >
+              <LayoutGrid size={14} />
+              <span>{gridEditMode ? 'Update selection' : 'Insert'}</span>
+            </button>
+          </div>
+          <p className={customGridInvalid ? 'layout-custom-grid-error' : 'panel-muted'}>
+            Cover fills to the cell border. Fill may distort placeholders.
+          </p>
+          {customGrid ? (
+            <CustomGridPreview
+              columns={customGrid.columns}
+              imageFit={customGrid.imageFit}
+              mediaPosition={customGrid.mediaPosition}
+              rows={customGrid.rows}
+              textCount={customGrid.textCount}
+            />
+          ) : null}
+        </form>
+      </PanelSection>
       <PanelSection title="Stack">
         <p className="panel-muted">{layers.length + 1} layers on current page</p>
         <div className="layer-list ew-panel-card">
           {layers.map((layer) => {
             const Icon = layer.icon;
-            const dropPosition = dropIndicator?.layerId === layer.id ? dropIndicator.position : undefined;
+            const dropPosition =
+              dropIndicator?.layerId === layer.id ? dropIndicator.position : undefined;
             const rowClassName = [
               'layer-row',
               'ew-surface',
@@ -127,7 +352,9 @@ export function LayersPanel({
                 }}
                 onDragLeave={(event) => {
                   if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
-                  setDropIndicator((current) => (current?.layerId === layer.id ? undefined : current));
+                  setDropIndicator((current) =>
+                    current?.layerId === layer.id ? undefined : current,
+                  );
                 }}
                 onDrop={(event) => {
                   event.preventDefault();
@@ -153,9 +380,9 @@ export function LayersPanel({
                   }
                   onSelectElement?.(layer.id);
                 }}
-                >
-                  <GripVertical size={15} />
-                  <Icon size={16} />
+              >
+                <GripVertical size={15} />
+                <Icon size={16} />
                 <span className="layer-row-name ew-ellipsis">{layer.name}</span>
                 <span
                   className="layer-row-actions"
@@ -214,6 +441,85 @@ export function LayersPanel({
           </strong>
         </div>
       </PanelSection>
+    </div>
+  );
+}
+
+function GridPresetPreview({ rows }: { rows: number[] }) {
+  return (
+    <span className="layout-image-grid-preview" aria-hidden="true">
+      {rows.map((count, rowIndex) => (
+        <span className="layout-image-grid-preview-row" key={`${count}-${rowIndex}`}>
+          {Array.from({ length: count }, (_, index) => (
+            <span className="layout-image-grid-preview-cell" key={index} />
+          ))}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function CustomGridPreview({
+  columns,
+  imageFit,
+  mediaPosition,
+  rows,
+  textCount,
+}: {
+  columns: number;
+  imageFit: ImageGridFit;
+  mediaPosition: ImageGridMediaPosition;
+  rows: number;
+  textCount: number;
+}) {
+  const previewStyle = {
+    '--layout-custom-grid-columns': columns,
+    '--layout-custom-grid-rows': rows,
+  } as CSSProperties;
+  const imageGrid = (
+    <div
+      className={`layout-custom-grid-preview-stage layout-custom-grid-preview-stage-${imageFit}`}
+      style={previewStyle}
+    >
+      {Array.from({ length: columns * rows }, (_, index) => (
+        <span className="layout-custom-grid-preview-cell" key={index}>
+          <span className="layout-custom-grid-preview-media" />
+        </span>
+      ))}
+    </div>
+  );
+  const textStack =
+    textCount > 0 ? (
+      <div className="layout-custom-grid-preview-text-stack">
+        {Array.from({ length: textCount }, (_, index) => (
+          <span className="layout-custom-grid-preview-text" key={index}>
+            T
+          </span>
+        ))}
+      </div>
+    ) : null;
+  const horizontal = mediaPosition === 'left' || mediaPosition === 'right';
+  const className = [
+    'layout-custom-grid-preview-content',
+    textCount === 0 ? 'layout-custom-grid-preview-content-single' : '',
+    horizontal ? 'layout-custom-grid-preview-content-horizontal' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const children =
+    mediaPosition === 'right' || mediaPosition === 'bottom'
+      ? [textStack, imageGrid]
+      : [imageGrid, textStack];
+
+  return (
+    <div
+      aria-label={`Custom grid preview ${columns} columns by ${rows} rows, ${textCount} text placeholders, ${imageFit} image fit`}
+      className="layout-custom-grid-preview"
+      role="img"
+    >
+      <div className={className}>
+        {children.map((child, index) => (child ? <div key={index}>{child}</div> : null))}
+      </div>
     </div>
   );
 }

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -33,6 +33,7 @@ import { localMediaImportConfig } from '../media/localMediaImportConfig';
 import { LayersPanel } from './LayersPanel';
 import { TextPanel } from './TextPanel';
 import type { RightPanelTab, TextPreset } from '../state/useEditorViewModel';
+import type { ImageGridRequest, SelectionGridRequest } from '../state/editorViewModelElements';
 import type { StockMediaErrorState } from '../state/use-stock-media-library';
 
 interface LeftToolPanelProps {
@@ -101,6 +102,8 @@ interface LeftToolPanelProps {
   onInsertStockMedia?: ((item: StockMediaItem) => void) | undefined;
   onInsertText?: ((preset: TextPreset) => void) | undefined;
   onInsertShape?: ((shape: ShapeKind) => void) | undefined;
+  onInsertImageGrid?: ((request: ImageGridRequest) => void) | undefined;
+  onApplyGridToSelection?: ((request: SelectionGridRequest) => void) | undefined;
   onSearchStockGifs?: ((query: string) => void) | undefined;
   onSearchStockImages?: ((query: string) => void) | undefined;
   onPreparePromptApi?: (() => Promise<void>) | undefined;
@@ -121,6 +124,7 @@ interface LeftToolPanelProps {
     | ((elementId: string, targetElementId: string, position?: 'before' | 'after') => void)
     | undefined;
   onAlignSelectedElement?: ((mode: AlignMode) => void) | undefined;
+  onEditSelectionGrid?: (() => void) | undefined;
   onSetSelectedElementZOrder?: ((mode: ZOrderMode) => void) | undefined;
   onUpdateElementFrame?: ((elementId: string, patch: ElementFramePatch) => void) | undefined;
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
@@ -203,6 +207,8 @@ export function LeftToolPanel({
   onInsertStockMedia,
   onInsertText,
   onInsertShape,
+  onInsertImageGrid,
+  onApplyGridToSelection,
   onSearchStockGifs,
   onSearchStockImages,
   onPreparePromptApi,
@@ -221,6 +227,7 @@ export function LeftToolPanel({
   onDeleteElement,
   onReorderElement,
   onAlignSelectedElement,
+  onEditSelectionGrid,
   onSetSelectedElementZOrder,
   onUpdateElementFrame,
   onUpdateElementStyle,
@@ -341,6 +348,8 @@ export function LeftToolPanel({
             {...(onSetElementVisibility ? { onSetElementVisibility } : {})}
             {...(onSetElementLock ? { onSetElementLock } : {})}
             {...(onDeleteElement ? { onDeleteElement } : {})}
+            {...(onApplyGridToSelection ? { onApplyGridToSelection } : {})}
+            {...(onInsertImageGrid ? { onInsertImageGrid } : {})}
             {...(onReorderElement ? { onReorderElement } : {})}
           />
         ) : null}
@@ -355,6 +364,7 @@ export function LeftToolPanel({
             {...(onDownloadFont ? { onDownloadFont } : {})}
             {...(onImportLocalFont ? { onImportLocalFont } : {})}
             {...(onAlignSelectedElement ? { onAlignSelectedElement } : {})}
+            {...(onEditSelectionGrid ? { onEditSelectionGrid } : {})}
             {...(onSetElementLock ? { onSetElementLock } : {})}
             {...(onSetSelectedElementZOrder ? { onSetSelectedElementZOrder } : {})}
             {...(onUpdateElementFrame ? { onUpdateElementFrame } : {})}

--- a/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
@@ -45,6 +45,7 @@ export function EditorLeftPanelSurface({
       onDeleteElement={isHistoryReadOnly ? undefined : vm.deleteElement}
       onReorderElement={isHistoryReadOnly ? undefined : vm.reorderElement}
       onAlignSelectedElement={isHistoryReadOnly ? undefined : vm.alignSelectedElement}
+      onEditSelectionGrid={isHistoryReadOnly ? undefined : () => vm.setActiveTab('layout')}
       onSetSelectedElementZOrder={isHistoryReadOnly ? undefined : vm.setSelectedElementZOrder}
       onUpdateElementFrame={isHistoryReadOnly ? undefined : vm.updateElementFrame}
       onUpdateElementStyle={isHistoryReadOnly ? undefined : vm.updateElementStyle}
@@ -94,6 +95,8 @@ export function EditorLeftPanelSurface({
       onInsertStockMedia={isHistoryReadOnly ? undefined : vm.insertStockMedia}
       onInsertText={isHistoryReadOnly ? undefined : vm.insertTextElement}
       onInsertShape={isHistoryReadOnly ? undefined : vm.insertShapeElement}
+      onInsertImageGrid={isHistoryReadOnly ? undefined : vm.insertImageGridPlaceholders}
+      onApplyGridToSelection={isHistoryReadOnly ? undefined : vm.applyGridToSelectedElements}
       onSearchStockGifs={(query) => {
         void vm.searchStockGifs(query);
       }}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type Konva from 'konva';
 import type { AppServices } from '../../../app/composition';
+import { placeholderImage } from '../../../domain/assets/placeholderImage';
 import type { ProjectDocument } from '../../../domain/documents/model';
 import { pageVisibility } from '../../../domain/documents/pageVisibility';
-import type {
-  ShareMetadata,
-  SharePublishProgress,
-} from '../../../services/contracts/interfaces';
+import type { ShareMetadata, SharePublishProgress } from '../../../services/contracts/interfaces';
 import { editorAutomationController } from '../../../services/automation/editorAutomationController';
 import type { EditorAutomationDelegate } from '../../../services/automation/editorAutomationController';
 import { imageGenerationModel } from '../../../services/image-generation/imageGenerationModel';
@@ -37,7 +35,10 @@ import { presentationMovieControls, type MovieHoldState } from '../media/present
 import { useEditorViewModel, type OperationNoticeState } from '../state/useEditorViewModel';
 import { SharePanel } from '../../share/SharePanel';
 import { copyShareText } from '../../share/shareClipboard';
-import { KeyboardShortcutsDialog, type KeyboardShortcutAction } from '../../components/KeyboardShortcutsDialog';
+import {
+  KeyboardShortcutsDialog,
+  type KeyboardShortcutAction,
+} from '../../components/KeyboardShortcutsDialog';
 import { editorShellBrowserUtils } from '../browser/editorShellBrowserUtils';
 import { BrowserPresenterSessionService } from '../../../services/presenter/presenterSessionService';
 import type {
@@ -115,8 +116,9 @@ export function EditorShell({ services }: EditorShellProps) {
 function EditorDesktopShell({ services }: EditorShellProps) {
   const vm = useEditorViewModel(services);
   const presenterTranscriptionLanguage =
-    vm.translationLanguageOptions.find((language) => language.code === vm.translationTargetLanguage) ??
-    vm.activeSlideLanguage;
+    vm.translationLanguageOptions.find(
+      (language) => language.code === vm.translationTargetLanguage,
+    ) ?? vm.activeSlideLanguage;
   const automationDelegateRef = useRef(vm.automation);
   const prepareProjectFontsForPublicShareRef = useRef(vm.prepareProjectFontsForPublicShare);
   const movieHoldStateRef = useRef<MovieHoldState | undefined>(undefined);
@@ -151,7 +153,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const [isExportingImages, setIsExportingImages] = useState(false);
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
   const [shareMetadata, setShareMetadata] = useState<ShareMetadata | undefined>();
-  const [sharePublishProgress, setSharePublishProgress] = useState<SharePublishProgress | undefined>();
+  const [sharePublishProgress, setSharePublishProgress] = useState<
+    SharePublishProgress | undefined
+  >();
   const stageRef = useRef<Konva.Stage>(null);
   const imageExportStageRef = useRef<Konva.Stage>(null);
   const workspaceRef = useRef<HTMLElement>(null);
@@ -162,15 +166,21 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const imageExportNoticeTimeoutRef = useRef<number | undefined>(undefined);
   const presenterFullscreenEnteredRef = useRef(false);
   const pendingShareAfterLocalSaveRef = useRef(false);
-  const lastPublishedShareSelectionRef = useRef<{
-    projectSignature: string;
-    selectedRecordingId?: string | undefined;
-    shareId: string;
-  } | undefined>(undefined);
-  const sharePublishPromiseRef = useRef<{
-    promise: Promise<ShareMetadata>;
-    selectedRecordingId?: string | undefined;
-  } | undefined>(undefined);
+  const lastPublishedShareSelectionRef = useRef<
+    | {
+        projectSignature: string;
+        selectedRecordingId?: string | undefined;
+        shareId: string;
+      }
+    | undefined
+  >(undefined);
+  const sharePublishPromiseRef = useRef<
+    | {
+        promise: Promise<ShareMetadata>;
+        selectedRecordingId?: string | undefined;
+      }
+    | undefined
+  >(undefined);
   const toolbarImageInputRef = useRef<HTMLInputElement>(null);
   const hasSelection = vm.selection.elementIds.length > 0;
   const isHistoryReadOnly = vm.versionHistoryOpen;
@@ -212,7 +222,8 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     },
     options: [
       {
-        compatibility: imageGenerationState?.status === 'unavailable' ? 'incompatible' : 'compatible',
+        compatibility:
+          imageGenerationState?.status === 'unavailable' ? 'incompatible' : 'compatible',
         id: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
         label: imageGenerationModel.IMAGE_GENERATION_DISPLAY_NAME,
         modelId: imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
@@ -254,52 +265,58 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     ],
   );
 
-  const publishCurrentProjectShare = useCallback(async (selectedRecordingId?: string) => {
-    const inFlightSharePublish = sharePublishPromiseRef.current;
-    if (inFlightSharePublish && inFlightSharePublish.selectedRecordingId === selectedRecordingId) {
-      return inFlightSharePublish.promise;
-    }
-    if (inFlightSharePublish) {
-      await inFlightSharePublish.promise.catch(() => undefined);
-    }
-    const preparedShare = services.shareService.getProjectShareMetadata(vm.project);
-    const shareId = shareMetadata?.shareId ?? preparedShare.shareId;
-    setShareMetadata((current) => ({
-      ...(current ?? preparedShare),
-      shareId,
-      status: 'syncing',
-    }));
-
-    const publishPromise = (async () => {
-      const fontResult = await prepareProjectFontsForPublicShareRef.current();
-      return services.shareService.updateShare(
-        shareId,
-        createProjectForSelectedShareRecording(fontResult.project, selectedRecordingId),
-        {
-          onProgress: setSharePublishProgress,
-        },
-      );
-    })();
-    sharePublishPromiseRef.current = { promise: publishPromise, selectedRecordingId };
-    try {
-      const nextShare = await publishPromise;
-      lastPublishedShareSelectionRef.current = {
-        projectSignature: getProjectPublishSignature(vm.project),
-        selectedRecordingId,
-        shareId: nextShare.shareId,
-      };
-      setShareMetadata(nextShare);
-      return nextShare;
-    } catch (error) {
-      setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
-      throw error;
-    } finally {
-      if (sharePublishPromiseRef.current?.promise === publishPromise) {
-        sharePublishPromiseRef.current = undefined;
+  const publishCurrentProjectShare = useCallback(
+    async (selectedRecordingId?: string) => {
+      const inFlightSharePublish = sharePublishPromiseRef.current;
+      if (
+        inFlightSharePublish &&
+        inFlightSharePublish.selectedRecordingId === selectedRecordingId
+      ) {
+        return inFlightSharePublish.promise;
       }
-      setSharePublishProgress(undefined);
-    }
-  }, [services.shareService, shareMetadata?.shareId, vm.project]);
+      if (inFlightSharePublish) {
+        await inFlightSharePublish.promise.catch(() => undefined);
+      }
+      const preparedShare = services.shareService.getProjectShareMetadata(vm.project);
+      const shareId = shareMetadata?.shareId ?? preparedShare.shareId;
+      setShareMetadata((current) => ({
+        ...(current ?? preparedShare),
+        shareId,
+        status: 'syncing',
+      }));
+
+      const publishPromise = (async () => {
+        const fontResult = await prepareProjectFontsForPublicShareRef.current();
+        return services.shareService.updateShare(
+          shareId,
+          createProjectForSelectedShareRecording(fontResult.project, selectedRecordingId),
+          {
+            onProgress: setSharePublishProgress,
+          },
+        );
+      })();
+      sharePublishPromiseRef.current = { promise: publishPromise, selectedRecordingId };
+      try {
+        const nextShare = await publishPromise;
+        lastPublishedShareSelectionRef.current = {
+          projectSignature: getProjectPublishSignature(vm.project),
+          selectedRecordingId,
+          shareId: nextShare.shareId,
+        };
+        setShareMetadata(nextShare);
+        return nextShare;
+      } catch (error) {
+        setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
+        throw error;
+      } finally {
+        if (sharePublishPromiseRef.current?.promise === publishPromise) {
+          sharePublishPromiseRef.current = undefined;
+        }
+        setSharePublishProgress(undefined);
+      }
+    },
+    [services.shareService, shareMetadata?.shareId, vm.project],
+  );
 
   function getReusablePublishedShare(
     share: ShareMetadata | undefined,
@@ -316,19 +333,22 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     return undefined;
   }
 
-  const hasPublishedCurrentProjectShare = useCallback((
-    share: ShareMetadata | undefined,
-    selectedRecordingId: string | undefined,
-    project: ProjectDocument,
-  ) => {
-    if (!share || (share.status !== 'published' && share.status !== 'copied')) return false;
-    const lastPublishedShareSelection = lastPublishedShareSelectionRef.current;
-    return (
-      lastPublishedShareSelection?.shareId === share.shareId &&
-      lastPublishedShareSelection.selectedRecordingId === selectedRecordingId &&
-      lastPublishedShareSelection.projectSignature === getProjectPublishSignature(project)
-    );
-  }, []);
+  const hasPublishedCurrentProjectShare = useCallback(
+    (
+      share: ShareMetadata | undefined,
+      selectedRecordingId: string | undefined,
+      project: ProjectDocument,
+    ) => {
+      if (!share || (share.status !== 'published' && share.status !== 'copied')) return false;
+      const lastPublishedShareSelection = lastPublishedShareSelectionRef.current;
+      return (
+        lastPublishedShareSelection?.shareId === share.shareId &&
+        lastPublishedShareSelection.selectedRecordingId === selectedRecordingId &&
+        lastPublishedShareSelection.projectSignature === getProjectPublishSignature(project)
+      );
+    },
+    [],
+  );
 
   function exportCurrentPageAsPng() {
     const dataUrl = stageRef.current?.toDataURL({ mimeType: 'image/png', pixelRatio: 2 });
@@ -357,13 +377,18 @@ function EditorDesktopShell({ services }: EditorShellProps) {
 
   function getImageExportFrames(options: ImageExportOptions): ImageExportFrame[] {
     return editorImageExport.getFrames({
-      getPageImageFileName: services.exportService.getPageImageFileName.bind(services.exportService),
+      getPageImageFileName: services.exportService.getPageImageFileName.bind(
+        services.exportService,
+      ),
       options,
       project: vm.project,
     });
   }
 
-  async function renderImageExportFrame(frame: ImageExportFrame, format: ImageExportOptions['format']) {
+  async function renderImageExportFrame(
+    frame: ImageExportFrame,
+    format: ImageExportOptions['format'],
+  ) {
     await editorImageExport.preloadFrameImages(vm.project, frame.pageId);
     setImageExportFrame(frame);
     await editorImageExport.waitForNextPaint();
@@ -750,6 +775,19 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     openLeftPanel();
   }
 
+  function revealElementsForImagePlaceholder(elementId: string) {
+    const selectedElement = vm.project.elements[elementId];
+    if (
+      selectedElement?.type !== 'image' ||
+      selectedElement.assetId !== placeholderImage.PLACEHOLDER_IMAGE_ASSET_ID
+    ) {
+      return false;
+    }
+    vm.setActiveTab('elements');
+    openLeftPanel();
+    return true;
+  }
+
   function openDesignFontList() {
     vm.setActiveTab('design');
     openLeftPanel();
@@ -758,7 +796,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
 
   function selectElement(elementId: string, options?: { additive?: boolean }) {
     vm.selectElement(elementId, options);
-    if (!options?.additive) revealMediaSettingsForElement(elementId);
+    if (options?.additive) return;
+    if (revealElementsForImagePlaceholder(elementId)) return;
+    revealMediaSettingsForElement(elementId);
   }
 
   function importMediaFile(file: File) {
@@ -1091,12 +1131,14 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           updatedAt: new Date().toISOString(),
         };
         vm.addTranscriptRecording(editorOwnedRecording);
-        getPresenterSessionService().publishState(createPresenterStatePayload({
-          activePageId: vm.activePageId,
-          animationPreview: vm.animationPreview,
-          presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
-          project: projectWithRecording,
-        }));
+        getPresenterSessionService().publishState(
+          createPresenterStatePayload({
+            activePageId: vm.activePageId,
+            animationPreview: vm.animationPreview,
+            presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
+            project: projectWithRecording,
+          }),
+        );
         return;
       }
       if (message.command === 'update-stream-peer') {
@@ -1383,11 +1425,13 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             canTranslateSelection={vm.canTranslateSelection}
             isTranslating={vm.isTranslating}
             translationNotice={vm.translationNotice}
-            onAlignSelectedElement={
+            onAlignSelectedElement={isHistoryReadOnly ? undefined : vm.alignSelectedElement}
+            onEditSelectionGrid={
               isHistoryReadOnly
                 ? undefined
                 : () => {
-                    vm.alignSelectedElement('page-center');
+                    vm.setActiveTab('layout');
+                    openLeftPanel();
                   }
             }
             onAnimationPreviewAdvance={
@@ -1416,6 +1460,14 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             }
             onCancelBackgroundSelection={
               isHistoryReadOnly ? undefined : vm.cancelBackgroundSelectionMode
+            }
+            onCanvasBackgroundDoubleClick={
+              isHistoryReadOnly
+                ? undefined
+                : () => {
+                    vm.setActiveTab('layout');
+                    openLeftPanel();
+                  }
             }
             onClearSelection={isHistoryReadOnly ? undefined : vm.clearSelection}
             onDeleteSelectedElement={isHistoryReadOnly ? undefined : vm.deleteSelectedElement}

--- a/apps/editor/src/ui/editor/state/editorViewModelElements.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelElements.ts
@@ -1,18 +1,56 @@
 import type {
+  Asset,
   DesignElement,
+  ImageElement,
   Page,
   ProjectDocument,
   ShapeElement,
   ShapeKind,
+  TextElement,
 } from '../../../domain/documents/model';
+import { placeholderImage } from '../../../domain/assets/placeholderImage';
 import type { TextPreset } from './useEditorViewModel';
 
 const PASTED_ELEMENT_OFFSET = 32;
+const GRID_SPLIT_GAP = 16;
+const IMAGE_GRID_MARGIN_X = 96;
+const IMAGE_GRID_MARGIN_Y = 72;
+const PLACEHOLDER_IMAGE_ASPECT_RATIO = 433 / 287;
+const IMAGE_GRID_CONTENT_GAP = 72;
+
+export type GridSplitLayout = 'auto' | 'one-two' | 'two-by-two' | 'two-one';
+export type ImageGridFit = 'contain' | 'cover' | 'stretch';
+export type ImageGridPreset = 'one' | 'two-columns' | 'three-two-one' | 'four-square';
+export type ImageGridMediaPosition = 'bottom' | 'left' | 'right' | 'top';
+export type ImageGridRequest =
+  | ImageGridPreset
+  | {
+      columns: number;
+      imageFit?: ImageGridFit;
+      mediaPosition?: ImageGridMediaPosition;
+      rows: number;
+      textCount?: number;
+    };
+export interface SelectionGridRequest {
+  columns: number;
+  imageFit?: ImageGridFit;
+  mediaPosition?: ImageGridMediaPosition;
+  rows: number;
+}
 
 export interface ElementClipboardState {
   assets: ProjectDocument['assets'];
   elements: DesignElement[];
 }
+
+const placeholderImageAsset: Asset = {
+  id: placeholderImage.PLACEHOLDER_IMAGE_ASSET_ID,
+  type: 'image',
+  name: placeholderImage.PLACEHOLDER_IMAGE_NAME,
+  mimeType: placeholderImage.PLACEHOLDER_IMAGE_MIME_TYPE,
+  objectUrl: placeholderImage.PLACEHOLDER_IMAGE_URL,
+  storage: 'inline',
+};
 
 function getSelectedElementsForClipboard(input: {
   activePageId: string;
@@ -48,6 +86,442 @@ function createPastedElements(input: {
     y: element.y + PASTED_ELEMENT_OFFSET,
     locked: false,
   }));
+}
+
+function getImageGridFrameBounds(page: Page) {
+  return {
+    height: Math.max(1, page.height - IMAGE_GRID_MARGIN_Y * 2),
+    width: Math.max(1, page.width - IMAGE_GRID_MARGIN_X * 2),
+    x: IMAGE_GRID_MARGIN_X,
+    y: IMAGE_GRID_MARGIN_Y,
+  };
+}
+
+function splitImageGridContentBounds(input: {
+  bounds: { height: number; width: number; x: number; y: number };
+  mediaPosition: ImageGridMediaPosition;
+  textCount: number;
+}) {
+  if (input.textCount < 1) return { imageBounds: input.bounds, textBounds: [] };
+
+  const horizontal = input.mediaPosition === 'left' || input.mediaPosition === 'right';
+  if (horizontal) {
+    const availableWidth = Math.max(1, input.bounds.width - IMAGE_GRID_CONTENT_GAP);
+    const imageWidth = Math.max(1, availableWidth * 0.56);
+    const textWidth = Math.max(1, availableWidth - imageWidth);
+    const leftPane = {
+      ...input.bounds,
+      width: input.mediaPosition === 'left' ? imageWidth : textWidth,
+    };
+    const rightPane = {
+      ...input.bounds,
+      width: input.mediaPosition === 'left' ? textWidth : imageWidth,
+      x: input.bounds.x + leftPane.width + IMAGE_GRID_CONTENT_GAP,
+    };
+    return input.mediaPosition === 'left'
+      ? { imageBounds: leftPane, textBounds: createTextFrameStack(rightPane, input.textCount) }
+      : { imageBounds: rightPane, textBounds: createTextFrameStack(leftPane, input.textCount) };
+  }
+
+  const textPaneHeight = getTextPaneHeight(input.bounds.height, input.textCount);
+  const imagePaneHeight = Math.max(1, input.bounds.height - textPaneHeight - IMAGE_GRID_CONTENT_GAP);
+  const topPane = {
+    ...input.bounds,
+    height: input.mediaPosition === 'top' ? imagePaneHeight : textPaneHeight,
+  };
+  const bottomPane = {
+    ...input.bounds,
+    height: input.mediaPosition === 'top' ? textPaneHeight : imagePaneHeight,
+    y: input.bounds.y + topPane.height + IMAGE_GRID_CONTENT_GAP,
+  };
+  return input.mediaPosition === 'top'
+    ? { imageBounds: topPane, textBounds: createTextFrameStack(bottomPane, input.textCount) }
+    : { imageBounds: bottomPane, textBounds: createTextFrameStack(topPane, input.textCount) };
+}
+
+function getTextPaneHeight(totalHeight: number, textCount: number) {
+  const preferredHeight = textCount <= 1 ? 260 : 156 * textCount + GRID_SPLIT_GAP * (textCount - 1);
+  return Math.max(148, Math.min(totalHeight * 0.44, preferredHeight));
+}
+
+function createTextFrameStack(
+  bounds: { height: number; width: number; x: number; y: number },
+  count: number,
+) {
+  const gap = count > 1 ? GRID_SPLIT_GAP : 0;
+  const maxItemHeight = count <= 1 ? Math.min(bounds.height, 260) : 156;
+  const height = Math.max(1, Math.min(maxItemHeight, (bounds.height - gap * (count - 1)) / count));
+  const stackHeight = height * count + gap * (count - 1);
+  const top = bounds.y + Math.max(0, (bounds.height - stackHeight) / 2);
+  return Array.from({ length: count }, (_, index) => ({
+    height,
+    width: bounds.width,
+    x: bounds.x,
+    y: top + index * (height + gap),
+  }));
+}
+
+function getImageGridLayout(request: ImageGridRequest) {
+  if (typeof request !== 'string') {
+    return {
+      columns: Math.max(1, request.columns),
+      count: Math.max(1, request.columns) * Math.max(1, request.rows),
+      rows: Math.max(1, request.rows),
+    };
+  }
+  if (request === 'one') return { columns: 1, count: 1, rows: 1 };
+  if (request === 'two-columns') return { columns: 2, count: 2, rows: 1 };
+  if (request === 'three-two-one') return { columns: 2, count: 3, rows: 2 };
+  return { columns: 2, count: 4, rows: 2 };
+}
+
+function createImageGridFrames(input: {
+  bounds?: { height: number; width: number; x: number; y: number };
+  page: Page;
+  request: ImageGridRequest;
+}) {
+  const bounds = input.bounds ?? getImageGridFrameBounds(input.page);
+  const layout = getImageGridLayout(input.request);
+  const cellWidth = Math.max(
+    1,
+    (bounds.width - GRID_SPLIT_GAP * (layout.columns - 1)) / layout.columns,
+  );
+  const cellHeight = Math.max(
+    1,
+    (bounds.height - GRID_SPLIT_GAP * (layout.rows - 1)) / layout.rows,
+  );
+  const placements =
+    input.request === 'three-two-one'
+      ? [
+          { column: 0, row: 0 },
+          { column: 1, row: 0 },
+          { column: 0.5, row: 1 },
+        ]
+      : undefined;
+
+  return Array.from({ length: layout.count }, (_, index) => {
+    const placement = placements?.[index];
+    const column = placement?.column ?? index % layout.columns;
+    const row = placement?.row ?? Math.floor(index / layout.columns);
+    return {
+      height: cellHeight,
+      width: cellWidth,
+      x: bounds.x + column * (cellWidth + GRID_SPLIT_GAP),
+      y: bounds.y + row * (cellHeight + GRID_SPLIT_GAP),
+    };
+  });
+}
+
+function createImageGridPlaceholderElements(input: {
+  createElementId: (index: number, type: 'image' | 'text') => string;
+  page: Page;
+  request: ImageGridRequest;
+}) {
+  const textCount =
+    typeof input.request === 'string' ? 0 : Math.max(0, Math.floor(input.request.textCount ?? 0));
+  const mediaPosition =
+    typeof input.request === 'string' ? 'left' : (input.request.mediaPosition ?? 'left');
+  const imageFit = typeof input.request === 'string' ? 'cover' : (input.request.imageFit ?? 'cover');
+  const contentBounds = splitImageGridContentBounds({
+    bounds: getImageGridFrameBounds(input.page),
+    mediaPosition,
+    textCount,
+  });
+  const frames = createImageGridFrames({
+    bounds: contentBounds.imageBounds,
+    page: input.page,
+    request: input.request,
+  });
+  const elements: ImageElement[] = frames.map((frame, index) =>
+    createImageGridImagePlaceholder({
+      elementId: input.createElementId(index, 'image'),
+      fit: imageFit,
+      frame,
+    }),
+  );
+  const textElements: TextElement[] = contentBounds.textBounds.map((frame, index) =>
+    createImageGridTextPlaceholder({
+      elementId: input.createElementId(index, 'text'),
+      frame,
+    }),
+  );
+  return {
+    assets: { [placeholderImage.PLACEHOLDER_IMAGE_ASSET_ID]: placeholderImageAsset },
+    elements: [...elements, ...textElements],
+  };
+}
+
+function createImageGridImagePlaceholder(input: {
+  elementId: string;
+  fit: ImageGridFit;
+  frame: { height: number; width: number; x: number; y: number };
+}) {
+  const containedFrame =
+    input.fit === 'contain' ? fitPlaceholderImageWithinFrame(input.frame) : input.frame;
+  const crop = input.fit === 'cover' ? createCoverCropForFrame(input.frame) : undefined;
+  return {
+    id: input.elementId,
+    type: 'image',
+    assetId: placeholderImage.PLACEHOLDER_IMAGE_ASSET_ID,
+    ...containedFrame,
+    rotation: 0,
+    locked: false,
+    visible: true,
+    opacity: 1,
+    ...(crop ? { crop } : {}),
+  } satisfies ImageElement;
+}
+
+function fitPlaceholderImageWithinFrame(frame: {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+}) {
+  const width = Math.min(frame.width, frame.height * PLACEHOLDER_IMAGE_ASPECT_RATIO);
+  const height = width / PLACEHOLDER_IMAGE_ASPECT_RATIO;
+  return {
+    height,
+    width,
+    x: frame.x + (frame.width - width) / 2,
+    y: frame.y + (frame.height - height) / 2,
+  };
+}
+
+function createImageGridTextPlaceholder(input: {
+  elementId: string;
+  frame: { height: number; width: number; x: number; y: number };
+}) {
+  return {
+    id: input.elementId,
+    type: 'text',
+    text: 'Add a heading',
+    ...input.frame,
+    rotation: 0,
+    locked: false,
+    visible: true,
+    opacity: 1,
+    fontFamily: 'Orbitron',
+    fontSize: 96,
+    fontWeight: 800,
+    fill: '#37FD76',
+    align: 'center',
+    lineHeight: 1.04,
+    verticalAlign: 'middle',
+  } satisfies TextElement;
+}
+
+function createCoverCropForFrame(frame: { width: number; height: number }) {
+  const frameAspectRatio = frame.width > 0 && frame.height > 0 ? frame.width / frame.height : 1;
+  if (frameAspectRatio > PLACEHOLDER_IMAGE_ASPECT_RATIO) {
+    const height = PLACEHOLDER_IMAGE_ASPECT_RATIO / frameAspectRatio;
+    return {
+      height,
+      width: 1,
+      x: 0,
+      y: (1 - height) / 2,
+    };
+  }
+
+  const width = frameAspectRatio / PLACEHOLDER_IMAGE_ASPECT_RATIO;
+  return {
+    height: 1,
+    width,
+    x: (1 - width) / 2,
+    y: 0,
+  };
+}
+
+function getElementBounds(elements: DesignElement[]) {
+  if (elements.length === 0) return undefined;
+  const left = Math.min(...elements.map((element) => element.x));
+  const top = Math.min(...elements.map((element) => element.y));
+  const right = Math.max(...elements.map((element) => element.x + element.width));
+  const bottom = Math.max(...elements.map((element) => element.y + element.height));
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+function createGridSplitFramePatches(input: {
+  layout?: GridSplitLayout;
+  page: Page;
+  project: ProjectDocument;
+  selectedElementIds: string[];
+}) {
+  const selectedElementIdSet = new Set(input.selectedElementIds);
+  const selectedElements = input.page.elementIds
+    .filter((elementId) => selectedElementIdSet.has(elementId))
+    .map((elementId) => input.project.elements[elementId])
+    .filter((element): element is DesignElement => Boolean(element));
+  if (selectedElements.length < 2) return {};
+
+  const bounds = getElementBounds(selectedElements);
+  if (!bounds) return {};
+
+  const layout = input.layout ?? 'auto';
+  const columns =
+    selectedElements.length === 3 && layout !== 'auto'
+      ? 2
+      : Math.ceil(Math.sqrt(selectedElements.length));
+  const rows = Math.ceil(selectedElements.length / columns);
+  const cellWidth = Math.max(1, (bounds.width - GRID_SPLIT_GAP * (columns - 1)) / columns);
+  const cellHeight = Math.max(1, (bounds.height - GRID_SPLIT_GAP * (rows - 1)) / rows);
+  const placements =
+    selectedElements.length === 3 && layout === 'one-two'
+      ? [
+          { column: 0.5, row: 0 },
+          { column: 0, row: 1 },
+          { column: 1, row: 1 },
+        ]
+      : selectedElements.length === 3 && layout === 'two-one'
+        ? [
+            { column: 0, row: 0 },
+            { column: 1, row: 0 },
+            { column: 0.5, row: 1 },
+          ]
+        : undefined;
+
+  return Object.fromEntries(
+    selectedElements.map((element, index) => {
+      const placement = placements?.[index];
+      const column = placement?.column ?? index % columns;
+      const row = placement?.row ?? Math.floor(index / columns);
+      const aspectRatio =
+        element.width > 0 && element.height > 0 ? element.width / element.height : 1;
+      const width = Math.min(cellWidth, cellHeight * aspectRatio);
+      const height = width / aspectRatio;
+      const cellX = bounds.x + column * (cellWidth + GRID_SPLIT_GAP);
+      const cellY = bounds.y + row * (cellHeight + GRID_SPLIT_GAP);
+      return [
+        element.id,
+        {
+          height,
+          width,
+          x: cellX + (cellWidth - width) / 2,
+          y: cellY + (cellHeight - height) / 2,
+        },
+      ];
+    }),
+  );
+}
+
+function createSelectionGridFramePatches(input: {
+  page: Page;
+  project: ProjectDocument;
+  request: SelectionGridRequest;
+  selectedElementIds: string[];
+}) {
+  const selectedElementIdSet = new Set(input.selectedElementIds);
+  const selectedElements = input.page.elementIds
+    .filter((elementId) => selectedElementIdSet.has(elementId))
+    .map((elementId) => input.project.elements[elementId])
+    .filter((element): element is DesignElement => Boolean(element));
+  if (selectedElements.length < 2) return {};
+
+  const bounds = getElementBounds(selectedElements);
+  if (!bounds) return {};
+
+  const textElements = selectedElements.filter((element) => element.type === 'text');
+  const visualElements = selectedElements.filter((element) => element.type !== 'text');
+  if (textElements.length === 0 || visualElements.length === 0) {
+    return createSelectionGridPatchesForElements({
+      bounds,
+      columns: input.request.columns,
+      elements: selectedElements,
+      fit: input.request.imageFit ?? 'contain',
+      rows: input.request.rows,
+    });
+  }
+
+  const splitBounds = splitImageGridContentBounds({
+    bounds,
+    mediaPosition: input.request.mediaPosition ?? 'left',
+    textCount: textElements.length,
+  });
+  return {
+    ...createSelectionGridPatchesForElements({
+      bounds: splitBounds.imageBounds,
+      columns: input.request.columns,
+      elements: visualElements,
+      fit: input.request.imageFit ?? 'contain',
+      rows: input.request.rows,
+    }),
+    ...createSelectionTextStackPatches(textElements, splitBounds.textBounds),
+  };
+}
+
+function createSelectionGridPatchesForElements(input: {
+  bounds: { height: number; width: number; x: number; y: number };
+  columns: number;
+  elements: DesignElement[];
+  fit: ImageGridFit;
+  rows: number;
+}) {
+  if (input.elements.length === 0) return {};
+  const requestedColumns = Math.max(1, Math.floor(input.columns));
+  const rows = Math.min(input.elements.length, Math.max(1, Math.floor(input.rows)));
+  const columns = Math.max(requestedColumns, Math.ceil(input.elements.length / rows));
+  const cellWidth = Math.max(1, (input.bounds.width - GRID_SPLIT_GAP * (columns - 1)) / columns);
+  const cellHeight = Math.max(1, (input.bounds.height - GRID_SPLIT_GAP * (rows - 1)) / rows);
+
+  return Object.fromEntries(
+    input.elements.map((element, index) => {
+      const column = Math.floor(index / rows);
+      const row = index % rows;
+      const cell = {
+        height: cellHeight,
+        width: cellWidth,
+        x: input.bounds.x + column * (cellWidth + GRID_SPLIT_GAP),
+        y: input.bounds.y + row * (cellHeight + GRID_SPLIT_GAP),
+      };
+      return [
+        element.id,
+        input.fit === 'cover' || input.fit === 'stretch'
+          ? cell
+          : fitElementInsideFrame({
+              frame: cell,
+              sourceHeight: element.height,
+              sourceWidth: element.width,
+            }),
+      ];
+    }),
+  );
+}
+
+function createSelectionTextStackPatches(
+  elements: DesignElement[],
+  frames: Array<{ height: number; width: number; x: number; y: number }>,
+) {
+  return Object.fromEntries(
+    elements.map((element, index) => {
+      const frame = frames[index] ?? frames[frames.length - 1];
+      return [
+        element.id,
+        frame
+          ? { height: frame.height, width: frame.width, x: frame.x, y: frame.y }
+          : { height: element.height, width: element.width, x: element.x, y: element.y },
+      ];
+    }),
+  );
+}
+
+function fitElementInsideFrame(input: {
+  frame: { height: number; width: number; x: number; y: number };
+  sourceHeight: number;
+  sourceWidth: number;
+}) {
+  if (input.sourceWidth <= 0 || input.sourceHeight <= 0) return input.frame;
+  const scale = Math.min(
+    input.frame.width / input.sourceWidth,
+    input.frame.height / input.sourceHeight,
+  );
+  const width = Math.max(1, input.sourceWidth * scale);
+  const height = Math.max(1, input.sourceHeight * scale);
+  return {
+    height,
+    width,
+    x: input.frame.x + (input.frame.width - width) / 2,
+    y: input.frame.y + (input.frame.height - height) / 2,
+  };
 }
 
 function getTextPresetStyles(project: ProjectDocument) {
@@ -213,7 +687,10 @@ function createShapeElement(input: {
 
 export const editorViewModelElements = {
   collectClipboardAssets,
+  createGridSplitFramePatches,
+  createImageGridPlaceholderElements,
   createPastedElements,
+  createSelectionGridFramePatches,
   createShapeElement,
   createTextElement,
   getSelectedElementsForClipboard,

--- a/apps/editor/src/ui/editor/state/mediaPlaceholderReplacement.ts
+++ b/apps/editor/src/ui/editor/state/mediaPlaceholderReplacement.ts
@@ -1,0 +1,134 @@
+import { placeholderImage } from '../../../domain/assets/placeholderImage';
+import type {
+  GifElement,
+  ImageElement,
+  ProjectDocument,
+  VideoElement,
+} from '../../../domain/documents/model';
+
+type MediaPlaceholderFrame = Pick<
+  ImageElement,
+  'height' | 'locked' | 'opacity' | 'rotation' | 'visible' | 'width' | 'x' | 'y'
+>;
+
+function getSelectedImagePlaceholder(input: {
+  project: ProjectDocument;
+  selectedElementIds: string[];
+}) {
+  if (input.selectedElementIds.length !== 1) return undefined;
+  const element = input.project.elements[input.selectedElementIds[0] ?? ''];
+  if (element?.type !== 'image') return undefined;
+  return element.assetId === placeholderImage.PLACEHOLDER_IMAGE_ASSET_ID ? element : undefined;
+}
+
+function fitMediaInsidePlaceholder(input: {
+  mediaHeight: number;
+  mediaWidth: number;
+  placeholder: MediaPlaceholderFrame;
+}) {
+  if (
+    input.mediaWidth <= 0 ||
+    input.mediaHeight <= 0 ||
+    input.placeholder.width <= 0 ||
+    input.placeholder.height <= 0
+  ) {
+    return {
+      height: input.placeholder.height,
+      width: input.placeholder.width,
+      x: input.placeholder.x,
+      y: input.placeholder.y,
+    };
+  }
+
+  const scale = Math.min(
+    input.placeholder.width / input.mediaWidth,
+    input.placeholder.height / input.mediaHeight,
+  );
+  const width = Math.max(1, Math.round(input.mediaWidth * scale));
+  const height = Math.max(1, Math.round(input.mediaHeight * scale));
+  return {
+    height,
+    width,
+    x: Math.round(input.placeholder.x + (input.placeholder.width - width) / 2),
+    y: Math.round(input.placeholder.y + (input.placeholder.height - height) / 2),
+  };
+}
+
+function createImageElement(input: {
+  assetId: string;
+  mediaHeight: number;
+  mediaWidth: number;
+  placeholder: ImageElement;
+}) {
+  const frame = fitMediaInsidePlaceholder(input);
+  return {
+    id: input.placeholder.id,
+    type: 'image',
+    assetId: input.assetId,
+    ...frame,
+    rotation: input.placeholder.rotation,
+    locked: input.placeholder.locked,
+    visible: input.placeholder.visible,
+    opacity: input.placeholder.opacity,
+  } satisfies ImageElement;
+}
+
+function createGifElement(input: {
+  assetId: string;
+  mediaHeight: number;
+  mediaWidth: number;
+  placeholder: ImageElement;
+}) {
+  const frame = fitMediaInsidePlaceholder(input);
+  return {
+    id: input.placeholder.id,
+    type: 'gif',
+    assetId: input.assetId,
+    ...frame,
+    rotation: input.placeholder.rotation,
+    locked: input.placeholder.locked,
+    visible: input.placeholder.visible,
+    opacity: input.placeholder.opacity,
+    playing: true,
+  } satisfies GifElement;
+}
+
+function createVideoElement(input: {
+  assetId: string;
+  durationSeconds?: number | undefined;
+  mediaHeight: number;
+  mediaWidth: number;
+  placeholder: ImageElement;
+}) {
+  const frame = fitMediaInsidePlaceholder(input);
+  return {
+    id: input.placeholder.id,
+    type: 'video',
+    assetId: input.assetId,
+    ...frame,
+    rotation: input.placeholder.rotation,
+    locked: input.placeholder.locked,
+    visible: input.placeholder.visible,
+    opacity: input.placeholder.opacity,
+    loop: true,
+    controls: true,
+    muted: true,
+    autoplayInPreview: true,
+    playing: true,
+    trimStartSeconds: 0,
+    repeatMode: 'loop',
+    ...(input.durationSeconds !== undefined
+      ? {
+          durationSeconds: input.durationSeconds,
+          trimEndSeconds: input.durationSeconds,
+        }
+      : {}),
+  } satisfies VideoElement;
+}
+
+export const mediaPlaceholderReplacement = {
+  createGifElement,
+  createImageElement,
+  createVideoElement,
+  getSelectedImagePlaceholder,
+};

--- a/apps/editor/src/ui/editor/state/use-local-media-import.ts
+++ b/apps/editor/src/ui/editor/state/use-local-media-import.ts
@@ -4,6 +4,7 @@ import { fitImageWithinPage } from '../../../domain/images/imageSizing';
 import type { ProjectDocument } from '../../../domain/documents/model';
 import { createPrefixedId } from '../../../services/ids/idUtils';
 import { localMediaFiles } from './local-media-files';
+import { mediaPlaceholderReplacement } from './mediaPlaceholderReplacement';
 
 export interface MediaImportProgressState {
   detail: string;
@@ -18,6 +19,7 @@ interface UseLocalMediaImportOptions {
     options?: { selectedElementIds?: string[] },
   ) => void;
   project: ProjectDocument;
+  selectedElementIds: string[];
 }
 
 function waitForNextPaint() {
@@ -35,6 +37,7 @@ export function useLocalMediaImport({
   activePageId,
   commitProject,
   project,
+  selectedElementIds,
 }: UseLocalMediaImportOptions) {
   const [mediaImportProgress, setMediaImportProgress] = useState<
     MediaImportProgressState | undefined
@@ -103,18 +106,41 @@ export function useLocalMediaImport({
         pageWidth: page.width,
         pageHeight: page.height,
       });
+      const placeholder = mediaPlaceholderReplacement.getSelectedImagePlaceholder({
+        project,
+        selectedElementIds,
+      });
 
       if (assetType === 'gif') {
+        const asset = {
+          id: assetId,
+          type: 'gif',
+          name: mediaName,
+          mimeType: file.type || 'image/gif',
+          objectUrl: mediaUrl,
+        } as const;
+        if (placeholder) {
+          commitProject(
+            (currentProject) =>
+              new basicCommands.ReplaceElementWithMediaCommand(placeholder.id, {
+                asset,
+                element: mediaPlaceholderReplacement.createGifElement({
+                  assetId,
+                  mediaHeight: mediaSize.height,
+                  mediaWidth: mediaSize.width,
+                  placeholder,
+                }),
+              }).execute(currentProject),
+            { selectedElementIds: [placeholder.id] },
+          );
+          imported = true;
+          return;
+        }
+
         commitProject(
           (currentProject) =>
             new basicCommands.AddMediaElementCommand(activePageId, {
-              asset: {
-                id: assetId,
-                type: 'gif',
-                name: mediaName,
-                mimeType: file.type || 'image/gif',
-                objectUrl: mediaUrl,
-              },
+              asset,
               element: {
                 id: elementId,
                 type: 'gif',
@@ -137,16 +163,36 @@ export function useLocalMediaImport({
       }
 
       if (assetType === 'video') {
+        const asset = {
+          id: assetId,
+          type: 'video',
+          name: mediaName,
+          mimeType: file.type || 'video/mp4',
+          objectUrl: mediaUrl,
+        } as const;
+        if (placeholder) {
+          commitProject(
+            (currentProject) =>
+              new basicCommands.ReplaceElementWithMediaCommand(placeholder.id, {
+                asset,
+                element: mediaPlaceholderReplacement.createVideoElement({
+                  assetId,
+                  durationSeconds: videoDurationSeconds,
+                  mediaHeight: mediaSize.height,
+                  mediaWidth: mediaSize.width,
+                  placeholder,
+                }),
+              }).execute(currentProject),
+            { selectedElementIds: [placeholder.id] },
+          );
+          imported = true;
+          return;
+        }
+
         commitProject(
           (currentProject) =>
             new basicCommands.AddMediaElementCommand(activePageId, {
-              asset: {
-                id: assetId,
-                type: 'video',
-                name: mediaName,
-                mimeType: file.type || 'video/mp4',
-                objectUrl: mediaUrl,
-              },
+              asset,
               element: {
                 id: elementId,
                 type: 'video',
@@ -179,16 +225,35 @@ export function useLocalMediaImport({
         return;
       }
 
+      const asset = {
+        id: assetId,
+        type: 'image',
+        name: mediaName,
+        mimeType: file.type || 'image/*',
+        objectUrl: mediaUrl,
+      } as const;
+      if (placeholder) {
+        commitProject(
+          (currentProject) =>
+            new basicCommands.ReplaceElementWithMediaCommand(placeholder.id, {
+              asset,
+              element: mediaPlaceholderReplacement.createImageElement({
+                assetId,
+                mediaHeight: mediaSize.height,
+                mediaWidth: mediaSize.width,
+                placeholder,
+              }),
+            }).execute(currentProject),
+          { selectedElementIds: [placeholder.id] },
+        );
+        imported = true;
+        return;
+      }
+
       commitProject(
         (currentProject) =>
           new basicCommands.AddImageElementCommand(activePageId, {
-            asset: {
-              id: assetId,
-              type: 'image',
-              name: mediaName,
-              mimeType: file.type || 'image/*',
-              objectUrl: mediaUrl,
-            },
+            asset,
             element: {
               id: elementId,
               type: 'image',

--- a/apps/editor/src/ui/editor/state/use-stock-media-library.ts
+++ b/apps/editor/src/ui/editor/state/use-stock-media-library.ts
@@ -3,6 +3,7 @@ import { basicCommands } from '../../../domain/commands/elements/basicCommands';
 import { fitImageWithinPage } from '../../../domain/images/imageSizing';
 import type { ProjectDocument } from '../../../domain/documents/model';
 import { createPrefixedId } from '../../../services/ids/idUtils';
+import { mediaPlaceholderReplacement } from './mediaPlaceholderReplacement';
 import type {
   DownloadedStockMedia,
   StockMediaConfig,
@@ -28,6 +29,7 @@ interface UseStockMediaLibraryOptions {
     options?: { selectedElementIds?: string[] },
   ) => void;
   project: ProjectDocument;
+  selectedElementIds: string[];
   setMediaSettingsOpen: (open: boolean) => void;
   stockMediaService: StockMediaService;
 }
@@ -38,6 +40,7 @@ export function useStockMediaLibrary({
   activePageId,
   commitProject,
   project,
+  selectedElementIds,
   setMediaSettingsOpen,
   stockMediaService,
 }: UseStockMediaLibraryOptions) {
@@ -156,17 +159,41 @@ export function useStockMediaLibrary({
       pageWidth: page.width,
       pageHeight: page.height,
     });
+    const placeholder = mediaPlaceholderReplacement.getSelectedImagePlaceholder({
+      project,
+      selectedElementIds,
+    });
+    const asset = {
+      id: assetId,
+      type: 'image',
+      name: item.title,
+      mimeType: media.mimeType,
+      objectUrl: media.objectUrl,
+    } as const;
+
+    if (placeholder) {
+      commitProject(
+        (currentProject) =>
+          new basicCommands.ReplaceElementWithMediaCommand(placeholder.id, {
+            asset,
+            element: mediaPlaceholderReplacement.createImageElement({
+              assetId,
+              mediaHeight: item.height,
+              mediaWidth: item.width,
+              placeholder,
+            }),
+          }).execute(currentProject),
+        { selectedElementIds: [placeholder.id] },
+      );
+      addRecentStockMedia(item);
+      void stockMediaService.trackImageDownload(item).catch(() => undefined);
+      return;
+    }
 
     commitProject(
       (currentProject) =>
         new basicCommands.AddImageElementCommand(activePageId, {
-          asset: {
-            id: assetId,
-            type: 'image',
-            name: item.title,
-            mimeType: media.mimeType,
-            objectUrl: media.objectUrl,
-          },
+          asset,
           element: {
             id: elementId,
             type: 'image',
@@ -208,17 +235,40 @@ export function useStockMediaLibrary({
       pageWidth: page.width,
       pageHeight: page.height,
     });
+    const placeholder = mediaPlaceholderReplacement.getSelectedImagePlaceholder({
+      project,
+      selectedElementIds,
+    });
+    const asset = {
+      id: assetId,
+      type: 'gif',
+      name: item.title,
+      mimeType: media.mimeType,
+      objectUrl: media.objectUrl,
+    } as const;
+
+    if (placeholder) {
+      commitProject(
+        (currentProject) =>
+          new basicCommands.ReplaceElementWithMediaCommand(placeholder.id, {
+            asset,
+            element: mediaPlaceholderReplacement.createGifElement({
+              assetId,
+              mediaHeight: item.height,
+              mediaWidth: item.width,
+              placeholder,
+            }),
+          }).execute(currentProject),
+        { selectedElementIds: [placeholder.id] },
+      );
+      addRecentStockMedia(item);
+      return;
+    }
 
     commitProject(
       (currentProject) =>
         new basicCommands.AddMediaElementCommand(activePageId, {
-          asset: {
-            id: assetId,
-            type: 'gif',
-            name: item.title,
-            mimeType: media.mimeType,
-            objectUrl: media.objectUrl,
-          },
+          asset,
           element: {
             id: elementId,
             type: 'gif',
@@ -260,17 +310,40 @@ export function useStockMediaLibrary({
       pageWidth: page.width,
       pageHeight: page.height,
     });
+    const placeholder = mediaPlaceholderReplacement.getSelectedImagePlaceholder({
+      project,
+      selectedElementIds,
+    });
+    const asset = {
+      id: assetId,
+      type: 'video',
+      name: item.title,
+      mimeType: media.mimeType,
+      objectUrl: media.objectUrl,
+    } as const;
+
+    if (placeholder) {
+      commitProject(
+        (currentProject) =>
+          new basicCommands.ReplaceElementWithMediaCommand(placeholder.id, {
+            asset,
+            element: mediaPlaceholderReplacement.createVideoElement({
+              assetId,
+              mediaHeight: item.height,
+              mediaWidth: item.width,
+              placeholder,
+            }),
+          }).execute(currentProject),
+        { selectedElementIds: [placeholder.id] },
+      );
+      addRecentStockMedia(item);
+      return;
+    }
 
     commitProject(
       (currentProject) =>
         new basicCommands.AddMediaElementCommand(activePageId, {
-          asset: {
-            id: assetId,
-            type: 'video',
-            name: item.title,
-            mimeType: media.mimeType,
-            objectUrl: media.objectUrl,
-          },
+          asset,
           element: {
             id: elementId,
             type: 'video',

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -62,7 +62,12 @@ import { editorViewModelProgress } from './editorViewModelProgress';
 import { editorViewModelProject } from './editorViewModelProject';
 import { editorViewModelRuntime } from './editorViewModelRuntime';
 import { editorViewModelElements } from './editorViewModelElements';
-import type { ElementClipboardState } from './editorViewModelElements';
+import type {
+  ElementClipboardState,
+  GridSplitLayout,
+  ImageGridRequest,
+  SelectionGridRequest,
+} from './editorViewModelElements';
 import { editorViewModelHistory } from './editorViewModelHistory';
 import type { EditorHistory } from './editorViewModelHistory';
 import { editorViewModelPages } from './editorViewModelPages';
@@ -231,9 +236,7 @@ export function useEditorViewModel(services: AppServices) {
   const [presentationImportProgress, setPresentationImportProgress] = useState<
     PresentationImportProgressState | undefined
   >();
-  const [missingPowerPointFonts, setMissingPowerPointFonts] = useState<MissingPowerPointFont[]>(
-    [],
-  );
+  const [missingPowerPointFonts, setMissingPowerPointFonts] = useState<MissingPowerPointFont[]>([]);
   const [hasPersistedLocalProject, setHasPersistedLocalProject] = useState(false);
   const hasPersistedLocalProjectRef = useRef(hasPersistedLocalProject);
   const [activePageId, setActivePageId] = useState(initialProject.pages[0]?.id ?? '');
@@ -241,9 +244,8 @@ export function useEditorViewModel(services: AppServices) {
   const activePageIdRef = useRef(activePageId);
   const [selectedElementIds, setSelectedElementIds] = useState<string[]>([]);
   const selectedElementIdsRef = useRef(selectedElementIds);
-  const [selectionTarget, setSelectionTarget] = useState<NonNullable<SelectionState['target']>>(
-    'presentation',
-  );
+  const [selectionTarget, setSelectionTarget] =
+    useState<NonNullable<SelectionState['target']>>('presentation');
   const [history, setHistory] = useState<EditorHistory>({ past: [], future: [] });
   const [zoomPercent, setZoomPercent] = useState(100);
   const [pagesPanelOpen, setPagesPanelOpen] = useState(false);
@@ -295,8 +297,9 @@ export function useEditorViewModel(services: AppServices) {
     elements: [],
   });
   const [isTranslating, setIsTranslating] = useState(false);
-  const [deckTranslationProgress, setDeckTranslationProgress] =
-    useState<DeckTranslationProgressState | undefined>();
+  const [deckTranslationProgress, setDeckTranslationProgress] = useState<
+    DeckTranslationProgressState | undefined
+  >();
   const [translationNotice, setTranslationNotice] = useState<string | undefined>();
   const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
   const [versionHistoryEntries, setVersionHistoryEntries] = useState<VersionHistoryEntry[]>([]);
@@ -327,8 +330,9 @@ export function useEditorViewModel(services: AppServices) {
   const [remoteImportStatus, setRemoteImportStatus] = useState<RemoteImportStatus>('loading');
   const [remoteImportProjects, setRemoteImportProjects] = useState<MirrorProjectSummary[]>([]);
   const [remoteImportError, setRemoteImportError] = useState<string | undefined>();
-  const [remoteImportProgress, setRemoteImportProgress] =
-    useState<RemoteImportProgressState | undefined>();
+  const [remoteImportProgress, setRemoteImportProgress] = useState<
+    RemoteImportProgressState | undefined
+  >();
   const [mirrorConfig, setMirrorConfig] = useState<MinioMirrorConfig>(
     () => storedMirrorConfig ?? minioMirrorService.DEFAULT_MINIO_MIRROR_CONFIG,
   );
@@ -350,19 +354,17 @@ export function useEditorViewModel(services: AppServices) {
     activePageId,
     commitProject,
     project,
+    selectedElementIds,
     setMediaSettingsOpen,
     stockMediaService: services.stockMediaService,
   });
-  const {
-    clearMediaImportProgress,
-    importImageFile,
-    mediaImportProgress,
-    replaceVideoAsset,
-  } = useLocalMediaImport({
-    activePageId,
-    commitProject,
-    project,
-  });
+  const { clearMediaImportProgress, importImageFile, mediaImportProgress, replaceVideoAsset } =
+    useLocalMediaImport({
+      activePageId,
+      commitProject,
+      project,
+      selectedElementIds,
+    });
   const {
     backgroundPreparation,
     backgroundPreview,
@@ -495,7 +497,9 @@ export function useEditorViewModel(services: AppServices) {
       setIsFullscreen(isFullscreenActive);
       if (wasFullscreenRef.current && !isFullscreenActive) {
         const previewPageId =
-          presenterPageIdRef.current ?? animationPreviewRef.current?.pageId ?? activePageIdRef.current;
+          presenterPageIdRef.current ??
+          animationPreviewRef.current?.pageId ??
+          activePageIdRef.current;
         if (previewPageId && projectRef.current.pages.some((page) => page.id === previewPageId)) {
           setActivePageId(previewPageId);
           setActivePageFocusKey((current) => current + 1);
@@ -543,7 +547,10 @@ export function useEditorViewModel(services: AppServices) {
         if (!isMounted) return;
         if (savedProject) {
           const normalizedProject = editorViewModelProject.normalizeProjectDocument(savedProject);
-          await editorViewModelRuntime.loadProjectFonts(normalizedProject, services.fontImportService);
+          await editorViewModelRuntime.loadProjectFonts(
+            normalizedProject,
+            services.fontImportService,
+          );
           if (!isMounted) return;
           setProject(normalizedProject);
           setActivePageId(normalizedProject.pages[0]?.id ?? '');
@@ -754,7 +761,11 @@ export function useEditorViewModel(services: AppServices) {
         setModelStates((currentStates) =>
           currentStates.map((state) =>
             state.id === id
-              ? { ...state, status: 'downloading', ...editorViewModelProgress.getDownloadProgressPatch(progress, details) }
+              ? {
+                  ...state,
+                  status: 'downloading',
+                  ...editorViewModelProgress.getDownloadProgressPatch(progress, details),
+                }
               : state,
           ),
         );
@@ -821,7 +832,8 @@ export function useEditorViewModel(services: AppServices) {
     }
     if (services.translatorService.getLanguageDetectionProviderStates) {
       const nextLanguageDetectionProviders =
-        selectedLanguageDetectionProviderId && services.translatorService.setLanguageDetectionProvider
+        selectedLanguageDetectionProviderId &&
+        services.translatorService.setLanguageDetectionProvider
           ? await services.translatorService.setLanguageDetectionProvider(
               selectedLanguageDetectionProviderId,
             )
@@ -1512,7 +1524,9 @@ export function useEditorViewModel(services: AppServices) {
           projectDirectoryName: nextName,
         });
       } else {
-        await services.projectRepository.saveProject(nextProject, { projectDirectoryName: nextName });
+        await services.projectRepository.saveProject(nextProject, {
+          projectDirectoryName: nextName,
+        });
       }
       setProject(nextProject);
       lastVersionProjectRef.current = nextProject;
@@ -1667,7 +1681,8 @@ export function useEditorViewModel(services: AppServices) {
         title: 'Mapping animations',
       });
       await editorViewModelRuntime.waitForNextPaint();
-      const normalizedProject = editorViewModelProject.normalizeProjectDocument(importedProjectWithFonts);
+      const normalizedProject =
+        editorViewModelProject.normalizeProjectDocument(importedProjectWithFonts);
       await editorViewModelRuntime.loadProjectFonts(normalizedProject, services.fontImportService);
       setPresentationImportProgress({
         detail: 'Opening the imported project in the editor.',
@@ -1753,7 +1768,9 @@ export function useEditorViewModel(services: AppServices) {
       })),
     );
     if (result.warnings.some((warning) => warning.code === 'font-missing')) {
-      throw new Error(result.warnings[0]?.message ?? `${trimmedReplacement} could not be downloaded.`);
+      throw new Error(
+        result.warnings[0]?.message ?? `${trimmedReplacement} could not be downloaded.`,
+      );
     }
 
     commitProject((currentProject) => ({
@@ -1825,7 +1842,8 @@ export function useEditorViewModel(services: AppServices) {
 
   useEffect(() => {
     if (!powerPointIo.consumeLocalSampleImportRequest()) return;
-    void powerPointIo.loadLocalSampleInput()
+    void powerPointIo
+      .loadLocalSampleInput()
       .then((input) => importPowerPointRef.current(input))
       .catch((error: unknown) => {
         pptxImportLogger.error('Local PowerPoint sample import failed.', error);
@@ -1938,16 +1956,18 @@ export function useEditorViewModel(services: AppServices) {
     }
   }
 
-  async function prepareProjectFontsForPublicShare(
-    options?: { onProgress?: (progress: LocalFontMirrorProgress) => void },
-  ) {
+  async function prepareProjectFontsForPublicShare(options?: {
+    onProgress?: (progress: LocalFontMirrorProgress) => void;
+  }) {
     const result = await services.localFontMirrorService.importProjectFonts(projectRef.current, {
       ...(options?.onProgress ? { onProgress: options.onProgress } : {}),
     });
     if (result.project !== projectRef.current) {
       setProject(result.project);
       projectRef.current = result.project;
-      await editorViewModelRuntime.loadProjectFonts(result.project, services.fontImportService).catch(() => undefined);
+      await editorViewModelRuntime
+        .loadProjectFonts(result.project, services.fontImportService)
+        .catch(() => undefined);
     }
     return result;
   }
@@ -2138,7 +2158,9 @@ export function useEditorViewModel(services: AppServices) {
     } catch (error: unknown) {
       setRemoteImportStatus('failed');
       setRemoteImportProgress(undefined);
-      setRemoteImportError(error instanceof Error ? error.message : 'Remote storage import failed.');
+      setRemoteImportError(
+        error instanceof Error ? error.message : 'Remote storage import failed.',
+      );
       setMirrorState({
         enabled: Boolean(config),
         status: 'failed',
@@ -2196,8 +2218,12 @@ export function useEditorViewModel(services: AppServices) {
     const entry = entryOverride ?? versionHistoryEntries.find((item) => item.id === versionId);
     const versionProject = await services.projectRepository.loadVersion(versionId);
     if (!versionProject) return;
-    const normalizedVersionProject = editorViewModelProject.normalizeProjectDocument(versionProject);
-    await editorViewModelRuntime.loadProjectFonts(normalizedVersionProject, services.fontImportService);
+    const normalizedVersionProject =
+      editorViewModelProject.normalizeProjectDocument(versionProject);
+    await editorViewModelRuntime.loadProjectFonts(
+      normalizedVersionProject,
+      services.fontImportService,
+    );
     setSelectedVersionId(versionId);
     setPreviewProject(normalizedVersionProject);
     const nextPageId = entry?.firstChangedPageId ?? normalizedVersionProject.pages[0]?.id ?? '';
@@ -2350,7 +2376,9 @@ export function useEditorViewModel(services: AppServices) {
   function editTheme(themeId: string) {
     const theme = projectRef.current.themes?.[themeId];
     if (!theme) return;
-    commitProject((currentProject) => new basicCommands.EditThemeCommand(theme).execute(currentProject));
+    commitProject((currentProject) =>
+      new basicCommands.EditThemeCommand(theme).execute(currentProject),
+    );
   }
 
   function changeTheme() {
@@ -2469,7 +2497,9 @@ export function useEditorViewModel(services: AppServices) {
     if (elementIds.length === 0) return [];
 
     const pageIdsByElementId = new Map(
-      project.pages.flatMap((page) => page.elementIds.map((elementId) => [elementId, page.id] as const)),
+      project.pages.flatMap((page) =>
+        page.elementIds.map((elementId) => [elementId, page.id] as const),
+      ),
     );
     const pageById = new Map(project.pages.map((page) => [page.id, page]));
     const concurrency = scope === 'deck' ? DECK_TRANSLATION_CONCURRENCY : elementIds.length;
@@ -2513,10 +2543,7 @@ export function useEditorViewModel(services: AppServices) {
         if (!element || element.type !== 'text') return undefined;
         const pageId = pageIdsByElementId.get(elementId);
         if (shouldTrackDeckProgress && pageId) {
-          activeElementCountByPageId.set(
-            pageId,
-            (activeElementCountByPageId.get(pageId) ?? 0) + 1,
-          );
+          activeElementCountByPageId.set(pageId, (activeElementCountByPageId.get(pageId) ?? 0) + 1);
           updateDeckTranslationProgress(pageId);
         }
         const translatedText = await services.translatorService.translate(
@@ -2998,11 +3025,61 @@ export function useEditorViewModel(services: AppServices) {
     setActiveTab('design');
   }
 
+  function insertImageGridPlaceholders(request: ImageGridRequest) {
+    const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
+    if (!page) return;
+    const grid = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index, type) =>
+        createPrefixedId(type === 'text' ? `layout-text-${index + 1}` : `image-grid-${index + 1}`),
+      page,
+      request,
+    });
+    commitProject(
+      (currentProject) =>
+        new basicCommands.AddElementsCommand(activePageId, grid.elements, grid.assets).execute(
+          currentProject,
+        ),
+      { selectedElementIds: grid.elements.map((element) => element.id) },
+    );
+  }
+
   function alignSelectedElement(mode: AlignMode) {
     const elementId = selectedElementIds[0];
     if (!elementId) return;
     commitProject((currentProject) =>
       new basicCommands.AlignElementCommand(activePageId, elementId, mode).execute(currentProject),
+    );
+  }
+
+  function splitSelectedElementsIntoGrid(layout: GridSplitLayout = 'auto') {
+    if (selectedElementIds.length < 2) return;
+    const page = project.pages.find((item) => item.id === activePageId);
+    if (!page) return;
+    const patches = editorViewModelElements.createGridSplitFramePatches({
+      layout,
+      page,
+      project,
+      selectedElementIds,
+    });
+    if (Object.keys(patches).length === 0) return;
+    commitProject((currentProject) =>
+      new basicCommands.UpdateElementFramesCommand(patches).execute(currentProject),
+    );
+  }
+
+  function applyGridToSelectedElements(request: SelectionGridRequest) {
+    if (selectedElementIds.length < 2) return;
+    const page = project.pages.find((item) => item.id === activePageId);
+    if (!page) return;
+    const patches = editorViewModelElements.createSelectionGridFramePatches({
+      page,
+      project,
+      request,
+      selectedElementIds,
+    });
+    if (Object.keys(patches).length === 0) return;
+    commitProject((currentProject) =>
+      new basicCommands.UpdateElementFramesCommand(patches).execute(currentProject),
     );
   }
 
@@ -3066,7 +3143,8 @@ export function useEditorViewModel(services: AppServices) {
     if (!nextPage) return;
 
     commitProject(
-      (currentProject) => editorViewModelPages.insertPageAfter(currentProject, afterPageId, nextPage),
+      (currentProject) =>
+        editorViewModelPages.insertPageAfter(currentProject, afterPageId, nextPage),
       { activePageId: pageId, selectedElementIds: [] },
     );
   }
@@ -3418,7 +3496,10 @@ export function useEditorViewModel(services: AppServices) {
     pasteCopiedElements,
     insertTextElement,
     insertShapeElement,
+    insertImageGridPlaceholders,
+    applyGridToSelectedElements,
     alignSelectedElement,
+    splitSelectedElementsIntoGrid,
     setSelectedElementZOrder,
     flipSelectedImage,
     updateImageCrop,

--- a/apps/editor/src/ui/editor/toolbars/FloatingSelectionToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/FloatingSelectionToolbar.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+import type { AlignMode } from '../../../domain/commands/elements/basicCommands';
+
 interface ToolbarAction {
   label: string;
   icon: string;
@@ -10,13 +13,14 @@ interface ToolbarAction {
 
 interface FloatingSelectionToolbarProps {
   elementType?: 'gif' | 'image' | 'shape' | 'text' | 'video' | undefined;
-  onAlignCenter?: (() => void) | undefined;
+  onAlign?: ((mode: AlignMode) => void) | undefined;
   onBringForward?: (() => void) | undefined;
   onBackgroundSelectionToggle?: (() => void) | undefined;
   onCropImage?: (() => void) | undefined;
   onFlipImage?: (() => void) | undefined;
   onDelete?: (() => void) | undefined;
   onDuplicate?: (() => void) | undefined;
+  onEditAsGrid?: (() => void) | undefined;
   onOpenAnimations?: (() => void) | undefined;
   onSendBackward?: (() => void) | undefined;
   onTranslateSelectedText?: (() => void) | undefined;
@@ -24,17 +28,33 @@ interface FloatingSelectionToolbarProps {
   cropActive?: boolean;
   canTranslateSelection?: boolean;
   disabled?: boolean;
+  selectionCount?: number;
 }
+
+interface AlignOption {
+  icon: string;
+  label: string;
+  mode: AlignMode;
+}
+
+const alignOptions: AlignOption[] = [
+  { icon: 'align_horizontal_left', label: 'Center left', mode: 'page-left-center' },
+  { icon: 'align_horizontal_center', label: 'Center', mode: 'page-center' },
+  { icon: 'align_horizontal_right', label: 'Center right', mode: 'page-right-center' },
+  { icon: 'align_vertical_top', label: 'Center top', mode: 'page-top-center' },
+  { icon: 'align_vertical_bottom', label: 'Center bottom', mode: 'page-bottom-center' },
+];
 
 export function FloatingSelectionToolbar({
   elementType,
-  onAlignCenter,
+  onAlign,
   onBackgroundSelectionToggle,
   onBringForward,
   onCropImage,
   onFlipImage,
   onDelete,
   onDuplicate,
+  onEditAsGrid,
   onOpenAnimations,
   onSendBackward,
   onTranslateSelectedText,
@@ -42,7 +62,15 @@ export function FloatingSelectionToolbar({
   cropActive = false,
   canTranslateSelection = false,
   disabled = false,
+  selectionCount = 1,
 }: FloatingSelectionToolbarProps) {
+  const [alignMenuOpen, setAlignMenuOpen] = useState(false);
+  const multiSelectionGroups: ToolbarAction[][] = [
+    [
+      { label: 'Animate', icon: 'animation', display: 'label', onClick: onOpenAnimations },
+      { label: 'Delete', icon: 'delete', onClick: onDelete, tone: 'danger' },
+    ],
+  ];
   const imageGroups: ToolbarAction[][] = [
     [
       {
@@ -64,7 +92,7 @@ export function FloatingSelectionToolbar({
       },
     ],
     [
-      { label: 'Align Center', icon: 'align_horizontal_center', onClick: onAlignCenter },
+      { label: 'Align', icon: 'align_horizontal_center', onClick: undefined },
       { label: 'Send Backward', icon: 'flip_to_back', onClick: onSendBackward },
       { label: 'Bring Forward', icon: 'flip_to_front', onClick: onBringForward },
     ],
@@ -76,7 +104,7 @@ export function FloatingSelectionToolbar({
   ];
 
   const objectGroups: ToolbarAction[][] = [
-    [{ label: 'Align Center', icon: 'align_horizontal_center', onClick: onAlignCenter }],
+    [{ label: 'Align', icon: 'align_horizontal_center', onClick: undefined }],
     [
       { label: 'Bring Forward', icon: 'flip_to_front', onClick: onBringForward },
       { label: 'Send Backward', icon: 'flip_to_back', onClick: onSendBackward },
@@ -98,7 +126,12 @@ export function FloatingSelectionToolbar({
     [{ label: 'Delete', icon: 'delete', onClick: onDelete, tone: 'danger' }],
   ];
 
-  const groups = elementType === 'image' ? imageGroups : objectGroups;
+  const groups =
+    selectionCount > 1
+      ? multiSelectionGroups
+      : elementType === 'image'
+        ? imageGroups
+        : objectGroups;
 
   return (
     <div className="floating-toolbar" aria-label="Selected element actions">
@@ -108,26 +141,106 @@ export function FloatingSelectionToolbar({
           key={group.map((item) => item.label).join('-')}
         >
           {groupIndex > 0 ? <span className="floating-toolbar-divider" aria-hidden="true" /> : null}
-          {group.map((action) => (
+          {selectionCount > 1 && groupIndex === 0 ? (
+            <>
+              <div className="floating-toolbar-menu-shell">
+                <button
+                  aria-label="Edit as grid"
+                  className="floating-toolbar-button"
+                  disabled={disabled || !onEditAsGrid}
+                  title="Edit as grid"
+                  type="button"
+                  onClick={onEditAsGrid}
+                >
+                  <span className="material-symbols-outlined">grid_view</span>
+                  <span className="floating-toolbar-label">Edit as grid</span>
+                </button>
+              </div>
+              <span className="floating-toolbar-divider" aria-hidden="true" />
+            </>
+          ) : null}
+          {group.map((action) =>
+            action.label === 'Align' ? (
+              <AlignDropdown
+                disabled={disabled || !onAlign}
+                key={action.label}
+                menuOpen={alignMenuOpen}
+                onAlign={onAlign}
+                onOpenChange={setAlignMenuOpen}
+              />
+            ) : (
+              <button
+                className={`floating-toolbar-button floating-toolbar-button-${action.tone ?? 'default'}${
+                  action.active ? ' floating-toolbar-button-active' : ''
+                }`}
+                key={action.label}
+                title={action.label}
+                aria-label={action.label}
+                disabled={disabled || action.disabled}
+                type="button"
+                onClick={action.onClick}
+              >
+                <span className="material-symbols-outlined">{action.icon}</span>
+                {action.display === 'label' ? (
+                  <span className="floating-toolbar-label">{action.label}</span>
+                ) : null}
+              </button>
+            ),
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AlignDropdown({
+  disabled,
+  menuOpen,
+  onAlign,
+  onOpenChange,
+}: {
+  disabled: boolean;
+  menuOpen: boolean;
+  onAlign: ((mode: AlignMode) => void) | undefined;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <div className="floating-toolbar-menu-shell">
+      <button
+        aria-expanded={menuOpen}
+        aria-haspopup="menu"
+        aria-label="Align"
+        className="floating-toolbar-button"
+        disabled={disabled}
+        title="Align"
+        type="button"
+        onClick={() => {
+          onOpenChange(!menuOpen);
+        }}
+      >
+        <span className="material-symbols-outlined">align_horizontal_center</span>
+        <span className="material-symbols-outlined floating-toolbar-caret">expand_more</span>
+      </button>
+      {menuOpen ? (
+        <div className="floating-toolbar-align-menu" role="menu">
+          {alignOptions.map((option) => (
             <button
-              className={`floating-toolbar-button floating-toolbar-button-${action.tone ?? 'default'}${
-                action.active ? ' floating-toolbar-button-active' : ''
-              }`}
-              key={action.label}
-              title={action.label}
-              aria-label={action.label}
-              disabled={disabled || action.disabled}
+              aria-label={option.label}
+              className="floating-toolbar-align-option"
+              key={option.mode}
+              role="menuitem"
               type="button"
-              onClick={action.onClick}
+              onClick={() => {
+                onAlign?.(option.mode);
+                onOpenChange(false);
+              }}
             >
-              <span className="material-symbols-outlined">{action.icon}</span>
-              {action.display === 'label' ? (
-                <span className="floating-toolbar-label">{action.label}</span>
-              ) : null}
+              <span className="material-symbols-outlined">{option.icon}</span>
+              <span>{option.label}</span>
             </button>
           ))}
         </div>
-      ))}
+      ) : null}
     </div>
   );
 }

--- a/apps/editor/src/ui/styles/floating-toolbar.css
+++ b/apps/editor/src/ui/styles/floating-toolbar.css
@@ -23,6 +23,147 @@
   background: var(--ew-border);
 }
 
+.floating-toolbar-menu-shell {
+  position: relative;
+  display: inline-flex;
+}
+
+.floating-toolbar-caret {
+  margin-left: -2px;
+  font-size: 15px;
+}
+
+.floating-toolbar-grid-menu {
+  position: absolute;
+  top: 34px;
+  left: 0;
+  width: 220px;
+  padding: 6px;
+  border: 1px solid var(--ew-border);
+  border-radius: 4px;
+  background: rgba(9, 16, 12, 0.98);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(14px);
+  z-index: 10;
+}
+
+.floating-toolbar-grid-option {
+  width: 100%;
+  min-height: 50px;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 7px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ew-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.floating-toolbar-align-menu {
+  position: absolute;
+  top: 34px;
+  left: 0;
+  width: 168px;
+  padding: 6px;
+  border: 1px solid var(--ew-border);
+  border-radius: 4px;
+  background: rgba(9, 16, 12, 0.98);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(14px);
+  z-index: 10;
+}
+
+.floating-toolbar-align-option {
+  width: 100%;
+  min-height: 34px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ew-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.floating-toolbar-align-option:hover {
+  background: rgba(55, 253, 118, 0.12);
+}
+
+.floating-toolbar-align-option .material-symbols-outlined {
+  color: var(--ew-green-fixed);
+  font-size: 17px;
+}
+
+.floating-toolbar-align-option span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.floating-toolbar-grid-option:hover {
+  background: rgba(55, 253, 118, 0.12);
+}
+
+.floating-toolbar-grid-option strong,
+.floating-toolbar-grid-option small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.floating-toolbar-grid-option strong {
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.floating-toolbar-grid-option small {
+  margin-top: 2px;
+  color: var(--ew-muted);
+  font-size: 10px;
+}
+
+.floating-toolbar-grid-preview {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+  padding: 4px;
+  border: 1px solid rgba(55, 253, 118, 0.28);
+  border-radius: 3px;
+  background: rgba(55, 253, 118, 0.06);
+}
+
+.floating-toolbar-grid-preview-row {
+  display: flex;
+  justify-content: center;
+  gap: 3px;
+}
+
+.floating-toolbar-grid-preview-cell {
+  width: 9px;
+  height: 9px;
+  border: 1px solid rgba(55, 253, 118, 0.72);
+  background: rgba(55, 253, 118, 0.24);
+}
+
+.floating-toolbar-grid-preview-cell-empty {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: transparent;
+}
+
 .floating-toolbar-button {
   min-width: 28px;
   height: 28px;

--- a/apps/editor/src/ui/styles/layers-panel.css
+++ b/apps/editor/src/ui/styles/layers-panel.css
@@ -28,6 +28,267 @@
   font-size: 12px;
 }
 
+.layout-image-grid-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.layout-image-grid-option {
+  min-height: 76px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  justify-items: center;
+  gap: 6px;
+  padding: 8px 6px;
+  border-radius: 4px;
+  color: var(--ew-text);
+  cursor: pointer;
+}
+
+.layout-image-grid-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.layout-image-grid-option svg {
+  color: var(--ew-green);
+}
+
+.layout-image-grid-option span:last-child {
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.layout-image-grid-preview {
+  width: 44px;
+  height: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+  padding: 4px;
+  border: 1px solid rgba(55, 253, 118, 0.24);
+  border-radius: 3px;
+  background: rgba(55, 253, 118, 0.06);
+}
+
+.layout-image-grid-preview-row {
+  display: flex;
+  justify-content: center;
+  gap: 3px;
+}
+
+.layout-image-grid-preview-cell {
+  width: 12px;
+  height: 8px;
+  border: 1px solid rgba(55, 253, 118, 0.7);
+  background: rgba(55, 253, 118, 0.18);
+}
+
+.layout-custom-grid-form {
+  display: grid;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.layout-custom-grid-label {
+  color: var(--ew-muted);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.layout-custom-grid-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.layout-custom-grid-fields {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.layout-custom-grid-field {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.layout-custom-grid-field span {
+  color: var(--ew-muted);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.layout-custom-grid-row input,
+.layout-custom-grid-row select,
+.layout-custom-grid-fields input {
+  min-width: 0;
+  height: 34px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 4px;
+  outline: 0;
+  background: rgba(3, 11, 12, 0.72);
+  color: var(--ew-text);
+  font-size: 12px;
+  font-weight: 800;
+  padding: 0 10px;
+}
+
+.layout-custom-grid-row select {
+  appearance: none;
+}
+
+.layout-custom-grid-row input:focus,
+.layout-custom-grid-row select:focus,
+.layout-custom-grid-fields input:focus {
+  border-color: var(--ew-green);
+  box-shadow: 0 0 0 2px rgba(55, 253, 118, 0.12);
+}
+
+.layout-custom-grid-submit {
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  border-radius: 4px;
+  color: var(--ew-text);
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.layout-custom-grid-submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.layout-custom-grid-submit svg {
+  color: var(--ew-green);
+}
+
+.layout-custom-grid-error {
+  margin: 0;
+  color: #f87171;
+  font-size: 11px;
+}
+
+.layout-custom-grid-preview {
+  min-height: 112px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(55, 253, 118, 0.18);
+  border-radius: 4px;
+  background:
+    linear-gradient(rgba(55, 253, 118, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(55, 253, 118, 0.045) 1px, transparent 1px),
+    rgba(3, 11, 12, 0.68);
+  background-size: 12px 12px;
+  padding: 14px;
+}
+
+.layout-custom-grid-preview-content {
+  width: 196px;
+  height: 82px;
+  display: grid;
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.layout-custom-grid-preview-content-horizontal {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: none;
+}
+
+.layout-custom-grid-preview-content-single {
+  grid-template-columns: none;
+  grid-template-rows: none;
+}
+
+.layout-custom-grid-preview-stage {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(var(--layout-custom-grid-columns), minmax(0, 1fr));
+  grid-template-rows: repeat(var(--layout-custom-grid-rows), minmax(0, 1fr));
+  gap: 5px;
+  padding: 5px;
+  border: 1px solid rgba(55, 253, 118, 0.34);
+  border-radius: 3px;
+  background:
+    linear-gradient(135deg, rgba(55, 253, 118, 0.12), rgba(55, 253, 118, 0.03)),
+    rgba(55, 253, 118, 0.05);
+}
+
+.layout-custom-grid-preview-text-stack {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  gap: 4px;
+}
+
+.layout-custom-grid-preview-text {
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(55, 253, 118, 0.5);
+  border-radius: 3px;
+  background:
+    linear-gradient(90deg, rgba(55, 253, 118, 0.16), rgba(55, 253, 118, 0.06)),
+    rgba(55, 253, 118, 0.08);
+  color: var(--ew-green-fixed);
+  font-size: 11px;
+  font-weight: 900;
+}
+
+.layout-custom-grid-preview-cell {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(55, 253, 118, 0.7);
+  border-radius: 2px;
+  background: rgba(55, 253, 118, 0.08);
+  overflow: hidden;
+}
+
+.layout-custom-grid-preview-media {
+  display: block;
+  border-radius: 1px;
+  background: rgba(55, 253, 118, 0.28);
+}
+
+.layout-custom-grid-preview-stage-cover .layout-custom-grid-preview-media {
+  width: 100%;
+  height: 100%;
+}
+
+.layout-custom-grid-preview-stage-contain .layout-custom-grid-preview-media {
+  width: 72%;
+  height: 56%;
+  outline: 1px solid rgba(55, 253, 118, 0.44);
+}
+
+.layout-custom-grid-preview-stage-stretch .layout-custom-grid-preview-cell {
+  border-color: rgba(255, 210, 120, 0.72);
+}
+
+.layout-custom-grid-preview-stage-stretch .layout-custom-grid-preview-media {
+  width: 100%;
+  height: 100%;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(255, 210, 120, 0.28),
+    rgba(255, 210, 120, 0.28) 3px,
+    rgba(55, 253, 118, 0.18) 3px,
+    rgba(55, 253, 118, 0.18) 6px
+  );
+}
+
 .layer-row {
   min-height: 40px;
   gap: 8px;

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -130,6 +130,25 @@ describe('editor commands', () => {
     expect(project.elements['image-hero']?.x).toBe(55);
   });
 
+  it('aligns an element to centered page edges', () => {
+    const project = sampleProject.createSampleProject();
+    const left = new basicCommands.AlignElementCommand(
+      'page-1',
+      'image-hero',
+      'page-left-center',
+    ).execute(project);
+    const bottom = new basicCommands.AlignElementCommand(
+      'page-1',
+      'image-hero',
+      'page-bottom-center',
+    ).execute(project);
+
+    expect(left.elements['image-hero']?.x).toBe(0);
+    expect(left.elements['image-hero']?.y).toBe((1080 - 735) / 2);
+    expect(bottom.elements['image-hero']?.x).toBe((1920 - 980) / 2);
+    expect(bottom.elements['image-hero']?.y).toBe(1080 - 735);
+  });
+
   it('brings an element to front by moving its id to the end', () => {
     const project = sampleProject.createSampleProject();
     const command = new basicCommands.SetZOrderCommand('page-1', 'image-hero', 'front');
@@ -210,6 +229,49 @@ describe('editor commands', () => {
     expect(next.pages[0]?.elementIds).toEqual(project.pages[0]?.elementIds);
     expect(next.assets['asset-generated-replacement']).toBeDefined();
     expect(next.assets['asset-hero']).toBeDefined();
+    expect(project.elements['image-hero']).toMatchObject({ type: 'image', assetId: 'asset-hero' });
+  });
+
+  it('replaces an element with media while preserving its id and z-order', () => {
+    const project = sampleProject.createSampleProject();
+    const command = new basicCommands.ReplaceElementWithMediaCommand('image-hero', {
+      asset: {
+        id: 'asset-gif-replacement',
+        type: 'gif',
+        name: 'replacement.gif',
+        mimeType: 'image/gif',
+        objectUrl: 'blob:replacement-gif',
+      },
+      element: {
+        id: 'image-hero',
+        type: 'gif',
+        assetId: 'asset-gif-replacement',
+        x: 120,
+        y: 220,
+        width: 640,
+        height: 360,
+        rotation: 0,
+        locked: false,
+        visible: true,
+        opacity: 1,
+        playing: true,
+      },
+    });
+    const next = command.execute(project);
+
+    expect(next).not.toBe(project);
+    expect(next.elements['image-hero']).toMatchObject({
+      id: 'image-hero',
+      type: 'gif',
+      assetId: 'asset-gif-replacement',
+      x: 120,
+      y: 220,
+      width: 640,
+      height: 360,
+      playing: true,
+    });
+    expect(next.pages[0]?.elementIds).toEqual(project.pages[0]?.elementIds);
+    expect(next.assets['asset-gif-replacement']).toBeDefined();
     expect(project.elements['image-hero']).toMatchObject({ type: 'image', assetId: 'asset-hero' });
   });
 

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -244,6 +244,206 @@ describe('CanvasWorkspace', () => {
     );
   });
 
+  it('snaps a dragged element to the page vertical center and draws one guide', async () => {
+    const onUpdateElementFrame = vi.fn<(elementId: string, patch: ElementFramePatch) => void>();
+    const stageRef = createRef<Konva.Stage>();
+    const baseProject = sampleProject.createBlankProject();
+    const project: ProjectDocument = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'shape-snap': {
+          id: 'shape-snap',
+          type: 'shape',
+          shape: 'rect',
+          x: 900,
+          y: 120,
+          width: 100,
+          height: 80,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          fill: '#37FD76',
+        },
+      },
+      pages: baseProject.pages.map((page) =>
+        page.id === 'page-1' ? { ...page, elementIds: ['shape-snap'] } : page,
+      ),
+    };
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['shape-snap'] }}
+        stageRef={stageRef}
+        onUpdateElementFrame={onUpdateElementFrame}
+      />,
+    );
+
+    const shapeNode = stageRef.current
+      ?.find('Rect')
+      .find((node) => (node as Konva.Rect).fill() === '#37FD76') as Konva.Rect | undefined;
+    expect(shapeNode).toBeDefined();
+
+    act(() => {
+      shapeNode!.fire('dragmove', { target: shapeNode });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute('data-drag-guide', 'active');
+    });
+    expect(stageRef.current?.find('.magnet-guide-line-vertical')).toHaveLength(1);
+    expect(stageRef.current?.find('.magnet-guide-line-horizontal')).toHaveLength(0);
+    expect(shapeNode!.x()).toBeCloseTo(364);
+
+    act(() => {
+      shapeNode!.fire('dragend', { target: shapeNode });
+    });
+
+    expect(onUpdateElementFrame).toHaveBeenCalledWith(
+      'shape-snap',
+      expect.objectContaining({ x: 910 }),
+    );
+  });
+
+  it('snaps a multi-selected drag and commits one batched frame update', () => {
+    const onUpdateElementFrames = vi.fn<(patches: Record<string, ElementFramePatch>) => void>();
+    const stageRef = createRef<Konva.Stage>();
+    const baseProject = sampleProject.createBlankProject();
+    const project: ProjectDocument = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'shape-left': {
+          id: 'shape-left',
+          type: 'shape',
+          shape: 'rect',
+          x: 800,
+          y: 120,
+          width: 100,
+          height: 80,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          fill: '#37FD76',
+        },
+        'shape-right': {
+          id: 'shape-right',
+          type: 'shape',
+          shape: 'rect',
+          x: 950,
+          y: 120,
+          width: 100,
+          height: 80,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          fill: '#FFFFFF',
+        },
+      },
+      pages: baseProject.pages.map((page) =>
+        page.id === 'page-1' ? { ...page, elementIds: ['shape-left', 'shape-right'] } : page,
+      ),
+    };
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['shape-left', 'shape-right'] }}
+        stageRef={stageRef}
+        onUpdateElementFrames={onUpdateElementFrames}
+      />,
+    );
+
+    const leftNode = stageRef.current
+      ?.find('Rect')
+      .find((node) => (node as Konva.Rect).fill() === '#37FD76') as Konva.Rect | undefined;
+    expect(leftNode).toBeDefined();
+
+    act(() => {
+      leftNode!.x(330);
+      leftNode!.fire('dragend', { target: leftNode });
+    });
+
+    expect(onUpdateElementFrames).toHaveBeenCalledWith({
+      'shape-left': { x: 835, y: 120 },
+      'shape-right': { x: 985, y: 120 },
+    });
+  });
+
+  it('snaps resized element width to a nearby object width', () => {
+    const onUpdateElementFrame = vi.fn<(elementId: string, patch: ElementFramePatch) => void>();
+    const stageRef = createRef<Konva.Stage>();
+    const baseProject = sampleProject.createBlankProject();
+    const project: ProjectDocument = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'shape-resize': {
+          id: 'shape-resize',
+          type: 'shape',
+          shape: 'rect',
+          x: 120,
+          y: 120,
+          width: 100,
+          height: 80,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          fill: '#37FD76',
+        },
+        'shape-reference': {
+          id: 'shape-reference',
+          type: 'shape',
+          shape: 'rect',
+          x: 360,
+          y: 120,
+          width: 120,
+          height: 300,
+          rotation: 0,
+          locked: false,
+          visible: true,
+          opacity: 1,
+          fill: '#FFFFFF',
+        },
+      },
+      pages: baseProject.pages.map((page) =>
+        page.id === 'page-1' ? { ...page, elementIds: ['shape-resize', 'shape-reference'] } : page,
+      ),
+    };
+
+    render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['shape-resize'] }}
+        stageRef={stageRef}
+        onUpdateElementFrame={onUpdateElementFrame}
+      />,
+    );
+
+    const resizeNode = stageRef.current
+      ?.find('Rect')
+      .find((node) => (node as Konva.Rect).fill() === '#37FD76') as Konva.Rect | undefined;
+    expect(resizeNode).toBeDefined();
+
+    act(() => {
+      resizeNode!.scaleX(1.15);
+      resizeNode!.fire('transformend', { target: resizeNode });
+    });
+
+    expect(onUpdateElementFrame).toHaveBeenCalledWith(
+      'shape-resize',
+      expect.objectContaining({ width: 120 }),
+    );
+  });
+
   it('shrinks the live text editor frame to the typed text height', () => {
     const onSelectElement = vi.fn();
     const onUpdateElementFrame = vi.fn<(elementId: string, patch: ElementFramePatch) => void>();

--- a/apps/editor/tests/unit/ui/editor/EditorShell.elements-stock.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.elements-stock.test.tsx
@@ -76,6 +76,38 @@ describe('EditorShell elements and stock media workflows', () => {
     });
   });
 
+  it('opens Elements when selecting an image placeholder and replaces it with a stock image', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    const stockMediaService = new ReadyStockMediaService();
+    services.stockMediaService = stockMediaService;
+
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'Layout');
+    fireEvent.click(screen.getByRole('button', { name: 'Insert 1 image grid' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Web AI placeholder image' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Elements' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Insert image by Ada Photo' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-selected-elements',
+        expect.stringMatching(/^image-grid-1-/),
+      );
+    });
+    expect(stockMediaService.downloadedItems).toEqual([
+      { item: stockImage, sourceUrl: stockImage.mediaUrl },
+    ]);
+  });
+
   it('inserts an Unsplash image before download tracking finishes', async () => {
     const user = userEvent.setup();
     const services = createAppServices();
@@ -109,6 +141,28 @@ describe('EditorShell elements and stock media workflows', () => {
       expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
         'data-selected-elements',
         expect.stringMatching(/^video-/),
+      );
+    });
+    expect(screen.getByLabelText('Launch GIF').tagName.toLowerCase()).toBe('video');
+    expect(screen.getByLabelText('Launch GIF')).toHaveAttribute('src', 'blob:giphy-video');
+  });
+
+  it('replaces a selected image placeholder with a stock GIF movie in the same slot', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices();
+    services.stockMediaService = new ReadyStockMediaService();
+
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'Layout');
+    fireEvent.click(screen.getByRole('button', { name: 'Insert 1 image grid' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Web AI placeholder image' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Insert GIF Launch GIF' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-selected-elements',
+        expect.stringMatching(/^image-grid-1-/),
       );
     });
     expect(screen.getByLabelText('Launch GIF').tagName.toLowerCase()).toBe('video');

--- a/apps/editor/tests/unit/ui/editor/EditorShell.test-harness.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.test-harness.ts
@@ -30,7 +30,7 @@ async function startFullscreenPresentation(user: ReturnType<typeof userEvent.set
 
 async function openLeftTab(
   user: ReturnType<typeof userEvent.setup>,
-  name: 'AI Tools' | 'Animate' | 'Elements' | 'Layout',
+  name: 'AI Tools' | 'Animate' | 'Design' | 'Elements' | 'Layout',
 ) {
   void user;
   const tab = screen.getByRole('tab', { name });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.workspace-controls.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.workspace-controls.test.tsx
@@ -1,14 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { EditorShell } from '../../../../src/ui/editor/shell/EditorShell';
 import { editorShellTestHarness } from './EditorShell.test-harness';
 
-const {
-  createAppServices,
-  openLeftTab,
-  selectImageLayer,
-} = editorShellTestHarness;
+const { createAppServices, openLeftTab, selectImageLayer } = editorShellTestHarness;
 
 describe('EditorShell workspace controls', () => {
   afterEach(() => {
@@ -27,6 +23,21 @@ describe('EditorShell workspace controls', () => {
     expect(screen.getByRole('tab', { name: 'Layout' })).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('opens the layout panel when the canvas background is double-clicked', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<EditorShell services={createAppServices()} />);
+
+    await openLeftTab(user, 'Elements');
+    expect(screen.getByRole('tab', { name: 'Elements' })).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.dblClick(container.querySelector('canvas')!);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Layout' })).toHaveAttribute('aria-selected', 'true');
+    });
+    expect(screen.getByText('Image grids')).toBeInTheDocument();
+  });
+
   it('keeps pages and tool panels mutually exclusive', async () => {
     const user = userEvent.setup();
     render(<EditorShell services={createAppServices()} />);
@@ -43,6 +54,125 @@ describe('EditorShell workspace controls', () => {
 
     expect(screen.getByLabelText('Pages')).toBeInTheDocument();
     expect(screen.queryByText('4 layers on current page')).not.toBeInTheDocument();
+  });
+
+  it('inserts placeholder image grids from the layout panel', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await openLeftTab(user, 'Layout');
+    fireEvent.click(screen.getByRole('button', { name: 'Insert 3 images grid' }));
+
+    expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+      'data-selected-elements',
+      expect.stringMatching(/image-grid-1.*image-grid-2.*image-grid-3/),
+    );
+    expect(screen.getAllByRole('button', { name: 'Web AI placeholder image' })).toHaveLength(3);
+  });
+
+  it('inserts custom placeholder image grids from the layout panel', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await openLeftTab(user, 'Layout');
+    const columnsInput = screen.getByRole('spinbutton', { name: 'Grid columns' });
+    const rowsInput = screen.getByRole('spinbutton', { name: 'Grid rows' });
+    const insertButton = screen.getByRole('button', { name: 'Insert' });
+    await user.clear(columnsInput);
+    await user.type(columnsInput, '2');
+    await user.clear(rowsInput);
+    await user.type(rowsInput, '2');
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Text placeholders' }), {
+      target: { value: '0' },
+    });
+    expect(
+      screen.getByRole('img', {
+        name: 'Custom grid preview 2 columns by 2 rows, 0 text placeholders, cover image fit',
+      }),
+    ).toBeInTheDocument();
+    expect(insertButton).toBeEnabled();
+    await user.click(insertButton);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-selected-elements',
+        expect.stringMatching(/image-grid-1.*image-grid-2.*image-grid-3.*image-grid-4/),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Web AI placeholder image' })).toHaveLength(4);
+    });
+  });
+
+  it('inserts custom image and text placeholder layouts from the layout panel', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await openLeftTab(user, 'Layout');
+    const columnsInput = screen.getByRole('spinbutton', { name: 'Grid columns' });
+    const rowsInput = screen.getByRole('spinbutton', { name: 'Grid rows' });
+    const textInput = screen.getByRole('spinbutton', { name: 'Text placeholders' });
+    const imageFitSelect = screen.getByRole('combobox', { name: 'Image fit' });
+    expect(screen.getByText('Arrangement')).toBeInTheDocument();
+    expect(screen.getByText('Image behavior')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'object-fit: fill' })).toBeInTheDocument();
+    expect(columnsInput).toHaveValue(1);
+    expect(rowsInput).toHaveValue(1);
+    expect(textInput).toHaveValue(1);
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Media position' }), 'left');
+    await user.selectOptions(imageFitSelect, 'contain');
+    await user.click(screen.getByRole('button', { name: 'Insert' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-selected-elements',
+        expect.stringMatching(/image-grid-1.*layout-text-1/),
+      );
+    });
+    expect(screen.getAllByRole('button', { name: 'Web AI placeholder image' })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Add a heading' })).toBeInTheDocument();
+  });
+
+  it('blocks invalid custom placeholder image grid sizes', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await openLeftTab(user, 'Layout');
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Grid columns' }), {
+      target: { value: '9' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Insert' })).toBeDisabled();
+    expect(screen.queryByRole('img', { name: /Custom grid preview/ })).not.toBeInTheDocument();
+  });
+
+  it('updates the custom image grid preview while typing', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await openLeftTab(user, 'Layout');
+    const columnsInput = screen.getByRole('spinbutton', { name: 'Grid columns' });
+    const rowsInput = screen.getByRole('spinbutton', { name: 'Grid rows' });
+    const textInput = screen.getByRole('spinbutton', { name: 'Text placeholders' });
+    await user.clear(columnsInput);
+    await user.type(columnsInput, '4');
+    await user.clear(rowsInput);
+    await user.type(rowsInput, '3');
+    await user.clear(textInput);
+    await user.type(textInput, '1');
+
+    const preview = screen.getByRole('img', {
+      name: 'Custom grid preview 4 columns by 3 rows, 1 text placeholders, cover image fit',
+    });
+    expect(preview).toBeInTheDocument();
+    expect(preview.querySelectorAll('.layout-custom-grid-preview-cell')).toHaveLength(12);
+    expect(preview.querySelectorAll('.layout-custom-grid-preview-text')).toHaveLength(1);
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Image fit' }), 'contain');
+    expect(
+      screen.getByRole('img', {
+        name: 'Custom grid preview 4 columns by 3 rows, 1 text placeholders, contain image fit',
+      }),
+    ).toBeInTheDocument();
   });
 
   it('marks the workspace as zoomed out when the user scales below 100%', () => {
@@ -103,6 +233,28 @@ describe('EditorShell workspace controls', () => {
       'aria-pressed',
       'true',
     );
+  });
+
+  it('opens Layout to edit a multi-selection as a grid and makes the update undoable', async () => {
+    const user = userEvent.setup();
+    render(<EditorShell services={createAppServices()} />);
+
+    await user.keyboard('{Meta>}a{/Meta}');
+
+    expect(screen.getByRole('button', { name: 'Edit as grid' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit as grid' }));
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Layout' })).toHaveAttribute('aria-selected', 'true');
+    });
+    expect(screen.getByText('Edit selected grid')).toBeInTheDocument();
+    expect(screen.getByText('3 selected elements')).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: 'Grid columns' })).toHaveValue(2);
+    expect(screen.getByRole('spinbutton', { name: 'Grid rows' })).toHaveValue(2);
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Image fit' }), 'stretch');
+    fireEvent.click(screen.getByRole('button', { name: 'Update selection' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    expect(screen.getByText('3 selected elements')).toBeInTheDocument();
   });
 
   it('renames the project from the toolbar', async () => {
@@ -171,7 +323,8 @@ describe('EditorShell workspace controls', () => {
       'true',
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Align Center' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Align' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Center left' }));
     fireEvent.click(screen.getByRole('button', { name: 'Send Backward' }));
     fireEvent.click(screen.getByRole('button', { name: 'Bring Forward' }));
 

--- a/apps/editor/tests/unit/ui/editor/canvasMagnetGuides.test.ts
+++ b/apps/editor/tests/unit/ui/editor/canvasMagnetGuides.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { canvasMagnetGuides } from '../../../../src/ui/editor/canvas/canvasMagnetGuides';
+
+describe('canvasMagnetGuides', () => {
+  it('snaps to the page vertical center without adding a horizontal guide', () => {
+    const snap = canvasMagnetGuides.getDragSnap({
+      movingRect: { x: 351, y: 40, width: 70, height: 50 },
+      stageHeight: 432,
+      stageWidth: 768,
+      targetRects: [],
+      threshold: 6,
+    });
+
+    expect(snap.deltaX).toBe(-2);
+    expect(snap.deltaY).toBe(0);
+    expect(snap.guides).toEqual([
+      expect.objectContaining({
+        id: 'page-vertical-center',
+        orientation: 'vertical',
+        source: 'page',
+      }),
+    ]);
+  });
+
+  it('snaps to both page centers independently', () => {
+    const snap = canvasMagnetGuides.getDragSnap({
+      movingRect: { x: 351, y: 193, width: 70, height: 50 },
+      stageHeight: 432,
+      stageWidth: 768,
+      targetRects: [],
+      threshold: 6,
+    });
+
+    expect(snap.deltaX).toBe(-2);
+    expect(snap.deltaY).toBe(-2);
+    expect(snap.guides.map((guide) => guide.orientation)).toEqual(['vertical', 'horizontal']);
+  });
+
+  it('snaps to nearby object anchors and returns bounded object guides', () => {
+    const snap = canvasMagnetGuides.getDragSnap({
+      movingRect: { x: 94, y: 150, width: 50, height: 40 },
+      stageHeight: 432,
+      stageWidth: 768,
+      targetRects: [{ id: 'target', x: 150, y: 170, width: 80, height: 60 }],
+      threshold: 6,
+    });
+
+    expect(snap.deltaX).toBe(6);
+    expect(snap.guides[0]).toEqual(
+      expect.objectContaining({
+        id: 'object-vertical-target-right-left',
+        orientation: 'vertical',
+        source: 'object',
+        y1: 132,
+        y2: 248,
+      }),
+    );
+  });
+
+  it('snaps resized width and height to nearby object dimensions', () => {
+    const snap = canvasMagnetGuides.getResizeSnap({
+      resizedRect: { x: 20, y: 30, width: 123, height: 77 },
+      targetRects: [{ id: 'reference', x: 220, y: 40, width: 128, height: 80 }],
+      threshold: 6,
+    });
+
+    expect(snap.width).toBe(128);
+    expect(snap.height).toBe(80);
+    expect(snap.guides.map((guide) => guide.kind)).toEqual(['size', 'size']);
+  });
+});

--- a/apps/editor/tests/unit/ui/editor/editorViewModelElements.test.ts
+++ b/apps/editor/tests/unit/ui/editor/editorViewModelElements.test.ts
@@ -97,4 +97,269 @@ describe('editor view model element helpers', () => {
       visible: true,
     });
   });
+
+  it('creates proportional grid split patches in page order', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const patches = editorViewModelElements.createGridSplitFramePatches({
+      page: page!,
+      project,
+      selectedElementIds: ['text-title', 'image-hero', 'text-subtitle'],
+    });
+
+    expect(Object.keys(patches)).toEqual(['image-hero', 'text-subtitle', 'text-title']);
+    const imagePatch = patches['image-hero'];
+    const subtitlePatch = patches['text-subtitle'];
+    const titlePatch = patches['text-title'];
+    expect(imagePatch).toBeDefined();
+    expect(subtitlePatch).toBeDefined();
+    expect(titlePatch).toBeDefined();
+    expect(typeof imagePatch?.width).toBe('number');
+    expect(typeof imagePatch?.height).toBe('number');
+    expect(subtitlePatch?.x).toBeGreaterThan(imagePatch?.x ?? 0);
+    expect(titlePatch?.y).toBeGreaterThan(imagePatch?.y ?? 0);
+    expect((imagePatch?.width ?? 1) / (imagePatch?.height ?? 1)).toBeCloseTo(980 / 735);
+  });
+
+  it('centers the third item in the second row for a two plus one grid split', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const patches = editorViewModelElements.createGridSplitFramePatches({
+      layout: 'two-one',
+      page: page!,
+      project,
+      selectedElementIds: ['text-title', 'image-hero', 'text-subtitle'],
+    });
+
+    const imagePatch = patches['image-hero'];
+    const subtitlePatch = patches['text-subtitle'];
+    const titlePatch = patches['text-title'];
+    expect(titlePatch?.y).toBeGreaterThan(imagePatch?.y ?? 0);
+    expect(titlePatch?.x).toBeGreaterThan(imagePatch?.x ?? 0);
+    expect(titlePatch?.x).toBeLessThan(subtitlePatch?.x ?? Number.POSITIVE_INFINITY);
+  });
+
+  it('centers the first item in the first row for a one plus two grid split', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const patches = editorViewModelElements.createGridSplitFramePatches({
+      layout: 'one-two',
+      page: page!,
+      project,
+      selectedElementIds: ['text-title', 'image-hero', 'text-subtitle'],
+    });
+
+    const imagePatch = patches['image-hero'];
+    const subtitlePatch = patches['text-subtitle'];
+    const titlePatch = patches['text-title'];
+    expect(imagePatch?.y).toBeLessThan(subtitlePatch?.y ?? Number.POSITIVE_INFINITY);
+    expect(imagePatch?.x).toBeGreaterThan(subtitlePatch?.x ?? 0);
+    expect(imagePatch?.x).toBeLessThan(titlePatch?.x ?? Number.POSITIVE_INFINITY);
+  });
+
+  it('creates three selected placeholder images in a centered grid layout', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const grid = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index) => `grid-image-${index + 1}`,
+      page: page!,
+      request: 'three-two-one',
+    });
+
+    const imageElements = grid.elements.filter((element) => element.type === 'image');
+    expect(Object.keys(grid.assets)).toEqual(['asset-placeholder-web-ai']);
+    expect(grid.elements).toHaveLength(3);
+    expect(imageElements.map((element) => element.assetId)).toEqual([
+      'asset-placeholder-web-ai',
+      'asset-placeholder-web-ai',
+      'asset-placeholder-web-ai',
+    ]);
+    expect(imageElements[2]?.y).toBeGreaterThan(imageElements[0]?.y ?? 0);
+    expect(imageElements[2]?.x).toBeGreaterThan(imageElements[0]?.x ?? 0);
+    expect(imageElements[2]?.x).toBeLessThan(imageElements[1]?.x ?? Number.POSITIVE_INFINITY);
+    for (const element of imageElements) {
+      const renderedAspectRatio = element.width / element.height;
+      expect(element.crop).toBeDefined();
+      const cropAspectRatio =
+        (433 * (element.crop?.width ?? 1)) / (287 * (element.crop?.height ?? 1));
+      expect(cropAspectRatio).toBeCloseTo(renderedAspectRatio);
+    }
+  });
+
+  it('creates custom placeholder image grids from explicit columns and rows', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const grid = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index) => `grid-image-${index + 1}`,
+      page: page!,
+      request: { columns: 3, rows: 2 },
+    });
+
+    expect(grid.elements).toHaveLength(6);
+    expect(grid.elements.map((element) => element.id)).toEqual([
+      'grid-image-1',
+      'grid-image-2',
+      'grid-image-3',
+      'grid-image-4',
+      'grid-image-5',
+      'grid-image-6',
+    ]);
+    expect(grid.elements[1]?.x).toBeGreaterThan(grid.elements[0]?.x ?? 0);
+    expect(grid.elements[2]?.x).toBeGreaterThan(grid.elements[1]?.x ?? 0);
+    expect(grid.elements[3]?.y).toBeGreaterThan(grid.elements[0]?.y ?? 0);
+    expect(grid.elements[3]?.x).toBe(grid.elements[0]?.x);
+  });
+
+  it('creates custom image and text placeholder layouts in the requested order', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const grid = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index, type) => `${type}-${index + 1}`,
+      page: page!,
+      request: { columns: 1, mediaPosition: 'left', rows: 1, textCount: 1 },
+    });
+
+    const image = grid.elements.find((element) => element.type === 'image');
+    const text = grid.elements.find((element) => element.type === 'text');
+    expect(grid.elements).toHaveLength(2);
+    expect(image).toBeDefined();
+    expect(text).toMatchObject({
+      id: 'text-1',
+      fontSize: 96,
+      text: 'Add a heading',
+      type: 'text',
+    });
+    expect(image?.x).toBeLessThan(text?.x ?? 0);
+    expect(text?.y).toBeGreaterThan(image?.y ?? 0);
+    expect(text?.height).toBeGreaterThanOrEqual(240);
+    expect(text?.height).toBeLessThan(image?.height ?? 0);
+    expect(image?.x).toBeLessThan(120);
+    expect(image?.height).toBeGreaterThan(900);
+  });
+
+  it('keeps top text compact and gives the image grid the dominant area', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const grid = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index, type) => `${type}-${index + 1}`,
+      page: page!,
+      request: { columns: 2, mediaPosition: 'bottom', rows: 2, textCount: 1 },
+    });
+
+    const image = grid.elements.find((element) => element.type === 'image');
+    const text = grid.elements.find((element) => element.type === 'text');
+    expect(text?.height).toBeGreaterThanOrEqual(240);
+    expect(image?.height).toBeGreaterThan(text?.height ?? 0);
+    expect(text?.y).toBeLessThan(image?.y ?? Number.POSITIVE_INFINITY);
+  });
+
+  it('applies custom image fit modes to generated grid placeholders', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const cover = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index, type) => `${type}-cover-${index + 1}`,
+      page: page!,
+      request: { columns: 1, imageFit: 'cover', rows: 1 },
+    });
+    const contain = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index, type) => `${type}-contain-${index + 1}`,
+      page: page!,
+      request: { columns: 1, imageFit: 'contain', rows: 1 },
+    });
+    const stretch = editorViewModelElements.createImageGridPlaceholderElements({
+      createElementId: (index, type) => `${type}-stretch-${index + 1}`,
+      page: page!,
+      request: { columns: 1, imageFit: 'stretch', rows: 1 },
+    });
+
+    const coverImage = cover.elements.find((element) => element.type === 'image');
+    const containImage = contain.elements.find((element) => element.type === 'image');
+    const stretchImage = stretch.elements.find((element) => element.type === 'image');
+    expect(coverImage?.crop).toBeDefined();
+    expect(containImage?.crop).toBeUndefined();
+    expect(containImage?.width).toBeLessThan(coverImage?.width ?? 0);
+    expect(stretchImage?.crop).toBeUndefined();
+    expect(stretchImage?.width).toBe(coverImage?.width);
+    expect(stretchImage?.height).toBe(coverImage?.height);
+  });
+
+  it('creates custom grid frame patches for the current selection', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const patches = editorViewModelElements.createSelectionGridFramePatches({
+      page: page!,
+      project,
+      request: { columns: 2, imageFit: 'contain', rows: 2 },
+      selectedElementIds: ['text-title', 'image-hero', 'text-subtitle'],
+    });
+
+    expect(Object.keys(patches)).toEqual(['image-hero', 'text-subtitle', 'text-title']);
+    expect(patches['image-hero']?.x).toBeLessThan(patches['text-subtitle']?.x ?? 0);
+    expect(patches['text-title']?.y).toBeGreaterThan(patches['image-hero']?.y ?? 0);
+    expect((patches['image-hero']?.width ?? 1) / (patches['image-hero']?.height ?? 1)).toBeCloseTo(
+      980 / 735,
+    );
+  });
+
+  it('honors fewer requested rows by expanding columns for selected visual elements', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+    const images = Array.from({ length: 5 }, (_, index) => {
+      const element = {
+        ...project.elements['image-hero']!,
+        id: `image-${index + 1}`,
+        x: 100 + index * 24,
+        y: 160 + index * 28,
+      };
+      project.elements[element.id] = element;
+      page!.elementIds.push(element.id);
+      return element.id;
+    });
+
+    const patches = editorViewModelElements.createSelectionGridFramePatches({
+      page: page!,
+      project,
+      request: { columns: 1, imageFit: 'stretch', mediaPosition: 'right', rows: 2 },
+      selectedElementIds: ['text-title', ...images],
+    });
+    const imageRows = new Set(images.map((id) => Math.round(patches[id]?.y ?? 0)));
+
+    expect(imageRows.size).toBe(2);
+    expect(patches[images[2]!]?.x).toBeGreaterThan(patches[images[0]!]?.x ?? 0);
+  });
+
+  it('does not shrink a single selected visual element when requested rows exceed it', () => {
+    const project = sampleProject.createSampleProject();
+    const page = project.pages[0];
+    expect(page).toBeDefined();
+
+    const patches = editorViewModelElements.createSelectionGridFramePatches({
+      page: page!,
+      project,
+      request: { columns: 1, imageFit: 'cover', mediaPosition: 'left', rows: 3 },
+      selectedElementIds: ['image-hero', 'text-title'],
+    });
+
+    expect(patches['image-hero']?.height).toBeGreaterThan(400);
+    expect(patches['image-hero']?.x).toBeLessThan(patches['text-title']?.x ?? 0);
+  });
 });


### PR DESCRIPTION
## Summary

- Add canvas magnet guides for aligning and spacing elements during drag interactions
- Integrate guide-aware element commands, media replacement, selection, and editor panel workflows
- Refine floating toolbar and layers-panel styling and controls
- Expand unit and component coverage for magnet guides and updated editor behavior

## Testing

- Added and updated unit and component tests covering commands, canvas guides, workspace controls, shell behavior, and element view-model state
- Not run (not requested)