### PR TITLE
Add PostHog analytics to landing and joystick apps

### DIFF
--- a/apps/editor/.env.production
+++ b/apps/editor/.env.production
@@ -1,2 +1,0 @@
-VITE_POSTHOG_KEY=phc_m3Xa7Eu3ab39T46WUodeyn7HENWM8YYechHAo9Wk43t5
-VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -3,16 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FDGKZ1Q1XC"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-FDGKZ1Q1XC");
-    </script>
+    <!-- localstudio:analytics -->
     <meta
       name="description"
       content="LocalStudio.dev editor is a browser-native AI slide workspace for creating, editing, importing, presenting, and sharing local-first decks."

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@giphy/js-fetch-api": "^5.8.0",
     "@huggingface/transformers": "^4.2.0",
+    "@localstudio/analytics-config": "*",
     "@localstudio/app-routes": "*",
     "@localstudio/brand": "*",
     "@localstudio/presenter-remote": "*",

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig, type Connect, type Plugin } from 'vite';
+import { analyticsHtmlPlugin } from '../../scripts/vite/analyticsHtmlPlugin';
 import { localNetworkOriginRoute } from '../../scripts/vite/localNetworkOriginRoute';
 import { localPowerPointSampleRoute } from '../../scripts/vite/localPowerPointSampleRoute';
 
@@ -107,6 +108,7 @@ function editorManualChunks(id: string) {
 export default defineConfig({
   base: editorBase,
   plugins: [
+    analyticsHtmlPlugin(),
     localNetworkOriginRoute(),
     localPowerPointSampleRoute(),
     webMcpRouteAlias(),

--- a/apps/joystick/index.html
+++ b/apps/joystick/index.html
@@ -4,16 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#07140d" />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FDGKZ1Q1XC"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-FDGKZ1Q1XC");
-    </script>
+    <!-- localstudio:analytics -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="LocalStack 🕹️" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/apps/joystick/package.json
+++ b/apps/joystick/package.json
@@ -10,10 +10,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@localstudio/analytics-config": "*",
     "@localstudio/brand": "*",
     "@localstudio/presenter-remote": "*",
     "jsqr": "^1.4.0",
     "lucide-react": "^1.21.0",
+    "posthog-js": "^1.407.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   }

--- a/apps/joystick/src/main.tsx
+++ b/apps/joystick/src/main.tsx
@@ -5,6 +5,7 @@ import type { JoystickSignalingService } from './app/JoystickApp';
 import { JoystickCoverageDiagnosticsPage } from './app/e2e/JoystickCoverageDiagnosticsPage';
 import { registerJoystickServiceWorker } from './app/register-joystick-service-worker';
 import './styles/joystick.css';
+import './services/analytics/posthog';
 
 type JoystickWindow = Window & {
   __LOCALSTUDIO_JOYSTICK_SIGNALING_SERVICE__?: JoystickSignalingService | undefined;

--- a/apps/joystick/src/services/analytics/posthog.ts
+++ b/apps/joystick/src/services/analytics/posthog.ts
@@ -17,5 +17,3 @@ if (!postHogConfig.apiKey) {
     enable_recording_console_log: false,
   });
 }
-
-export { posthog };

--- a/apps/joystick/vite.config.ts
+++ b/apps/joystick/vite.config.ts
@@ -1,11 +1,12 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { analyticsHtmlPlugin } from '../../scripts/vite/analyticsHtmlPlugin';
 
 const siteBase = process.env.LOCALSTUDIO_JOYSTICK_BASE_PATH ?? '/joystick/';
 
 export default defineConfig({
   base: siteBase,
-  plugins: [react()],
+  plugins: [analyticsHtmlPlugin(), react()],
   build: {
     emptyOutDir: false,
     outDir: '../../dist/joystick',

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -4,16 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#f8f5ed" />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FDGKZ1Q1XC"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-FDGKZ1Q1XC");
-    </script>
+    <!-- localstudio:analytics -->
     <meta
       name="description"
       content="LocalStudio.dev is a local-first AI design studio for generating editable slides, images, translations, and image edits with browser-native Web AI."

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -10,10 +10,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@localstudio/analytics-config": "*",
     "@localstudio/app-routes": "*",
     "@localstudio/brand": "*",
     "@localstudio/presenter-remote": "*",
     "lucide-react": "^1.21.0",
+    "posthog-js": "^1.407.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   }

--- a/apps/landing/src/main.tsx
+++ b/apps/landing/src/main.tsx
@@ -4,6 +4,7 @@ import { LandingPage } from './LandingPage';
 import { configureLandingScrollRestoration } from './routing/configureLandingScrollRestoration';
 import { getStandaloneAppRedirectUrl } from './routing/standaloneAppRedirect';
 import './landing.css';
+import './services/analytics/posthog';
 
 const standaloneRedirectUrl = getStandaloneAppRedirectUrl(window.location);
 if (standaloneRedirectUrl) {

--- a/apps/landing/src/services/analytics/posthog.ts
+++ b/apps/landing/src/services/analytics/posthog.ts
@@ -17,5 +17,3 @@ if (!postHogConfig.apiKey) {
     enable_recording_console_log: false,
   });
 }
-
-export { posthog };

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig, type Connect, type Plugin } from 'vite';
+import { analyticsHtmlPlugin } from '../../scripts/vite/analyticsHtmlPlugin';
 import { rewriteEditorPreviewRoute } from './src/routing/rewriteEditorPreviewRoute';
 import { localNetworkOriginRoute } from '../../scripts/vite/localNetworkOriginRoute';
 import { localPowerPointSampleRoute } from '../../scripts/vite/localPowerPointSampleRoute';
@@ -73,6 +74,7 @@ function inlineStylesheetLinks(): Plugin {
 export default defineConfig({
   base: siteBase,
   plugins: [
+    analyticsHtmlPlugin(),
     localNetworkOriginRoute(),
     localPowerPointSampleRoute(),
     presenterRemoteSignalingRoute(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       "dependencies": {
         "@giphy/js-fetch-api": "^5.8.0",
         "@huggingface/transformers": "^4.2.0",
+        "@localstudio/analytics-config": "*",
         "@localstudio/app-routes": "*",
         "@localstudio/brand": "*",
         "@localstudio/presenter-remote": "*",
@@ -74,10 +75,12 @@
       "name": "@localstudio/joystick",
       "version": "0.1.0",
       "dependencies": {
+        "@localstudio/analytics-config": "*",
         "@localstudio/brand": "*",
         "@localstudio/presenter-remote": "*",
         "jsqr": "^1.4.0",
         "lucide-react": "^1.21.0",
+        "posthog-js": "^1.407.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
       }
@@ -86,10 +89,12 @@
       "name": "@localstudio/landing",
       "version": "0.1.0",
       "dependencies": {
+        "@localstudio/analytics-config": "*",
         "@localstudio/app-routes": "*",
         "@localstudio/brand": "*",
         "@localstudio/presenter-remote": "*",
         "lucide-react": "^1.21.0",
+        "posthog-js": "^1.407.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
       }
@@ -1665,6 +1670,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@localstudio/analytics-config": {
+      "resolved": "packages/analytics-config",
+      "link": true
     },
     "node_modules/@localstudio/app-routes": {
       "resolved": "packages/app-routes",
@@ -10124,6 +10133,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "packages/analytics-config": {
+      "name": "@localstudio/analytics-config",
+      "version": "0.1.0"
     },
     "packages/app-routes": {
       "name": "@localstudio/app-routes",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:docs": "npm run dev --workspace @localstudio/docs",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "typecheck": "npm run typecheck --workspace @localstudio/app-routes && npm run typecheck --workspace @localstudio/brand && npm run typecheck --workspace @localstudio/presenter-remote && npm run typecheck --workspace @localstudio/landing && npm run typecheck --workspace @localstudio/editor && npm run typecheck --workspace @localstudio/joystick && npm run typecheck --workspace @localstudio/docs",
+    "typecheck": "npm run typecheck --workspace @localstudio/analytics-config && npm run typecheck --workspace @localstudio/app-routes && npm run typecheck --workspace @localstudio/brand && npm run typecheck --workspace @localstudio/presenter-remote && npm run typecheck --workspace @localstudio/landing && npm run typecheck --workspace @localstudio/editor && npm run typecheck --workspace @localstudio/joystick && npm run typecheck --workspace @localstudio/docs",
     "test": "npm run test --workspace @localstudio/landing && npm run test --workspace @localstudio/editor && npm run test --workspace @localstudio/joystick && npm run test --workspace @localstudio/docs",
     "test:e2e": "playwright test --project=chromium",
     "test:e2e:coverage": "npm run test:e2e:coverage:editor && npm run test:e2e:coverage:landing && npm run test:e2e:coverage:public-deck && npm run test:e2e:coverage:webmcp && npm run test:e2e:coverage:joystick",

--- a/packages/analytics-config/package.json
+++ b/packages/analytics-config/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@localstudio/analytics-config",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./config": "./src/config.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit --pretty false"
+  }
+}

--- a/packages/analytics-config/src/config.ts
+++ b/packages/analytics-config/src/config.ts
@@ -1,0 +1,9 @@
+export const localStudioAnalyticsConfig = {
+  googleAnalytics: {
+    measurementId: 'G-FDGKZ1Q1XC',
+  },
+  postHog: {
+    apiHost: 'https://us.i.posthog.com',
+    apiKey: 'phc_m3Xa7Eu3ab39T46WUodeyn7HENWM8YYechHAo9Wk43t5',
+  },
+} as const;

--- a/packages/analytics-config/tsconfig.json
+++ b/packages/analytics-config/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/scripts/vite/analyticsHtmlPlugin.ts
+++ b/scripts/vite/analyticsHtmlPlugin.ts
@@ -1,0 +1,27 @@
+import type { Plugin } from 'vite';
+import { localStudioAnalyticsConfig } from '@localstudio/analytics-config/config';
+
+const analyticsHtmlPlaceholder = '<!-- localstudio:analytics -->';
+
+function getGoogleAnalyticsHtml() {
+  const { measurementId } = localStudioAnalyticsConfig.googleAnalytics;
+  return `<script async src="https://www.googletagmanager.com/gtag/js?id=${measurementId}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "${measurementId}");
+    </script>`;
+}
+
+export function analyticsHtmlPlugin(): Plugin {
+  return {
+    name: 'localstudio-analytics-html',
+    transformIndexHtml(html) {
+      return html.replace(analyticsHtmlPlaceholder, getGoogleAnalyticsHtml());
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
   },
   "files": ["playwright.config.ts"],
   "references": [
+    { "path": "./packages/analytics-config" },
     { "path": "./packages/app-routes" },
     { "path": "./packages/brand" },
     { "path": "./packages/presenter-remote" },


### PR DESCRIPTION
## Summary

- Add PostHog to the landing and joystick applications
- Configure production PostHog credentials and host
- Enable autocapture and pageview tracking

## Testing

- Not run (not requested)