### PR TITLE
Translate speaker notes with slide text

### DIFF
--- a/apps/editor/src/domain/commands/elements/text-theme-commands.ts
+++ b/apps/editor/src/domain/commands/elements/text-theme-commands.ts
@@ -44,6 +44,30 @@ class TranslateTextElementsCommand implements EditorCommand {
   }
 }
 
+class TranslateSpeakerNotesCommand implements EditorCommand {
+  readonly description = 'Translate speaker notes';
+
+  constructor(private readonly translations: Record<string, string>) {}
+
+  execute(project: ProjectDocument): ProjectDocument {
+    let didChange = false;
+    const pages = project.pages.map((page) => {
+      const translation = this.translations[page.id];
+      if (translation === undefined || translation === page.speakerNotes) return page;
+      didChange = true;
+      return { ...page, speakerNotes: translation };
+    });
+
+    if (!didChange) return project;
+
+    return {
+      ...project,
+      pages,
+      updatedAt: projectMutationUtils.getProjectUpdatedAt(),
+    };
+  }
+}
+
 class ApplyThemeCommand implements EditorCommand {
   readonly description = 'Apply theme';
 
@@ -87,4 +111,5 @@ export const textThemeCommands = {
   EditThemeCommand,
   SaveThemeCommand,
   TranslateTextElementsCommand,
+  TranslateSpeakerNotesCommand,
 };

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -2547,6 +2547,23 @@ export function useEditorViewModel(services: AppServices) {
     );
   }
 
+  function getTranslatableSpeakerNotePageIds(
+    scope: TranslationScope,
+    sourceProject = project,
+    options?: { pageId?: string },
+  ) {
+    if (scope === 'selection') return [];
+
+    const pages =
+      scope === 'slide'
+        ? sourceProject.pages.filter((page) => page.id === (options?.pageId ?? activePageId))
+        : sourceProject.pages;
+
+    return pages
+      .filter((page) => Boolean(page.speakerNotes?.trim()))
+      .map((page) => page.id);
+  }
+
   async function translateTextScope(
     scope: TranslationScope,
     targetLanguage = 'pt',
@@ -2557,7 +2574,12 @@ export function useEditorViewModel(services: AppServices) {
       project,
       options?.pageId ? { pageId: options.pageId } : undefined,
     );
-    if (elementIds.length === 0) return [];
+    const speakerNotePageIds = getTranslatableSpeakerNotePageIds(
+      scope,
+      project,
+      options?.pageId ? { pageId: options.pageId } : undefined,
+    );
+    if (elementIds.length === 0 && speakerNotePageIds.length === 0) return [];
 
     const pageIdsByElementId = new Map(
       project.pages.flatMap((page) =>
@@ -2577,6 +2599,12 @@ export function useEditorViewModel(services: AppServices) {
         const pageId = pageIdsByElementId.get(elementId);
         if (!pageId) continue;
         pendingElementCountByPageId.set(pageId, (pendingElementCountByPageId.get(pageId) ?? 0) + 1);
+      }
+      for (const pageId of speakerNotePageIds) {
+        pendingElementCountByPageId.set(
+          pageId,
+          (pendingElementCountByPageId.get(pageId) ?? 0) + 1,
+        );
       }
       totalPageCount = pendingElementCountByPageId.size;
       setDeckTranslationProgress({
@@ -2643,14 +2671,56 @@ export function useEditorViewModel(services: AppServices) {
       ),
     );
 
+    const translatedNotes = Object.fromEntries(
+      (
+        await textTranslationLayout.mapWithConcurrency(
+          speakerNotePageIds,
+          concurrency,
+          async (pageId) => {
+            const page = pageById.get(pageId);
+            if (!page?.speakerNotes?.trim()) return undefined;
+            if (shouldTrackDeckProgress) {
+              activeElementCountByPageId.set(
+                pageId,
+                (activeElementCountByPageId.get(pageId) ?? 0) + 1,
+              );
+              updateDeckTranslationProgress(pageId);
+            }
+            const translatedNotes = await services.translatorService.translate(
+              page.speakerNotes,
+              targetLanguage,
+              options?.sourceLanguage ? { sourceLanguage: options.sourceLanguage } : undefined,
+            );
+            if (shouldTrackDeckProgress) {
+              activeElementCountByPageId.delete(pageId);
+              const pendingElementCount = (pendingElementCountByPageId.get(pageId) ?? 1) - 1;
+              if (pendingElementCount > 0) {
+                pendingElementCountByPageId.set(pageId, pendingElementCount);
+              } else {
+                pendingElementCountByPageId.delete(pageId);
+                completedPageCount += 1;
+              }
+              updateDeckTranslationProgress(pageId);
+            }
+            return [pageId, translatedNotes] as const;
+          },
+        )
+      ).filter((entry): entry is readonly [string, string] => Boolean(entry)),
+    );
+
     commitProject((currentProject) =>
-      new basicCommands.TranslateTextElementsCommand(translations).execute(currentProject),
+      new basicCommands.TranslateSpeakerNotesCommand(translatedNotes).execute(
+        new basicCommands.TranslateTextElementsCommand(translations).execute(currentProject),
+      ),
     );
     return Array.from(
       new Set(
-        elementIds
-          .map((elementId) => pageIdsByElementId.get(elementId))
-          .filter((pageId): pageId is string => Boolean(pageId)),
+        [
+          ...elementIds
+            .map((elementId) => pageIdsByElementId.get(elementId))
+            .filter((pageId): pageId is string => Boolean(pageId)),
+          ...speakerNotePageIds,
+        ],
       ),
     );
   }

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -623,6 +623,25 @@ describe('editor commands', () => {
     });
   });
 
+  it('translates speaker notes immutably', () => {
+    const project = {
+      ...sampleProject.createSampleProject(),
+      pages: [
+        {
+          ...sampleProject.createSampleProject().pages[0]!,
+          speakerNotes: 'Original speaker notes',
+        },
+      ],
+    };
+    const next = new basicCommands.TranslateSpeakerNotesCommand({
+      'page-1': 'Translated speaker notes',
+    }).execute(project);
+
+    expect(next).not.toBe(project);
+    expect(next.pages[0]?.speakerNotes).toBe('Translated speaker notes');
+    expect(project.pages[0]?.speakerNotes).toBe('Original speaker notes');
+  });
+
   it('skips locked text translations', () => {
     const project = {
       ...sampleProject.createSampleProject(),

--- a/apps/editor/tests/unit/ui/editor/EditorShell.translation.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.translation.test.tsx
@@ -67,6 +67,26 @@ describe('EditorShell translation workflows', () => {
     expect(screen.getByText('Pair: pt → pt')).toBeInTheDocument();
   });
 
+  it('translates speaker notes with the current slide', async () => {
+    const user = userEvent.setup();
+    const project = createThreeColumnCaptionProject();
+    project.pages[0]!.speakerNotes = 'Explain the future of AI.';
+    const services = createAppServices({ initialProject: project });
+    const translator = new RecordingTranslatorService();
+    services.translatorService = translator;
+    render(<EditorShell services={services} />);
+
+    await openLeftTab(user, 'AI Tools');
+    await user.selectOptions(screen.getByLabelText('Translate to'), 'pt');
+    fireEvent.click(screen.getByRole('button', { name: 'Translate Hero split' }));
+
+    await waitFor(() => {
+      expect(translator.translate).toHaveBeenCalledWith('Explain the future of AI.', 'pt', {
+        sourceLanguage: 'en',
+      });
+    });
+  });
+
   it('restores the toolbar source language after undoing a slide translation with Ctrl+Z', async () => {
     const user = userEvent.setup();
     const services = createAppServices();


### PR DESCRIPTION
## Summary

- Add speaker-note translation support alongside slide text translation.
- Track speaker-note translation in deck progress updates.
- Apply translated notes immutably through a dedicated editor command.
- Add command and editor workflow coverage.

## Testing

- Added unit coverage for immutable speaker-note translation.
- Added editor workflow coverage verifying translation of the current slide’s notes.