### PR TITLE
Enable cross-tab element and slide clipboard paste

### DIFF
--- a/apps/editor/src/ui/editor/browser/editorShellBrowserUtils.ts
+++ b/apps/editor/src/ui/editor/browser/editorShellBrowserUtils.ts
@@ -2,6 +2,8 @@ import type { WebMcpModelContext } from '../../../services/webmcp/webMcpToolAdap
 
 const EDITOR_OBJECT_CLIPBOARD_TYPE = 'application/x-localstudio-editor-elements';
 const EDITOR_OBJECT_CLIPBOARD_MARKER = '1';
+const MAX_EDITOR_OBJECT_CLIPBOARD_BYTES = 1024 * 1024;
+const SLIDE_CLIPBOARD_PREFIX = 'LocalStudio.dev slide: ';
 
 function isEditableElement(target: EventTarget | null) {
   return (
@@ -50,6 +52,37 @@ function writeEditorObjectClipboardMarker(clipboardData: DataTransfer | null) {
   clipboardData.setData('text/plain', 'LocalStudio.dev editor elements');
 }
 
+function writeEditorObjectClipboardPayload(clipboardData: DataTransfer | null, payload: string) {
+  if (!clipboardData || payload.length > MAX_EDITOR_OBJECT_CLIPBOARD_BYTES) return;
+  clipboardData.setData(EDITOR_OBJECT_CLIPBOARD_TYPE, payload);
+  clipboardData.setData('text/plain', 'LocalStudio.dev editor elements');
+}
+
+function readEditorObjectClipboardPayload(clipboardData: DataTransfer | null) {
+  if (!clipboardData) return undefined;
+  const payload = clipboardData.getData?.(EDITOR_OBJECT_CLIPBOARD_TYPE);
+  if (!payload || payload === EDITOR_OBJECT_CLIPBOARD_MARKER) return undefined;
+  if (payload.length > MAX_EDITOR_OBJECT_CLIPBOARD_BYTES) return undefined;
+  return payload;
+}
+
+async function writeSlideClipboardPayload(payload: string) {
+  if (payload.length > MAX_EDITOR_OBJECT_CLIPBOARD_BYTES || !navigator.clipboard?.writeText) return false;
+  try {
+    await navigator.clipboard.writeText(`${SLIDE_CLIPBOARD_PREFIX}${payload}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readSlideClipboardPayload(clipboardData: DataTransfer | null) {
+  const text = clipboardData?.getData?.('text/plain') ?? '';
+  if (!text.startsWith(SLIDE_CLIPBOARD_PREFIX)) return undefined;
+  const payload = text.slice(SLIDE_CLIPBOARD_PREFIX.length);
+  return payload.length <= MAX_EDITOR_OBJECT_CLIPBOARD_BYTES ? payload : undefined;
+}
+
 function isWebMcpEnabled() {
   if (typeof window === 'undefined') return false;
   return new URL(window.location.href).searchParams.get('webmcp') === '1';
@@ -71,6 +104,10 @@ export const editorShellBrowserUtils = {
   getClipboardImageFile,
   hasEditorObjectClipboardMarker,
   writeEditorObjectClipboardMarker,
+  writeEditorObjectClipboardPayload,
+  readEditorObjectClipboardPayload,
+  writeSlideClipboardPayload,
+  readSlideClipboardPayload,
   isWebMcpEnabled,
   isWebMcpProtocolEnabled,
   getWebMcpModelContext,

--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -21,6 +21,7 @@ interface ScrollingCanvasWorkspaceProps extends CanvasWorkspaceProps {
   onActivePageFromScroll?: ((pageId: string) => void) | undefined;
   onDeletePage?: ((pageId: string) => void) | undefined;
   onDuplicatePage?: ((pageId: string) => void) | undefined;
+  onCopyPage?: ((pageId: string) => void) | undefined;
   onRenamePage?: ((pageId: string, name: string) => void) | undefined;
   onReorderPage?: ((pageId: string, targetIndex: number) => void) | undefined;
   onSetPageVisibility?: ((pageId: string, visible: boolean) => void) | undefined;
@@ -45,6 +46,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
       onAddPage,
       onDeletePage,
       onDuplicatePage,
+      onCopyPage,
       onRenamePage,
       onReorderPage,
       onSetPageVisibility,
@@ -191,6 +193,7 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
                 {...(onAddPage ? { onAddPage } : {})}
                 {...(onDeletePage ? { onDeletePage } : {})}
                 {...(onDuplicatePage ? { onDuplicatePage } : {})}
+                {...(onCopyPage ? { onCopyPage } : {})}
                 {...(onRenamePage ? { onRenamePage } : {})}
                 {...(onReorderPage ? { onReorderPage } : {})}
                 {...(onSetPageVisibility ? { onSetPageVisibility } : {})}
@@ -262,6 +265,7 @@ interface PageHeaderProps {
   onAddPage?: (afterPageId?: string) => void;
   onDeletePage?: (pageId: string) => void;
   onDuplicatePage?: (pageId: string) => void;
+  onCopyPage?: (pageId: string) => void;
   onRenamePage?: (pageId: string, name: string) => void;
   onReorderPage?: (pageId: string, targetIndex: number) => void;
   onSetPageVisibility?: (pageId: string, visible: boolean) => void;
@@ -281,6 +285,7 @@ function PageHeader({
   onAddPage,
   onDeletePage,
   onDuplicatePage,
+  onCopyPage,
   onRenamePage,
   onReorderPage,
   onSetPageVisibility,
@@ -324,6 +329,11 @@ function PageHeader({
           label={`Duplicate ${name}`}
           icon="content_copy"
           onClick={() => onDuplicatePage?.(pageId)}
+        />
+        <IconAction
+          label={`Copy ${name} to clipboard`}
+          icon="file_copy"
+          onClick={() => onCopyPage?.(pageId)}
         />
         <IconAction
           disabled={!canTranslate}

--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -327,7 +327,7 @@ function PageHeader({
         />
         <IconAction
           label={`Duplicate ${name}`}
-          icon="content_copy"
+          icon="library_add"
           onClick={() => onDuplicatePage?.(pageId)}
         />
         <IconAction

--- a/apps/editor/src/ui/editor/panels/PagesPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/PagesPanel.tsx
@@ -271,7 +271,7 @@ export function PagesPanel({
                     }}
                   >
                     <span className="material-symbols-outlined" aria-hidden="true">
-                      content_copy
+                      library_add
                     </span>
                   </button>
                   <button

--- a/apps/editor/src/ui/editor/panels/PagesPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/PagesPanel.tsx
@@ -13,6 +13,7 @@ interface PagesPanelProps {
   onClose?: (() => void) | undefined;
   onDeletePage?: ((pageId: string) => void) | undefined;
   onDuplicatePage?: ((pageId: string) => void) | undefined;
+  onCopyPage?: ((pageId: string) => void) | undefined;
   onRenamePage?: ((pageId: string, name: string) => void) | undefined;
   onReorderPage?: ((pageId: string, targetIndex: number) => void) | undefined;
   onSelectPage?: ((pageId: string) => void) | undefined;
@@ -36,6 +37,7 @@ export function PagesPanel({
   onClose,
   onDeletePage,
   onDuplicatePage,
+  onCopyPage,
   onRenamePage,
   onReorderPage,
   onSelectPage,
@@ -270,6 +272,16 @@ export function PagesPanel({
                   >
                     <span className="material-symbols-outlined" aria-hidden="true">
                       content_copy
+                    </span>
+                  </button>
+                  <button
+                    className="icon-button"
+                    type="button"
+                    aria-label={`Copy ${page.name}`}
+                    onClick={() => onCopyPage?.(page.id)}
+                  >
+                    <span className="material-symbols-outlined" aria-hidden="true">
+                      file_copy
                     </span>
                   </button>
                   <button

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1247,8 +1247,12 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       )
         return;
       event.preventDefault();
-      vm.copySelectedElements();
-      editorShellBrowserUtils.writeEditorObjectClipboardMarker(event.clipboardData);
+      const clipboard = vm.copySelectedElements();
+      if (!clipboard) return;
+      editorShellBrowserUtils.writeEditorObjectClipboardPayload(
+        event.clipboardData,
+        JSON.stringify(clipboard),
+      );
     }
 
     function handleCut(event: ClipboardEvent) {
@@ -1260,14 +1264,35 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       )
         return;
       event.preventDefault();
+      const clipboard = vm.copySelectedElements();
+      if (!clipboard) return;
       vm.cutSelectedElements();
-      editorShellBrowserUtils.writeEditorObjectClipboardMarker(event.clipboardData);
+      editorShellBrowserUtils.writeEditorObjectClipboardPayload(
+        event.clipboardData,
+        JSON.stringify(clipboard),
+      );
     }
 
     function handlePaste(event: ClipboardEvent) {
       if (isHistoryReadOnly) return;
       if (editorShellBrowserUtils.isEditableInteractionTarget(event.target)) return;
       event.preventDefault();
+      const slidePayload = editorShellBrowserUtils.readSlideClipboardPayload(event.clipboardData);
+      if (slidePayload) {
+        try {
+          if (vm.pasteSlideClipboardPayload(JSON.parse(slidePayload) as unknown)) return;
+        } catch {
+          // Continue to the object and image clipboard paths.
+        }
+      }
+      const payload = editorShellBrowserUtils.readEditorObjectClipboardPayload(event.clipboardData);
+      if (payload) {
+        try {
+          if (vm.pasteClipboardElements(JSON.parse(payload) as unknown)) return;
+        } catch {
+          // Fall through to the existing in-tab clipboard and image paths.
+        }
+      }
       if (
         editorShellBrowserUtils.hasEditorObjectClipboardMarker(event.clipboardData) &&
         vm.pasteCopiedElements()
@@ -1290,6 +1315,12 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       window.removeEventListener('paste', handlePaste);
     };
   }, [hasSelection, isHistoryReadOnly, vm]);
+
+  async function copyPageToClipboard(pageId: string) {
+    const payload = vm.getSlideClipboardPayload(pageId);
+    if (!payload) return;
+    await editorShellBrowserUtils.writeSlideClipboardPayload(JSON.stringify(payload));
+  }
 
   useEffect(() => {
     if (!editorShellBrowserUtils.isWebMcpProtocolEnabled()) return undefined;
@@ -1564,6 +1595,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             onAddPage={isHistoryReadOnly ? undefined : vm.addPage}
             onDeletePage={isHistoryReadOnly ? undefined : vm.deletePage}
             onDuplicatePage={isHistoryReadOnly ? undefined : vm.duplicatePage}
+            onCopyPage={isHistoryReadOnly ? undefined : (pageId) => void copyPageToClipboard(pageId)}
             onRenamePage={isHistoryReadOnly ? undefined : vm.renamePage}
             onReorderPage={isHistoryReadOnly ? undefined : vm.reorderPage}
             onSetPageVisibility={isHistoryReadOnly ? undefined : vm.setPageVisibility}
@@ -1664,6 +1696,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             onClose={togglePagesPanel}
             onDeletePage={isHistoryReadOnly ? undefined : vm.deletePage}
             onDuplicatePage={isHistoryReadOnly ? undefined : vm.duplicatePage}
+            onCopyPage={isHistoryReadOnly ? undefined : (pageId) => void copyPageToClipboard(pageId)}
             onRenamePage={isHistoryReadOnly ? undefined : vm.renamePage}
             onReorderPage={isHistoryReadOnly ? undefined : vm.reorderPage}
             onSelectPage={vm.selectPage}

--- a/apps/editor/src/ui/editor/state/editorViewModelElements.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelElements.ts
@@ -43,6 +43,12 @@ export interface ElementClipboardState {
   elements: DesignElement[];
 }
 
+export interface SlideClipboardState {
+  assets: ProjectDocument['assets'];
+  elements: DesignElement[];
+  page: Page;
+}
+
 const placeholderImageAsset: Asset = {
   id: placeholderImage.PLACEHOLDER_IMAGE_ASSET_ID,
   type: 'image',
@@ -86,6 +92,40 @@ function createPastedElements(input: {
     y: element.y + PASTED_ELEMENT_OFFSET,
     locked: false,
   }));
+}
+
+function isElementClipboardState(value: unknown): value is ElementClipboardState {
+  if (!value || typeof value !== 'object') return false;
+  const clipboard = value as Partial<ElementClipboardState>;
+  if (!clipboard.assets || typeof clipboard.assets !== 'object' || !Array.isArray(clipboard.elements)) {
+    return false;
+  }
+  return clipboard.elements.every((element) => {
+    if (!element || typeof element !== 'object') return false;
+    const candidate = element as Partial<DesignElement>;
+    return (
+      typeof candidate.id === 'string' &&
+      typeof candidate.type === 'string' &&
+      ['text', 'image', 'gif', 'video', 'shape'].includes(candidate.type) &&
+      typeof candidate.x === 'number' &&
+      typeof candidate.y === 'number'
+    );
+  });
+}
+
+function isSlideClipboardState(value: unknown): value is SlideClipboardState {
+  if (!value || typeof value !== 'object') return false;
+  const slide = value as Partial<SlideClipboardState>;
+  if (!slide.page || typeof slide.page !== 'object') return false;
+  const page = slide.page as Partial<Page>;
+  return Boolean(
+    typeof page.id === 'string' &&
+      typeof page.name === 'string' &&
+      typeof page.width === 'number' &&
+      typeof page.height === 'number' &&
+      Array.isArray(page.elementIds) &&
+      isElementClipboardState({ assets: slide.assets, elements: slide.elements }),
+  );
 }
 
 function getImageGridFrameBounds(page: Page) {
@@ -690,6 +730,8 @@ export const editorViewModelElements = {
   createGridSplitFramePatches,
   createImageGridPlaceholderElements,
   createPastedElements,
+  isElementClipboardState,
+  isSlideClipboardState,
   createSelectionGridFramePatches,
   createShapeElement,
   createTextElement,

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -66,6 +66,7 @@ import { editorViewModelRuntime } from './editorViewModelRuntime';
 import { editorViewModelElements } from './editorViewModelElements';
 import type {
   ElementClipboardState,
+  SlideClipboardState,
   GridSplitLayout,
   ImageGridRequest,
   SelectionGridRequest,
@@ -3028,18 +3029,22 @@ export function useEditorViewModel(services: AppServices) {
 
   function copySelectedElements() {
     const selectedElements = getSelectedElementsForClipboard();
-    if (selectedElements.length === 0) return;
-    setElementClipboard({
+    if (selectedElements.length === 0) return undefined;
+    const nextClipboard = {
       assets: editorViewModelElements.collectClipboardAssets(project, selectedElements),
       elements: selectedElements.map((element) => ({ ...element })),
-    });
+    };
+    setElementClipboard(nextClipboard);
+    return nextClipboard;
   }
 
-  function pasteCopiedElements() {
-    if (elementClipboard.elements.length === 0) return false;
+  function pasteClipboardElements(clipboard: unknown) {
+    if (!editorViewModelElements.isElementClipboardState(clipboard) || clipboard.elements.length === 0) {
+      return false;
+    }
     const pastedElements = editorViewModelElements.createPastedElements({
       createElementId: (sourceElementId) => createPrefixedId(`${sourceElementId}-copy`),
-      elements: elementClipboard.elements,
+      elements: clipboard.elements,
     });
 
     commitProject(
@@ -3047,15 +3052,19 @@ export function useEditorViewModel(services: AppServices) {
         new basicCommands.AddElementsCommand(
           activePageId,
           pastedElements,
-          elementClipboard.assets,
+          clipboard.assets,
         ).execute(currentProject),
       { selectedElementIds: pastedElements.map((element) => element.id) },
     );
     setElementClipboard({
-      assets: elementClipboard.assets,
+      assets: clipboard.assets,
       elements: pastedElements.map((element) => ({ ...element })),
     });
     return true;
+  }
+
+  function pasteCopiedElements() {
+    return pasteClipboardElements(elementClipboard);
   }
 
   function deleteElement(elementId: string) {
@@ -3293,6 +3302,52 @@ export function useEditorViewModel(services: AppServices) {
         ).execute(currentProject),
       { activePageId: nextPageId, selectedElementIds: [] },
     );
+  }
+
+  function getSlideClipboardPayload(pageId: string): SlideClipboardState | undefined {
+    const page = project.pages.find((item) => item.id === pageId);
+    if (!page) return undefined;
+    const elements = page.elementIds
+      .map((elementId) => project.elements[elementId])
+      .filter((element): element is NonNullable<typeof element> => Boolean(element));
+    return {
+      page: { ...page, elementIds: [...page.elementIds] },
+      elements: elements.map((element) => ({ ...element })),
+      assets: editorViewModelElements.collectClipboardAssets(project, elements),
+    };
+  }
+
+  function pasteSlideClipboardPayload(clipboard: unknown) {
+    if (!editorViewModelElements.isSlideClipboardState(clipboard)) return false;
+    const pageId = createPrefixedId('page');
+    const assetIds = new Map<string, string>();
+    const assets = Object.fromEntries(
+      Object.entries(clipboard.assets).map(([assetId, asset]) => {
+        const nextAssetId = createPrefixedId(`${assetId}-slide`);
+        assetIds.set(assetId, nextAssetId);
+        return [nextAssetId, { ...asset, id: nextAssetId }];
+      }),
+    );
+    const elementIds = new Map<string, string>();
+    const elements = clipboard.elements.map((element) => {
+      const nextElementId = createPrefixedId(`${element.id}-slide`);
+      elementIds.set(element.id, nextElementId);
+      const nextElement = { ...element, id: nextElementId };
+      if ('assetId' in nextElement) {
+        nextElement.assetId = assetIds.get(nextElement.assetId) ?? nextElement.assetId;
+      }
+      return nextElement;
+    });
+    const page = { ...clipboard.page, id: pageId, elementIds: elements.map((element) => element.id) };
+    commitProject(
+      (currentProject) => ({
+        ...editorViewModelPages.insertPageAfter(currentProject, activePageId, page),
+        elements: { ...currentProject.elements, ...Object.fromEntries(elements.map((element) => [element.id, element])) },
+        assets: { ...currentProject.assets, ...assets },
+      }),
+      { activePageId: pageId, selectedElementIds: [] },
+    );
+    return true;
   }
 
   function deletePage(pageId: string) {
@@ -3604,6 +3659,8 @@ export function useEditorViewModel(services: AppServices) {
     activateScrolledPage,
     addPage,
     duplicatePage,
+    getSlideClipboardPayload,
+    pasteSlideClipboardPayload,
     deletePage,
     reorderPage,
     renamePage,
@@ -3626,6 +3683,7 @@ export function useEditorViewModel(services: AppServices) {
     duplicateSelectedElement,
     copySelectedElements,
     cutSelectedElements,
+    pasteClipboardElements,
     pasteCopiedElements,
     insertTextElement,
     insertShapeElement,

--- a/apps/editor/tests/unit/ui/editor/EditorShell.clipboard-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.clipboard-fixtures.ts
@@ -3,14 +3,16 @@ import { vi } from 'vitest';
 function createClipboardData(options: { editorObject?: boolean; files?: File[] } = {}) {
   const data = new Map<string, string>();
   if (options.editorObject) data.set('application/x-localstudio-editor-elements', '1');
+  const types = Array.from(data.keys());
 
   return {
     files: options.files ?? [],
     items: [],
-    types: Array.from(data.keys()),
+    types,
     getData: vi.fn((type: string) => data.get(type) ?? ''),
     setData: vi.fn((type: string, value: string) => {
       data.set(type, value);
+      if (!types.includes(type)) types.push(type);
     }),
   };
 }

--- a/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
@@ -92,6 +92,21 @@ describe('EditorShell clipboard workflows', () => {
     });
   });
 
+  it('pastes an object copied from another editor tab', async () => {
+    const user = userEvent.setup();
+    const clipboardData = createClipboardData();
+
+    render(<EditorShell services={createAppServices()} />);
+    await selectImageLayer(user);
+    fireEvent.copy(window, { clipboardData });
+    fireEvent.paste(window, { clipboardData });
+
+    expect(await screen.findByRole('button', { name: 'Selected Image copy' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
   it('does not overwrite copied text when an editable field is active with a selected object', async () => {
     const user = userEvent.setup();
     render(<EditorShell services={createAppServices()} />);


### PR DESCRIPTION
## Summary

- Add serialized clipboard payloads for copying and pasting editor elements across tabs.
- Add page-level copy-to-clipboard actions for slides, including assets and elements.
- Validate clipboard payloads and enforce a 1 MB size limit.
- Preserve legacy in-tab clipboard behavior as a fallback.

## Testing

- Added unit coverage for pasting an object copied from another editor tab.