### PR TITLE
Harden MinIO mirror uploads and byte-based sync progress

### DIFF
--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -14,6 +14,7 @@ import { storageObjectUtils } from '../storage/storageObjectUtils';
 import { minioObjectUtils } from './minioObjectUtils';
 import type { MirrorManifest } from './minioMirrorFiles';
 import { minioMirrorFiles } from './minioMirrorFiles';
+import { minioObjectUploader } from './minioObjectUploader';
 
 export interface MinioMirrorConfig {
   endpoint: string;
@@ -38,6 +39,7 @@ export interface MinioMirrorCredentials {
 interface MinioMirrorServiceOptions {
   fetch?: typeof fetch;
   now?: () => Date;
+  sleep?: (delayMs: number) => Promise<void>;
   storage?: BrowserKeyValueStorage;
 }
 
@@ -83,6 +85,12 @@ function getProjectMirrorKey(projectName: string) {
 function getDefaultFetch() {
   if (typeof window !== 'undefined') return window.fetch.bind(window);
   return globalThis.fetch.bind(globalThis);
+}
+
+function defaultSleep(delayMs: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
 }
 
 function getProjectRoot(config: MinioMirrorConfig, projectKey: string) {
@@ -216,11 +224,13 @@ async function mapWithConcurrency<T, TResult>(
 class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
   private readonly requestFetch: typeof fetch;
   private readonly now: () => Date;
+  private readonly sleep: (delayMs: number) => Promise<void>;
   private readonly storage: BrowserKeyValueStorage | undefined;
 
   constructor(options: MinioMirrorServiceOptions = {}) {
     this.requestFetch = options.fetch ?? getDefaultFetch();
     this.now = options.now ?? (() => new Date());
+    this.sleep = options.sleep ?? defaultSleep;
     this.storage = options.storage ?? browserStorage.getBrowserLocalStorage();
   }
 
@@ -249,13 +259,25 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
     });
     const projectKey = getProjectMirrorKey(project.name);
     const remoteManifest = await this.loadRemoteManifest(projectKey, config);
-    const totalFiles = Math.max(files.length, 1);
-    let completedFiles = 0;
+    const totalBytes = Math.max(
+      files.reduce((total, file) => total + file.blob.size, 0),
+      1,
+    );
+    let completedBytes = 0;
+    const uploadedBytesByPath = new Map<string, number>();
+
+    const reportFileProgress = (file: MirrorFile, uploadedBytes: number, label: string) => {
+      const previousUploadedBytes = uploadedBytesByPath.get(file.path) ?? 0;
+      const nextUploadedBytes = Math.min(file.blob.size, Math.max(previousUploadedBytes, uploadedBytes));
+      completedBytes += nextUploadedBytes - previousUploadedBytes;
+      uploadedBytesByPath.set(file.path, nextUploadedBytes);
+      options?.onProgress?.({ current: completedBytes, label, total: totalBytes });
+    };
 
     options?.onProgress?.({
-      current: completedFiles,
+      current: completedBytes,
       label: 'Checking mirror files',
-      total: totalFiles,
+      total: totalBytes,
     });
 
     const manifestFile = files.find((file) => file.path === minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME);
@@ -263,20 +285,21 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
 
     const syncFile = async (file: MirrorFile) => {
       options?.onProgress?.({
-        current: completedFiles,
+        current: completedBytes,
         label: `Mirroring ${file.path}`,
-        total: totalFiles,
+        total: totalBytes,
       });
       const nextChecksum = await minioObjectUtils.sha256Hex(file.blob);
       if (remoteManifest?.files[file.path]?.checksum !== nextChecksum) {
-        await this.putObject(getProjectFileKey(config, projectKey, file.path), file.blob, config);
+        await this.putObject(
+          getProjectFileKey(config, projectKey, file.path),
+          file.blob,
+          config,
+          (uploadedBytes) =>
+            reportFileProgress(file, uploadedBytes, `Mirroring ${file.path}`),
+        );
       }
-      completedFiles += 1;
-      options?.onProgress?.({
-        current: completedFiles,
-        label: `Mirrored ${file.path}`,
-        total: totalFiles,
-      });
+      reportFileProgress(file, file.blob.size, `Mirrored ${file.path}`);
     };
 
     await runWithConcurrency(contentFiles, MIRROR_UPLOAD_CONCURRENCY, syncFile);
@@ -456,16 +479,28 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
     return (await response.json()) as MirrorManifest;
   }
 
-  private async putObject(key: string, blob: Blob, config: MinioMirrorConfig) {
-    const response = await this.signedFetch(
-      minioObjectUtils.createObjectUrl(config, key),
-      'PUT',
-      config,
-      getWriterCredentials(config),
+  private async putObject(
+    key: string,
+    blob: Blob,
+    config: MinioMirrorConfig,
+    onUploadedBytes?: (uploadedBytes: number) => void,
+  ) {
+    await minioObjectUploader.upload({
       blob,
-      blob.type,
-    );
-    if (!response.ok) throw new Error(`Could not upload ${key} to MinIO (${response.status}).`);
+      createUrl: (query) => minioObjectUtils.createObjectUrl(config, key, query),
+      key,
+      ...(onUploadedBytes ? { onUploadedBytes } : {}),
+      request: (url, method, body, contentType) =>
+        this.signedFetch(
+          url,
+          method,
+          config,
+          getWriterCredentials(config),
+          body,
+          contentType,
+        ),
+      sleep: this.sleep,
+    });
   }
 
   private async signedFetch(

--- a/apps/editor/src/services/mirror/minioObjectUploader.ts
+++ b/apps/editor/src/services/mirror/minioObjectUploader.ts
@@ -1,0 +1,182 @@
+interface MinioObjectUploadOptions {
+  blob: Blob;
+  createUrl: (query?: Record<string, string>) => URL;
+  key: string;
+  onUploadedBytes?: (uploadedBytes: number) => void;
+  request: (
+    url: URL,
+    method: string,
+    body?: Blob,
+    contentType?: string,
+  ) => Promise<Response>;
+  sleep: (delayMs: number) => Promise<void>;
+}
+
+const MINIO_UPLOAD_POLICY = {
+  attempts: 3,
+  initialDelayMs: 250,
+  multipartPartSize: 5 * 1024 * 1024,
+  retryableStatuses: new Set([408, 429, 500, 502, 503, 504]),
+} as const;
+
+function parseUploadId(xml: string): string | undefined {
+  const document = new DOMParser().parseFromString(xml, 'application/xml');
+  return document.querySelector('UploadId')?.textContent?.trim() || undefined;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function createCompleteMultipartBody(parts: Array<{ etag: string; partNumber: number }>): Blob {
+  const partXml = parts
+    .map(
+      ({ etag, partNumber }) =>
+        `<Part><PartNumber>${partNumber}</PartNumber><ETag>${escapeXml(etag)}</ETag></Part>`,
+    )
+    .join('');
+  return new Blob([`<CompleteMultipartUpload>${partXml}</CompleteMultipartUpload>`], {
+    type: 'application/xml',
+  });
+}
+
+async function requestWithRetry(
+  options: MinioObjectUploadOptions,
+  request: { body?: Blob; contentType?: string; method: string; url: URL },
+  operation: string,
+): Promise<Response> {
+  for (let attempt = 1; attempt <= MINIO_UPLOAD_POLICY.attempts; attempt += 1) {
+    let response: Response;
+    try {
+      response = await options.request(
+        request.url,
+        request.method,
+        request.body,
+        request.contentType,
+      );
+    } catch (error: unknown) {
+      if (attempt === MINIO_UPLOAD_POLICY.attempts) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Could not ${operation} after ${MINIO_UPLOAD_POLICY.attempts} attempts: ${detail}`,
+          { cause: error },
+        );
+      }
+      await options.sleep(MINIO_UPLOAD_POLICY.initialDelayMs * 2 ** (attempt - 1));
+      continue;
+    }
+
+    if (response.ok) return response;
+    if (
+      attempt === MINIO_UPLOAD_POLICY.attempts ||
+      !MINIO_UPLOAD_POLICY.retryableStatuses.has(response.status)
+    ) {
+      throw new Error(`Could not ${operation} to MinIO (${response.status}).`);
+    }
+    await options.sleep(MINIO_UPLOAD_POLICY.initialDelayMs * 2 ** (attempt - 1));
+  }
+
+  throw new Error(`Could not ${operation}.`);
+}
+
+async function uploadSingleObject(options: MinioObjectUploadOptions): Promise<void> {
+  await requestWithRetry(
+    options,
+    {
+      body: options.blob,
+      contentType: options.blob.type,
+      method: 'PUT',
+      url: options.createUrl(),
+    },
+    `upload ${options.key}`,
+  );
+  options.onUploadedBytes?.(options.blob.size);
+}
+
+async function abortMultipartUpload(
+  options: MinioObjectUploadOptions,
+  uploadId: string,
+): Promise<void> {
+  try {
+    await options.request(options.createUrl({ uploadId }), 'DELETE');
+  } catch {
+    // Preserve the original multipart failure.
+  }
+}
+
+async function uploadMultipartObject(options: MinioObjectUploadOptions): Promise<void> {
+  const initiateResponse = await requestWithRetry(
+    options,
+    { method: 'POST', url: options.createUrl({ uploads: '' }) },
+    `initiate multipart upload for ${options.key}`,
+  );
+  const uploadId = parseUploadId(await initiateResponse.text());
+  if (!uploadId) {
+    throw new Error(`Could not initiate multipart upload for ${options.key}: missing upload ID.`);
+  }
+
+  try {
+    const completedParts: Array<{ etag: string; partNumber: number }> = [];
+    let uploadedBytes = 0;
+    for (
+      let offset = 0, partNumber = 1;
+      offset < options.blob.size;
+      offset += MINIO_UPLOAD_POLICY.multipartPartSize, partNumber += 1
+    ) {
+      const part = options.blob.slice(
+        offset,
+        Math.min(options.blob.size, offset + MINIO_UPLOAD_POLICY.multipartPartSize),
+        options.blob.type,
+      );
+      const partResponse = await requestWithRetry(
+        options,
+        {
+          body: part,
+          contentType: options.blob.type,
+          method: 'PUT',
+          url: options.createUrl({ partNumber: String(partNumber), uploadId }),
+        },
+        `upload ${options.key} part ${partNumber}`,
+      );
+      const etag = partResponse.headers.get('etag')?.trim();
+      if (!etag) {
+        throw new Error(`Could not upload ${options.key} part ${partNumber}: missing ETag.`);
+      }
+      completedParts.push({ etag, partNumber });
+      uploadedBytes += part.size;
+      options.onUploadedBytes?.(uploadedBytes);
+    }
+
+    const completeBody = createCompleteMultipartBody(completedParts);
+    await requestWithRetry(
+      options,
+      {
+        body: completeBody,
+        contentType: completeBody.type,
+        method: 'POST',
+        url: options.createUrl({ uploadId }),
+      },
+      `complete multipart upload for ${options.key}`,
+    );
+  } catch (error: unknown) {
+    await abortMultipartUpload(options, uploadId);
+    throw error;
+  }
+}
+
+async function upload(options: MinioObjectUploadOptions): Promise<void> {
+  if (options.blob.size <= MINIO_UPLOAD_POLICY.multipartPartSize) {
+    await uploadSingleObject(options);
+    return;
+  }
+  await uploadMultipartObject(options);
+}
+
+export const minioObjectUploader = {
+  upload,
+};

--- a/apps/editor/src/ui/editor/state/editorViewModelProgress.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelProgress.ts
@@ -1,4 +1,7 @@
-import type { ModelDownloadProgressDetails } from '../../../services/contracts/interfaces';
+import type {
+  MirrorSyncProgress,
+  ModelDownloadProgressDetails,
+} from '../../../services/contracts/interfaces';
 
 const IMAGE_GENERATION_DIMENSION_MULTIPLE = 16;
 
@@ -21,7 +24,25 @@ function normalizeImageGenerationDimension(value: number) {
   );
 }
 
+function getMirrorProgressFraction(progress: MirrorSyncProgress): number {
+  if (progress.total <= 0) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, progress.current / progress.total));
+}
+
+function selectMonotonicMirrorProgress(
+  current: MirrorSyncProgress | undefined,
+  next: MirrorSyncProgress,
+): MirrorSyncProgress {
+  return !current || getMirrorProgressFraction(next) >= getMirrorProgressFraction(current)
+    ? next
+    : current;
+}
+
 export const editorViewModelProgress = {
   getDownloadProgressPatch,
   normalizeImageGenerationDimension,
+  selectMonotonicMirrorProgress,
 };

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -2053,7 +2053,11 @@ export function useEditorViewModel(services: AppServices) {
         services.projectRepository,
         mirrorConfigRef.current!,
         {
-          onProgress: setMirrorSyncProgress,
+          onProgress: (progress) => {
+            setMirrorSyncProgress((current) =>
+              editorViewModelProgress.selectMonotonicMirrorProgress(current, progress),
+            );
+          },
         },
       );
       const previousMirroredProjectName = lastMirroredProjectNameRef.current;

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -99,6 +99,35 @@ function createProjectWithInlineMirrorAssets(assetCount: number): ProjectDocumen
   return project;
 }
 
+function createProjectWithLargeMirrorAsset(): ProjectDocument {
+  const project = sampleProject.createSampleProject();
+  const firstPage = project.pages[0];
+  if (!firstPage) throw new Error('Sample project must contain a page.');
+  project.assets['large-asset'] = {
+    id: 'large-asset',
+    type: 'image',
+    mimeType: 'image/png',
+    name: 'Large asset',
+    objectUrl: 'blob:https://localstudio.test/large-asset',
+    storage: 'inline',
+  };
+  project.elements['large-image'] = {
+    id: 'large-image',
+    type: 'image',
+    assetId: 'large-asset',
+    x: 40,
+    y: 60,
+    width: 120,
+    height: 80,
+    rotation: 0,
+    opacity: 1,
+    locked: false,
+    visible: true,
+  };
+  firstPage.elementIds.push('large-image');
+  return project;
+}
+
 describe('minioMirrorService.createMirrorFiles', () => {
   it('creates a complete portable project mirror payload', async () => {
     const project = sampleProject.createSampleProject();
@@ -403,7 +432,7 @@ describe('minioMirrorService.MinioMirrorService', () => {
         },
       },
     };
-    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = getRequestUrl(input);
       if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
         return Promise.resolve(new Response(JSON.stringify(remoteManifest), { status: 200 }));
@@ -470,6 +499,282 @@ describe('minioMirrorService.MinioMirrorService', () => {
     expect(maxActivePuts).toBeGreaterThan(1);
     expect(maxActivePuts).toBeLessThanOrEqual(3);
     expect(putOrder.at(-1)).toContain('localstudio-mirror.json');
+  });
+
+  it('uploads large public objects with the S3 multipart protocol', async () => {
+    const requests: Array<{
+      body: BodyInit | null | undefined;
+      method: string;
+      url: string;
+    }> = [];
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      const method = init?.method ?? 'GET';
+      requests.push({ body: init?.body, method, url });
+      const parsedUrl = new URL(url);
+      if (method === 'POST' && parsedUrl.searchParams.has('uploads')) {
+        return Promise.resolve(
+          new Response(
+            '<InitiateMultipartUploadResult><UploadId>upload-123</UploadId></InitiateMultipartUploadResult>',
+            { status: 200 },
+          ),
+        );
+      }
+      if (method === 'PUT' && parsedUrl.searchParams.has('partNumber')) {
+        const partNumber = parsedUrl.searchParams.get('partNumber');
+        return Promise.resolve(
+          new Response('', { headers: { ETag: `"etag-${partNumber}"` }, status: 200 }),
+        );
+      }
+      if (method === 'POST' && parsedUrl.searchParams.get('uploadId') === 'upload-123') {
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+    const largeBlob = new Blob([new Uint8Array(5 * 1024 * 1024 + 3)], {
+      type: 'video/mp4',
+    });
+
+    await service.uploadPublicObject('mirrors/media.mp4', largeBlob, config);
+
+    const initiateRequest = requests.find(({ method, url }) => {
+      const parsedUrl = new URL(url);
+      return method === 'POST' && parsedUrl.searchParams.has('uploads');
+    });
+    const partRequests = requests.filter(({ method, url }) => {
+      const parsedUrl = new URL(url);
+      return method === 'PUT' && parsedUrl.searchParams.has('partNumber');
+    });
+    const completeRequest = requests.find(({ method, url }) => {
+      const parsedUrl = new URL(url);
+      return method === 'POST' && parsedUrl.searchParams.get('uploadId') === 'upload-123';
+    });
+    expect(initiateRequest).toBeDefined();
+    expect(partRequests.map(({ body }) => (body as Blob).size)).toEqual([5 * 1024 * 1024, 3]);
+    const completeDocument = new DOMParser().parseFromString(
+      await (completeRequest?.body as Blob).text(),
+      'application/xml',
+    );
+    expect(
+      Array.from(completeDocument.querySelectorAll('Part')).map((part) => ({
+        etag: part.querySelector('ETag')?.textContent,
+        partNumber: part.querySelector('PartNumber')?.textContent,
+      })),
+    ).toEqual([
+      { etag: '"etag-1"', partNumber: '1' },
+      { etag: '"etag-2"', partNumber: '2' },
+    ]);
+    expect(requests.some(({ method, url }) => method === 'PUT' && !new URL(url).search)).toBe(false);
+  });
+
+  it('reports multipart sync progress in uploaded bytes after each completed part', async () => {
+    const project = createProjectWithLargeMirrorAsset();
+    const largeBytes = new Uint8Array(5 * 1024 * 1024 + 3);
+    const largeBlob = new Blob([largeBytes], {
+      type: 'image/png',
+    });
+    const progressUpdates: Array<{ current: number; label: string; total: number }> = [];
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (url === 'blob:https://localstudio.test/large-asset') {
+        return Promise.resolve(
+          new Response(largeBytes, { headers: { 'content-type': 'image/png' } }),
+        );
+      }
+      const parsedUrl = new URL(url);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'POST' && parsedUrl.searchParams.has('uploads')) {
+        return Promise.resolve(
+          new Response(
+            '<InitiateMultipartUploadResult><UploadId>progress-upload</UploadId></InitiateMultipartUploadResult>',
+          ),
+        );
+      }
+      if (init?.method === 'PUT' && parsedUrl.searchParams.has('partNumber')) {
+        return Promise.resolve(
+          new Response('', {
+            headers: { ETag: `"part-${parsedUrl.searchParams.get('partNumber')}"` },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await service.syncProject(project, new VersionedRepository([], project), config, {
+      onProgress: (progress) => progressUpdates.push(progress),
+    });
+
+    expect(progressUpdates[0]?.total).toBeGreaterThan(largeBlob.size);
+    expect(
+      progressUpdates.some(
+        ({ current, label, total }) =>
+          label === 'Mirroring assets/large-asset.png' &&
+          current >= 5 * 1024 * 1024 &&
+          current < total,
+      ),
+    ).toBe(true);
+    expect(progressUpdates.at(-1)?.current).toBe(progressUpdates.at(-1)?.total);
+  });
+
+  it('retries only the failed multipart part', async () => {
+    const retryDelays: number[] = [];
+    const partAttempts = new Map<string, number>();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(getRequestUrl(input));
+      if (init?.method === 'POST' && url.searchParams.has('uploads')) {
+        return Promise.resolve(
+          new Response(
+            '<InitiateMultipartUploadResult><UploadId>retry-upload</UploadId></InitiateMultipartUploadResult>',
+          ),
+        );
+      }
+      if (init?.method === 'PUT' && url.searchParams.has('partNumber')) {
+        const partNumber = url.searchParams.get('partNumber') ?? '';
+        const attempts = (partAttempts.get(partNumber) ?? 0) + 1;
+        partAttempts.set(partNumber, attempts);
+        return Promise.resolve(
+          new Response('', {
+            headers: attempts > 1 || partNumber === '1' ? { ETag: `"part-${partNumber}"` } : {},
+            status: partNumber === '2' && attempts === 1 ? 503 : 200,
+          }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({
+      fetch: fetchMock,
+      sleep: (delayMs) => {
+        retryDelays.push(delayMs);
+        return Promise.resolve();
+      },
+    });
+
+    await service.uploadPublicObject(
+      'mirrors/retry.mp4',
+      new Blob([new Uint8Array(5 * 1024 * 1024 + 1)], { type: 'video/mp4' }),
+      config,
+    );
+
+    expect(Object.fromEntries(partAttempts)).toEqual({ '1': 1, '2': 2 });
+    expect(retryDelays).toEqual([250]);
+  });
+
+  it('aborts an incomplete multipart upload without hiding the original failure', async () => {
+    const methods: string[] = [];
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(getRequestUrl(input));
+      methods.push(`${init?.method ?? 'GET'}:${url.search}`);
+      if (init?.method === 'POST' && url.searchParams.has('uploads')) {
+        return Promise.resolve(
+          new Response(
+            '<InitiateMultipartUploadResult><UploadId>abort-upload</UploadId></InitiateMultipartUploadResult>',
+          ),
+        );
+      }
+      if (init?.method === 'PUT') return Promise.resolve(new Response('', { status: 200 }));
+      return Promise.resolve(new Response('', { status: 204 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await expect(
+      service.uploadPublicObject(
+        'mirrors/missing-etag.mp4',
+        new Blob([new Uint8Array(5 * 1024 * 1024 + 1)], { type: 'video/mp4' }),
+        config,
+      ),
+    ).rejects.toThrow('Could not upload mirrors/missing-etag.mp4 part 1: missing ETag.');
+    expect(methods).toContain('DELETE:?uploadId=abort-upload');
+  });
+
+  it('retries transient network upload failures with exponential backoff', async () => {
+    const project = sampleProject.createSampleProject();
+    const retryDelays: number[] = [];
+    let projectUploadAttempts = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT' && url.endsWith('/project.json')) {
+        projectUploadAttempts += 1;
+        if (projectUploadAttempts < 3) {
+          return Promise.reject(new TypeError('Failed to fetch'));
+        }
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({
+      fetch: fetchMock,
+      sleep: (delayMs) => {
+        retryDelays.push(delayMs);
+        return Promise.resolve();
+      },
+    });
+
+    await service.syncProject(project, new VersionedRepository([], project), config);
+
+    expect(projectUploadAttempts).toBe(3);
+    expect(retryDelays).toEqual([250, 500]);
+  });
+
+  it('retries retryable upload responses before committing the manifest', async () => {
+    const project = sampleProject.createSampleProject();
+    const retryDelays: number[] = [];
+    let manifestUploadAttempts = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT' && url.endsWith('/localstudio-mirror.json')) {
+        manifestUploadAttempts += 1;
+        return Promise.resolve(
+          new Response('', { status: manifestUploadAttempts === 1 ? 503 : 200 }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({
+      fetch: fetchMock,
+      sleep: (delayMs) => {
+        retryDelays.push(delayMs);
+        return Promise.resolve();
+      },
+    });
+
+    await service.syncProject(project, new VersionedRepository([], project), config);
+
+    expect(manifestUploadAttempts).toBe(2);
+    expect(retryDelays).toEqual([250]);
+  });
+
+  it('reports the object key after network upload retries are exhausted', async () => {
+    const project = sampleProject.createSampleProject();
+    let projectUploadAttempts = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      if (init?.method === 'GET' && url.endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response('', { status: 404 }));
+      }
+      if (init?.method === 'PUT' && url.endsWith('/project.json')) {
+        projectUploadAttempts += 1;
+        return Promise.reject(new TypeError('Failed to fetch'));
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({
+      fetch: fetchMock,
+      sleep: () => Promise.resolve(),
+    });
+
+    await expect(
+      service.syncProject(project, new VersionedRepository([], project), config),
+    ).rejects.toThrow(/Could not upload mirrors\/.+\/project\.json after 3 attempts: Failed to fetch/);
+    expect(projectUploadAttempts).toBe(3);
   });
 
   it('uses writer credentials when sync checks and uploads mirror files', async () => {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
@@ -206,6 +206,52 @@ describe('EditorShell mirror workflows', () => {
     expect(mirrorService.syncProject).toHaveBeenCalledTimes(1);
   });
 
+  it('does not move displayed mirror progress backwards during one sync', async () => {
+    const services = createAppServices();
+    const mirrorService = new RecordingMirrorService();
+    const repository = new DeferredLoadingProjectRepository();
+    let reportProgress: ((current: number) => void) | undefined;
+    let resolveSync: (() => void) | undefined;
+    services.projectRepository = repository;
+    services.mirrorService = mirrorService;
+    mirrorService.syncProject.mockImplementation(
+      (project, projectRepository, config, options) => {
+        void project;
+        void projectRepository;
+        void config;
+        reportProgress = (current) => {
+          options?.onProgress?.({ current, label: `Mirrored file ${current}`, total: 5 });
+        };
+        reportProgress(3);
+        return new Promise((resolve) => {
+          resolveSync = () => resolve({ enabled: true, status: 'synced' });
+        });
+      },
+    );
+
+    render(<EditorShell services={services} />);
+
+    act(() => {
+      repository.resolveLoadedProject({
+        ...services.initialProject,
+        name: 'Mirrored Folder',
+      });
+    });
+
+    expect(await screen.findByRole('status', { name: 'Mirror syncing 60%' })).toBeInTheDocument();
+
+    act(() => {
+      reportProgress?.(2);
+    });
+
+    expect(screen.getByRole('status', { name: 'Mirror syncing 60%' })).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Mirror syncing 40%' })).not.toBeInTheDocument();
+
+    act(() => {
+      resolveSync?.();
+    });
+  });
+
   it('keeps saved mirror config disabled after refreshing the page', async () => {
     const firstServices = createAppServices();
     const firstRepository = new DeferredLoadingProjectRepository();

--- a/tests/e2e/editor/minio-mirror-service-contract-browser.ts
+++ b/tests/e2e/editor/minio-mirror-service-contract-browser.ts
@@ -12,6 +12,8 @@ export type MinioMirrorServiceContractResult = {
   }>;
   listError: string;
   listOrder: string[];
+  multipartCompletedParts: number;
+  multipartPartSizes: number[];
   uploadError: string;
 };
 
@@ -211,6 +213,47 @@ export async function evaluateMinioMirrorServiceContract(): Promise<MinioMirrorS
       fetch: () => Promise.resolve(new Response('', { status: 500 })),
     }).uploadPublicObject('mirrors/share.json', new Blob(['{}']), config),
   );
+  const multipartRequests: Array<{ body: BodyInit | null | undefined; method: string; url: string }> =
+    [];
+  const multipartService = new minioMirrorService.MinioMirrorService({
+    fetch: (input, init) => {
+      const url = stringifyFetchInput(input);
+      const method = init?.method ?? 'GET';
+      multipartRequests.push({ body: init?.body, method, url });
+      const parsedUrl = new URL(url);
+      if (method === 'POST' && parsedUrl.searchParams.has('uploads')) {
+        return Promise.resolve(
+          new Response(
+            '<InitiateMultipartUploadResult><UploadId>browser-upload</UploadId></InitiateMultipartUploadResult>',
+          ),
+        );
+      }
+      if (method === 'PUT' && parsedUrl.searchParams.has('partNumber')) {
+        return Promise.resolve(
+          new Response('', {
+            headers: { ETag: `"browser-part-${parsedUrl.searchParams.get('partNumber')}"` },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    },
+  });
+  await multipartService.uploadPublicObject(
+    'mirrors/browser-large.mp4',
+    new Blob([new Uint8Array(5 * 1024 * 1024 + 7)], { type: 'video/mp4' }),
+    config,
+  );
+  const multipartPartSizes = multipartRequests
+    .filter(({ method, url }) => method === 'PUT' && new URL(url).searchParams.has('partNumber'))
+    .map(({ body }) => (body as Blob).size);
+  const completeRequest = multipartRequests.find(
+    ({ method, url }) =>
+      method === 'POST' && new URL(url).searchParams.get('uploadId') === 'browser-upload',
+  );
+  const completeDocument = new DOMParser().parseFromString(
+    await (completeRequest?.body as Blob).text(),
+    'application/xml',
+  );
 
   return {
     deleteError,
@@ -220,6 +263,8 @@ export async function evaluateMinioMirrorServiceContract(): Promise<MinioMirrorS
     downloadProgress,
     listError,
     listOrder,
+    multipartCompletedParts: completeDocument.querySelectorAll('Part').length,
+    multipartPartSizes,
     uploadError,
   };
 }

--- a/tests/e2e/editor/service-contracts-minio-mirror.spec.ts
+++ b/tests/e2e/editor/service-contracts-minio-mirror.spec.ts
@@ -15,6 +15,8 @@ test('executes MinIO mirror service contracts in the browser runtime', async ({ 
     downloadFileError: 'Could not download mirrored file project.json (500).',
     listError: 'Could not list MinIO mirrors (500).',
     listOrder: ['Zulu Project', 'Beta Project', 'Alpha Project'],
+    multipartCompletedParts: 2,
+    multipartPartSizes: [5 * 1024 * 1024, 7],
     uploadError: 'Could not upload mirrors/share.json to MinIO (500).',
   });
   expect(result.downloadProgress).toEqual(


### PR DESCRIPTION
## Summary

- Add retry handling with exponential backoff for transient MinIO upload failures.
- Support multipart uploads for objects larger than 5 MiB, including completion and abort cleanup.
- Report mirror progress by uploaded bytes and prevent displayed progress from moving backwards.
- Add coverage for multipart uploads, retries, failures, progress reporting, and UI behavior.

## Testing

- Not run (not requested)