### PR TITLE
Add configurable text border styling

### DIFF
--- a/apps/editor/src/domain/commands/elements/element-edit-commands.ts
+++ b/apps/editor/src/domain/commands/elements/element-edit-commands.ts
@@ -152,12 +152,19 @@ class UpdateElementStyleCommand implements EditorCommand {
           ? { fontSize: Math.max(1, this.patch.fontSize) }
           : {}),
         ...(this.patch.fontWeight !== undefined ? { fontWeight: this.patch.fontWeight } : {}),
+        ...(typeof this.patch.stroke === 'string' ? { stroke: this.patch.stroke } : {}),
+        ...(this.patch.strokeWidth !== undefined
+          ? { strokeWidth: Math.max(0, this.patch.strokeWidth) }
+          : {}),
       };
       if (typeof this.patch.hyperlink === 'string') {
         nextTextElement.hyperlink = this.patch.hyperlink;
       }
       if (this.patch.hyperlink === null) {
         delete nextTextElement.hyperlink;
+      }
+      if (this.patch.stroke === null) {
+        delete nextTextElement.stroke;
       }
       nextElement = nextTextElement;
     }

--- a/apps/editor/src/domain/documents/model.ts
+++ b/apps/editor/src/domain/documents/model.ts
@@ -252,6 +252,8 @@ export interface TextElement extends BaseElement {
   fontSize: number;
   fontWeight: number;
   fill: string;
+  stroke?: string;
+  strokeWidth?: number;
   align: 'left' | 'center' | 'right';
   hyperlink?: string;
   lineHeight?: number;

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -1271,6 +1271,9 @@ export function CanvasWorkspace({
                     fontSize={element.fontSize * scaleY}
                     fontStyle={element.fontWeight >= 700 ? 'bold' : 'normal'}
                     fill={element.fill}
+                    {...(element.stroke && (element.strokeWidth ?? 0) > 0
+                      ? { stroke: element.stroke, strokeWidth: element.strokeWidth }
+                      : {})}
                     align={element.align}
                     lineHeight={element.lineHeight ?? 1.05}
                     padding={TEXT_FRAME_PADDING * scaleY}

--- a/apps/editor/src/ui/editor/panels/PageMiniPreview.tsx
+++ b/apps/editor/src/ui/editor/panels/PageMiniPreview.tsx
@@ -80,6 +80,10 @@ function MiniElement({
           fontFamily: element.fontFamily,
           fontSize: `${Math.max(4, (element.fontSize / page.width) * 100)}cqw`,
           fontWeight: element.fontWeight,
+          WebkitTextStroke:
+            element.stroke && (element.strokeWidth ?? 0) > 0
+              ? `${element.strokeWidth}px ${element.stroke}`
+              : undefined,
           lineHeight: 0.9,
           overflow: 'visible',
           textAlign: element.align,

--- a/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
+++ b/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
@@ -12,6 +12,8 @@ import type { ElementStylePatch } from '../../../../domain/commands/elements/bas
 import type { TextElement } from '../../../../domain/documents/model';
 import type { FontCatalogItem } from '../../../../services/contracts/interfaces';
 import { textStyleOptions } from '../../text/textStyleOptions';
+import { DesignColorField } from '../design-controls/DesignColorField';
+import { DesignSelectField } from '../design-controls/DesignSelectField';
 
 export interface TextStyleControls {
   downloadingFontFamily?: string | undefined;
@@ -33,6 +35,10 @@ export interface TextStyleControls {
 
 const regularTextWeight = 400;
 const boldTextWeight = 800;
+const textBorderOptions = [
+  { value: 'none', label: 'No border' },
+  { value: 'color', label: 'Color border' },
+] as const;
 
 function fontMatchesQuery(fontFamily: string, query: string) {
   const normalizedQuery = query.trim().toLowerCase();
@@ -258,6 +264,46 @@ export function TextStyleInspector({
             }}
           />
         </label>
+        <DesignSelectField
+          ariaLabel="Selected text border mode"
+          label="Border"
+          options={textBorderOptions}
+          value={element.stroke && (element.strokeWidth ?? 0) > 0 ? 'color' : 'none'}
+          onChange={(value) => {
+            onUpdateStyle(
+              value === 'color'
+                ? {
+                    stroke: element.stroke ?? '#000000',
+                    strokeWidth: element.strokeWidth && element.strokeWidth > 0 ? element.strokeWidth : 2,
+                  }
+                : { stroke: null, strokeWidth: 0 },
+            );
+          }}
+        />
+        {element.stroke && (element.strokeWidth ?? 0) > 0 ? (
+          <>
+            <DesignColorField
+              ariaLabel="Selected text border color"
+              label="Border color"
+              value={element.stroke}
+              onChange={(stroke) => {
+                onUpdateStyle({ stroke });
+              }}
+            />
+            <label className="design-control ew-field-scope">
+              <span>Border width</span>
+              <input
+                aria-label="Selected text border width"
+                min="1"
+                type="number"
+                value={element.strokeWidth ?? 2}
+                onChange={(event) => {
+                  onUpdateStyle({ strokeWidth: Number(event.target.value) });
+                }}
+              />
+            </label>
+          </>
+        ) : null}
         <div className="text-align-grid" aria-label="Selected text alignment">
           {([
             { align: 'left' as const, icon: AlignLeft, label: 'Align selected text left' },

--- a/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
+++ b/apps/editor/tests/unit/domain/commands/basicCommands.test.ts
@@ -401,6 +401,8 @@ describe('editor commands', () => {
       fontSize: 72,
       fontWeight: 900,
       opacity: 0.7,
+      stroke: '#000000',
+      strokeWidth: 6,
     }).execute(project);
 
     expect(next).not.toBe(project);
@@ -410,6 +412,8 @@ describe('editor commands', () => {
       fontSize: 72,
       fontWeight: 900,
       opacity: 0.7,
+      stroke: '#000000',
+      strokeWidth: 6,
     });
     expect(project.elements['text-title']).toMatchObject({
       align: 'center',

--- a/tests/e2e/editor/contextual-design-inspector.spec.ts
+++ b/tests/e2e/editor/contextual-design-inspector.spec.ts
@@ -19,6 +19,9 @@ test.describe('editor contextual design inspector journey', () => {
     await page.getByLabel('Selected text font size').fill('42');
     await page.getByRole('button', { name: 'Bold selected text' }).click();
     await page.getByRole('button', { name: 'Align selected text center' }).click();
+    await page.getByLabel('Selected text border mode').selectOption('color');
+    await page.getByLabel('Selected text border color').fill('#000000');
+    await page.getByLabel('Selected text border width').fill('6');
     await page
       .getByRole('tablist', { name: 'Movie inspector sections' })
       .getByRole('tab', { name: 'Text' })


### PR DESCRIPTION
## Summary

- Add optional stroke color and width properties to text elements.
- Expose border mode, color, and width controls in the text style inspector.
- Render text borders on the canvas and mini preview.
- Extend command and end-to-end coverage for border updates.

## Testing

- Updated unit coverage for text style commands.
- Updated Playwright coverage for the contextual text inspector journey.