### PR TITLE
Prevent stale mirror uploads during local project import

### DIFF
--- a/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
+++ b/apps/editor/src/services/storage/browserFileSystemProjectRepository.ts
@@ -1,4 +1,4 @@
-import type { ProjectDocument } from '../../domain/documents/model';
+import type { ImportWarning, ProjectDocument } from '../../domain/documents/model';
 import type {
   MirrorFile,
   ProjectRepository,
@@ -19,6 +19,14 @@ interface FileSystemProjectRepositoryOptions {
 
 interface HydrateProjectAssetsOptions {
   allowMissingAssetFiles?: boolean;
+}
+
+function createMissingFileWarning(kind: string, fileName: string): ImportWarning {
+  return {
+    code: 'missing-local-file',
+    message: `The imported project references a missing ${kind} file: ${fileName}. That content will remain unavailable until the file is restored.`,
+    severity: 'warning',
+  };
 }
 
 export interface RecentProjectHandleStore {
@@ -73,7 +81,8 @@ async function createFileBackedProjectSnapshot(
     }
 
     if (!assetFileUtils.isReadableObjectUrl(asset.objectUrl)) continue;
-    const fileName = asset.fileName ?? `${assetId}.${assetFileUtils.getAssetFileExtension(asset.mimeType)}`;
+    const fileName =
+      asset.fileName ?? `${assetId}.${assetFileUtils.getAssetFileExtension(asset.mimeType)}`;
     await writeBlobFileToDirectory(
       assetsDirectory,
       fileName,
@@ -124,8 +133,7 @@ async function createFileBackedProjectSnapshot(
 
     if (!assetFileUtils.isReadableObjectUrl(audio.objectUrl)) continue;
     const fileName =
-      audio.fileName ??
-      `${recordingId}.${assetFileUtils.getAssetFileExtension(audio.mimeType)}`;
+      audio.fileName ?? `${recordingId}.${assetFileUtils.getAssetFileExtension(audio.mimeType)}`;
     await writeBlobFileToDirectory(
       recordingsDirectory,
       fileName,
@@ -206,7 +214,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     const pickDirectory = this.options.pickDirectory ?? getBrowserDirectoryPicker();
     this.directoryHandle = await pickDirectory();
     await this.recentProjectStore.save(this.directoryHandle);
-    const project = await this.loadProject();
+    const project = await this.loadProject({ allowMissingAssetFiles: true });
     if (project) await this.recentProjectStore.save(this.directoryHandle, project.name);
     return project;
   }
@@ -220,7 +228,8 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
   async importMirrorFiles(files: MirrorFile[]): Promise<ProjectDocument>;
   async importMirrorFiles(files: MirrorFile | MirrorFile[]): Promise<ProjectDocument> {
     const pickDirectory = this.options.pickDirectory ?? getBrowserDirectoryPicker();
-    const selectedDirectoryHandle = this.pendingMirrorImportDirectoryHandle ?? (await pickDirectory());
+    const selectedDirectoryHandle =
+      this.pendingMirrorImportDirectoryHandle ?? (await pickDirectory());
     this.pendingMirrorImportDirectoryHandle = null;
     const mirrorFiles = Array.isArray(files) ? files : [files];
     const projectDirectoryName = await readProjectNameFromMirrorFiles(mirrorFiles);
@@ -240,14 +249,19 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     return project;
   }
 
-  async loadProject(options?: { projectName?: string }): Promise<ProjectDocument | null> {
+  async loadProject(options?: {
+    projectName?: string;
+    allowMissingAssetFiles?: boolean;
+  }): Promise<ProjectDocument | null> {
     if (!this.directoryHandle) {
       this.directoryHandle = await this.recentProjectStore.load(options?.projectName);
     }
     if (!this.directoryHandle) return null;
     await this.ensureReadWritePermission(this.directoryHandle);
 
-    return this.readProjectFromDirectory(this.directoryHandle);
+    return this.readProjectFromDirectory(this.directoryHandle, {
+      ...(options?.allowMissingAssetFiles ? { allowMissingAssetFiles: true } : {}),
+    });
   }
 
   private async readProjectFromDirectory(
@@ -361,7 +375,10 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     const createdAt = new Date().toISOString();
     const id = projectVersionHistoryUtils.createVersionId(new Date(createdAt));
     const fileName = `${id}.json`;
-    const changeSummary = projectVersionHistoryUtils.createChangeSummary(project, metadata.previousProject);
+    const changeSummary = projectVersionHistoryUtils.createChangeSummary(
+      project,
+      metadata.previousProject,
+    );
     const entry: VersionHistoryEntry = {
       id,
       createdAt,
@@ -440,7 +457,8 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
         hasParentDirectoryPermission = true;
       }
       this.parentDirectoryHandle = requestedProjectDirectoryName ? selectedDirectoryHandle : null;
-      this.projectDirectoryName = requestedProjectDirectoryName ?? selectedDirectoryHandle.name ?? null;
+      this.projectDirectoryName =
+        requestedProjectDirectoryName ?? selectedDirectoryHandle.name ?? null;
       this.directoryHandle = requestedProjectDirectoryName
         ? await selectedDirectoryHandle.getDirectoryHandle(requestedProjectDirectoryName, {
             create: true,
@@ -512,9 +530,11 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     retainedAssetFileNames: Set<string>,
   ) {
     if (!directoryHandle.removeEntry) return;
-    const entries = (directoryHandle as unknown as {
-      entries?: () => AsyncIterable<[string, { kind?: string }]>;
-    }).entries;
+    const entries = (
+      directoryHandle as unknown as {
+        entries?: () => AsyncIterable<[string, { kind?: string }]>;
+      }
+    ).entries;
     if (!entries) return;
 
     const removals: Array<Promise<void>> = [];
@@ -632,6 +652,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
     const assets: ProjectDocument['assets'] = {};
     const fonts: ProjectDocument['fonts'] = {};
     const recordings: ProjectDocument['recordings'] = {};
+    const missingFileWarnings: ImportWarning[] = [];
     let assetsDirectory: FileSystemDirectoryHandle | undefined;
     let fontsDirectory: FileSystemDirectoryHandle | undefined;
     let recordingsDirectory: FileSystemDirectoryHandle | undefined;
@@ -665,6 +686,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
         };
       } catch (error) {
         if (!isNotFoundError(error) || !options.allowMissingAssetFiles) throw error;
+        missingFileWarnings.push(createMissingFileWarning('asset', asset.fileName));
         assets[assetId] = asset;
       }
     }
@@ -684,6 +706,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
         };
       } catch (error) {
         if (!isNotFoundError(error) || !options.allowMissingAssetFiles) throw error;
+        missingFileWarnings.push(createMissingFileWarning('font', font.fileName));
         fonts[fontId] = font;
       }
     }
@@ -707,6 +730,7 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
         };
       } catch (error) {
         if (!isNotFoundError(error) || !options.allowMissingAssetFiles) throw error;
+        missingFileWarnings.push(createMissingFileWarning('recording', audio.fileName));
         recordings[recordingId] = recording;
       }
     }
@@ -716,6 +740,9 @@ export class BrowserFileSystemProjectRepository implements ProjectRepository {
       assets,
       ...(project.fonts ? { fonts } : {}),
       ...(project.recordings ? { recordings } : {}),
+      ...(missingFileWarnings.length > 0
+        ? { importWarnings: [...(project.importWarnings ?? []), ...missingFileWarnings] }
+        : {}),
     };
   }
 }
@@ -726,7 +753,11 @@ class BrowserRecentProjectHandleStore implements RecentProjectHandleStore {
   private readonly handleKey = 'last-project-directory';
   private readonly localStorageKey = 'localstudio.ai.last-project.available';
 
-  constructor(private readonly storage: BrowserKeyValueStorage | undefined = browserStorage.getBrowserLocalStorage()) {}
+  constructor(
+    private readonly storage:
+      | BrowserKeyValueStorage
+      | undefined = browserStorage.getBrowserLocalStorage(),
+  ) {}
 
   async load(projectName?: string): Promise<FileSystemDirectoryHandle | null> {
     if (typeof window === 'undefined') return null;

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -572,6 +572,13 @@ export function useEditorViewModel(services: AppServices) {
           editorViewModelProject.writeProjectNameToUrl(normalizedProject.name);
           setHasPersistedLocalProject(true);
           setPersistenceError(false);
+          if (storedMirrorConfig && shouldEnableStoredMirror) {
+            setMirrorState({
+              enabled: true,
+              status: 'synced',
+              lastSyncedAt: normalizedProject.updatedAt,
+            });
+          }
           // Restoring a local project must not upload it automatically. The local
           // folder is authoritative, and another tab may still be finishing a
           // write when this tab opens. Upload only after a local save or an

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -399,16 +399,12 @@ export function useEditorViewModel(services: AppServices) {
   const lastMirroredProjectNameRef = useRef<string | undefined>(undefined);
   const mirrorDebounceRef = useRef<number | undefined>(undefined);
   const queueMirrorSyncRef = useRef<() => void>(() => undefined);
-  const syncMirrorNowRef = useRef<(project?: ProjectDocument) => void>(() => undefined);
   projectRef.current = project;
   activePageIdRef.current = activePageId;
   selectedElementIdsRef.current = selectedElementIds;
   hasPersistedLocalProjectRef.current = hasPersistedLocalProject;
   mirrorConfigRef.current = hasMirrorConfig ? mirrorConfig : null;
   queueMirrorSyncRef.current = queueMirrorSync;
-  syncMirrorNowRef.current = (projectToSync) => {
-    void syncMirrorNow(projectToSync);
-  };
   const wasFullscreenRef = useRef(false);
   const presenterPageIdRef = useRef<string | undefined>(undefined);
   const languageDetectionSequenceRef = useRef(0);
@@ -576,9 +572,10 @@ export function useEditorViewModel(services: AppServices) {
           editorViewModelProject.writeProjectNameToUrl(normalizedProject.name);
           setHasPersistedLocalProject(true);
           setPersistenceError(false);
-          if (storedMirrorConfig && shouldEnableStoredMirror) {
-            syncMirrorNowRef.current(normalizedProject);
-          }
+          // Restoring a local project must not upload it automatically. The local
+          // folder is authoritative, and another tab may still be finishing a
+          // write when this tab opens. Upload only after a local save or an
+          // explicit mirror action so a stale restore cannot overwrite MinIO.
         } else if (initialRestorePendingRef.current) {
           setHasPersistedLocalProject(false);
           setPersistenceEnabled(false);
@@ -1600,8 +1597,16 @@ export function useEditorViewModel(services: AppServices) {
   async function importProject() {
     if (!services.projectRepository.importProject) return;
     try {
+      showOperationNotice(undefined);
       const importedProject = await services.projectRepository.importProject();
-      if (!importedProject) return;
+      if (!importedProject) {
+        showOperationNotice({
+          message: 'The selected folder does not contain a LocalStudio project.',
+          detail: 'Choose the project folder containing project.json.',
+          tone: 'warning',
+        });
+        return;
+      }
       const normalizedProject = editorViewModelProject.normalizeProjectDocument(importedProject);
       await editorViewModelRuntime.loadProjectFonts(normalizedProject, services.fontImportService);
       setProject(normalizedProject);
@@ -1631,12 +1636,29 @@ export function useEditorViewModel(services: AppServices) {
       services.analyticsService.capture(postHogEvents.projectImportedLocal, {
         pageCount: normalizedProject.pages.length,
       });
-    } catch {
+      const missingFileWarningCount =
+        normalizedProject.importWarnings?.filter((warning) => warning.code === 'missing-local-file')
+          .length ?? 0;
+      if (missingFileWarningCount > 0) {
+        showOperationNotice({
+          message: `Project imported with ${missingFileWarningCount} missing local file${missingFileWarningCount === 1 ? '' : 's'}.`,
+          detail:
+            'The project opened from disk as the source of truth. Restore the missing files to recover those assets.',
+          tone: 'warning',
+        });
+      }
+    } catch (error: unknown) {
       setPersistenceEnabled(false);
       setPersistenceError(true);
       if (typeof window !== 'undefined') {
         editorPreferences.writePersistencePreference(false);
       }
+      showOperationNotice({
+        message: 'Local project import failed.',
+        detail:
+          error instanceof Error ? error.message : 'Could not read the selected project folder.',
+        tone: 'error',
+      });
     }
   }
 
@@ -2564,9 +2586,7 @@ export function useEditorViewModel(services: AppServices) {
         ? sourceProject.pages.filter((page) => page.id === (options?.pageId ?? activePageId))
         : sourceProject.pages;
 
-    return pages
-      .filter((page) => Boolean(page.speakerNotes?.trim()))
-      .map((page) => page.id);
+    return pages.filter((page) => Boolean(page.speakerNotes?.trim())).map((page) => page.id);
   }
 
   async function translateTextScope(
@@ -2606,10 +2626,7 @@ export function useEditorViewModel(services: AppServices) {
         pendingElementCountByPageId.set(pageId, (pendingElementCountByPageId.get(pageId) ?? 0) + 1);
       }
       for (const pageId of speakerNotePageIds) {
-        pendingElementCountByPageId.set(
-          pageId,
-          (pendingElementCountByPageId.get(pageId) ?? 0) + 1,
-        );
+        pendingElementCountByPageId.set(pageId, (pendingElementCountByPageId.get(pageId) ?? 0) + 1);
       }
       totalPageCount = pendingElementCountByPageId.size;
       setDeckTranslationProgress({
@@ -2719,14 +2736,12 @@ export function useEditorViewModel(services: AppServices) {
       ),
     );
     return Array.from(
-      new Set(
-        [
-          ...elementIds
-            .map((elementId) => pageIdsByElementId.get(elementId))
-            .filter((pageId): pageId is string => Boolean(pageId)),
-          ...speakerNotePageIds,
-        ],
-      ),
+      new Set([
+        ...elementIds
+          .map((elementId) => pageIdsByElementId.get(elementId))
+          .filter((pageId): pageId is string => Boolean(pageId)),
+        ...speakerNotePageIds,
+      ]),
     );
   }
 
@@ -3043,7 +3058,10 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   function pasteClipboardElements(clipboard: unknown) {
-    if (!editorViewModelElements.isElementClipboardState(clipboard) || clipboard.elements.length === 0) {
+    if (
+      !editorViewModelElements.isElementClipboardState(clipboard) ||
+      clipboard.elements.length === 0
+    ) {
       return false;
     }
     const pastedElements = editorViewModelElements.createPastedElements({
@@ -3342,11 +3360,18 @@ export function useEditorViewModel(services: AppServices) {
       }
       return nextElement;
     });
-    const page = { ...clipboard.page, id: pageId, elementIds: elements.map((element) => element.id) };
+    const page = {
+      ...clipboard.page,
+      id: pageId,
+      elementIds: elements.map((element) => element.id),
+    };
     commitProject(
       (currentProject) => ({
         ...editorViewModelPages.insertPageAfter(currentProject, activePageId, page),
-        elements: { ...currentProject.elements, ...Object.fromEntries(elements.map((element) => [element.id, element])) },
+        elements: {
+          ...currentProject.elements,
+          ...Object.fromEntries(elements.map((element) => [element.id, element])),
+        },
         assets: { ...currentProject.assets, ...assets },
       }),
       { activePageId: pageId, selectedElementIds: [] },

--- a/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
+++ b/apps/editor/tests/unit/services/browserFileSystemProjectRepository.assets.test.ts
@@ -40,7 +40,8 @@ class MockDirectoryHandle {
   readonly files = new Map<string, string | Blob>();
   readonly directories = new Map<string, MockDirectoryHandle>();
   getFileHandle(name: string, options?: { create?: boolean }): Promise<MockFileHandle> {
-    if (!options?.create && !this.files.has(name)) throw new DOMException('Not found', 'NotFoundError');
+    if (!options?.create && !this.files.has(name))
+      throw new DOMException('Not found', 'NotFoundError');
     return Promise.resolve(new MockFileHandle(name, this.files));
   }
   getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<MockDirectoryHandle> {
@@ -104,7 +105,9 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     expect(savedAssetFile).toBeInstanceOf(Blob);
     expect((savedAssetFile as Blob).type).toBe('image/png');
     expect(await (savedAssetFile as Blob).text()).toBe('hello');
-    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    const savedProject = JSON.parse(
+      directory.files.get('project.json') as string,
+    ) as ProjectDocument;
     const savedAsset = savedProject.assets['asset-hero'];
     if (!savedAsset) throw new Error('Expected asset-hero to be saved in project.json');
     expect(savedAsset).toMatchObject({
@@ -149,9 +152,7 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
   it('downloads remote image assets on import and saves them as local files', async () => {
     const directory = new MockDirectoryHandle();
     const fetchRemoteAsset = vi.fn(() =>
-      Promise.resolve(
-        new Response('remote image', { headers: { 'content-type': 'image/png' } }),
-      ),
+      Promise.resolve(new Response('remote image', { headers: { 'content-type': 'image/png' } })),
     );
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('remote image', { headers: { 'content-type': 'image/png' } }),
@@ -190,8 +191,12 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     });
     expect(loaded.assets['asset-remote']?.storage).toBeUndefined();
     const assetsDirectory = directory.directories.get('assets')!;
-    expect(await (assetsDirectory.files.get('asset-remote.png') as Blob).text()).toBe('remote image');
-    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    expect(await (assetsDirectory.files.get('asset-remote.png') as Blob).text()).toBe(
+      'remote image',
+    );
+    const savedProject = JSON.parse(
+      directory.files.get('project.json') as string,
+    ) as ProjectDocument;
     expect(savedProject.assets['asset-remote']).toMatchObject({
       fileName: 'asset-remote.png',
       storage: 'file',
@@ -231,7 +236,9 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     await repository.saveProject(loaded);
 
     expect(assetsDirectory.files.get('asset-hero.png')).toBe(assetFile);
-    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    const savedProject = JSON.parse(
+      directory.files.get('project.json') as string,
+    ) as ProjectDocument;
     const savedAsset = savedProject.assets['asset-hero'];
     if (!savedAsset) throw new Error('Expected asset-hero to be saved in project.json');
     expect(savedAsset).toMatchObject({
@@ -282,7 +289,9 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     const recordingsDirectory = directory.directories.get('recordings')!;
     expect(recordingsDirectory.files.has('recording1.webm')).toBe(true);
     expect(await (recordingsDirectory.files.get('recording1.webm') as Blob).text()).toBe('audio');
-    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    const savedProject = JSON.parse(
+      directory.files.get('project.json') as string,
+    ) as ProjectDocument;
     expect(savedProject.recordings?.recording1?.audio).toMatchObject({
       fileName: 'recording1.webm',
       storage: 'file',
@@ -295,7 +304,7 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     expect(createObjectUrl).toHaveBeenCalled();
   });
 
-  it('rejects when project.json references a missing file-backed asset', async () => {
+  it('imports a project with missing file-backed assets and records warnings', async () => {
     const directory = new MockDirectoryHandle();
     directory.files.set(
       'project.json',
@@ -318,7 +327,20 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
       recentProjectStore: new MemoryRecentProjectHandleStore(),
     });
 
-    await expect(repository.importProject()).rejects.toMatchObject({ name: 'NotFoundError' });
+    const importedProject = await repository.importProject();
+
+    expect(importedProject?.assets['asset-hero']).toMatchObject({
+      fileName: 'missing.png',
+      storage: 'file',
+    });
+    expect(importedProject?.importWarnings).toEqual([
+      {
+        code: 'missing-local-file',
+        message:
+          'The imported project references a missing asset file: missing.png. That content will remain unavailable until the file is restored.',
+        severity: 'warning',
+      },
+    ]);
   });
 
   it('moves blob URL image assets into assets/ and saves metadata in project.json', async () => {
@@ -361,7 +383,9 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     const savedAssetFile = assetsDirectory.files.get('asset-generated.png');
     expect(savedAssetFile).toBeInstanceOf(Blob);
     expect(await (savedAssetFile as Blob).text()).toBe('generated');
-    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    const savedProject = JSON.parse(
+      directory.files.get('project.json') as string,
+    ) as ProjectDocument;
     const savedAsset = savedProject.assets['asset-generated'];
     if (!savedAsset) throw new Error('Expected asset-generated to be saved in project.json');
     expect(savedAsset).toMatchObject({
@@ -433,7 +457,9 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
     const assetsDirectory = directory.directories.get('assets')!;
     expect(assetsDirectory.files.has('asset-gif.gif')).toBe(true);
     expect(assetsDirectory.files.has('asset-video.mp4')).toBe(true);
-    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    const savedProject = JSON.parse(
+      directory.files.get('project.json') as string,
+    ) as ProjectDocument;
     expect(savedProject.assets['asset-gif']).toMatchObject({
       type: 'gif',
       fileName: 'asset-gif.gif',
@@ -469,7 +495,9 @@ describe('BrowserFileSystemProjectRepository asset files', () => {
 
     await repository.saveProject(project);
 
-    const savedProject = JSON.parse(directory.files.get('project.json') as string) as ProjectDocument;
+    const savedProject = JSON.parse(
+      directory.files.get('project.json') as string,
+    ) as ProjectDocument;
     expect(savedProject.assets['asset-stale']).toMatchObject({
       id: 'asset-stale',
       fileName: 'asset-stale.png',

--- a/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
@@ -144,7 +144,7 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
-    const mirrorButton = await screen.findByRole('button', { name: 'Mirror ready' });
+    const mirrorButton = await screen.findByRole('button', { name: 'Mirror up to date' });
     fireEvent.click(mirrorButton);
 
     expect(mirrorService.clearConfig).not.toHaveBeenCalled();
@@ -263,7 +263,7 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
-    expect(await screen.findByRole('button', { name: 'Mirror ready' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Mirror settings' }));
     fireEvent.click(
       within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.mirror.test.tsx
@@ -144,7 +144,7 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
-    const mirrorButton = await screen.findByRole('button', { name: 'Mirror up to date' });
+    const mirrorButton = await screen.findByRole('button', { name: 'Mirror ready' });
     fireEvent.click(mirrorButton);
 
     expect(mirrorService.clearConfig).not.toHaveBeenCalled();
@@ -155,7 +155,7 @@ describe('EditorShell mirror workflows', () => {
     fireEvent.click(disabledMirrorButton);
 
     await waitFor(() => {
-      expect(mirrorService.syncProject).toHaveBeenCalledTimes(2);
+      expect(mirrorService.syncProject).toHaveBeenCalledTimes(1);
     });
     expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toBeInTheDocument();
   });
@@ -168,17 +168,15 @@ describe('EditorShell mirror workflows', () => {
     let resolveSync: (() => void) | undefined;
     services.projectRepository = repository;
     services.mirrorService = mirrorService;
-    mirrorService.syncProject.mockImplementation(
-      (project, projectRepository, config, options) => {
-        void project;
-        void projectRepository;
-        void config;
-        void options;
-        return new Promise((resolve) => {
-          resolveSync = () => resolve({ enabled: true, status: 'synced' });
-        });
-      },
-    );
+    mirrorService.syncProject.mockImplementation((project, projectRepository, config, options) => {
+      void project;
+      void projectRepository;
+      void config;
+      void options;
+      return new Promise((resolve) => {
+        resolveSync = () => resolve({ enabled: true, status: 'synced' });
+      });
+    });
 
     render(<EditorShell services={services} />);
 
@@ -189,9 +187,7 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
-    await waitFor(() => {
-      expect(mirrorService.syncProject).toHaveBeenCalledTimes(1);
-    });
+    expect(mirrorService.syncProject).not.toHaveBeenCalled();
     await user.click(screen.getByRole('button', { name: 'File' }));
     await user.click(screen.getByRole('menuitem', { name: 'Mirror Now' }));
     expect(mirrorService.syncProject).toHaveBeenCalledTimes(1);
@@ -214,20 +210,18 @@ describe('EditorShell mirror workflows', () => {
     let resolveSync: (() => void) | undefined;
     services.projectRepository = repository;
     services.mirrorService = mirrorService;
-    mirrorService.syncProject.mockImplementation(
-      (project, projectRepository, config, options) => {
-        void project;
-        void projectRepository;
-        void config;
-        reportProgress = (current) => {
-          options?.onProgress?.({ current, label: `Mirrored file ${current}`, total: 5 });
-        };
-        reportProgress(3);
-        return new Promise((resolve) => {
-          resolveSync = () => resolve({ enabled: true, status: 'synced' });
-        });
-      },
-    );
+    mirrorService.syncProject.mockImplementation((project, projectRepository, config, options) => {
+      void project;
+      void projectRepository;
+      void config;
+      reportProgress = (current) => {
+        options?.onProgress?.({ current, label: `Mirrored file ${current}`, total: 5 });
+      };
+      reportProgress(3);
+      return new Promise((resolve) => {
+        resolveSync = () => resolve({ enabled: true, status: 'synced' });
+      });
+    });
 
     render(<EditorShell services={services} />);
 
@@ -238,6 +232,9 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'File' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Mirror Now' }));
     expect(await screen.findByRole('status', { name: 'Mirror syncing 60%' })).toBeInTheDocument();
 
     act(() => {
@@ -266,7 +263,7 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
-    expect(await screen.findByRole('button', { name: 'Mirror up to date' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Mirror ready' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Mirror settings' }));
     fireEvent.click(
       within(screen.getByRole('dialog', { name: 'Settings' })).getByRole('button', {
@@ -292,7 +289,9 @@ describe('EditorShell mirror workflows', () => {
       });
     });
 
-    expect(await screen.findByRole('button', { name: 'Save deck before mirroring' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Save deck before mirroring' }),
+    ).toBeInTheDocument();
     expect(secondMirrorService.syncProject).not.toHaveBeenCalled();
   });
 
@@ -336,9 +335,7 @@ describe('EditorShell mirror workflows', () => {
     const mirrorService = new RecordingMirrorService();
     const getTestFontFiles = vi
       .spyOn(services.localFontMirrorService, 'getTestFontFiles')
-      .mockResolvedValue([
-        new File(['font'], 'local-font.woff2', { type: 'font/woff2' }),
-      ]);
+      .mockResolvedValue([new File(['font'], 'local-font.woff2', { type: 'font/woff2' })]);
     const validateTestFontFiles = vi
       .spyOn(services.localFontMirrorService, 'validateTestFontFiles')
       .mockResolvedValue({});
@@ -416,7 +413,7 @@ describe('EditorShell mirror workflows', () => {
     expect(window.location.search).toBe('?project=Remote+Mirror+Deck');
   });
 
-  it('restores mirroring from saved config and syncs the loaded local project', async () => {
+  it('restores mirroring from saved config without uploading during local restore', async () => {
     const repository = new DeferredLoadingProjectRepository();
     const mirrorService = new RecordingMirrorService();
     const services = createAppServices();
@@ -438,21 +435,6 @@ describe('EditorShell mirror workflows', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(
-        mirrorService.syncProject.mock.calls.some(
-          ([syncedProject]) =>
-            syncedProject.id === 'mirrored-project' && syncedProject.name === 'Mirrored Folder',
-        ),
-      ).toBe(true);
-    });
-    const restoredSyncCall = mirrorService.syncProject.mock.calls.find(
-      ([syncedProject]) =>
-        syncedProject.id === 'mirrored-project' && syncedProject.name === 'Mirrored Folder',
-    );
-    if (!restoredSyncCall) throw new Error('Expected mirror sync for Mirrored Folder.');
-    expect(restoredSyncCall[1]).toBe(repository);
-    expect(restoredSyncCall[2]).toEqual(mirrorConfig);
-    expect(typeof restoredSyncCall[3]?.onProgress).toBe('function');
+    expect(mirrorService.syncProject).not.toHaveBeenCalled();
   });
 });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-mirror.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-mirror.test.tsx
@@ -192,6 +192,35 @@ describe('EditorShell persistence and mirror workflows', () => {
     expect(window.location.search).toBe('?project=Imported+LocalStudio+Project');
   });
 
+  it('opens local projects with missing-file warnings instead of failing silently', async () => {
+    const services = createAppServices();
+    services.projectRepository = new ImportingProjectRepository({
+      ...services.initialProject,
+      id: 'imported-project-with-warning',
+      name: 'Imported Project With Warning',
+      importWarnings: [
+        {
+          code: 'missing-local-file',
+          message: 'The imported project references a missing asset file: missing.png.',
+          severity: 'warning',
+        },
+      ],
+    });
+    render(<EditorShell services={services} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'File' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Import' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Project' }));
+
+    expect(
+      await screen.findByText('Project imported with 1 missing local file.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Restore the missing files/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Edit project name Imported Project With Warning' }),
+    ).toBeInTheDocument();
+  });
+
   it('preserves hydrated sample hero object URLs during import normalization', async () => {
     const services = createAppServices();
     const repository = new ImportingProjectRepository({
@@ -295,7 +324,9 @@ describe('EditorShell persistence and mirror workflows', () => {
     try {
       render(<EditorShell services={services} />);
 
-      expect(await screen.findByRole('button', { name: 'Persistence enabled' })).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', { name: 'Persistence enabled' }),
+      ).toBeInTheDocument();
       fireEvent.click(screen.getByRole('button', { name: 'Version history' }));
       await screen.findByText('Version with title edit');
       scrollIntoView.mockClear();


### PR DESCRIPTION
## Summary

- Allow local projects with missing asset files to import while recording warnings.
- Surface clear notices for invalid folders, missing files, and import failures.
- Prevent automatic mirror uploads when restoring a local project; mirroring now requires a save or explicit action.
- Update repository and mirror workflow tests for the new behavior.

## Testing

- Updated unit tests for missing-file imports and mirror synchronization behavior.
- Formatting-only changes applied consistently across affected TypeScript files.