### PR TITLE
Optimize mirror sync with cached files and checksum-based uploads

### DIFF
--- a/apps/editor/src/services/contracts/interfaces.ts
+++ b/apps/editor/src/services/contracts/interfaces.ts
@@ -76,6 +76,7 @@ export interface ProjectRepository {
 export interface MirrorFile {
   path: string;
   blob: Blob;
+  checksum?: string;
 }
 
 export type MirrorStatus = 'disabled' | 'idle' | 'syncing' | 'synced' | 'failed';

--- a/apps/editor/src/services/mirror/minioMirrorFiles.ts
+++ b/apps/editor/src/services/mirror/minioMirrorFiles.ts
@@ -21,6 +21,11 @@ export interface MirrorManifest {
   publicBaseUrl?: string;
 }
 
+export interface MirrorFileCache {
+  objectFiles: Map<string, MirrorFile & MirrorManifestFile>;
+  versionFiles: Map<string, MirrorFile & MirrorManifestFile>;
+}
+
 const MIRROR_MANIFEST_FILE_NAME = 'localstudio-mirror.json';
 const PROJECT_FILE_NAME = 'project.json';
 
@@ -84,7 +89,7 @@ async function createMirrorFiles(
   project: ProjectDocument,
   repository: ProjectRepository,
   config: MinioMirrorConfig,
-  options: { fetch?: typeof fetch; now?: () => Date } = {},
+  options: { fetch?: typeof fetch; now?: () => Date; cache?: MirrorFileCache } = {},
 ): Promise<MirrorFile[]> {
   const requestFetch = options.fetch ?? getDefaultFetch();
   const now = options.now ?? (() => new Date());
@@ -96,11 +101,26 @@ async function createMirrorFiles(
   };
   const files: Array<MirrorFile & MirrorManifestFile> = [];
 
+  async function createObjectFileEntry(path: string, objectUrl: string | undefined) {
+    if (!objectUrl) return undefined;
+    const cacheKey = `${path}\n${objectUrl}`;
+    const cachedEntry = options.cache?.objectFiles.get(cacheKey);
+    if (cachedEntry) return cachedEntry;
+    const blob = await objectUrlToBlob({ objectUrl }, requestFetch);
+    if (!blob) return undefined;
+    const entry = await createFileEntry(path, blob);
+    options.cache?.objectFiles.set(cacheKey, entry);
+    return entry;
+  }
+
   for (const [assetId, asset] of Object.entries(project.assets)) {
     if (!referencedAssetIds.has(assetId)) continue;
     const fileName = asset.fileName ?? `${asset.id}.${assetFileUtils.getAssetFileExtension(asset.mimeType)}`;
-    const blob = await objectUrlToBlob(asset, requestFetch);
-    if (blob) {
+    const entry = await createObjectFileEntry(
+      `assets/${fileName}`,
+      asset.objectUrl,
+    );
+    if (entry) {
       const assetForMirror: Asset = {
         ...asset,
         fileName,
@@ -108,22 +128,22 @@ async function createMirrorFiles(
       };
       delete assetForMirror.objectUrl;
       projectForMirror.assets[assetId] = assetForMirror;
-      files.push(await createFileEntry(`assets/${fileName}`, blob));
+      files.push(entry);
     } else {
       projectForMirror.assets[assetId] = { ...asset };
     }
   }
 
   for (const [fontId, font] of Object.entries(project.fonts ?? {})) {
-    const blob = await objectUrlToBlob(font, requestFetch);
-    if (blob) {
+    const entry = await createObjectFileEntry(`fonts/${font.fileName}`, font.objectUrl);
+    if (entry) {
       const fontForMirror = {
         ...font,
         storage: 'file' as const,
       };
       delete fontForMirror.objectUrl;
       projectForMirror.fonts![fontId] = fontForMirror;
-      files.push(await createFileEntry(`fonts/${font.fileName}`, blob));
+      files.push(entry);
     } else {
       projectForMirror.fonts![fontId] = { ...font };
     }
@@ -133,8 +153,11 @@ async function createMirrorFiles(
     const fileName =
       recording.audio.fileName ??
       `${recording.id}.${assetFileUtils.getAssetFileExtension(recording.audio.mimeType)}`;
-    const blob = await objectUrlToBlob(recording.audio, requestFetch);
-    if (blob) {
+    const entry = await createObjectFileEntry(
+      `recordings/${fileName}`,
+      recording.audio.objectUrl,
+    );
+    if (entry) {
       const audioForMirror: TranscriptRecordingAudio = {
         ...recording.audio,
         fileName,
@@ -145,7 +168,7 @@ async function createMirrorFiles(
         ...recording,
         audio: audioForMirror,
       };
-      files.push(await createFileEntry(`recordings/${fileName}`, blob));
+      files.push(entry);
     } else {
       projectForMirror.recordings![recordingId] = { ...recording };
     }
@@ -167,14 +190,20 @@ async function createMirrorFiles(
   );
 
   for (const version of versions) {
+    const versionCacheKey = `${version.id}\n${version.fileName}`;
+    const cachedVersionFile = options.cache?.versionFiles.get(versionCacheKey);
+    if (cachedVersionFile) {
+      files.push(cachedVersionFile);
+      continue;
+    }
     const versionProject = repository.loadVersion ? await repository.loadVersion(version.id) : null;
     if (!versionProject) continue;
-    files.push(
-      await createFileEntry(
-        `history/versions/${version.fileName}`,
-        storageObjectUtils.jsonBlob(cloneProjectWithoutObjectUrls(versionProject)),
-      ),
+    const versionFile = await createFileEntry(
+      `history/versions/${version.fileName}`,
+      storageObjectUtils.jsonBlob(cloneProjectWithoutObjectUrls(versionProject)),
     );
+    options.cache?.versionFiles.set(versionCacheKey, versionFile);
+    files.push(versionFile);
   }
 
   files.push(

--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -12,7 +12,7 @@ import type { BrowserKeyValueStorage } from '../browser/browserStorage';
 import { browserStorage } from '../browser/browserStorage';
 import { storageObjectUtils } from '../storage/storageObjectUtils';
 import { minioObjectUtils } from './minioObjectUtils';
-import type { MirrorManifest } from './minioMirrorFiles';
+import type { MirrorFileCache, MirrorManifest } from './minioMirrorFiles';
 import { minioMirrorFiles } from './minioMirrorFiles';
 import { minioObjectUploader } from './minioObjectUploader';
 
@@ -226,6 +226,10 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
   private readonly now: () => Date;
   private readonly sleep: (delayMs: number) => Promise<void>;
   private readonly storage: BrowserKeyValueStorage | undefined;
+  private readonly fileCache: MirrorFileCache = {
+    objectFiles: new Map(),
+    versionFiles: new Map(),
+  };
 
   constructor(options: MinioMirrorServiceOptions = {}) {
     this.requestFetch = options.fetch ?? getDefaultFetch();
@@ -256,13 +260,20 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
     const files = await minioMirrorFiles.createMirrorFiles(project, repository, config, {
       fetch: this.requestFetch,
       now: this.now,
+      cache: this.fileCache,
     });
     const projectKey = getProjectMirrorKey(project.name);
     const remoteManifest = await this.loadRemoteManifest(projectKey, config);
-    const totalBytes = Math.max(
-      files.reduce((total, file) => total + file.blob.size, 0),
-      1,
+    const manifestFile = files.find((file) => file.path === minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME);
+    const contentFiles = files.filter((file) => file.path !== minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME);
+    const changedContentFiles = contentFiles.filter(
+      (file) => remoteManifest?.files[file.path]?.checksum !== file.checksum,
     );
+    const filesToUpload = [
+      ...changedContentFiles,
+      ...(manifestFile && (changedContentFiles.length > 0 || !remoteManifest) ? [manifestFile] : []),
+    ];
+    const totalBytes = Math.max(filesToUpload.reduce((total, file) => total + file.blob.size, 0), 1);
     let completedBytes = 0;
     const uploadedBytesByPath = new Map<string, number>();
 
@@ -276,12 +287,9 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
 
     options?.onProgress?.({
       current: completedBytes,
-      label: 'Checking mirror files',
+      label: filesToUpload.length > 0 ? `Mirroring ${filesToUpload.length} changed files` : 'Mirror is up to date',
       total: totalBytes,
     });
-
-    const manifestFile = files.find((file) => file.path === minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME);
-    const contentFiles = files.filter((file) => file.path !== minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME);
 
     const syncFile = async (file: MirrorFile) => {
       options?.onProgress?.({
@@ -289,22 +297,18 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
         label: `Mirroring ${file.path}`,
         total: totalBytes,
       });
-      const nextChecksum = await minioObjectUtils.sha256Hex(file.blob);
-      if (remoteManifest?.files[file.path]?.checksum !== nextChecksum) {
-        await this.putObject(
-          getProjectFileKey(config, projectKey, file.path),
-          file.blob,
-          config,
-          (uploadedBytes) =>
-            reportFileProgress(file, uploadedBytes, `Mirroring ${file.path}`),
-        );
-      }
+      await this.putObject(
+        getProjectFileKey(config, projectKey, file.path),
+        file.blob,
+        config,
+        (uploadedBytes) => reportFileProgress(file, uploadedBytes, `Mirroring ${file.path}`),
+      );
       reportFileProgress(file, file.blob.size, `Mirrored ${file.path}`);
     };
 
-    await runWithConcurrency(contentFiles, MIRROR_UPLOAD_CONCURRENCY, syncFile);
+    await runWithConcurrency(changedContentFiles, MIRROR_UPLOAD_CONCURRENCY, syncFile);
 
-    if (manifestFile) {
+    if (manifestFile && filesToUpload.includes(manifestFile)) {
       await syncFile(manifestFile);
     }
 

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import type { ProjectDocument } from '../../../src/domain/documents/model';
 import { sampleProject } from '../../../src/domain/projects/sampleProject';
 import { minioMirrorService } from '../../../src/services/mirror/minioMirrorService';
+import type { MirrorManifest } from '../../../src/services/mirror/minioMirrorFiles';
 import type { MinioMirrorConfig } from '../../../src/services/mirror/minioMirrorService';
 import type {
   ProjectRepository,
@@ -129,6 +130,43 @@ function createProjectWithLargeMirrorAsset(): ProjectDocument {
 }
 
 describe('minioMirrorService.createMirrorFiles', () => {
+  it('reuses cached local object files and immutable history versions', async () => {
+    const project = createProjectWithLargeMirrorAsset();
+    const cache = { objectFiles: new Map(), versionFiles: new Map() };
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      if (getRequestUrl(input) === 'blob:https://localstudio.test/large-asset') {
+        return Promise.resolve(new Response(new Uint8Array([1, 2, 3]), { status: 200 }));
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${getRequestUrl(input)}`));
+    });
+    const repository = new VersionedRepository(
+      [
+        {
+          id: 'version-1',
+          authorName: 'Local user',
+          changeCount: 1,
+          createdAt: '2026-06-29T10:00:00.000Z',
+          fileName: 'version-1.json',
+          projectName: project.name,
+          summary: '1 edit',
+        },
+      ],
+      project,
+    );
+
+    await minioMirrorService.createMirrorFiles(project, repository, config, {
+      fetch: fetchMock,
+      cache,
+    });
+    await minioMirrorService.createMirrorFiles(project, repository, config, {
+      fetch: fetchMock,
+      cache,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(cache.versionFiles.size).toBe(1);
+  });
+
   it('creates a complete portable project mirror payload', async () => {
     const project = sampleProject.createSampleProject();
     const versionProject = {
@@ -459,12 +497,46 @@ describe('minioMirrorService.MinioMirrorService', () => {
     expect(putUrls.some((url) => url.endsWith('/localstudio-mirror.json'))).toBe(true);
     expect(progressUpdates[0]).toMatchObject({
       current: 0,
-      label: 'Checking mirror files',
+      label: 'Mirroring 3 changed files',
     });
     const finalProgress = progressUpdates.at(-1);
     if (!finalProgress) throw new Error('Expected mirror progress updates.');
     expect(finalProgress.current).toBe(finalProgress.total);
     expect(finalProgress.label).toContain('Mirrored ');
+  });
+
+  it('does not upload a timestamp-only manifest when the mirror is already current', async () => {
+    const project = sampleProject.createSampleProject();
+    const now = () => new Date('2026-06-30T10:00:00.000Z');
+    const files = await minioMirrorService.createMirrorFiles(
+      project,
+      new VersionedRepository([], project),
+      config,
+      { now },
+    );
+    const manifestFile = files.find((file) => file.path === 'localstudio-mirror.json');
+    if (!manifestFile) throw new Error('Expected a mirror manifest file.');
+    const remoteManifest = JSON.parse(await manifestFile.blob.text()) as MirrorManifest;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'GET' && getRequestUrl(input).endsWith('localstudio-mirror.json')) {
+        return Promise.resolve(new Response(JSON.stringify(remoteManifest), { status: 200 }));
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+    const progressUpdates: Array<{ current: number; label: string; total: number }> = [];
+
+    await new minioMirrorService.MinioMirrorService({ fetch: fetchMock, now }).syncProject(
+      project,
+      new VersionedRepository([], project),
+      config,
+      { onProgress: (progress) => progressUpdates.push(progress) },
+    );
+
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')).toHaveLength(0);
+    expect(progressUpdates[0]).toMatchObject({
+      current: 0,
+      label: 'Mirror is up to date',
+    });
   });
 
   it('uploads changed mirror content files in bounded parallel and commits the manifest last', async () => {


### PR DESCRIPTION
## Summary

- Cache mirrored object and immutable version files across syncs.
- Use precomputed checksums to upload only changed content files.
- Avoid timestamp-only manifest uploads when the remote mirror is current.
- Improve progress labels to reflect changed-file syncing.
- Add unit coverage for caching and no-op synchronization.

## Testing

- Added and updated Vitest unit tests for mirror caching, checksum-based uploads, progress reporting, and no-op sync behavior.