### PR TITLE
Handle paginated MinIO project listings

### DIFF
--- a/apps/editor/src/services/mirror/minioMirrorService.ts
+++ b/apps/editor/src/services/mirror/minioMirrorService.ts
@@ -141,13 +141,6 @@ function getReaderCredentials(config: MinioMirrorConfig): MinioMirrorCredentials
   };
 }
 
-function parseMirrorProjects(xml: string) {
-  const document = new DOMParser().parseFromString(xml, 'application/xml');
-  return Array.from(document.querySelectorAll('Contents Key'))
-    .map((node) => node.textContent ?? '')
-    .filter((key) => key.endsWith(`/${minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME}`));
-}
-
 function parseObjectList(xml: string) {
   const document = new DOMParser().parseFromString(xml, 'application/xml');
   return {
@@ -316,25 +309,39 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
   }
 
   async listProjects(config: MinioMirrorConfig): Promise<MirrorProjectSummary[]> {
-    const url = minioObjectUtils.createObjectUrl(config, '', {
-      'list-type': '2',
-      'max-keys': '1000',
-      prefix: storageObjectUtils.normalizeObjectKeyPart(config.prefix)
-        ? `${storageObjectUtils.normalizeObjectKeyPart(config.prefix)}/`
-        : '',
-    });
-    const response = await this.signedFetch(url, 'GET', config, getReaderCredentials(config));
-    if (!response.ok) {
-      if (response.status === 403) {
-        throw new Error(
-          'Reader credentials cannot list the bucket or prefix (403). Grant read-only ListBucket on the bucket for Test/Import Remote, and GetObject on mirrored objects for public deck loading. Also verify the reader secret and region.',
-        );
+    const manifestKeys: string[] = [];
+    const prefix = storageObjectUtils.normalizeObjectKeyPart(config.prefix);
+    let continuationToken: string | undefined;
+    do {
+      const url = minioObjectUtils.createObjectUrl(config, '', {
+        ...(continuationToken ? { 'continuation-token': continuationToken } : {}),
+        'list-type': '2',
+        'max-keys': '1000',
+        prefix: prefix ? `${prefix}/` : '',
+      });
+      const response = await this.signedFetch(url, 'GET', config, getReaderCredentials(config));
+      if (!response.ok) {
+        if (response.status === 403) {
+          throw new Error(
+            'Reader credentials cannot list the bucket or prefix (403). Grant read-only ListBucket on the bucket for Test/Import Remote, and GetObject on mirrored objects for public deck loading. Also verify the reader secret and region.',
+          );
+        }
+        throw new Error(`Could not list MinIO mirrors (${response.status}).`);
       }
-      throw new Error(`Could not list MinIO mirrors (${response.status}).`);
-    }
-    const manifestKeys = parseMirrorProjects(await response.text());
-    const manifests = await Promise.all(
-      manifestKeys.map(async (key) => {
+
+      const objectList = parseObjectList(await response.text());
+      manifestKeys.push(
+        ...objectList.keys.filter((key) =>
+          key.endsWith(`/${minioMirrorFiles.MIRROR_MANIFEST_FILE_NAME}`),
+        ),
+      );
+      continuationToken = objectList.truncated ? objectList.nextContinuationToken : undefined;
+    } while (continuationToken);
+
+    const manifests = await mapWithConcurrency(
+      manifestKeys,
+      MIRROR_DOWNLOAD_CONCURRENCY,
+      async (key) => {
         const response = await this.signedFetch(
           minioObjectUtils.createObjectUrl(config, key),
           'GET',
@@ -349,7 +356,7 @@ class MinioMirrorService implements MirrorService<MinioMirrorConfig> {
           name: manifest.projectName,
           syncedAt: manifest.syncedAt,
         };
-      }),
+      },
     );
     return manifests
       .filter((item): item is MirrorProjectSummary => Boolean(item))

--- a/apps/editor/tests/unit/services/minioMirrorService.test.ts
+++ b/apps/editor/tests/unit/services/minioMirrorService.test.ts
@@ -923,6 +923,58 @@ describe('minioMirrorService.MinioMirrorService', () => {
     ]);
   });
 
+  it('lists remote mirrors across paginated object listings', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(getRequestUrl(input));
+      if (init?.method === 'GET' && url.searchParams.get('list-type') === '2') {
+        const continuationToken = url.searchParams.get('continuation-token');
+        return Promise.resolve(
+          new Response(
+            continuationToken === 'page-2'
+              ? `<ListBucketResult>
+                  <IsTruncated>false</IsTruncated>
+                  <Contents><Key>mirrors/Newest/localstudio-mirror.json</Key></Contents>
+                </ListBucketResult>`
+              : `<ListBucketResult>
+                  <IsTruncated>true</IsTruncated>
+                  <NextContinuationToken>page-2</NextContinuationToken>
+                  <Contents><Key>mirrors/Older/localstudio-mirror.json</Key></Contents>
+                  <Contents><Key>mirrors/Older/project.json</Key></Contents>
+                </ListBucketResult>`,
+            { status: 200 },
+          ),
+        );
+      }
+      if (init?.method === 'GET' && url.pathname.endsWith('/localstudio-mirror.json')) {
+        const projectName = url.pathname.includes('/Newest/') ? 'Newest' : 'Older';
+        return Promise.resolve(
+          Response.json({
+            files: {},
+            projectId: `project-${projectName.toLowerCase()}`,
+            projectName,
+            publicBaseUrl: splitCredentialConfig.publicBaseUrl,
+            schemaVersion: 1,
+            syncedAt:
+              projectName === 'Newest' ? '2026-08-11T18:00:00.000Z' : '2026-08-10T18:00:00.000Z',
+          }),
+        );
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+    const service = new minioMirrorService.MinioMirrorService({ fetch: fetchMock });
+
+    await expect(service.listProjects(splitCredentialConfig)).resolves.toEqual([
+      { id: 'Newest', name: 'Newest', syncedAt: '2026-08-11T18:00:00.000Z' },
+      { id: 'Older', name: 'Older', syncedAt: '2026-08-10T18:00:00.000Z' },
+    ]);
+    const listingUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === 'GET')
+      .map(([input]) => new URL(getRequestUrl(input)))
+      .filter((url) => url.searchParams.get('list-type') === '2');
+    expect(listingUrls).toHaveLength(2);
+    expect(listingUrls[1]?.searchParams.get('continuation-token')).toBe('page-2');
+  });
+
   it('reports mirrored file download progress', async () => {
     const progressEvents: Array<{
       downloadedBytes: number;

--- a/tests/e2e/editor/minio-mirror-service-contract-browser.ts
+++ b/tests/e2e/editor/minio-mirror-service-contract-browser.ts
@@ -39,8 +39,15 @@ export async function evaluateMinioMirrorServiceContract(): Promise<MinioMirrorS
 
   const manifestXml = [
     '<ListBucketResult>',
+    '<IsTruncated>true</IsTruncated>',
+    '<NextContinuationToken>mirror-list-page-2</NextContinuationToken>',
     '<Contents><Key>mirrors/beta/localstudio-mirror.json</Key></Contents>',
     '<Contents><Key>mirrors/alpha/localstudio-mirror.json</Key></Contents>',
+    '</ListBucketResult>',
+  ].join('');
+  const manifestSecondPageXml = [
+    '<ListBucketResult>',
+    '<IsTruncated>false</IsTruncated>',
     '<Contents><Key>mirrors/zulu/localstudio-mirror.json</Key></Contents>',
     '</ListBucketResult>',
   ].join('');
@@ -69,6 +76,9 @@ export async function evaluateMinioMirrorServiceContract(): Promise<MinioMirrorS
       const method = init?.method ?? 'GET';
       if (method === 'PUT') return Promise.resolve(new Response('', { status: 201 }));
       if (method === 'DELETE') return Promise.resolve(new Response(null, { status: 204 }));
+      if (url.includes('continuation-token=mirror-list-page-2')) {
+        return Promise.resolve(new Response(manifestSecondPageXml));
+      }
       if (url.includes('list-type=2') && url.includes('continuation-token=second-page')) {
         return Promise.resolve(new Response(objectListSecondPageXml));
       }


### PR DESCRIPTION
## Summary

- Add continuation-token pagination when listing MinIO mirror projects.
- Preserve manifest filtering and concurrent manifest loading across all pages.
- Extend unit and browser contract coverage for multi-page listings.

## Testing

- Added unit coverage for paginated remote mirror discovery.
- Updated the browser contract fixture to validate continuation-token handling.