### PR TITLE
Persist and mirror background assets and animations when pasting slides

### DIFF
--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -3339,10 +3339,15 @@ export function useEditorViewModel(services: AppServices) {
     const elements = page.elementIds
       .map((elementId) => project.elements[elementId])
       .filter((element): element is NonNullable<typeof element> => Boolean(element));
+    const assets = editorViewModelElements.collectClipboardAssets(project, elements);
+    if (page.background.type === 'asset') {
+      const backgroundAsset = project.assets[page.background.assetId];
+      if (backgroundAsset) assets[backgroundAsset.id] = { ...backgroundAsset };
+    }
     return {
       page: { ...page, elementIds: [...page.elementIds] },
       elements: elements.map((element) => ({ ...element })),
-      assets: editorViewModelElements.collectClipboardAssets(project, elements),
+      assets,
     };
   }
 
@@ -3367,10 +3372,30 @@ export function useEditorViewModel(services: AppServices) {
       }
       return nextElement;
     });
+    const animationBuilds = clipboard.page.animationBuilds?.flatMap((build) => {
+      const nextElementId = elementIds.get(build.elementId);
+      if (!nextElementId) return [];
+      return [
+        {
+          ...build,
+          id: createPrefixedId(`${build.id}-slide`),
+          elementId: nextElementId,
+        },
+      ];
+    });
     const page = {
       ...clipboard.page,
       id: pageId,
       elementIds: elements.map((element) => element.id),
+      background:
+        clipboard.page.background.type === 'asset'
+          ? {
+              ...clipboard.page.background,
+              assetId:
+                assetIds.get(clipboard.page.background.assetId) ?? clipboard.page.background.assetId,
+            }
+          : clipboard.page.background,
+      ...(animationBuilds ? { animationBuilds } : {}),
     };
     commitProject(
       (currentProject) => ({
@@ -3380,6 +3405,7 @@ export function useEditorViewModel(services: AppServices) {
           ...Object.fromEntries(elements.map((element) => [element.id, element])),
         },
         assets: { ...currentProject.assets, ...assets },
+        updatedAt: new Date().toISOString(),
       }),
       { activePageId: pageId, selectedElementIds: [] },
     );

--- a/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import { EditorShell } from '../../../../src/ui/editor/shell/EditorShell';
 import { editorShellTestHarness } from './EditorShell.test-harness';
 
 const {
   SavingProjectRepository,
+  RecordingMirrorService,
   createAppServices,
   createClipboardData,
   openLeftTab,
@@ -105,6 +107,80 @@ describe('EditorShell clipboard workflows', () => {
       'aria-pressed',
       'true',
     );
+  });
+
+  it('persists and mirrors a whole slide pasted from the system clipboard', async () => {
+    const user = userEvent.setup();
+    const initialProject = sampleProject.createSampleProject();
+    const backgroundAsset = {
+      ...initialProject.assets['asset-hero']!,
+      id: 'asset-background',
+      name: 'Slide background',
+    };
+    initialProject.assets[backgroundAsset.id] = backgroundAsset;
+    initialProject.pages[0] = {
+      ...initialProject.pages[0]!,
+      animationBuilds: [
+        {
+          id: 'build-image-hero',
+          elementId: 'image-hero',
+          effect: 'reveal',
+          trigger: 'on-click',
+          delayMs: 0,
+        },
+      ],
+      background: {
+        type: 'asset',
+        assetId: backgroundAsset.id,
+        colorFallback: '#050D10',
+      },
+    };
+    const services = createAppServices({ initialProject, skipStoredProjectLoad: true });
+    const repository = new SavingProjectRepository();
+    const mirrorService = new RecordingMirrorService();
+    services.projectRepository = repository;
+    services.mirrorService = mirrorService;
+    const writeText = vi.fn<(text: string) => Promise<void>>(() => Promise.resolve());
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<EditorShell services={services} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    await user.click(screen.getByRole('button', { name: 'Choose folder' }));
+    fireEvent.click(screen.getByRole('button', { name: 'File' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Mirror Now' }));
+    await waitFor(() => expect(mirrorService.syncProject).toHaveBeenCalledTimes(1));
+    mirrorService.syncProject.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'Copy Slide 1 to clipboard' }));
+    const copiedText = writeText.mock.calls[0]?.[0];
+    expect(copiedText).toContain('asset-background');
+
+    fireEvent.paste(window, {
+      clipboardData: {
+        getData: (type: string) => (type === 'text/plain' ? copiedText : ''),
+      },
+    });
+
+    await waitFor(() => {
+      const savedProject = repository.savedProjects.at(-1);
+      const pastedPage = savedProject?.pages[1];
+      expect(savedProject?.updatedAt).not.toBe(initialProject.updatedAt);
+      expect(pastedPage?.background).toMatchObject({ type: 'asset' });
+      if (pastedPage?.background.type !== 'asset') throw new Error('Expected an asset background.');
+      expect(pastedPage.background.assetId).not.toBe('asset-background');
+      expect(savedProject?.assets[pastedPage.background.assetId]).toBeDefined();
+      expect(pastedPage.animationBuilds?.[0]?.elementId).toBe(pastedPage.elementIds[0]);
+      expect(pastedPage.animationBuilds?.[0]?.id).not.toBe('build-image-hero');
+    });
+    await waitFor(() => {
+      expect(mirrorService.syncProject).toHaveBeenCalledTimes(1);
+    });
+    const syncedProject = mirrorService.syncProject.mock.calls[0]?.[0];
+    expect(syncedProject?.pages).toHaveLength(2);
   });
 
   it('does not overwrite copied text when an editable field is active with a selected object', async () => {


### PR DESCRIPTION
## Summary
- Preserve slide background assets when copying and pasting whole slides.
- Remap pasted background asset IDs and animation builds to the new slide and element IDs.
- Update project timestamps and verify mirrored persistence.

## Testing
- Added unit coverage for system clipboard slide paste persistence and mirroring.