### PR TITLE
Normalize text colors for native color inputs

### DIFF
--- a/apps/editor/src/ui/editor/panels/design-controls/DesignColorField.tsx
+++ b/apps/editor/src/ui/editor/panels/design-controls/DesignColorField.tsx
@@ -1,3 +1,5 @@
+import { colorInputValue } from './colorInputValue';
+
 interface DesignColorFieldProps {
   ariaLabel: string;
   className?: string | undefined;
@@ -19,7 +21,7 @@ export function DesignColorField({
       <input
         aria-label={ariaLabel}
         type="color"
-        value={value}
+        value={colorInputValue(value)}
         onChange={(event) => {
           onChange(event.target.value);
         }}

--- a/apps/editor/src/ui/editor/panels/design-controls/colorInputValue.ts
+++ b/apps/editor/src/ui/editor/panels/design-controls/colorInputValue.ts
@@ -1,0 +1,18 @@
+function isHexColor(value: string) {
+  return /^#[\da-f]{6}$/i.test(value);
+}
+
+function expandShortHexColor(value: string) {
+  if (!/^#[\da-f]{3}$/i.test(value)) return undefined;
+  return `#${value
+    .slice(1)
+    .split('')
+    .map((channel) => `${channel}${channel}`)
+    .join('')}`;
+}
+
+export function colorInputValue(value: string | undefined) {
+  const normalized = value?.trim() ?? '';
+  if (isHexColor(normalized)) return normalized.toLowerCase();
+  return expandShortHexColor(normalized)?.toLowerCase() ?? '#000000';
+}

--- a/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
+++ b/apps/editor/src/ui/editor/panels/text-style/TextStyleInspector.tsx
@@ -14,6 +14,7 @@ import type { FontCatalogItem } from '../../../../services/contracts/interfaces'
 import { textStyleOptions } from '../../text/textStyleOptions';
 import { DesignColorField } from '../design-controls/DesignColorField';
 import { DesignSelectField } from '../design-controls/DesignSelectField';
+import { colorInputValue } from '../design-controls/colorInputValue';
 
 export interface TextStyleControls {
   downloadingFontFamily?: string | undefined;
@@ -258,7 +259,7 @@ export function TextStyleInspector({
           <input
             aria-label="Selected text color"
             type="color"
-            value={element.fill}
+            value={colorInputValue(element.fill)}
             onChange={(event) => {
               onUpdateStyle({ fill: event.target.value });
             }}

--- a/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { ElementStylePatch } from '../../../domain/commands/elements/basicCommands';
 import type { TextElement } from '../../../domain/documents/model';
+import { colorInputValue } from '../panels/design-controls/colorInputValue';
 
 interface TextSelectionToolbarProps {
   disabled?: boolean;
@@ -101,7 +102,7 @@ export function TextSelectionToolbar({
           aria-label="Text color"
           disabled={disabled || element.locked}
           type="color"
-          value={element.fill}
+          value={colorInputValue(element.fill)}
           onChange={(event) => {
             updateStyle({ fill: event.target.value });
           }}

--- a/apps/editor/tests/unit/ui/editor/colorInputValue.test.ts
+++ b/apps/editor/tests/unit/ui/editor/colorInputValue.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { colorInputValue } from '../../../../src/ui/editor/panels/design-controls/colorInputValue';
+
+describe('colorInputValue', () => {
+  it('normalizes supported hex colors for native color inputs', () => {
+    expect(colorInputValue('#ABCDEF')).toBe('#abcdef');
+    expect(colorInputValue('#0f0')).toBe('#00ff00');
+  });
+
+  it('provides a valid fallback for colors native inputs cannot represent', () => {
+    expect(colorInputValue('rgba(255, 255, 255, 0.5)')).toBe('#000000');
+    expect(colorInputValue(undefined)).toBe('#000000');
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize full and shorthand hex colors before assigning them to native color inputs.
- Provide a safe fallback for unsupported or missing color values.
- Apply the normalization across design controls, text style inspection, and the text selection toolbar.

## Testing

- Added unit coverage for uppercase hex, shorthand hex, unsupported formats, and missing values.