### PR TITLE
Add alignment menu to the text selection toolbar

### DIFF
--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -147,6 +147,9 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
                 ? { onOpenAnimations: canvasProps.onOpenAnimations }
                 : {})}
               {...(onOpenFontPanel ? { onOpenFontPanel } : {})}
+              {...(canvasProps.onAlignSelectedElement
+                ? { onAlignSelectedElement: canvasProps.onAlignSelectedElement }
+                : {})}
               {...(canvasProps.onTranslateSelectedText
                 ? { onTranslateSelectedText: canvasProps.onTranslateSelectedText }
                 : {})}
@@ -201,7 +204,11 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
               />
               {shouldRenderCanvas ? (
                 <div
-                  className={isActive ? 'scroll-page-canvas-shell' : 'scroll-page-canvas-shell scroll-page-canvas-shell-preloaded'}
+                  className={
+                    isActive
+                      ? 'scroll-page-canvas-shell'
+                      : 'scroll-page-canvas-shell scroll-page-canvas-shell-preloaded'
+                  }
                   {...(!isActive ? { 'aria-hidden': true, inert: true } : {})}
                 >
                   <CanvasWorkspace
@@ -304,10 +311,7 @@ function PageHeader({
       >
         Page {index + 1} - {name}
       </button>
-      <div
-        className="scroll-page-actions ew-inline-row-tight"
-        aria-label={`${name} page actions`}
-      >
+      <div className="scroll-page-actions ew-inline-row-tight" aria-label={`${name} page actions`}>
         <IconAction
           disabled={!canMoveUp}
           label={`Move ${name} up`}

--- a/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import type { ElementStylePatch } from '../../../domain/commands/elements/basicCommands';
+import type { AlignMode, ElementStylePatch } from '../../../domain/commands/elements/basicCommands';
 import type { TextElement } from '../../../domain/documents/model';
 
 interface TextSelectionToolbarProps {
   disabled?: boolean;
   canTranslateSelection?: boolean;
   element: TextElement;
+  onAlignSelectedElement?: (mode: AlignMode) => void;
   onOpenAnimations?: () => void;
   onOpenFontPanel?: () => void;
   onTranslateSelectedText?: () => void;
@@ -15,6 +16,18 @@ interface TextSelectionToolbarProps {
 const FONT_SIZE_STEP = 4;
 const REGULAR_WEIGHT = 600;
 const BOLD_WEIGHT = 800;
+const textAlignmentOptions = [
+  { align: 'left' as const, icon: 'format_align_left', label: 'Align text left' },
+  { align: 'center' as const, icon: 'format_align_center', label: 'Align text center' },
+  { align: 'right' as const, icon: 'format_align_right', label: 'Align text right' },
+];
+const positioningOptions = [
+  { icon: 'align_horizontal_left', label: 'Center left', mode: 'page-left-center' as const },
+  { icon: 'align_horizontal_center', label: 'Center', mode: 'page-center' as const },
+  { icon: 'align_horizontal_right', label: 'Center right', mode: 'page-right-center' as const },
+  { icon: 'align_vertical_top', label: 'Center top', mode: 'page-top-center' as const },
+  { icon: 'align_vertical_bottom', label: 'Center bottom', mode: 'page-bottom-center' as const },
+];
 
 function normalizeHyperlink(value: string) {
   const trimmed = value.trim();
@@ -27,14 +40,20 @@ export function TextSelectionToolbar({
   disabled = false,
   canTranslateSelection = false,
   element,
+  onAlignSelectedElement,
   onOpenAnimations,
   onOpenFontPanel,
   onTranslateSelectedText,
   onUpdateElementStyle,
 }: TextSelectionToolbarProps) {
+  const [showAlignmentMenu, setShowAlignmentMenu] = useState(false);
   const [showLinkEditor, setShowLinkEditor] = useState(false);
-  const [linkDraft, setLinkDraft] = useState({ elementId: element.id, value: element.hyperlink ?? '' });
-  const linkValue = linkDraft.elementId === element.id ? linkDraft.value : (element.hyperlink ?? '');
+  const [linkDraft, setLinkDraft] = useState({
+    elementId: element.id,
+    value: element.hyperlink ?? '',
+  });
+  const linkValue =
+    linkDraft.elementId === element.id ? linkDraft.value : (element.hyperlink ?? '');
 
   function updateStyle(patch: ElementStylePatch) {
     if (disabled || element.locked) return;
@@ -123,32 +142,86 @@ export function TextSelectionToolbar({
         B
       </button>
 
-      <div className="text-toolbar-segment" aria-label="Text alignment">
-        {(['left', 'center', 'right'] as const).map((align) => (
-          <button
-            key={align}
-            aria-label={`Align text ${align}`}
-            aria-pressed={element.align === align}
-            className={
-              element.align === align
-                ? 'text-toolbar-button text-toolbar-button-active'
-                : 'text-toolbar-button'
-            }
-            disabled={disabled || element.locked}
-            type="button"
-            onClick={() => {
-              updateStyle({ align });
-            }}
+      <div className="text-toolbar-alignment">
+        <button
+          aria-expanded={showAlignmentMenu}
+          aria-haspopup="menu"
+          aria-label="Text alignment menu"
+          className={
+            showAlignmentMenu || element.align !== 'left'
+              ? 'text-toolbar-button text-toolbar-button-active'
+              : 'text-toolbar-button'
+          }
+          disabled={disabled || element.locked}
+          title="Align text"
+          type="button"
+          onClick={() => {
+            if (disabled || element.locked) return;
+            setShowAlignmentMenu((current) => !current);
+          }}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            {element.align === 'center'
+              ? 'format_align_center'
+              : element.align === 'right'
+                ? 'format_align_right'
+                : 'format_align_left'}
+          </span>
+          <span
+            className="material-symbols-outlined text-toolbar-alignment-caret"
+            aria-hidden="true"
           >
-            <span className="material-symbols-outlined" aria-hidden="true">
-              {align === 'left'
-                ? 'format_align_left'
-                : align === 'center'
-                  ? 'format_align_center'
-                  : 'format_align_right'}
-            </span>
-          </button>
-        ))}
+            expand_more
+          </span>
+        </button>
+        {showAlignmentMenu ? (
+          <div className="text-toolbar-alignment-menu" role="menu" aria-label="Text alignment">
+            {textAlignmentOptions.map((option) => (
+              <button
+                key={option.align}
+                aria-label={option.label}
+                aria-pressed={element.align === option.align}
+                className="text-toolbar-alignment-option"
+                disabled={disabled || element.locked}
+                title={option.label}
+                type="button"
+                onClick={() => {
+                  updateStyle({ align: option.align });
+                  setShowAlignmentMenu(false);
+                }}
+              >
+                <span className="material-symbols-outlined" aria-hidden="true">
+                  {option.icon}
+                </span>
+                <span>{option.label}</span>
+              </button>
+            ))}
+            {onAlignSelectedElement ? (
+              <>
+                <div className="text-toolbar-alignment-divider" role="separator" />
+                {positioningOptions.map((option) => (
+                  <button
+                    key={option.mode}
+                    aria-label={option.label}
+                    className="text-toolbar-alignment-option"
+                    disabled={disabled || element.locked}
+                    title={option.label}
+                    type="button"
+                    onClick={() => {
+                      onAlignSelectedElement(option.mode);
+                      setShowAlignmentMenu(false);
+                    }}
+                  >
+                    <span className="material-symbols-outlined" aria-hidden="true">
+                      {option.icon}
+                    </span>
+                    <span>{option.label}</span>
+                  </button>
+                ))}
+              </>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
       <button

--- a/apps/editor/src/ui/styles/text-format-toolbar.css
+++ b/apps/editor/src/ui/styles/text-format-toolbar.css
@@ -1,4 +1,3 @@
-
 .text-toolbar-font,
 .text-toolbar-size,
 .text-toolbar-button,
@@ -155,12 +154,66 @@
   color: var(--ew-green);
 }
 
-.text-toolbar-segment {
+.text-toolbar-alignment {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 2px;
   padding-left: 5px;
   border-left: 1px solid rgba(55, 253, 118, 0.18);
+}
+
+.text-toolbar-alignment-menu {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 6px);
+  left: 5px;
+  width: 168px;
+  padding: 6px;
+  border: 1px solid var(--ew-border);
+  border-radius: 4px;
+  background: rgba(9, 16, 12, 0.98);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(14px);
+}
+
+.text-toolbar-alignment-caret {
+  margin-left: -2px;
+  font-size: 15px !important;
+}
+
+.text-toolbar-alignment-option {
+  width: 100%;
+  min-height: 34px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ew-text);
+  text-align: left;
+  cursor: pointer;
+  font:
+    800 12px 'Open Sans',
+    sans-serif;
+}
+
+.text-toolbar-alignment-option:hover:not(:disabled),
+.text-toolbar-alignment-option[aria-pressed='true'] {
+  background: rgba(55, 253, 118, 0.12);
+}
+
+.text-toolbar-alignment-divider {
+  height: 1px;
+  margin: 5px 2px;
+  background: var(--ew-border);
+}
+
+.text-toolbar-alignment-option .material-symbols-outlined {
+  color: var(--ew-green-fixed);
+  font-size: 17px;
 }
 
 .text-selection-toolbar :disabled {

--- a/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
@@ -135,6 +135,7 @@ describe('ScrollingCanvasWorkspace', () => {
     const onOpenFontPanel = vi.fn();
     const onTranslateSelectedText = vi.fn();
     const onUpdateElementStyle = vi.fn();
+    const onAlignSelectedElement = vi.fn();
 
     render(
       <ScrollingCanvasWorkspace
@@ -144,6 +145,7 @@ describe('ScrollingCanvasWorkspace', () => {
         canTranslateSelection
         onOpenAnimations={onOpenAnimations}
         onOpenFontPanel={onOpenFontPanel}
+        onAlignSelectedElement={onAlignSelectedElement}
         onTranslateSelectedText={onTranslateSelectedText}
         onUpdateElementStyle={onUpdateElementStyle}
       />,
@@ -179,8 +181,14 @@ describe('ScrollingCanvasWorkspace', () => {
     );
     expect(onTranslateSelectedText).toHaveBeenCalledTimes(1);
 
+    await user.click(screen.getByRole('button', { name: 'Text alignment menu' }));
+    expect(screen.getByRole('menu', { name: 'Text alignment' })).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'Align text left' }));
     expect(onUpdateElementStyle).toHaveBeenCalledWith('text-subtitle', { align: 'left' });
+
+    await user.click(screen.getByRole('button', { name: 'Text alignment menu' }));
+    await user.click(screen.getByRole('button', { name: 'Center left' }));
+    expect(onAlignSelectedElement).toHaveBeenCalledWith('page-left-center');
 
     await user.click(screen.getByRole('button', { name: 'Edit text hyperlink' }));
     await user.clear(screen.getByRole('textbox', { name: 'Text hyperlink URL' }));

--- a/tests/e2e/editor/text-theme-and-layout.spec.ts
+++ b/tests/e2e/editor/text-theme-and-layout.spec.ts
@@ -19,6 +19,7 @@ test.describe('editor text theme and layout journey', () => {
     await expect(toolbar).toBeVisible();
     await toolbar.getByRole('spinbutton', { name: 'Text font size' }).fill('48');
     await toolbar.getByRole('button', { name: 'Bold text' }).click();
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
     await toolbar.getByRole('button', { name: 'Align text right' }).click();
     await toolbar.getByRole('button', { name: 'Edit text hyperlink' }).click();
     await toolbar.getByRole('textbox', { name: 'Text hyperlink URL' }).fill('localstudio.dev');
@@ -46,7 +47,8 @@ test.describe('editor text theme and layout journey', () => {
       .getByRole('tablist', { name: 'Movie inspector sections' })
       .getByRole('tab', { name: 'Arrange' })
       .click();
-    await expect.poll(async () => Number(await page.getByLabel('Selected element height').inputValue()))
+    await expect
+      .poll(async () => Number(await page.getByLabel('Selected element height').inputValue()))
       .toBeLessThan(120);
     await expect(page.getByRole('button', { name: 'Group', exact: true })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Ungroup' })).toBeDisabled();
@@ -63,7 +65,9 @@ test.describe('editor text theme and layout journey', () => {
     await expect(
       page.getByRole('button', { name: 'Open theme picker, current theme Default theme' }),
     ).toBeVisible();
-    await page.getByRole('button', { name: 'Open theme picker, current theme Default theme' }).click();
+    await page
+      .getByRole('button', { name: 'Open theme picker, current theme Default theme' })
+      .click();
     const themeChooser = page.getByRole('region', { name: 'Choose a theme' });
     await expect(themeChooser).toBeVisible();
     await expect(themeChooser.getByText('Default theme')).toBeVisible();
@@ -77,8 +81,13 @@ test.describe('editor text theme and layout journey', () => {
     const canvas = frame.locator('canvas').first();
     const canvasBox = await canvas.boundingBox();
     expect(canvasBox).not.toBeNull();
-    await page.mouse.click(canvasBox!.x + canvasBox!.width / 2, canvasBox!.y + canvasBox!.height / 2);
-    await expect(page.getByRole('button', { name: 'Open layout picker, current layout Blank' })).toBeVisible();
+    await page.mouse.click(
+      canvasBox!.x + canvasBox!.width / 2,
+      canvasBox!.y + canvasBox!.height / 2,
+    );
+    await expect(
+      page.getByRole('button', { name: 'Open layout picker, current layout Blank' }),
+    ).toBeVisible();
     await page.getByRole('button', { name: 'Open layout picker, current layout Blank' }).click();
     await expect(page.getByRole('region', { name: 'Choose a layout' })).toBeVisible();
     await expect(page.getByText('No imported layouts yet.')).toBeVisible();

--- a/tests/e2e/editor/text-theme-and-layout.spec.ts
+++ b/tests/e2e/editor/text-theme-and-layout.spec.ts
@@ -33,6 +33,7 @@ test.describe('editor text theme and layout journey', () => {
       'aria-pressed',
       'true',
     );
+    await toolbar.getByRole('button', { name: 'Text alignment menu' }).click();
     await expect(toolbar.getByRole('button', { name: 'Align text right' })).toHaveAttribute(
       'aria-pressed',
       'true',


### PR DESCRIPTION
## Summary

- Replace inline text alignment buttons with a compact alignment menu.
- Add selected-element positioning actions for page-based alignment.
- Forward the alignment callback through the scrolling canvas workspace.
- Update unit and Playwright coverage for the new menu interactions.

## Testing

- Added unit coverage for text and page alignment actions.
- Updated the editor text theme and layout Playwright journey.