### PR TITLE
Fix cross-project pasting of file-backed slide assets

### DIFF
--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -3359,6 +3359,12 @@ export function useEditorViewModel(services: AppServices) {
       Object.entries(clipboard.assets).map(([assetId, asset]) => {
         const nextAssetId = createPrefixedId(`${assetId}-slide`);
         assetIds.set(assetId, nextAssetId);
+        if (asset.storage === 'file' && /^(?:blob|data):/.test(asset.objectUrl ?? '')) {
+          const { fileName, storage, ...transferableAsset } = asset;
+          void fileName;
+          void storage;
+          return [nextAssetId, { ...transferableAsset, id: nextAssetId }];
+        }
         return [nextAssetId, { ...asset, id: nextAssetId }];
       }),
     );
@@ -3392,7 +3398,8 @@ export function useEditorViewModel(services: AppServices) {
           ? {
               ...clipboard.page.background,
               assetId:
-                assetIds.get(clipboard.page.background.assetId) ?? clipboard.page.background.assetId,
+                assetIds.get(clipboard.page.background.assetId) ??
+                clipboard.page.background.assetId,
             }
           : clipboard.page.background,
       ...(animationBuilds ? { animationBuilds } : {}),

--- a/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
@@ -119,7 +119,7 @@ describe('EditorShell clipboard workflows', () => {
       storage: 'file',
     };
     const backgroundAsset = {
-      ...initialProject.assets['asset-hero']!,
+      ...initialProject.assets['asset-hero'],
       fileName: 'background.png',
       id: 'asset-background',
       name: 'Slide background',

--- a/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.clipboard.test.tsx
@@ -112,8 +112,15 @@ describe('EditorShell clipboard workflows', () => {
   it('persists and mirrors a whole slide pasted from the system clipboard', async () => {
     const user = userEvent.setup();
     const initialProject = sampleProject.createSampleProject();
+    initialProject.assets['asset-hero'] = {
+      ...initialProject.assets['asset-hero']!,
+      fileName: 'hero.png',
+      objectUrl: 'data:image/png;base64,aGVyby1ieXRlcw==',
+      storage: 'file',
+    };
     const backgroundAsset = {
       ...initialProject.assets['asset-hero']!,
+      fileName: 'background.png',
       id: 'asset-background',
       name: 'Slide background',
     };
@@ -172,7 +179,11 @@ describe('EditorShell clipboard workflows', () => {
       expect(pastedPage?.background).toMatchObject({ type: 'asset' });
       if (pastedPage?.background.type !== 'asset') throw new Error('Expected an asset background.');
       expect(pastedPage.background.assetId).not.toBe('asset-background');
-      expect(savedProject?.assets[pastedPage.background.assetId]).toBeDefined();
+      expect(savedProject?.assets[pastedPage.background.assetId]).toMatchObject({
+        objectUrl: backgroundAsset.objectUrl,
+      });
+      expect(savedProject?.assets[pastedPage.background.assetId]).not.toHaveProperty('fileName');
+      expect(savedProject?.assets[pastedPage.background.assetId]).not.toHaveProperty('storage');
       expect(pastedPage.animationBuilds?.[0]?.elementId).toBe(pastedPage.elementIds[0]);
       expect(pastedPage.animationBuilds?.[0]?.id).not.toBe('build-image-hero');
     });
@@ -275,6 +286,4 @@ describe('EditorShell clipboard workflows', () => {
       'true',
     );
   });
-
-
 });

--- a/tests/e2e/editor/local-persistence.spec.ts
+++ b/tests/e2e/editor/local-persistence.spec.ts
@@ -5,6 +5,138 @@ import { expect, test, withIsolatedDevServer } from '../support/journey-test';
 const getServer = withIsolatedDevServer(test);
 
 test.describe('editor local persistence journey', () => {
+  test('copies a file-backed slide asset into another browser-private project', async ({
+    context,
+    page,
+  }) => {
+    await installFakeOpfs(page);
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'], {
+      origin: getServer().baseURL,
+    });
+    await page.goto(getServer().baseURL);
+    await page.evaluate(() => {
+      const createdAt = '2026-08-12T12:00:00.000Z';
+      const sourceProject = {
+        id: 'source-project',
+        name: 'Source Deck',
+        createdAt,
+        updatedAt: createdAt,
+        assets: {
+          'source-background': {
+            id: 'source-background',
+            type: 'image',
+            name: 'Source background',
+            mimeType: 'image/png',
+            fileName: 'source-background.png',
+            storage: 'file',
+          },
+        },
+        elements: {},
+        pages: [
+          {
+            id: 'source-page',
+            name: 'Source Slide',
+            width: 1920,
+            height: 1080,
+            background: {
+              type: 'asset',
+              assetId: 'source-background',
+              colorFallback: '#050D10',
+            },
+            elementIds: [],
+          },
+        ],
+      };
+      const destinationProject = {
+        id: 'destination-project',
+        name: 'Destination Deck',
+        createdAt,
+        updatedAt: createdAt,
+        assets: {},
+        elements: {},
+        pages: [
+          {
+            id: 'destination-page',
+            name: 'Destination Slide',
+            width: 1920,
+            height: 1080,
+            background: { type: 'color', color: '#050D10' },
+            elementIds: [],
+          },
+        ],
+      };
+      const prefix = 'localstudio.e2e.opfs.file:projects/';
+      window.localStorage.setItem('ew-canvas-ai.persistence-enabled', 'true');
+      window.localStorage.setItem(
+        `${prefix}Source%20Deck/project.json`,
+        JSON.stringify(sourceProject),
+      );
+      window.localStorage.setItem(
+        `${prefix}Source%20Deck/assets/source-background.png`,
+        'source-background-bytes',
+      );
+      window.localStorage.setItem(
+        `${prefix}Destination%20Deck/project.json`,
+        JSON.stringify(destinationProject),
+      );
+    });
+
+    const sourceUrl = new URL('/editor/', getServer().baseURL);
+    sourceUrl.searchParams.set('project', 'Source Deck');
+    await page.goto(sourceUrl.toString());
+    await expect(page.getByRole('button', { name: 'Browser storage enabled' })).toBeVisible();
+    await page.getByRole('button', { name: 'Copy Source Slide to clipboard' }).click();
+    const clipboardPayload = await page.evaluate(() => navigator.clipboard.readText());
+
+    const destinationPage = await context.newPage();
+    await installFakeOpfs(destinationPage);
+    const destinationUrl = new URL('/editor/', getServer().baseURL);
+    destinationUrl.searchParams.set('project', 'Destination Deck');
+    await destinationPage.goto(destinationUrl.toString());
+    await expect(
+      destinationPage.getByRole('button', { name: 'Browser storage enabled' }),
+    ).toBeVisible();
+    await destinationPage.evaluate((payload) => {
+      const clipboardData = new DataTransfer();
+      clipboardData.setData('text/plain', payload);
+      window.dispatchEvent(
+        new ClipboardEvent('paste', {
+          bubbles: true,
+          clipboardData,
+        }),
+      );
+    }, clipboardPayload);
+
+    await expect
+      .poll(() =>
+        destinationPage.evaluate(() => {
+          const prefix = 'localstudio.e2e.opfs.file:projects/Destination%20Deck/';
+          const storedProject = window.localStorage.getItem(`${prefix}project.json`);
+          if (!storedProject) return undefined;
+          const project = JSON.parse(storedProject) as {
+            assets: Record<string, { fileName?: string; objectUrl?: string; storage?: string }>;
+            pages: Array<{ background: { type: string; assetId?: string } }>;
+          };
+          const pastedBackground = project.pages[1]?.background;
+          if (pastedBackground?.type !== 'asset' || !pastedBackground.assetId) return undefined;
+          const asset = project.assets[pastedBackground.assetId];
+          if (!asset?.fileName) return undefined;
+          return {
+            bytes: window.localStorage.getItem(`${prefix}assets/${asset.fileName}`),
+            objectUrl: asset.objectUrl,
+            pageCount: project.pages.length,
+            storage: asset.storage,
+          };
+        }),
+      )
+      .toEqual({
+        bytes: 'source-background-bytes',
+        objectUrl: undefined,
+        pageCount: 2,
+        storage: 'file',
+      });
+  });
+
   test('keeps the plain editor route fresh and restores a named browser-private project', async ({
     page,
   }) => {
@@ -68,7 +200,9 @@ test.describe('editor local persistence journey', () => {
     await projectFolderNameInput.press('Enter');
 
     await expect(page.getByRole('button', { name: 'Persistence enabled' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Edit project name E2E Folder Deck' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Edit project name E2E Folder Deck' }),
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Version history' })).toBeEnabled();
 
     await editor.renameProject('E2E Folder Deck Renamed');
@@ -77,7 +211,9 @@ test.describe('editor local persistence journey', () => {
     await expect(page.getByRole('button', { name: 'Persistence enabled' })).toBeVisible();
 
     const persistedKeys = await page.evaluate(() =>
-      Array.from({ length: window.localStorage.length }, (_, index) => window.localStorage.key(index))
+      Array.from({ length: window.localStorage.length }, (_, index) =>
+        window.localStorage.key(index),
+      )
         .filter((key): key is string => Boolean(key))
         .filter((key) => key.includes('localstudio.e2e.opfs.file:')),
     );


### PR DESCRIPTION
## Summary

- Strip non-transferable file metadata when pasting blob/data URL assets.
- Preserve asset URLs and remap pasted page background references.
- Add unit and end-to-end coverage for cross-project slide asset paste persistence.

## Testing

- Added and updated clipboard workflow unit tests.
- Added Playwright coverage for copying a file-backed asset between browser-private projects.