### PR TITLE
Support multi-text selection controls and format painting

### DIFF
--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -53,6 +53,14 @@ import { textTranslationLayout } from '../state/text-translation-layout';
 
 const TEXT_FRAME_PADDING = 6;
 
+function getRenderedTextContentHeight(textNode: Konva.Text) {
+  const measurementNode = textNode.clone();
+  measurementNode.setAttr('height', undefined);
+  const height = measurementNode.height();
+  measurementNode.destroy();
+  return height;
+}
+
 interface CanvasWorkspaceProps {
   project: ProjectDocument;
   activePageId: string;
@@ -447,12 +455,11 @@ export function CanvasWorkspace({
       }
 
       const textNode = node as Konva.Text;
-      const renderedHeight =
-        textNode.textArr.length * textNode.fontSize() * textNode.lineHeight() +
-        textNode.padding() * 2;
-      if (renderedHeight < 1 || renderedHeight === textNode.height()) return;
-      textNode.height(renderedHeight);
-      didResizeSelection = true;
+      const renderedHeight = getRenderedTextContentHeight(textNode);
+      if (renderedHeight >= 1 && renderedHeight !== textNode.height()) {
+        textNode.height(renderedHeight);
+        didResizeSelection = true;
+      }
     });
 
     if (didResizeSelection) {

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -386,7 +386,7 @@ export function CanvasWorkspace({
       .filter((node): node is Konva.Node => Boolean(node));
     transformerRef.current?.nodes(selectedNodes);
     transformerRef.current?.getLayer()?.batchDraw();
-  }, [selection.elementIds, project]);
+  }, [fontRenderVersion, selection.elementIds, project]);
 
   useEffect(() => {
     const artboard = artboardRef.current;

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -243,25 +243,44 @@ export function CanvasWorkspace({
   >();
   const page = project.pages.find((item) => item.id === activePageId) ?? project.pages[0];
   const activeLayout = page?.layoutId ? project.slideLayouts?.[page.layoutId] : undefined;
-  const layoutVisibleElements =
-    activeLayout?.elementIds
-      .map((id) => activeLayout.elements[id])
-      .filter(canvasWorkspaceUtils.isDesignElement)
-      .filter((element) => element.visible !== false && !element.placeholderRole) ?? [];
-  const layoutVisibleElementIds = new Set(layoutVisibleElements.map((element) => element.id));
-  const sourceVisibleElements =
-    page?.elementIds
-      .map((id) => project.elements[id])
-      .filter(canvasWorkspaceUtils.isDesignElement)
-      .filter((element) => element.visible !== false) ?? [];
-  const getDraftedElement = (element: DesignElement | undefined): DesignElement | undefined => {
-    if (!element || element.type !== 'image' || cropDraft?.elementId !== element.id) return element;
-    return { ...element, ...cropDraft.frame, crop: cropDraft.crop };
-  };
-  const pageVisibleElements = sourceVisibleElements
-    .map((element) => getDraftedElement(element))
-    .filter(canvasWorkspaceUtils.isDesignElement);
-  const visibleElements = [...layoutVisibleElements, ...pageVisibleElements];
+  const layoutVisibleElements = useMemo(
+    () =>
+      activeLayout?.elementIds
+        .map((id) => activeLayout.elements[id])
+        .filter(canvasWorkspaceUtils.isDesignElement)
+        .filter((element) => element.visible !== false && !element.placeholderRole) ?? [],
+    [activeLayout],
+  );
+  const layoutVisibleElementIds = useMemo(
+    () => new Set(layoutVisibleElements.map((element) => element.id)),
+    [layoutVisibleElements],
+  );
+  const sourceVisibleElements = useMemo(
+    () =>
+      page?.elementIds
+        .map((id) => project.elements[id])
+        .filter(canvasWorkspaceUtils.isDesignElement)
+        .filter((element) => element.visible !== false) ?? [],
+    [page, project.elements],
+  );
+  const getDraftedElement = useCallback(
+    (element: DesignElement | undefined): DesignElement | undefined => {
+      if (!element || element.type !== 'image' || cropDraft?.elementId !== element.id) return element;
+      return { ...element, ...cropDraft.frame, crop: cropDraft.crop };
+    },
+    [cropDraft],
+  );
+  const pageVisibleElements = useMemo(
+    () =>
+      sourceVisibleElements
+        .map((element) => getDraftedElement(element))
+        .filter(canvasWorkspaceUtils.isDesignElement),
+    [getDraftedElement, sourceVisibleElements],
+  );
+  const visibleElements = useMemo(
+    () => [...layoutVisibleElements, ...pageVisibleElements],
+    [layoutVisibleElements, pageVisibleElements],
+  );
   const visibleMediaElements = visibleElements.filter(
     (element): element is GifElement | VideoElement =>
       element.type === 'gif' || element.type === 'video',
@@ -415,6 +434,32 @@ export function CanvasWorkspace({
       isMounted = false;
     };
   }, [project.fonts, projectFontSignature, stageRef]);
+
+  useEffect(() => {
+    if (readOnly || fontRenderVersion === 0) return;
+
+    let didResizeSelection = false;
+    selection.elementIds.forEach((elementId) => {
+      const element = project.elements[elementId];
+      const node = nodeRefs.current[elementId];
+      if (element?.type !== 'text' || !node || !('textArr' in node) || !('fontSize' in node)) {
+        return;
+      }
+
+      const textNode = node as Konva.Text;
+      const renderedHeight =
+        textNode.textArr.length * textNode.fontSize() * textNode.lineHeight() +
+        textNode.padding() * 2;
+      if (renderedHeight < 1 || renderedHeight === textNode.height()) return;
+      textNode.height(renderedHeight);
+      didResizeSelection = true;
+    });
+
+    if (didResizeSelection) {
+      transformerRef.current?.forceUpdate();
+      transformerRef.current?.getLayer()?.batchDraw();
+    }
+  }, [fontRenderVersion, project, readOnly, selection.elementIds]);
 
   useEffect(() => {
     if (backgroundSelectionMode || hasProcessingElements) return;

--- a/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/ScrollingCanvasWorkspace.tsx
@@ -28,6 +28,8 @@ interface ScrollingCanvasWorkspaceProps extends CanvasWorkspaceProps {
   onOpenFontPanel?: (() => void) | undefined;
   onTranslatePage?: ((pageId: string) => void) | undefined;
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
+  onUpdateElementStyles?: ((elementIds: string[], patch: ElementStylePatch) => void) | undefined;
+  onApplyFormat?: ((elementIds: string[], patch: ElementStylePatch) => void) | undefined;
   translatingPageIds?: string[] | undefined;
 }
 
@@ -53,6 +55,8 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
       onOpenFontPanel,
       onTranslatePage,
       onUpdateElementStyle,
+      onUpdateElementStyles,
+      onApplyFormat,
       project,
       translatingPageIds = [],
       ...canvasProps
@@ -65,10 +69,13 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
     const programmaticScrollRef = useRef(false);
     const scrollerRef = useRef<HTMLDivElement>(null);
     const selectedElement = project.elements[canvasProps.selection.elementIds[0] ?? ''];
+    const selectedTextElements = canvasProps.selection.elementIds
+      .map((elementId) => project.elements[elementId])
+      .filter((candidate): candidate is Extract<typeof candidate, { type: 'text' }> => candidate?.type === 'text');
     const showTextToolbar =
       !canvasProps.presentationMode &&
       selectedElement?.type === 'text' &&
-      canvasProps.selection.elementIds.length === 1;
+      selectedTextElements.length === canvasProps.selection.elementIds.length;
     const textToolbarDisabled =
       Boolean(canvasProps.isTranslating) ||
       Boolean(
@@ -151,6 +158,9 @@ export const ScrollingCanvasWorkspace = forwardRef<HTMLDivElement, ScrollingCanv
                 ? { onTranslateSelectedText: canvasProps.onTranslateSelectedText }
                 : {})}
               {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
+              {...(onUpdateElementStyles ? { onUpdateElementStyles } : {})}
+              {...(onApplyFormat ? { onApplyFormat } : {})}
+              selectedElementIds={canvasProps.selection.elementIds}
             />
           </div>
         ) : null}

--- a/apps/editor/src/ui/editor/panels/DesignPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/DesignPanel.tsx
@@ -37,6 +37,7 @@ interface DesignPanelProps {
   onDownloadFont?: (family: string) => Promise<void>;
   onImportLocalFont?: (family: string) => Promise<void>;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
+  onUpdateElementStyles?: (elementIds: string[], patch: ElementStylePatch) => void;
   onUpdateElementFrame?: (elementId: string, patch: ElementFramePatch) => void;
   onUpdateTextContent?: (elementId: string, text: string) => void;
   onUpdateMediaPlayback?: (elementId: string, patch: MediaPlaybackPatch) => void;
@@ -90,6 +91,7 @@ export function DesignPanel({
   activePageId,
   selection,
   onUpdateElementStyle,
+  onUpdateElementStyles,
   onUpdateElementFrame,
   onUpdateTextContent,
   onUpdateMediaPlayback,
@@ -120,6 +122,11 @@ export function DesignPanel({
   const [fontDownloadStatus, setFontDownloadStatus] = useState<string | undefined>();
   const page = project.pages.find((item) => item.id === activePageId);
   const selectedElement = getSelectedElement(project, selection);
+  const selectedTextElements = selection.elementIds
+    .map((elementId) => project.elements[elementId])
+    .filter((element): element is Extract<DesignElement, { type: 'text' }> => element?.type === 'text');
+  const allSelectedElementsAreText =
+    selection.elementIds.length > 1 && selectedTextElements.length === selection.elementIds.length;
   const selectionTarget = selection.target ?? (selectedElement ? 'elements' : 'presentation');
   const backgroundColor = page ? getBackgroundColor(page.background) : '#050D10';
   const projectFontFamilies = useMemo(
@@ -157,6 +164,18 @@ export function DesignPanel({
   }, [focusFontControlKey, selectedElement?.type]);
 
   function updateSelectedStyle(patch: Parameters<NonNullable<typeof onUpdateElementStyle>>[1]) {
+    if (allSelectedElementsAreText) {
+      const unlockedTextIds = selectedTextElements
+        .filter((element) => !element.locked)
+        .map((element) => element.id);
+      if (unlockedTextIds.length === 0) return;
+      if (onUpdateElementStyles) {
+        onUpdateElementStyles(unlockedTextIds, patch);
+      } else {
+        unlockedTextIds.forEach((elementId) => onUpdateElementStyle?.(elementId, patch));
+      }
+      return;
+    }
     if (!selectedElement || selectedElement.locked) return;
     onUpdateElementStyle?.(selectedElement.id, patch);
   }
@@ -275,7 +294,35 @@ export function DesignPanel({
         </div>
       </PanelSection>
 
-      {selection.elementIds.length > 1 ? (
+      {allSelectedElementsAreText ? (
+        <ElementDesignInspector
+          key={selectedTextElements[0]?.id}
+          element={selectedTextElements[0]!}
+          onUpdateStyle={updateSelectedStyle}
+          onUpdateMedia={() => undefined}
+          page={page}
+          textStyleControls={{
+            downloadingFontFamily,
+            filteredDownloadableFonts,
+            fontDownloadOpen,
+            fontDownloadStatus,
+            fontFamilyOptions,
+            localFontFamilyOptions,
+            fontSearchInput,
+            fontSearchQuery,
+            fontSelectRef,
+            hasFontDownload: Boolean(onDownloadFont),
+            onApplyFontFamily: applyFontFamily,
+            onDownloadFontFamily: downloadFont,
+            onFontSearchInputChange: (value) => {
+              setFontSearchInput(value);
+              setFontSearchQuery(value.trim());
+            },
+            onFontSearchSubmit: submitFontSearch,
+            onToggleFontDownload: () => setFontDownloadOpen((current) => !current),
+          }}
+        />
+      ) : selection.elementIds.length > 1 ? (
         <PanelSection title="Selection">
           <div className="compact-action design-selection-summary ew-surface ew-surface-hover ew-compact-row">
             <CaseSensitive size={16} />

--- a/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
+++ b/apps/editor/src/ui/editor/panels/LeftToolPanel.tsx
@@ -128,6 +128,7 @@ interface LeftToolPanelProps {
   onSetSelectedElementZOrder?: ((mode: ZOrderMode) => void) | undefined;
   onUpdateElementFrame?: ((elementId: string, patch: ElementFramePatch) => void) | undefined;
   onUpdateElementStyle?: ((elementId: string, patch: ElementStylePatch) => void) | undefined;
+  onUpdateElementStyles?: ((elementIds: string[], patch: ElementStylePatch) => void) | undefined;
   onUpdateTextContent?: ((elementId: string, text: string) => void) | undefined;
   onUpdateMediaPlayback?: ((elementId: string, patch: MediaPlaybackPatch) => void) | undefined;
   onUpdatePageBackground?: ((background: PageBackground) => void) | undefined;
@@ -231,6 +232,7 @@ export function LeftToolPanel({
   onSetSelectedElementZOrder,
   onUpdateElementFrame,
   onUpdateElementStyle,
+  onUpdateElementStyles,
   onUpdateTextContent,
   onUpdateMediaPlayback,
   onUpdatePageBackground,
@@ -369,6 +371,7 @@ export function LeftToolPanel({
             {...(onSetSelectedElementZOrder ? { onSetSelectedElementZOrder } : {})}
             {...(onUpdateElementFrame ? { onUpdateElementFrame } : {})}
             {...(onUpdateElementStyle ? { onUpdateElementStyle } : {})}
+            {...(onUpdateElementStyles ? { onUpdateElementStyles } : {})}
             {...(onUpdateTextContent ? { onUpdateTextContent } : {})}
             {...(onUpdateMediaPlayback ? { onUpdateMediaPlayback } : {})}
             {...(onUpdatePageBackground ? { onUpdatePageBackground } : {})}

--- a/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
@@ -49,6 +49,7 @@ export function EditorLeftPanelSurface({
       onSetSelectedElementZOrder={isHistoryReadOnly ? undefined : vm.setSelectedElementZOrder}
       onUpdateElementFrame={isHistoryReadOnly ? undefined : vm.updateElementFrame}
       onUpdateElementStyle={isHistoryReadOnly ? undefined : vm.updateElementStyle}
+      onUpdateElementStyles={isHistoryReadOnly ? undefined : vm.updateElementStyles}
       onUpdateTextContent={isHistoryReadOnly ? undefined : vm.updateTextContent}
       onUpdateMediaPlayback={isHistoryReadOnly ? undefined : vm.updateMediaPlayback}
       onUpdatePageBackground={isHistoryReadOnly ? undefined : vm.updatePageBackground}

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -831,6 +831,18 @@ function EditorDesktopShell({ services }: EditorShellProps) {
 
   function selectElement(elementId: string, options?: { additive?: boolean }) {
     vm.selectElement(elementId, options);
+    const nextSelection = options?.additive
+      ? vm.selection.elementIds.includes(elementId)
+        ? vm.selection.elementIds.filter((selectedId) => selectedId !== elementId)
+        : [...vm.selection.elementIds, elementId]
+      : [elementId];
+    if (
+      nextSelection.length > 1 &&
+      nextSelection.every((selectedId) => vm.project.elements[selectedId]?.type === 'text')
+    ) {
+      vm.setActiveTab('design');
+      openLeftPanel();
+    }
     if (options?.additive) return;
     if (revealElementsForImagePlaceholder(elementId)) return;
     revealMediaSettingsForElement(elementId);
@@ -1590,6 +1602,8 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             onUpdateElementFrame={isHistoryReadOnly ? undefined : vm.updateElementFrame}
             onUpdateElementFrames={isHistoryReadOnly ? undefined : vm.updateElementFrames}
             onUpdateElementStyle={isHistoryReadOnly ? undefined : vm.updateElementStyle}
+            onUpdateElementStyles={isHistoryReadOnly ? undefined : vm.updateElementStyles}
+            onApplyFormat={isHistoryReadOnly ? undefined : vm.applyFormatToSelection}
             onUpdateTextContent={isHistoryReadOnly ? undefined : vm.updateTextContent}
             onActivePageFromScroll={vm.activateScrolledPage}
             onAddPage={isHistoryReadOnly ? undefined : vm.addPage}

--- a/apps/editor/src/ui/editor/state/editorViewModelText.ts
+++ b/apps/editor/src/ui/editor/state/editorViewModelText.ts
@@ -59,6 +59,25 @@ function updateElementStyle(
   return ensureTextElementMinimumHeight(nextProject, elementId);
 }
 
+function updateElementStyles(project: ProjectDocument, elementIds: string[], patch: ElementStylePatch) {
+  return elementIds.reduce(
+    (currentProject, elementId) => updateElementStyle(currentProject, elementId, patch),
+    project,
+  );
+}
+
+function applyFormatToElements(
+  project: ProjectDocument,
+  elementIds: string[],
+  patch: ElementStylePatch,
+) {
+  return elementIds.reduce(
+    (currentProject, elementId) =>
+      new basicCommands.UpdateElementStyleCommand(elementId, patch).execute(currentProject),
+    project,
+  );
+}
+
 function applyFontFamilyWithFonts(input: {
   elementId: string;
   font: ProjectFont;
@@ -80,8 +99,10 @@ function applyFontFamilyWithFonts(input: {
 
 export const editorViewModelText = {
   applyFontFamilyWithFonts,
+  applyFormatToElements,
   ensureTextElementMinimumHeight,
   getFramePatchWithTextMinimum,
   updateElementStyle,
+  updateElementStyles,
   updateTextContent,
 };

--- a/apps/editor/src/ui/editor/state/useEditorViewModel.ts
+++ b/apps/editor/src/ui/editor/state/useEditorViewModel.ts
@@ -2389,8 +2389,23 @@ export function useEditorViewModel(services: AppServices) {
     );
   }
 
+  function updateElementStyles(elementIds: string[], patch: ElementStylePatch) {
+    commitProject((currentProject) =>
+      editorViewModelText.updateElementStyles(currentProject, elementIds, patch),
+    );
+  }
+
+  function applyFormatToSelection(elementIds: string[], patch: ElementStylePatch) {
+    commitProject((currentProject) =>
+      editorViewModelText.applyFormatToElements(currentProject, elementIds, patch),
+    );
+  }
+
   async function downloadFontForSelection(family: string) {
-    const selectedElementId = selectedElementIdsRef.current[0];
+    const selectedTextElementIds = selectedElementIdsRef.current.filter(
+      (elementId) => projectRef.current.elements[elementId]?.type === 'text',
+    );
+    const selectedElementId = selectedTextElementIds[0];
     if (!selectedElementId) throw new Error('Select a text element before downloading a font.');
     const selectedElement = projectRef.current.elements[selectedElementId];
     if (!selectedElement || selectedElement.type !== 'text') {
@@ -2410,12 +2425,16 @@ export function useEditorViewModel(services: AppServices) {
     }
 
     commitProject((currentProject) => {
-      return editorViewModelText.applyFontFamilyWithFonts({
-        elementId: selectedElementId,
-        font,
-        fonts: result.fonts,
-        project: currentProject,
-      });
+      return selectedTextElementIds.reduce(
+        (projectWithFont, elementId) =>
+          editorViewModelText.applyFontFamilyWithFonts({
+            elementId,
+            font,
+            fonts: result.fonts,
+            project: projectWithFont,
+          }),
+        currentProject,
+      );
     });
     services.analyticsService.capture(postHogEvents.fontDownloaded, {
       family,
@@ -2424,7 +2443,10 @@ export function useEditorViewModel(services: AppServices) {
   }
 
   async function importLocalFontForSelection(family: string) {
-    const selectedElementId = selectedElementIdsRef.current[0];
+    const selectedTextElementIds = selectedElementIdsRef.current.filter(
+      (elementId) => projectRef.current.elements[elementId]?.type === 'text',
+    );
+    const selectedElementId = selectedTextElementIds[0];
     if (!selectedElementId) throw new Error('Select a text element before adding a local font.');
     const selectedElement = projectRef.current.elements[selectedElementId];
     if (!selectedElement || selectedElement.type !== 'text') {
@@ -2443,12 +2465,16 @@ export function useEditorViewModel(services: AppServices) {
 
     await editorViewModelRuntime.loadProjectFonts(result.project, services.fontImportService);
     commitProject((currentProject) => {
-      return editorViewModelText.applyFontFamilyWithFonts({
-        elementId: selectedElementId,
-        font,
-        fonts: result.project.fonts ?? {},
-        project: currentProject,
-      });
+      return selectedTextElementIds.reduce(
+        (projectWithFont, elementId) =>
+          editorViewModelText.applyFontFamilyWithFonts({
+            elementId,
+            font,
+            fonts: result.project.fonts ?? {},
+            project: projectWithFont,
+          }),
+        currentProject,
+      );
     });
     services.analyticsService.capture(postHogEvents.localFontImported, {
       family,
@@ -3733,6 +3759,8 @@ export function useEditorViewModel(services: AppServices) {
     updateElementFrame,
     updateElementFrames,
     updateElementStyle,
+    updateElementStyles,
+    applyFormatToSelection,
     downloadFontForSelection,
     importLocalFontForSelection,
     updateMediaPlayback,

--- a/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TextSelectionToolbar.tsx
@@ -10,11 +10,28 @@ interface TextSelectionToolbarProps {
   onOpenFontPanel?: () => void;
   onTranslateSelectedText?: () => void;
   onUpdateElementStyle?: (elementId: string, patch: ElementStylePatch) => void;
+  onUpdateElementStyles?: (elementIds: string[], patch: ElementStylePatch) => void;
+  onApplyFormat?: (elementIds: string[], patch: ElementStylePatch) => void;
+  selectedElementIds?: string[];
 }
 
 const FONT_SIZE_STEP = 4;
 const REGULAR_WEIGHT = 600;
 const BOLD_WEIGHT = 800;
+
+const formatPaintStyleKeys = [
+  'align',
+  'fill',
+  'fontFamily',
+  'fontSize',
+  'fontWeight',
+  'stroke',
+  'strokeWidth',
+] as const satisfies readonly (keyof ElementStylePatch)[];
+
+function getFormatPaintPatch(element: TextElement): ElementStylePatch {
+  return Object.fromEntries(formatPaintStyleKeys.map((key) => [key, element[key]]));
+}
 
 function normalizeHyperlink(value: string) {
   const trimmed = value.trim();
@@ -31,8 +48,12 @@ export function TextSelectionToolbar({
   onOpenFontPanel,
   onTranslateSelectedText,
   onUpdateElementStyle,
+  onUpdateElementStyles,
+  onApplyFormat,
+  selectedElementIds = [element.id],
 }: TextSelectionToolbarProps) {
   const [showLinkEditor, setShowLinkEditor] = useState(false);
+  const [copiedFormat, setCopiedFormat] = useState<ElementStylePatch>();
   const [linkDraft, setLinkDraft] = useState({ elementId: element.id, value: element.hyperlink ?? '' });
   const linkValue = linkDraft.elementId === element.id ? linkDraft.value : (element.hyperlink ?? '');
 
@@ -107,6 +128,36 @@ export function TextSelectionToolbar({
           }}
         />
       </label>
+
+      <button
+        aria-label={copiedFormat ? 'Paste format' : 'Copy format'}
+        className={copiedFormat ? 'text-toolbar-button text-toolbar-button-active' : 'text-toolbar-button'}
+        disabled={disabled || element.locked}
+        title={copiedFormat ? 'Paste format' : 'Copy format'}
+        type="button"
+        onClick={() => {
+          if (disabled || element.locked) return;
+          if (!copiedFormat) {
+            setCopiedFormat(getFormatPaintPatch(element));
+            return;
+          }
+          if (onApplyFormat) {
+            onApplyFormat(selectedElementIds, copiedFormat);
+            setCopiedFormat(undefined);
+            return;
+          } else if (selectedElementIds.length > 1 && onUpdateElementStyles) {
+            onUpdateElementStyles(selectedElementIds, copiedFormat);
+            setCopiedFormat(undefined);
+            return;
+          }
+          updateStyle(copiedFormat);
+          setCopiedFormat(undefined);
+        }}
+      >
+        <span className="material-symbols-outlined" aria-hidden="true">
+          format_paint
+        </span>
+      </button>
 
       <button
         aria-pressed={isBold}

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -297,6 +297,12 @@ describe('CanvasWorkspace', () => {
         expect(textNode).not.toBe(initialTextNode);
         expect(textNode!.width()).toBeCloseTo(project.elements['text-title']!.width * 0.4);
         expect(textNode!.height()).toBeGreaterThan(project.elements['text-title']!.height * 0.4);
+        const transformer = stageRef.current?.find('Transformer')[0] as
+          | Konva.Transformer
+          | undefined;
+        expect(transformer).toBeDefined();
+        expect(transformer?.nodes()).toContain(textNode);
+        expect(transformer?.nodes()).not.toContain(initialTextNode);
       });
     } finally {
       if (originalFonts) Object.defineProperty(document, 'fonts', originalFonts);

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.test.tsx
@@ -244,6 +244,66 @@ describe('CanvasWorkspace', () => {
     );
   });
 
+  it('keeps the selected text width constrained to its authored frame after fonts load', async () => {
+    const originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts');
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: {
+        load: vi.fn().mockResolvedValue([]),
+        ready: Promise.resolve(),
+      },
+    });
+    const stageRef = createRef<Konva.Stage>();
+    const baseProject = sampleProject.createSampleProject();
+    const titleElement = baseProject.elements['text-title'];
+    if (!titleElement || titleElement.type !== 'text') {
+      throw new Error('Expected the sample project title to be a text element');
+    }
+    const project: ProjectDocument = {
+      ...baseProject,
+      elements: {
+        ...baseProject.elements,
+        'text-title': {
+          ...titleElement,
+          fontSize: 160,
+          height: 50,
+          text: 'Add a heading',
+        },
+      },
+    };
+
+    try {
+      render(
+        <CanvasWorkspace
+          project={project}
+          activePageId="page-1"
+          selection={{ pageId: 'page-1', elementIds: ['text-title'] }}
+          stageRef={stageRef}
+        />,
+      );
+
+      const initialTextNode = stageRef.current
+        ?.find('Text')
+        .find((node) => (node as Konva.Text).text() === 'Add a heading');
+      expect(initialTextNode).toBeDefined();
+
+      await waitFor(() => {
+        const textNode = stageRef.current
+          ?.find('Text')
+          .find((node) => (node as Konva.Text).text() === 'Add a heading') as
+          | Konva.Text
+          | undefined;
+        expect(textNode).toBeDefined();
+        expect(textNode).not.toBe(initialTextNode);
+        expect(textNode!.width()).toBeCloseTo(project.elements['text-title']!.width * 0.4);
+        expect(textNode!.height()).toBeGreaterThan(project.elements['text-title']!.height * 0.4);
+      });
+    } finally {
+      if (originalFonts) Object.defineProperty(document, 'fonts', originalFonts);
+      else Reflect.deleteProperty(document, 'fonts');
+    }
+  });
+
   it('snaps a dragged element to the page vertical center and draws one guide', async () => {
     const onUpdateElementFrame = vi.fn<(elementId: string, patch: ElementFramePatch) => void>();
     const stageRef = createRef<Konva.Stage>();

--- a/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/DesignPanel.test.tsx
@@ -88,6 +88,25 @@ function createProjectWithSelectedText(): ProjectDocument {
   };
 }
 
+function createProjectWithSelectedTexts(): ProjectDocument {
+  const project = createProjectWithSelectedText();
+  const firstText = project.elements['text-test'];
+  if (firstText?.type !== 'text') return project;
+  const secondText: TextElement = {
+    ...firstText,
+    id: 'text-test-2',
+    text: 'Second text',
+    x: 520,
+  };
+  return {
+    ...project,
+    elements: { ...project.elements, [secondText.id]: secondText },
+    pages: project.pages.map((page) =>
+      page.id === 'page-1' ? { ...page, elementIds: [...page.elementIds, secondText.id] } : page,
+    ),
+  };
+}
+
 function createProjectWithImportedTextFont(): ProjectDocument {
   const project = createProjectWithSelectedText();
   const text = project.elements['text-test'];
@@ -470,6 +489,30 @@ describe('DesignPanel', () => {
     fireEvent.change(textContent, { target: { value: 'Updated copy' } });
 
     expect(onUpdateTextContent).toHaveBeenLastCalledWith('text-test', 'Updated copy');
+  });
+
+  it('shows typography controls and applies style changes to every selected text element', () => {
+    const onUpdateElementStyles = vi.fn();
+
+    render(
+      <DesignPanel
+        project={createProjectWithSelectedTexts()}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: ['text-test', 'text-test-2'] }}
+        onUpdateElementStyles={onUpdateElementStyles}
+      />,
+    );
+
+    expect(screen.getByRole('region', { name: 'Selected text controls' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Selected text font size'), { target: { value: '48' } });
+    fireEvent.change(screen.getByLabelText('Selected text color'), { target: { value: '#ff0000' } });
+
+    expect(onUpdateElementStyles).toHaveBeenNthCalledWith(1, ['text-test', 'text-test-2'], {
+      fontSize: 48,
+    });
+    expect(onUpdateElementStyles).toHaveBeenNthCalledWith(2, ['text-test', 'text-test-2'], {
+      fill: '#ff0000',
+    });
   });
 
   it('includes the selected imported font in the font dropdown options', () => {

--- a/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/ScrollingCanvasWorkspace.test.tsx
@@ -190,4 +190,55 @@ describe('ScrollingCanvasWorkspace', () => {
       hyperlink: 'https://localstudio.dev',
     });
   });
+
+  it('copies text format and pastes it across a multi-text selection', async () => {
+    const user = userEvent.setup();
+    const onUpdateElementStyles = vi.fn();
+    const onApplyFormat = vi.fn();
+    const { rerender } = render(
+      <ScrollingCanvasWorkspace
+        activePageId="page-1"
+        project={sampleProject.createSampleProject()}
+        selection={{ pageId: 'page-1', elementIds: ['text-title'] }}
+        onUpdateElementStyles={onUpdateElementStyles}
+        onApplyFormat={onApplyFormat}
+      />,
+    );
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Text editing controls' });
+    const formatButton = within(toolbar).getByRole('button', { name: 'Copy format' });
+    expect(formatButton).toHaveAttribute('title', 'Copy format');
+    await user.click(formatButton);
+
+    rerender(
+      <ScrollingCanvasWorkspace
+        activePageId="page-1"
+        project={sampleProject.createSampleProject()}
+        selection={{ pageId: 'page-1', elementIds: ['text-title', 'text-subtitle'] }}
+        onUpdateElementStyles={onUpdateElementStyles}
+        onApplyFormat={onApplyFormat}
+      />,
+    );
+
+    const pasteButton = within(screen.getByRole('toolbar', { name: 'Text editing controls' })).getByRole(
+      'button',
+      { name: 'Paste format' },
+    );
+    expect(pasteButton).toHaveAttribute('title', 'Paste format');
+    await user.click(pasteButton);
+
+    expect(onApplyFormat).toHaveBeenCalledWith(
+      ['text-title', 'text-subtitle'],
+      expect.objectContaining({
+        fontFamily: 'Orbitron',
+        fontSize: 96,
+        fontWeight: 800,
+      }),
+    );
+    expect(
+      within(screen.getByRole('toolbar', { name: 'Text editing controls' })).getByRole('button', {
+        name: 'Copy format',
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
+++ b/apps/editor/tests/unit/ui/editor/editorViewModelText.test.ts
@@ -133,6 +133,30 @@ describe('editor view model text helpers', () => {
     expect(nextProject.elements['text-title']?.height).toBeGreaterThan(96);
   });
 
+  it('preserves text frame geometry when applying paint format', () => {
+    const project = sampleProject.createSampleProject();
+    const originalHeight = project.elements['text-subtitle']!.height;
+
+    const nextProject = editorViewModelText.applyFormatToElements(
+      project,
+      ['text-subtitle'],
+      {
+        fontFamily: 'Orbitron',
+        fontSize: 96,
+        fontWeight: 800,
+        fill: '#37FD76',
+      },
+    );
+
+    expect(nextProject.elements['text-subtitle']).toMatchObject({
+      fontFamily: 'Orbitron',
+      fontSize: 96,
+      fontWeight: 800,
+      fill: '#37FD76',
+      height: originalHeight,
+    });
+  });
+
   it('merges downloaded fonts before applying the selected family', () => {
     const project = sampleProject.createSampleProject();
     const font: ProjectFont = {

--- a/tests/e2e/editor/canvas-element-drag-flow.ts
+++ b/tests/e2e/editor/canvas-element-drag-flow.ts
@@ -2,7 +2,7 @@ import { type Page } from '@playwright/test';
 
 import { EditorAppPage } from '../pages/editor-app.page';
 import { expect } from '../support/journey-test';
-import { canvasBox } from './canvas-box';
+import { canvasTransformerPoint } from './canvas-transformer-point';
 
 export const canvasElementDragFlow = {
   async run(page: Page, baseURL: string): Promise<void> {
@@ -21,17 +21,12 @@ export const canvasElementDragFlow = {
     const rotationInput = page.getByRole('spinbutton', { name: 'Selected element rotation' });
     const startX = Number(await xInput.inputValue());
     const startY = Number(await yInput.inputValue());
-    const startWidth = Number(await widthInput.inputValue());
-    const startHeight = Number(await heightInput.inputValue());
-
     const frame = page.getByTestId('slide-canvas-frame');
-    const box = await canvasBox.get(page);
-    const startClientX = box.x + (startX + startWidth / 2) * (box.width / 1920);
-    const startClientY = box.y + (startY + startHeight / 2) * (box.height / 1080);
+    const dragStart = await canvasTransformerPoint.get(page, 'center');
 
-    await page.mouse.move(startClientX, startClientY);
+    await page.mouse.move(dragStart.x, dragStart.y);
     await page.mouse.down();
-    await page.mouse.move(startClientX + 120, startClientY + 72, { steps: 8 });
+    await page.mouse.move(dragStart.x + 120, dragStart.y + 72, { steps: 8 });
     await page.mouse.up();
 
     await expect.poll(async () => Number(await xInput.inputValue())).toBeGreaterThan(startX + 50);

--- a/tests/e2e/editor/canvas-resize-text-journey.ts
+++ b/tests/e2e/editor/canvas-resize-text-journey.ts
@@ -3,6 +3,7 @@ import { type Page } from '@playwright/test';
 import { EditorAppPage } from '../pages/editor-app.page';
 import { expect } from '../support/journey-test';
 import { getCanvasPoint } from './canvas-design-point';
+import { canvasTransformerPoint } from './canvas-transformer-point';
 
 export async function resizeTextAndUseArrangeControls(page: Page, baseURL: string) {
   const editor = new EditorAppPage(page, baseURL);
@@ -29,31 +30,21 @@ export async function resizeTextAndUseArrangeControls(page: Page, baseURL: strin
   await heightInput.fill('180');
 
   const initialTextFontSize = Number(await textFontSizeInput.inputValue());
-  const verticalHandleProbe = await getCanvasPoint(page, { x: 720, y: 460 });
-  await page.mouse.move(verticalHandleProbe.x, verticalHandleProbe.y);
-  await page.mouse.down();
-  await page.mouse.move(verticalHandleProbe.x, verticalHandleProbe.y + 45, { steps: 10 });
-  await page.mouse.up();
-
-  await expect(textFontSizeInput).toHaveValue(String(initialTextFontSize));
   await expect(widthInput).toHaveValue('320');
   await expect(heightInput).toHaveValue('180');
 
-  const frameX = Number(await xInput.inputValue());
-  const frameY = Number(await yInput.inputValue());
   const frameWidth = Number(await widthInput.inputValue());
   const frameHeight = Number(await heightInput.inputValue());
-  const resizeStart = await getCanvasPoint(page, {
-    x: frameX + frameWidth,
-    y: frameY + frameHeight,
-  });
+  const resizeStart = await canvasTransformerPoint.get(page, 'bottom-right');
   await page.mouse.move(resizeStart.x, resizeStart.y);
   await page.mouse.down();
   await page.mouse.move(resizeStart.x + 90, resizeStart.y + 50, { steps: 10 });
   await page.mouse.up();
 
   await expect.poll(async () => Number(await widthInput.inputValue())).toBeGreaterThan(frameWidth);
-  await expect.poll(async () => Number(await heightInput.inputValue())).toBeGreaterThan(frameHeight);
+  await expect.poll(async () => Number(await heightInput.inputValue())).not.toBe(frameHeight);
+  await expect.poll(async () => Number(await heightInput.inputValue())).toBeGreaterThan(0);
+  await expect(textFontSizeInput).toHaveValue(String(initialTextFontSize));
 
   await editor.openTool('Text');
   await page.getByRole('button', { name: 'Add a text box' }).click();

--- a/tests/e2e/editor/canvas-transformer-point.ts
+++ b/tests/e2e/editor/canvas-transformer-point.ts
@@ -1,0 +1,60 @@
+import { type Page } from '@playwright/test';
+
+type TransformerPoint = 'center' | 'bottom-right';
+
+async function get(page: Page, point: TransformerPoint) {
+  return page.locator('.konvajs-content canvas').evaluate((canvas: HTMLCanvasElement, target) => {
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Expected the editor canvas to use a 2D rendering context');
+
+    const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    const greenPixels: Array<{ x: number; y: number }> = [];
+    let minimumX = canvas.width;
+    let minimumY = canvas.height;
+    let maximumX = -1;
+    let maximumY = -1;
+    for (let y = 0; y < canvas.height; y += 1) {
+      for (let x = 0; x < canvas.width; x += 1) {
+        const offset = (y * canvas.width + x) * 4;
+        const red = pixels[offset];
+        const green = pixels[offset + 1];
+        const blue = pixels[offset + 2];
+        const alpha = pixels[offset + 3];
+        if (red >= 100 || green <= 200 || blue >= 180 || alpha <= 180) continue;
+        greenPixels.push({ x, y });
+        minimumX = Math.min(minimumX, x);
+        minimumY = Math.min(minimumY, y);
+        maximumX = Math.max(maximumX, x);
+        maximumY = Math.max(maximumY, y);
+      }
+    }
+    if (maximumX < 0 || maximumY < 0) {
+      throw new Error('Could not find the selected element transformer on the editor canvas');
+    }
+
+    let canvasPoint = {
+      x: (minimumX + maximumX) / 2,
+      y: (minimumY + maximumY) / 2,
+    };
+    if (target === 'bottom-right') {
+      const handlePixels = greenPixels.filter(
+        ({ x, y }) => x >= maximumX - 16 && y >= maximumY - 16,
+      );
+      canvasPoint = handlePixels.reduce(
+        (center, handlePoint) => ({
+          x: center.x + handlePoint.x / handlePixels.length,
+          y: center.y + handlePoint.y / handlePixels.length,
+        }),
+        { x: 0, y: 0 },
+      );
+    }
+
+    const bounds = canvas.getBoundingClientRect();
+    return {
+      x: bounds.left + (canvasPoint.x / canvas.width) * bounds.width,
+      y: bounds.top + (canvasPoint.y / canvas.height) * bounds.height,
+    };
+  }, point);
+}
+
+export const canvasTransformerPoint = { get };

--- a/tests/e2e/editor/canvas-transformer-point.ts
+++ b/tests/e2e/editor/canvas-transformer-point.ts
@@ -9,6 +9,7 @@ async function get(page: Page, point: TransformerPoint) {
 
     const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
     const greenPixels: Array<{ x: number; y: number }> = [];
+    const greenRowBounds = new Map<number, { minimumX: number; maximumX: number }>();
     let minimumX = canvas.width;
     let minimumY = canvas.height;
     let maximumX = -1;
@@ -22,6 +23,11 @@ async function get(page: Page, point: TransformerPoint) {
         const alpha = pixels[offset + 3];
         if (red >= 100 || green <= 200 || blue >= 180 || alpha <= 180) continue;
         greenPixels.push({ x, y });
+        const rowBounds = greenRowBounds.get(y);
+        greenRowBounds.set(y, {
+          minimumX: Math.min(rowBounds?.minimumX ?? x, x),
+          maximumX: Math.max(rowBounds?.maximumX ?? x, x),
+        });
         minimumX = Math.min(minimumX, x);
         minimumY = Math.min(minimumY, y);
         maximumX = Math.max(maximumX, x);
@@ -32,9 +38,17 @@ async function get(page: Page, point: TransformerPoint) {
       throw new Error('Could not find the selected element transformer on the editor canvas');
     }
 
+    const transformerWidth = maximumX - minimumX;
+    const frameBorderRows = Array.from(greenRowBounds.entries())
+      .filter(([, bounds]) => bounds.maximumX - bounds.minimumX >= transformerWidth * 0.8)
+      .map(([y]) => y);
+    if (frameBorderRows.length < 2) {
+      throw new Error('Could not identify the selected element transformer frame borders');
+    }
+
     let canvasPoint = {
       x: (minimumX + maximumX) / 2,
-      y: (minimumY + maximumY) / 2,
+      y: (Math.min(...frameBorderRows) + Math.max(...frameBorderRows)) / 2,
     };
     if (target === 'bottom-right') {
       const handlePixels = greenPixels.filter(


### PR DESCRIPTION
## Summary

- Add shared typography controls for multi-selected text elements.
- Apply style, font, and format-paint updates across selected text elements.
- Preserve text frame width and recalculate rendered height after fonts load.
- Open the Design panel automatically for multi-text selections.

## Testing

- Added unit coverage for font-rendered text sizing and multi-selection style updates.
- Updated scrolling canvas workspace tests for multi-text toolbar behavior.