### PR TITLE
Render pasted media inside the Konva layer stack

### DIFF
--- a/apps/editor/src/ui/editor/canvas/CanvasMediaElement.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasMediaElement.tsx
@@ -29,6 +29,7 @@ function CanvasVideoElement({
   opacity,
   previewMode,
   scale,
+  onMediaElementChange,
 }: {
   animationState: ElementAnimationRenderState;
   assetName: string;
@@ -38,6 +39,10 @@ function CanvasVideoElement({
   opacity: number;
   previewMode: boolean;
   scale: { x: number; y: number };
+  onMediaElementChange: (
+    elementId: string,
+    media: HTMLImageElement | HTMLVideoElement | null,
+  ) => void;
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const reverseIntervalRef = useRef<number | undefined>(undefined);
@@ -58,6 +63,13 @@ function CanvasVideoElement({
     !element.startOnClick &&
     !animationState.hidden &&
     !animationState.mediaActionPending;
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    onMediaElementChange(element.id, video);
+    return () => onMediaElementChange(element.id, null);
+  }, [element.id, onMediaElementChange]);
 
   function stopReversePlayback() {
     if (reverseIntervalRef.current === undefined) return;
@@ -259,6 +271,57 @@ function CanvasVideoElement({
   );
 }
 
+function CanvasGifElement({
+  animationState,
+  assetName,
+  assetUrl,
+  element,
+  interactive,
+  opacity,
+  previewMode,
+  scale,
+  onMediaElementChange,
+}: {
+  animationState: ElementAnimationRenderState;
+  assetName: string;
+  assetUrl: string | undefined;
+  element: GifElement;
+  interactive: boolean;
+  opacity: number;
+  previewMode: boolean;
+  scale: { x: number; y: number };
+  onMediaElementChange: (
+    elementId: string,
+    media: HTMLImageElement | HTMLVideoElement | null,
+  ) => void;
+}) {
+  const imageRef = useRef<HTMLImageElement>(null);
+  const shouldPlayGif =
+    element.playing &&
+    (!previewMode || !animationState.hidden || Boolean(animationState.activeBuild));
+  const gifPlaybackKey = animationState.activeBuild
+    ? `${element.id}-${animationState.playbackRunId ?? 'static'}-${animationState.activeBuild.id}`
+    : `${element.id}-${animationState.playbackRunId ?? 'static'}-${shouldPlayGif ? 'playing' : 'hidden'}`;
+
+  useEffect(() => {
+    const image = imageRef.current;
+    if (!image) return;
+    onMediaElementChange(element.id, image);
+    return () => onMediaElementChange(element.id, null);
+  }, [element.id, gifPlaybackKey, onMediaElementChange]);
+
+  return (
+    <img
+      aria-label={assetName}
+      className="canvas-media-element"
+      key={gifPlaybackKey}
+      ref={imageRef}
+      src={shouldPlayGif ? assetUrl : undefined}
+      style={getMediaStyle(element, scale, interactive, opacity)}
+    />
+  );
+}
+
 export function CanvasMediaElement({
   animationState,
   assetName,
@@ -268,6 +331,7 @@ export function CanvasMediaElement({
   opacity,
   previewMode,
   scale,
+  onMediaElementChange,
 }: {
   animationState: ElementAnimationRenderState;
   assetName: string;
@@ -277,21 +341,23 @@ export function CanvasMediaElement({
   opacity: number;
   previewMode: boolean;
   scale: { x: number; y: number };
+  onMediaElementChange: (
+    elementId: string,
+    media: HTMLImageElement | HTMLVideoElement | null,
+  ) => void;
 }) {
   if (element.type === 'gif') {
-    const shouldPlayGif =
-      element.playing &&
-      (!previewMode || !animationState.hidden || Boolean(animationState.activeBuild));
-    const gifPlaybackKey = animationState.activeBuild
-      ? `${element.id}-${animationState.playbackRunId ?? 'static'}-${animationState.activeBuild.id}`
-      : `${element.id}-${animationState.playbackRunId ?? 'static'}-${shouldPlayGif ? 'playing' : 'hidden'}`;
     return (
-      <img
-        aria-label={assetName}
-        className="canvas-media-element"
-        key={gifPlaybackKey}
-        src={shouldPlayGif ? assetUrl : undefined}
-        style={getMediaStyle(element, scale, interactive, opacity)}
+      <CanvasGifElement
+        animationState={animationState}
+        assetName={assetName}
+        assetUrl={assetUrl}
+        element={element}
+        interactive={interactive}
+        opacity={opacity}
+        previewMode={previewMode}
+        scale={scale}
+        onMediaElementChange={onMediaElementChange}
       />
     );
   }
@@ -306,6 +372,7 @@ export function CanvasMediaElement({
       opacity={opacity}
       previewMode={previewMode}
       scale={scale}
+      onMediaElementChange={onMediaElementChange}
     />
   );
 }

--- a/apps/editor/src/ui/editor/canvas/CanvasMediaNode.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasMediaNode.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type Konva from 'konva';
+import { Image as KonvaImage } from 'react-konva';
+import type { CommonElementProps } from './canvas-element-props';
+
+export function CanvasMediaNode({
+  commonProps,
+  media,
+  nodeRef,
+  redrawContinuously,
+}: {
+  commonProps: CommonElementProps;
+  media: HTMLImageElement | HTMLVideoElement;
+  nodeRef: (node: Konva.Node | null) => void;
+  redrawContinuously: boolean;
+}) {
+  const imageRef = useRef<Konva.Image>(null);
+  const setImageRef = useCallback(
+    (node: Konva.Image | null) => {
+      imageRef.current = node;
+      nodeRef(node);
+    },
+    [nodeRef],
+  );
+
+  useEffect(() => {
+    let animationFrameId: number | undefined;
+    const redraw = () => imageRef.current?.getLayer()?.batchDraw();
+    const redrawFrame = () => {
+      redraw();
+      animationFrameId = window.requestAnimationFrame(redrawFrame);
+    };
+    const startRedraw = () => {
+      if (animationFrameId !== undefined) return;
+      animationFrameId = window.requestAnimationFrame(redrawFrame);
+    };
+    const stopRedraw = () => {
+      if (animationFrameId === undefined) return;
+      window.cancelAnimationFrame(animationFrameId);
+      animationFrameId = undefined;
+    };
+
+    redraw();
+    if (media instanceof HTMLVideoElement) {
+      media.addEventListener('loadeddata', redraw);
+      media.addEventListener('seeked', redraw);
+      media.addEventListener('timeupdate', redraw);
+      media.addEventListener('play', startRedraw);
+      media.addEventListener('pause', stopRedraw);
+      media.addEventListener('ended', stopRedraw);
+      if (!media.paused) startRedraw();
+    } else if (redrawContinuously) {
+      startRedraw();
+    }
+
+    return () => {
+      stopRedraw();
+      if (!(media instanceof HTMLVideoElement)) return;
+      media.removeEventListener('loadeddata', redraw);
+      media.removeEventListener('seeked', redraw);
+      media.removeEventListener('timeupdate', redraw);
+      media.removeEventListener('play', startRedraw);
+      media.removeEventListener('pause', stopRedraw);
+      media.removeEventListener('ended', stopRedraw);
+    };
+  }, [media, redrawContinuously]);
+
+  return <KonvaImage {...commonProps} image={media} ref={setImageRef} />;
+}

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -37,6 +37,7 @@ import { animationPresetEngine } from '../animation/animationPresetEngine';
 import { BackgroundSelectionPreview } from './BackgroundSelectionPreview';
 import { CanvasImageElement } from './CanvasImageElement';
 import { CanvasMediaElement } from './CanvasMediaElement';
+import { CanvasMediaNode } from './CanvasMediaNode';
 import { CanvasReadOnlyMediaElement } from './CanvasReadOnlyMediaElement';
 import { CanvasShapeElement } from './CanvasShapeElement';
 import { CanvasStatusHint } from './CanvasStatusHint';
@@ -232,6 +233,9 @@ export function CanvasWorkspace({
   } | null>(null);
   const [magnetGuides, setMagnetGuides] = useState<CanvasMagnetGuide[]>([]);
   const [marqueeSelection, setMarqueeSelection] = useState<MarqueeSelection | null>(null);
+  const [mediaElements, setMediaElements] = useState<
+    Record<string, HTMLImageElement | HTMLVideoElement>
+  >({});
   const [cropModeElementId, setCropModeElementId] = useState<string | null>(null);
   const [cropDraft, setCropDraft] = useState<
     | {
@@ -352,6 +356,19 @@ export function CanvasWorkspace({
   const setElementNodeRef = useCallback((elementId: string, node: Konva.Node | null) => {
     nodeRefs.current[elementId] = node;
   }, []);
+  const handleMediaElementChange = useCallback(
+    (elementId: string, media: HTMLImageElement | HTMLVideoElement | null) => {
+      setMediaElements((current) => {
+        if (current[elementId] === media) return current;
+        if (!media && !(elementId in current)) return current;
+        const next = { ...current };
+        if (media) next[elementId] = media;
+        else delete next[elementId];
+        return next;
+      });
+    },
+    [],
+  );
 
   useEffect(() => {
     const selectedNodes = selection.elementIds
@@ -1179,6 +1196,7 @@ export function CanvasWorkspace({
             />
           ) : null}
           <Stage
+            className="canvas-konva-stage"
             ref={stageRef}
             height={stageHeight}
             width={stageWidth}
@@ -1234,6 +1252,18 @@ export function CanvasWorkspace({
                 if (element.type === 'gif' || element.type === 'video') {
                   const selected = selection.elementIds.includes(element.id);
                   const asset = project.assets[element.assetId];
+                  const mediaElement = mediaElements[element.id];
+                  if (mediaElement && (!readOnly || hideReadOnlyMediaPlaceholder)) {
+                    return (
+                      <CanvasMediaNode
+                        commonProps={commonProps}
+                        key={element.id}
+                        media={mediaElement}
+                        nodeRef={nodeRef}
+                        redrawContinuously={element.type === 'gif' && element.playing}
+                      />
+                    );
+                  }
                   if (readOnly) {
                     return (
                       <CanvasReadOnlyMediaElement
@@ -1349,7 +1379,7 @@ export function CanvasWorkspace({
           </Stage>
           <div
             className="canvas-media-layer"
-            aria-hidden={visibleMediaElements.length === 0 ? true : undefined}
+            aria-hidden="true"
           >
             {visibleMediaElements.map((element) => {
               const asset = project.assets[element.assetId];
@@ -1367,6 +1397,7 @@ export function CanvasWorkspace({
                   opacity={getAnimationOpacity(element.opacity, animationState)}
                   previewMode={presentationMode || readOnly || isAnimationPreviewRunning}
                   scale={{ x: scaleX, y: scaleY }}
+                  onMediaElementChange={handleMediaElementChange}
                 />
               );
             })}

--- a/apps/editor/src/ui/styles/artboard-frame.css
+++ b/apps/editor/src/ui/styles/artboard-frame.css
@@ -26,8 +26,13 @@
 .canvas-media-layer {
   position: absolute;
   inset: 0;
-  z-index: 2;
+  z-index: 0;
   pointer-events: none;
+}
+
+.canvas-konva-stage {
+  position: relative;
+  z-index: 1;
 }
 
 .canvas-media-element {

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.media.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.media.test.tsx
@@ -1,4 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createRef } from 'react';
+import type Konva from 'konva';
 import { vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
 import { CanvasWorkspace } from '../../../../src/ui/editor/canvas/CanvasWorkspace';
@@ -75,6 +77,31 @@ describe('CanvasWorkspace media elements', () => {
     expect(previewVideo.preload).toBe('auto');
     expect(previewVideo.dataset.trimStart).toBe('2');
     expect(previewVideo.dataset.trimEnd).toBe('6');
+  });
+
+  it('renders video frames inside the Konva element stack so later images can cover them', async () => {
+    const stageRef = createRef<Konva.Stage>();
+    const project = createMediaProject();
+    project.pages[0]!.elementIds = ['video-demo', 'image-hero'];
+    const { container } = render(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        stageRef={stageRef}
+      />,
+    );
+
+    const video = container.querySelector('video[aria-label="Demo clip"]') as HTMLVideoElement;
+
+    await waitFor(() => {
+      const videoNode = stageRef.current
+        ?.find('Image')
+        .find((node) => (node as Konva.Image).image() === video);
+      expect(videoNode).toBeDefined();
+      expect(videoNode?.getZIndex()).toBe(1);
+      expect(videoNode?.getLayer()?.getChildren()[2]).not.toBe(videoNode);
+    });
   });
 
   it('plays start-on-click videos when their animation build becomes active', async () => {


### PR DESCRIPTION
## Summary

- Register image and video elements with the canvas workspace.
- Render media through Konva so later elements appear above pasted videos and images.
- Add continuous redraw handling for playing GIFs and videos.
- Keep the DOM media layer behind the Konva stage and mark it as hidden from assistive technology.

## Testing

- Added unit coverage verifying video frames render in the Konva element stack and preserve z-order for subsequent images.