### PR TITLE
Fix desktop presenter and remote stream layout

### DIFF
--- a/apps/editor/src/services/presenter/presenterRemoteStateFactory.ts
+++ b/apps/editor/src/services/presenter/presenterRemoteStateFactory.ts
@@ -1,6 +1,7 @@
 import type { DesignElement, Page, ProjectDocument } from '../../domain/documents/model';
 import { pageVisibility } from '../../domain/documents/pageVisibility';
 import { presenterRemoteDebugLog } from '@localstudio/presenter-remote/debug-log';
+import { presenterRemoteStreamSize } from '@localstudio/presenter-remote/stream-size';
 import type {
   PresenterRemotePreviewBatch,
   PresenterRemoteSlidePreview,
@@ -70,10 +71,10 @@ function createRemoteStateSkeleton(
     stream: {
       enabled: true,
       fps: 8,
-      height: 340,
+      height: presenterRemoteStreamSize.height,
       peerId: payload.streamPeerId,
       transport: 'peerjs',
-      width: 390,
+      width: presenterRemoteStreamSize.width,
     },
     timer,
     type: 'state',
@@ -140,10 +141,10 @@ function createRemoteState(
     stream: {
       enabled: true,
       fps: 8,
-      height: 340,
+      height: presenterRemoteStreamSize.height,
       peerId: payload.streamPeerId,
       transport: 'peerjs',
-      width: 390,
+      width: presenterRemoteStreamSize.width,
     },
     timer,
     type: 'state',

--- a/apps/editor/src/ui/presenter/presenterRemoteMirror.ts
+++ b/apps/editor/src/ui/presenter/presenterRemoteMirror.ts
@@ -1,4 +1,5 @@
 import type { DesignElement, Page, ProjectDocument } from '../../domain/documents/model';
+import { presenterRemoteStreamSize } from '@localstudio/presenter-remote/stream-size';
 import type { AnimationPreviewState } from '../editor/animation/useAnimationPreviewController';
 
 export interface PresenterRemoteMirrorFrame {
@@ -17,7 +18,7 @@ export interface PresenterRemoteMirrorSize {
   width: number;
 }
 
-const mirrorSize = { height: 340, width: 390 };
+const mirrorSize = presenterRemoteStreamSize;
 const mirrorBackground = '#020805';
 const mirrorPanel = '#07120d';
 const imageCache = new Map<string, HTMLImageElement>();
@@ -201,15 +202,15 @@ function renderFrame(canvas: HTMLCanvasElement, frame: PresenterRemoteMirrorFram
   context.scale(width / mirrorSize.width, height / mirrorSize.height);
   context.fillStyle = mirrorBackground;
   context.fillRect(0, 0, mirrorSize.width, mirrorSize.height);
-  const gradient = context.createLinearGradient(0, 0, 0, 180);
+  const gradient = context.createLinearGradient(0, 0, 0, 160);
   gradient.addColorStop(0, 'rgba(55,253,118,0.10)');
   gradient.addColorStop(1, 'rgba(55,253,118,0)');
   context.fillStyle = gradient;
-  context.fillRect(0, 0, mirrorSize.width, 120);
-  roundedRect(context, 8, 8, mirrorSize.width - 16, 330, 2);
+  context.fillRect(0, 0, mirrorSize.width, 128);
+  roundedRect(context, 4, 4, mirrorSize.width - 8, mirrorSize.height - 8, 4);
   context.fillStyle = mirrorPanel;
   context.fill();
-  drawSlide(context, frame, frame.activePage, { height: 306, width: mirrorSize.width - 24, x: 12, y: 20 });
+  drawSlide(context, frame, frame.activePage, { height: 270, width: 480, x: 16, y: 9 });
   context.restore();
 }
 

--- a/apps/editor/src/ui/styles/presenter.css
+++ b/apps/editor/src/ui/styles/presenter.css
@@ -29,15 +29,25 @@
   min-height: 0;
   min-width: 0;
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: 70px auto minmax(0, 1fr) minmax(120px, 21vh);
+  overflow: hidden;
 }
 
 .presenter-topbar {
+  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
   padding: 14px 20px;
+  scrollbar-width: none;
+}
+
+.presenter-topbar::-webkit-scrollbar {
+  display: none;
 }
 
 .presenter-clock-group {
@@ -284,15 +294,24 @@
 
 .presenter-stage {
   min-height: 0;
+  min-width: 0;
+  container-type: size;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
   padding: 0 36px;
   cursor: pointer;
 }
 
 .presenter-stage .canvas-workspace {
+  min-width: 0;
+  width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .presenter-stage .canvas-frame {
+  width: min(100%, 1180px, calc(100cqh * 16 / 9));
   max-width: 100%;
   max-height: 100%;
 }

--- a/apps/editor/tests/unit/services/presenterRemoteSessionService.previews.test.ts
+++ b/apps/editor/tests/unit/services/presenterRemoteSessionService.previews.test.ts
@@ -42,7 +42,7 @@ describe('BrowserPresenterSessionService remote previews', () => {
         notes: project.pages[0]!.speakerNotes ?? '',
         pageCount: project.pages.length,
         previewMode: 'stream',
-        stream: { enabled: true, fps: 8, height: 340, width: 390 },
+        stream: { enabled: true, fps: 8, height: 288, width: 512 },
         type: 'state',
       });
       expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
@@ -443,7 +443,7 @@ describe('BrowserPresenterSessionService remote previews', () => {
     expect(signalingService.getPublishedState('ABCD-1234')).toMatchObject({
       buildsRemaining: 1,
       previewMode: 'stream',
-      stream: { enabled: true, fps: 8, height: 340, width: 390 },
+      stream: { enabled: true, fps: 8, height: 288, width: 512 },
     });
     expect(signalingService.getPublishedState('ABCD-1234')?.slidePreview).toBeDefined();
     expect(JSON.stringify(signalingService.getPublishedState('ABCD-1234'))).not.toContain(

--- a/apps/joystick/src/styles/joystick.css
+++ b/apps/joystick/src/styles/joystick.css
@@ -172,6 +172,7 @@ input {
 
 .joystick-stream-hit-target {
   width: 100%;
+  height: 100%;
   min-height: 0;
   position: relative;
   display: grid;
@@ -187,6 +188,8 @@ input {
 .joystick-stream-fallback,
 .joystick-stream-video {
   grid-area: 1 / 1;
+  min-width: 0;
+  min-height: 0;
   width: 100%;
   height: 100%;
 }
@@ -502,7 +505,7 @@ input {
 .joystick-slide-bg,
 .joystick-slide-image,
 .joystick-slide-video {
-  object-fit: cover;
+  object-fit: fill;
   pointer-events: none;
 }
 

--- a/packages/presenter-remote/package.json
+++ b/packages/presenter-remote/package.json
@@ -15,6 +15,7 @@
     "./session-code": "./src/session-code.ts",
     "./signaling-client": "./src/signaling-client.ts",
     "./signaling-service": "./src/signaling-service.ts",
+    "./stream-size": "./src/stream-size.ts",
     "./timer-format": "./src/timer-format.ts",
     "./webrtc": "./src/webrtc.ts"
   },

--- a/packages/presenter-remote/src/stream-size.ts
+++ b/packages/presenter-remote/src/stream-size.ts
@@ -1,0 +1,4 @@
+export const presenterRemoteStreamSize = {
+  height: 288,
+  width: 512,
+} as const;

--- a/tests/e2e/editor/presenter-route-initial-state.ts
+++ b/tests/e2e/editor/presenter-route-initial-state.ts
@@ -1,11 +1,13 @@
 import { type Page } from '@playwright/test';
 
 import { expect } from '../support/journey-test';
+import { presenterRouteLayout } from './presenter-route-layout';
 
 export const presenterRouteInitialState = {
   async verify(page: Page): Promise<void> {
     await expect(page.getByLabel('Presenter status')).toContainText('Current: Slide 1 of 3');
     await expect(page.getByLabel('Presenter status')).toContainText('Builds remaining: 1');
     await expect(page.getByLabel('Speaker notes')).toHaveValue('Open with the metric.');
+    await presenterRouteLayout.verifyContainedSlide(page);
   },
 };

--- a/tests/e2e/editor/presenter-route-layout.ts
+++ b/tests/e2e/editor/presenter-route-layout.ts
@@ -1,0 +1,27 @@
+import { type Page } from '@playwright/test';
+
+import { expect } from '../support/journey-test';
+
+export const presenterRouteLayout = {
+  async verifyContainedSlide(page: Page): Promise<void> {
+    const mainBounds = await page.locator('.presenter-main').boundingBox();
+    const stageBounds = await page.getByLabel('Current slide').boundingBox();
+    const slideBounds = await page.getByTestId('slide-canvas-frame').boundingBox();
+    expect(mainBounds).not.toBeNull();
+    expect(stageBounds).not.toBeNull();
+    expect(slideBounds).not.toBeNull();
+    expect(stageBounds!.x).toBeGreaterThanOrEqual(mainBounds!.x);
+    expect(stageBounds!.x + stageBounds!.width).toBeLessThanOrEqual(
+      mainBounds!.x + mainBounds!.width,
+    );
+    expect(slideBounds!.x).toBeGreaterThanOrEqual(stageBounds!.x);
+    expect(slideBounds!.y).toBeGreaterThanOrEqual(stageBounds!.y);
+    expect(slideBounds!.x + slideBounds!.width).toBeLessThanOrEqual(
+      stageBounds!.x + stageBounds!.width,
+    );
+    expect(slideBounds!.y + slideBounds!.height).toBeLessThanOrEqual(
+      stageBounds!.y + stageBounds!.height,
+    );
+    expect(slideBounds!.width / slideBounds!.height).toBeCloseTo(16 / 9, 2);
+  },
+};

--- a/tests/e2e/editor/presenter-route-notes-resizer.ts
+++ b/tests/e2e/editor/presenter-route-notes-resizer.ts
@@ -1,6 +1,7 @@
 import { type Page } from '@playwright/test';
 
 import { expect } from '../support/journey-test';
+import { presenterRouteLayout } from './presenter-route-layout';
 
 export const presenterRouteNotesResizer = {
   async verify(page: Page): Promise<void> {
@@ -12,6 +13,7 @@ export const presenterRouteNotesResizer = {
     await page.keyboard.press('Home');
     await expect(notesResizer).toHaveAttribute('aria-valuenow', '280');
     await page.keyboard.press('End');
+    await presenterRouteLayout.verifyContainedSlide(page);
 
     const resizerBox = await notesResizer.boundingBox();
     expect(resizerBox).not.toBeNull();

--- a/tests/e2e/joystick/connected-peer-stream-gestures.ts
+++ b/tests/e2e/joystick/connected-peer-stream-gestures.ts
@@ -5,6 +5,22 @@ import { expect } from '../support/journey-test';
 export async function exerciseConnectedPeerStreamGestures(joystickPage: Page, presenterPage: Page) {
   await expect(joystickPage.getByRole('button', { name: 'Presenter stream preview' })).toBeVisible();
   const streamPreview = joystickPage.getByRole('button', { name: 'Presenter stream preview' });
+  await expect
+    .poll(() =>
+      streamPreview.evaluate((element) => {
+        const video = element.querySelector('video');
+        if (!video) return { sourceIsWidescreen: false, videoContained: false };
+        const frameBounds = element.getBoundingClientRect();
+        const videoBounds = video.getBoundingClientRect();
+        return {
+          sourceIsWidescreen:
+            video.videoWidth > 0 && Math.abs(video.videoWidth / video.videoHeight - 16 / 9) < 0.01,
+          videoContained:
+            videoBounds.right <= frameBounds.right + 1 && videoBounds.bottom <= frameBounds.bottom + 1,
+        };
+      }),
+    )
+    .toEqual({ sourceIsWidescreen: true, videoContained: true });
   await streamPreview.dispatchEvent('pointerdown', {
     clientX: 320,
     pointerType: 'touch',

--- a/tests/e2e/joystick/coverage-diagnostics.spec.ts
+++ b/tests/e2e/joystick/coverage-diagnostics.spec.ts
@@ -104,6 +104,16 @@ test.describe('joystick bundled runtime diagnostics coverage', () => {
     await streamPreview.click({ position: { x: 8, y: 20 } });
     await streamPreview.click({ position: { x: 220, y: 20 } });
     const streamVideo = streamPreview.locator('.joystick-stream-video');
+    const streamPreviewBounds = await streamPreview.boundingBox();
+    const streamVideoBounds = await streamVideo.boundingBox();
+    expect(streamPreviewBounds).not.toBeNull();
+    expect(streamVideoBounds).not.toBeNull();
+    expect(streamVideoBounds!.x + streamVideoBounds!.width).toBeLessThanOrEqual(
+      streamPreviewBounds!.x + streamPreviewBounds!.width + 1,
+    );
+    expect(streamVideoBounds!.y + streamVideoBounds!.height).toBeLessThanOrEqual(
+      streamPreviewBounds!.y + streamPreviewBounds!.height + 1,
+    );
     await streamVideo.dispatchEvent('waiting');
     await streamVideo.dispatchEvent('loadedmetadata');
     await streamVideo.dispatchEvent('canplay');

--- a/tests/e2e/joystick/trusted-reconnect-presenter-state.ts
+++ b/tests/e2e/joystick/trusted-reconnect-presenter-state.ts
@@ -19,6 +19,11 @@ export const trustedReconnectPresenterState = {
     );
     await expect(currentSlidePreview).toBeVisible();
     await expect(currentSlidePreview.getByLabel('Slide video')).toBeVisible();
+    await expect(currentSlidePreview.locator('.joystick-slide-bg')).toHaveCSS('object-fit', 'fill');
+    await expect(currentSlidePreview.locator('.joystick-slide-image').first()).toHaveCSS(
+      'object-fit',
+      'fill',
+    );
     await expect(page.getByRole('button', { name: 'Go to slide 2: Roadmap' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Go to slide 3: Risks' })).toBeVisible();
   },

--- a/tests/e2e/support/joystick-trusted-presenter-preview-image-url.ts
+++ b/tests/e2e/support/joystick-trusted-presenter-preview-image-url.ts
@@ -1,6 +1,6 @@
 export function createTrustedPresenterPreviewImageUrl(label: string, backgroundColor: string) {
   const encodedSvg = encodeURIComponent(
-    `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="${backgroundColor}"/><text x="28" y="96" fill="white" font-size="28">${label}</text></svg>`,
+    `<svg xmlns="http://www.w3.org/2000/svg" width="180" height="320"><rect width="180" height="320" fill="${backgroundColor}"/><text x="12" y="34" fill="white" font-size="18">Top</text><text x="12" y="166" fill="white" font-size="22">${label}</text><text x="12" y="304" fill="white" font-size="18">Bottom</text></svg>`,
   );
   return `data:image/svg+xml,${encodedSvg}`;
 }


### PR DESCRIPTION
## Summary

- Centralize the presenter remote stream size at 512×288 (16:9).
- Keep presenter slides contained within responsive desktop stage bounds.
- Improve joystick stream sizing and prevent preview cropping.
- Add layout and aspect-ratio assertions to presenter and joystick E2E coverage.

## Testing

- Added unit expectations for the updated remote stream dimensions.
- Added Playwright checks for contained slides, widescreen video, and non-cropping previews.
- Not run (not requested).