### PR TITLE
Keep automatically started movies playing after animation transitions

### DIFF
--- a/apps/editor/src/ui/editor/animation/animationPlaybackTiming.ts
+++ b/apps/editor/src/ui/editor/animation/animationPlaybackTiming.ts
@@ -1,0 +1,13 @@
+import type { ElementAnimationBuild } from '../../../domain/documents/model';
+
+const minimumMediaActionRenderMs = 75;
+
+function getBuildDurationMs(build: ElementAnimationBuild) {
+  const durationMs = Math.max(0, build.durationMs ?? build.delayMs);
+  if (build.mediaAction === 'play') return Math.max(minimumMediaActionRenderMs, durationMs);
+  return durationMs;
+}
+
+export const animationPlaybackTiming = {
+  getBuildDurationMs,
+};

--- a/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
+++ b/apps/editor/src/ui/editor/animation/useAnimationPreviewController.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type MutableRefObject } from 'react';
 import type { ElementAnimationBuild, ProjectDocument } from '../../../domain/documents/model';
 import { pageVisibility } from '../../../domain/documents/pageVisibility';
+import { animationPlaybackTiming } from './animationPlaybackTiming';
 
 export interface AnimationPreviewState {
   activeBuild: ElementAnimationBuild | undefined;
@@ -9,6 +10,7 @@ export interface AnimationPreviewState {
   hiddenElementIds: string[];
   mode: 'editor' | 'presenter';
   pageId: string;
+  pendingMediaActionBuildIds: string[];
   phase: 'transition' | 'animation' | 'waiting' | 'complete';
   playbackRunId?: number;
   playing: boolean;
@@ -21,12 +23,6 @@ interface AnimationPreviewControllerOptions {
   projectRef: MutableRefObject<ProjectDocument>;
   setActivePageId: (pageId: string) => void;
   setSelectedElementIds: (elementIds: string[]) => void;
-}
-
-function getBuildPlaybackDurationMs(build: ElementAnimationBuild) {
-  const durationMs = Math.max(0, build.durationMs ?? build.delayMs);
-  if (build.mediaAction === 'play') return Math.max(75, durationMs);
-  return durationMs;
 }
 
 export function useAnimationPreviewController({
@@ -75,6 +71,7 @@ export function useAnimationPreviewController({
             activeBuildElementId: undefined,
             animationProgress: 1,
             hiddenElementIds: [],
+            pendingMediaActionBuildIds: [],
             phase: 'complete',
             waitingForClick: false,
           }
@@ -100,7 +97,7 @@ export function useAnimationPreviewController({
   }
 
   function animateActiveBuild(build: ElementAnimationBuild) {
-    const durationMs = getBuildPlaybackDurationMs(build);
+    const durationMs = animationPlaybackTiming.getBuildDurationMs(build);
     const startMs = window.performance.now();
     if (animationPreviewFrameRef.current !== undefined) {
       window.cancelAnimationFrame(animationPreviewFrameRef.current);
@@ -114,6 +111,9 @@ export function useAnimationPreviewController({
             activeBuild: build,
             activeBuildElementId: build.elementId,
             animationProgress: durationMs === 0 ? 1 : 0,
+            pendingMediaActionBuildIds: current.pendingMediaActionBuildIds.filter(
+              (buildId) => buildId !== build.id,
+            ),
             phase: 'animation',
             waitingForClick: false,
           }
@@ -170,7 +170,7 @@ export function useAnimationPreviewController({
     scheduleAnimationPreview(() => {
       revealAnimationBuild(nextBuild);
       runNextAnimationBuild();
-    }, getBuildPlaybackDurationMs(nextBuild));
+    }, animationPlaybackTiming.getBuildDurationMs(nextBuild));
   }
 
   function advanceAnimationPreview() {
@@ -184,7 +184,7 @@ export function useAnimationPreviewController({
     scheduleAnimationPreview(() => {
       revealAnimationBuild(nextBuild);
       runNextAnimationBuild();
-    }, getBuildPlaybackDurationMs(nextBuild));
+    }, animationPlaybackTiming.getBuildDurationMs(nextBuild));
   }
 
   function playAnimationPreview(
@@ -210,6 +210,9 @@ export function useAnimationPreviewController({
         .map((build) => build.elementId),
       mode,
       pageId: page.id,
+      pendingMediaActionBuildIds: builds
+        .filter((build) => build.mediaAction === 'play')
+        .map((build) => build.id),
       phase: transitionDelay > 0 ? 'transition' : builds.length > 0 ? 'animation' : 'complete',
       playbackRunId: animationPreviewRunIdRef.current,
       playing: true,
@@ -297,6 +300,10 @@ export function useAnimationPreviewController({
               .slice(targetBuildIndex)
               .filter((build) => build.mediaAction !== 'play')
               .map((build) => build.elementId),
+            pendingMediaActionBuildIds: builds
+              .slice(targetBuildIndex)
+              .filter((build) => build.mediaAction === 'play')
+              .map((build) => build.id),
             phase: 'waiting',
             waitingForClick: true,
           }

--- a/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
+++ b/apps/editor/src/ui/editor/canvas/CanvasWorkspace.tsx
@@ -79,6 +79,7 @@ interface CanvasWorkspaceProps {
         hiddenElementIds: string[];
         mode?: 'editor' | 'presenter';
         pageId: string;
+        pendingMediaActionBuildIds?: string[];
         phase: 'transition' | 'animation' | 'waiting' | 'complete';
         playbackRunId?: number;
         playing: boolean;
@@ -994,7 +995,9 @@ export function CanvasWorkspace({
     return {
       activeBuild,
       hidden: animationPreviewHiddenElementIds.includes(element.id),
-      mediaActionPending: Boolean(mediaActionBuild),
+      mediaActionPending:
+        mediaActionBuild !== undefined &&
+        (animationPreview?.pendingMediaActionBuildIds?.includes(mediaActionBuild.id) ?? true),
       playbackRunId:
         animationPreview?.pageId === activePageId ? animationPreview.playbackRunId : undefined,
       preset: activeBuild

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -39,6 +39,7 @@ import {
 } from '../components/KeyboardShortcutsDialog';
 import { isKeyboardShortcutEditableTarget } from '../components/isKeyboardShortcutEditableTarget';
 import { CanvasWorkspace } from '../editor/canvas/CanvasWorkspace';
+import { animationPlaybackTiming } from '../editor/animation/animationPlaybackTiming';
 import { ProjectVideoPreloader } from '../editor/media/ProjectVideoPreloader';
 import {
   presentationMovieControls,
@@ -70,6 +71,7 @@ interface AnimationPreviewState {
   hiddenElementIds: string[];
   mode: 'presenter';
   pageId: string;
+  pendingMediaActionBuildIds: string[];
   phase: 'transition' | 'animation' | 'waiting' | 'complete';
   playing: boolean;
   waitingForClick: boolean;
@@ -357,10 +359,6 @@ function getTranscriptSegmentPageIndex(
   segmentIndex: number,
 ) {
   return resolveTranscriptSegmentPageIndex(segment, pages, segmentIndex) ?? 0;
-}
-
-function getBuildPlaybackDurationMs(build: ElementAnimationBuild) {
-  return Math.max(0, build.durationMs ?? build.delayMs);
 }
 
 function hasFinishedAssetPreload(loaded: number, total: number) {
@@ -1630,6 +1628,7 @@ export function PublicDeckViewer({
             activeBuildElementId: undefined,
             animationProgress: 1,
             hiddenElementIds: [],
+            pendingMediaActionBuildIds: [],
             phase: 'complete',
             waitingForClick: false,
           }
@@ -1655,7 +1654,7 @@ export function PublicDeckViewer({
   }, []);
 
   const animateActiveBuild = useCallback((build: ElementAnimationBuild) => {
-    const durationMs = getBuildPlaybackDurationMs(build);
+    const durationMs = animationPlaybackTiming.getBuildDurationMs(build);
     const startMs = window.performance.now();
     if (animationFrameRef.current !== undefined) {
       window.cancelAnimationFrame(animationFrameRef.current);
@@ -1669,6 +1668,9 @@ export function PublicDeckViewer({
             activeBuild: build,
             activeBuildElementId: build.elementId,
             animationProgress: durationMs === 0 ? 1 : 0,
+            pendingMediaActionBuildIds: current.pendingMediaActionBuildIds.filter(
+              (buildId) => buildId !== build.id,
+            ),
             phase: 'animation',
             waitingForClick: false,
           }
@@ -1725,7 +1727,7 @@ export function PublicDeckViewer({
     scheduleAnimation(() => {
       revealAnimationBuild(nextBuild);
       runNextAnimationBuildRef.current();
-    }, getBuildPlaybackDurationMs(nextBuild));
+    }, animationPlaybackTiming.getBuildDurationMs(nextBuild));
   }, [animateActiveBuild, completeAnimationSlide, revealAnimationBuild, scheduleAnimation]);
   useEffect(() => {
     runNextAnimationBuildRef.current = runNextAnimationBuild;
@@ -1742,7 +1744,7 @@ export function PublicDeckViewer({
     scheduleAnimation(() => {
       revealAnimationBuild(nextBuild);
       runNextAnimationBuild();
-    }, getBuildPlaybackDurationMs(nextBuild));
+    }, animationPlaybackTiming.getBuildDurationMs(nextBuild));
   }, [
     animateActiveBuild,
     completeAnimationSlide,
@@ -1771,6 +1773,9 @@ export function PublicDeckViewer({
           .map((build) => build.elementId),
         mode: 'presenter',
         pageId: page.id,
+        pendingMediaActionBuildIds: builds
+          .filter((build) => build.mediaAction === 'play')
+          .map((build) => build.id),
         phase: transitionDelay > 0 ? 'transition' : builds.length > 0 ? 'animation' : 'complete',
         playing: true,
         waitingForClick: false,

--- a/apps/editor/tests/unit/services/presenterRemoteSessionService.previews.test.ts
+++ b/apps/editor/tests/unit/services/presenterRemoteSessionService.previews.test.ts
@@ -429,6 +429,7 @@ describe('BrowserPresenterSessionService remote previews', () => {
         hiddenElementIds: [hiddenElementId],
         mode: 'presenter',
         pageId: page.id,
+        pendingMediaActionBuildIds: [],
         phase: 'waiting',
         playing: true,
         waitingForClick: true,

--- a/apps/editor/tests/unit/ui/editor/CanvasWorkspace.media.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/CanvasWorkspace.media.test.tsx
@@ -171,25 +171,25 @@ describe('CanvasWorkspace media elements', () => {
     pauseSpy.mockRestore();
   });
 
-  it('plays movie-start builds during editor animation preview', async () => {
+  it('keeps an automatically started movie playing after its build completes', async () => {
     const playSpy = vi
       .spyOn(HTMLMediaElement.prototype, 'play')
       .mockImplementation(() => Promise.resolve());
     const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
-    const project = updateVideoElement(createMediaProject(), { startOnClick: true });
+    const project = updateVideoElement(createMediaProject(), { startOnClick: false });
     project.pages[0]!.animationBuilds = [
       {
         id: 'video-build',
         elementId: 'video-demo',
         effect: 'reveal',
-        trigger: 'on-click',
+        trigger: 'after-transition',
         delayMs: 0,
         durationMs: 0,
         mediaAction: 'play',
       },
     ];
 
-    render(
+    const { rerender } = render(
       <CanvasWorkspace
         project={project}
         activePageId="page-1"
@@ -201,6 +201,7 @@ describe('CanvasWorkspace media elements', () => {
           hiddenElementIds: [],
           mode: 'editor',
           pageId: 'page-1',
+          pendingMediaActionBuildIds: ['video-build'],
           phase: 'animation',
           playing: true,
           waitingForClick: false,
@@ -209,6 +210,29 @@ describe('CanvasWorkspace media elements', () => {
     );
 
     await waitFor(() => expect(playSpy).toHaveBeenCalled());
+    pauseSpy.mockClear();
+
+    rerender(
+      <CanvasWorkspace
+        project={project}
+        activePageId="page-1"
+        selection={{ pageId: 'page-1', elementIds: [] }}
+        animationPreview={{
+          activeBuild: undefined,
+          activeBuildElementId: undefined,
+          animationProgress: 1,
+          hiddenElementIds: [],
+          mode: 'editor',
+          pageId: 'page-1',
+          pendingMediaActionBuildIds: [],
+          phase: 'complete',
+          playing: true,
+          waitingForClick: false,
+        }}
+      />,
+    );
+
+    expect(pauseSpy).not.toHaveBeenCalled();
     playSpy.mockRestore();
     pauseSpy.mockRestore();
   });

--- a/tests/e2e/public-deck/media-playback.spec.ts
+++ b/tests/e2e/public-deck/media-playback.spec.ts
@@ -39,7 +39,7 @@ test.describe('public deck media playback journey', () => {
     };
     payload.project.elements['video-public'] = {
       assetId: 'asset-public-video',
-      autoplayInPreview: false,
+      autoplayInPreview: true,
       controls: true,
       height: 405,
       id: 'video-public',
@@ -105,6 +105,18 @@ test.describe('public deck media playback journey', () => {
     };
     payload.project.pages[0].elementIds.push('image-public');
     payload.project.pages[1].elementIds.push('video-public', 'gif-public');
+    payload.project.pages[1].transition = { delayMs: 100, effect: 'fade' };
+    payload.project.pages[1].animationBuilds = [
+      {
+        delayMs: 0,
+        durationMs: 0,
+        effect: 'reveal',
+        elementId: 'video-public',
+        id: 'video-public-play',
+        mediaAction: 'play',
+        trigger: 'after-transition',
+      },
+    ];
 
     await page.route('**/e2e-share-with-video.json', async (route) => {
       await route.fulfill({ contentType: 'application/json', json: payload });
@@ -154,15 +166,14 @@ test.describe('public deck media playback journey', () => {
     const gif = page.locator('img[aria-label="Public animated loop"]');
     await expect(gif).toBeVisible();
     await expect(gif).toHaveAttribute('src', /e2e-public-loop\.png/);
+    await expect(page.getByTestId('slide-canvas-frame')).toHaveAttribute(
+      'data-animation-preview-phase',
+      'complete',
+    );
+    await expect.poll(() => video.evaluate((node: HTMLVideoElement) => node.paused)).toBe(false);
+    const playbackTime = await video.evaluate((node: HTMLVideoElement) => node.currentTime);
     await expect
-      .poll(() =>
-        video.evaluate((node: HTMLVideoElement) =>
-          node.play().then(
-            () => !node.paused,
-            () => false,
-          ),
-        ),
-      )
-      .toBe(true);
+      .poll(() => video.evaluate((node: HTMLVideoElement) => node.currentTime))
+      .toBeGreaterThan(playbackTime);
   });
 });


### PR DESCRIPTION
## Summary

- Preserve pending media-action state until each animation build starts.
- Keep automatically played videos running after their build completes.
- Apply a minimum render duration for media play actions.
- Add unit and public-deck E2E coverage for post-transition video playback.

## Testing

- Updated CanvasWorkspace media unit coverage.
- Updated public-deck media playback Playwright coverage to verify playback continues after the animation reaches completion.