### PR TITLE
Fix PPTX media MIME inference for GIF and video exports

### DIFF
--- a/apps/editor/src/services/exporting/pptxExportService.ts
+++ b/apps/editor/src/services/exporting/pptxExportService.ts
@@ -101,6 +101,34 @@ function blobToBase64Data(mimeType: string, bytes: Uint8Array) {
   return `${mimeType};base64,${btoa(binary)}`;
 }
 
+function normalizeMimeType(mimeType: string | undefined) {
+  return mimeType?.split(';', 1)[0]?.trim().toLowerCase() || undefined;
+}
+
+function getSpecificMimeType(mimeType: string | undefined) {
+  const normalized = normalizeMimeType(mimeType);
+  return normalized === 'application/octet-stream' || normalized?.endsWith('/*')
+    ? undefined
+    : normalized;
+}
+
+function inferMediaMimeType(asset: Asset) {
+  const fileName = (asset.fileName ?? asset.name).toLowerCase();
+  if (asset.type === 'gif' || fileName.endsWith('.gif')) return 'image/gif';
+  if (asset.type === 'video') {
+    if (fileName.endsWith('.mov')) return 'video/quicktime';
+    if (fileName.endsWith('.webm')) return 'video/webm';
+    return 'video/mp4';
+  }
+  if (fileName.endsWith('.jpg') || fileName.endsWith('.jpeg')) return 'image/jpeg';
+  if (fileName.endsWith('.webp')) return 'image/webp';
+  return 'image/png';
+}
+
+function resolveReadableMimeType(asset: Asset, blob: Blob) {
+  return getSpecificMimeType(blob.type) ?? getSpecificMimeType(asset.mimeType) ?? inferMediaMimeType(asset);
+}
+
 async function assetToData(asset: Asset | undefined, warnings: PresentationExportWarning[], element: DesignElement, page: Page) {
   if (!asset?.objectUrl) {
     warnings.push({
@@ -123,7 +151,11 @@ async function assetToData(asset: Asset | undefined, warnings: PresentationExpor
     });
     return undefined;
   }
-  return blobToBase64Data(asset.mimeType || blob.type || 'application/octet-stream', new Uint8Array(await blob.arrayBuffer()));
+  const mimeType = resolveReadableMimeType(asset, blob);
+  return {
+    data: blobToBase64Data(mimeType, new Uint8Array(await blob.arrayBuffer())),
+    mimeType,
+  };
 }
 
 async function backgroundAssetToData(
@@ -208,11 +240,11 @@ async function addImageElement(
     stage: 'embedding-media',
     total: context.stats.mediaElementCount,
   });
-  const data = await assetToData(asset, context.warnings, element, page);
-  if (!data) return;
+  const media = await assetToData(asset, context.warnings, element, page);
+  if (!media) return;
   slide.addImage({
     ...toPosition(element),
-    data,
+    data: media.data,
     ...(element.type === 'image' && element.flipX ? { flipH: true } : {}),
     objectName: element.id,
     rotate: element.rotation,
@@ -236,12 +268,12 @@ async function addVideoElement(
     stage: 'embedding-media',
     total: context.stats.mediaElementCount,
   });
-  const data = await assetToData(asset, context.warnings, element, page);
-  if (!data) return;
+  const media = await assetToData(asset, context.warnings, element, page);
+  if (!media) return;
   slide.addMedia({
     ...toPosition(element),
-    data,
-    extn: assetFileUtils.getAssetFileExtension(asset?.mimeType ?? 'video/mp4'),
+    data: media.data,
+    extn: assetFileUtils.getAssetFileExtension(media.mimeType),
     objectName: element.id,
     type: 'video',
   });

--- a/apps/editor/tests/unit/services/pptxExportService.test.ts
+++ b/apps/editor/tests/unit/services/pptxExportService.test.ts
@@ -329,4 +329,39 @@ describe('BrowserPptxExportService', () => {
       ]),
     );
   });
+
+  it('infers GIF and video package types when Blob and stored MIME metadata are generic', async () => {
+    const project = createExportProject();
+    project.assets.gifAsset!.mimeType = 'application/octet-stream';
+    project.assets.gifAsset!.objectUrl = tinyGifDataUrl.replace(
+      'image/gif',
+      'application/octet-stream',
+    );
+    project.assets.videoAsset!.mimeType = 'application/octet-stream';
+    project.assets.videoAsset!.objectUrl = tinyMp4DataUrl.replace(
+      'video/mp4',
+      'application/octet-stream',
+    );
+
+    const result = await new BrowserPptxExportService().exportPowerPoint(project);
+    const entries = await readPptxEntries(result.blob);
+    const mediaPaths = Object.keys(entries).filter((path) => path.startsWith('ppt/media/'));
+
+    const gifPath = mediaPaths.find((path) => path.endsWith('.gif'));
+    const videoPath = mediaPaths.find((path) => path.endsWith('.mp4'));
+    expect(gifPath).toBeDefined();
+    expect(videoPath).toBeDefined();
+    if (!gifPath || !videoPath) throw new Error('Expected GIF and MP4 package parts.');
+    expect(strFromU8(entries[gifPath]!.subarray(0, 6))).toBe('GIF89a');
+    expect(strFromU8(entries[videoPath]!.subarray(4, 8))).toBe('ftyp');
+    expect(readEntry(entries, '[Content_Types].xml')).toContain(
+      'Extension="gif" ContentType="image/gif"',
+    );
+    expect(readEntry(entries, '[Content_Types].xml')).toContain(
+      'Extension="mp4" ContentType="video/mp4"',
+    );
+    expect(readEntry(entries, 'ppt/slides/_rels/slide1.xml.rels')).toContain(
+      'relationships/video',
+    );
+  });
 });

--- a/tests/e2e/editor/pptx-animation-media-export-flow.ts
+++ b/tests/e2e/editor/pptx-animation-media-export-flow.ts
@@ -1,13 +1,14 @@
-import { type Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { type Page, type TestInfo } from '@playwright/test';
 import { strFromU8 } from 'fflate';
 
 import { EditorAppPage } from '../pages/editor-app.page';
 import { expect } from '../support/journey-test';
-import { getBigBuckBunnyMp4Fixture } from '../support/test-assets';
+import { createTinyGifFixture, getBigBuckBunnyMp4Fixture } from '../support/test-assets';
 import { pptxExportReader } from './pptx-export-reader';
 
 export const pptxAnimationMediaExportFlow = {
-  async run(page: Page, baseURL: string): Promise<void> {
+  async run(page: Page, baseURL: string, testInfo: TestInfo): Promise<void> {
     const editor = new EditorAppPage(page, baseURL);
     await editor.gotoNewProject();
     await editor.renameProject('E2E Animation Media Export');
@@ -29,15 +30,28 @@ export const pptxAnimationMediaExportFlow = {
     await page.getByRole('button', { name: 'Add animation' }).click();
 
     await editor.openTool('Assets');
-    await page.getByLabel('Import media file').setInputFiles(getBigBuckBunnyMp4Fixture());
+    const videoBytes = await readFile(getBigBuckBunnyMp4Fixture());
+    await page.getByLabel('Import media file').setInputFiles({
+      buffer: videoBytes,
+      mimeType: 'application/octet-stream',
+      name: 'generic-video.mp4',
+    });
+    const gifBytes = await readFile(await createTinyGifFixture(testInfo));
+    await page.getByLabel('Import media file').setInputFiles({
+      buffer: gifBytes,
+      mimeType: 'application/octet-stream',
+      name: 'generic-animation.gif',
+    });
     await editor.openTool('Layout');
-    await page.getByRole('button', { name: 'Big_Buck_Bunny_360_10s_1MB.mp4', exact: true }).click();
+    await page.getByRole('button', { name: 'generic-video.mp4', exact: true }).click();
     await editor.openTool('Design');
     await page
       .getByRole('tablist', { name: 'Movie inspector sections' })
       .getByRole('tab', { name: 'Movie' })
       .click();
     await page.getByLabel('Selected video start').selectOption('on-click');
+    await editor.openTool('Layout');
+    await page.getByRole('button', { name: 'generic-animation.gif', exact: true }).click();
 
     const files = await pptxExportReader.downloadFiles(page, editor, 'E2E Animation Media Export.pptx');
     const slideXml = strFromU8(files['ppt/slides/slide1.xml']);
@@ -49,8 +63,19 @@ export const pptxAnimationMediaExportFlow = {
     expect(slideXml).toContain('presetClass="entr"');
     expect(slideXml).toContain('presetClass="mediacall"');
     expect(slideXml).toContain('cmd="play"');
+    expect(contentTypesXml).toContain('ContentType="image/gif"');
     expect(contentTypesXml).toContain('ContentType="video/mp4"');
     expect(slideRelsXml).toContain('/video');
-    expect(Object.keys(files).some((path) => path.startsWith('ppt/media/') && path.endsWith('.mp4'))).toBe(true);
+    const gifPath = Object.keys(files).find(
+      (path) => path.startsWith('ppt/media/') && path.endsWith('.gif'),
+    );
+    const videoPath = Object.keys(files).find(
+      (path) => path.startsWith('ppt/media/') && path.endsWith('.mp4'),
+    );
+    expect(gifPath).toBeDefined();
+    expect(videoPath).toBeDefined();
+    if (!gifPath || !videoPath) throw new Error('Expected GIF and MP4 package parts.');
+    expect(strFromU8(files[gifPath].subarray(0, 6))).toBe('GIF89a');
+    expect(strFromU8(files[videoPath].subarray(4, 8))).toBe('ftyp');
   },
 };

--- a/tests/e2e/editor/pptx-animation-media-export-journey.ts
+++ b/tests/e2e/editor/pptx-animation-media-export-journey.ts
@@ -4,8 +4,8 @@ import { pptxAnimationMediaExportFlow } from './pptx-animation-media-export-flow
 import { pptxShapeImageExportFlow } from './pptx-shape-image-export-flow';
 
 export const pptxAnimationMediaExportJourney = {
-  async runAnimationMediaExport(page: Page, baseURL: string): Promise<void> {
-    await pptxAnimationMediaExportFlow.run(page, baseURL);
+  async runAnimationMediaExport(page: Page, baseURL: string, testInfo: TestInfo): Promise<void> {
+    await pptxAnimationMediaExportFlow.run(page, baseURL, testInfo);
   },
 
   async runShapeImageExport(page: Page, baseURL: string, testInfo: TestInfo): Promise<void> {

--- a/tests/e2e/editor/pptx-animation-media-export.spec.ts
+++ b/tests/e2e/editor/pptx-animation-media-export.spec.ts
@@ -4,11 +4,15 @@ import { test, withIsolatedDevServer } from '../support/journey-test';
 const getServer = withIsolatedDevServer(test);
 
 test.describe('editor PowerPoint animation and media export journey', () => {
-  test('exports transition timing, object animation timing, and embedded video package parts', async ({
+  test('exports transition timing, object animation timing, GIFs, and video package parts', async ({
     page,
-  }) => {
+  }, testInfo) => {
     test.setTimeout(90_000);
-    await pptxAnimationMediaExportJourney.runAnimationMediaExport(page, getServer().baseURL);
+    await pptxAnimationMediaExportJourney.runAnimationMediaExport(
+      page,
+      getServer().baseURL,
+      testInfo,
+    );
   });
 
   test('exports styled shape geometry and imported image media to PowerPoint', async ({


### PR DESCRIPTION
## Summary
- Normalize and infer media MIME types when Blob or asset metadata is generic.
- Preserve correct GIF and video extensions and PowerPoint content types during export.
- Extend unit and end-to-end coverage for generic MIME metadata and embedded media bytes.

## Testing
- Added unit coverage for GIF and MP4 package generation.
- Updated Playwright E2E coverage to import GIF and video files with generic MIME types and validate the exported PPTX contents.