### PR TITLE
Fix published audio recording flow across presenter and public deck views

### DIFF
--- a/apps/editor/src/services/presenter/presenterSessionService.ts
+++ b/apps/editor/src/services/presenter/presenterSessionService.ts
@@ -341,6 +341,16 @@ export class BrowserPresenterSessionService {
         });
         return;
       }
+      if (command === 'recording-checkpoint') {
+        if (!event.data.recording || typeof event.data.recording !== 'object') return;
+        if (event.data.audioChunk !== undefined && !(event.data.audioChunk instanceof Blob)) return;
+        handler({
+          audioChunk: event.data.audioChunk,
+          command,
+          recording: event.data.recording,
+        });
+        return;
+      }
       if (
         command === 'close' ||
         command === 'next' ||

--- a/apps/editor/src/services/presenter/presenterSessionTypes.ts
+++ b/apps/editor/src/services/presenter/presenterSessionTypes.ts
@@ -55,6 +55,7 @@ export type PresenterWindowCommand =
   | { command: 'request-state' }
   | { command: 'reset-timer' }
   | { command: 'resume-timer' }
+  | { audioChunk?: Blob | undefined; command: 'recording-checkpoint'; recording: TranscriptRecording }
   | { command: 'set-prompt-provider'; providerId: string }
   | { audioBlob?: Blob | undefined; command: 'save-recording'; recording: TranscriptRecording }
   | { command: 'start-presenting' }

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -3,7 +3,7 @@ import { localStudioAnalyticsConfig } from '@localstudio/analytics-config/config
 import type Konva from 'konva';
 import type { AppServices } from '../../../app/composition';
 import { placeholderImage } from '../../../domain/assets/placeholderImage';
-import type { ProjectDocument } from '../../../domain/documents/model';
+import type { ProjectDocument, TranscriptRecording } from '../../../domain/documents/model';
 import { pageVisibility } from '../../../domain/documents/pageVisibility';
 import type { ShareMetadata, SharePublishProgress } from '../../../services/contracts/interfaces';
 import { analyticsModelProperties } from '../../../services/analytics/analyticsModelProperties';
@@ -169,6 +169,9 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const imageExportNoticeTimeoutRef = useRef<number | undefined>(undefined);
   const presenterFullscreenEnteredRef = useRef(false);
   const pendingShareAfterLocalSaveRef = useRef(false);
+  const pendingPresenterRecordingsRef = useRef(
+    new Map<string, { chunks: Blob[]; recording: TranscriptRecording }>(),
+  );
   const lastPublishedShareSelectionRef = useRef<
     | {
         projectSignature: string;
@@ -201,7 +204,15 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const deckTranslationStatus = vm.deckTranslationProgress
     ? `Translating ${vm.deckTranslationProgress.currentPageName} · ${vm.deckTranslationProgress.completedPages}/${vm.deckTranslationProgress.totalPages}`
     : undefined;
-  const publicSharingAvailable = vm.mirrorState.enabled && vm.mirrorState.status === 'synced';
+  const publicSharingConfigured = vm.hasMirrorConfig;
+  const lastMirrorSyncTime = Date.parse(vm.mirrorState.lastSyncedAt ?? '');
+  const mirrorHasCurrentProject =
+    vm.mirrorState.enabled &&
+    vm.mirrorState.status === 'synced' &&
+    Number.isFinite(lastMirrorSyncTime) &&
+    lastMirrorSyncTime >= Date.parse(vm.project.updatedAt);
+  const publicSharingAvailable =
+    publicSharingConfigured && (Boolean(shareMetadata?.shareId) || mirrorHasCurrentProject);
   const publicSharingUnavailableReason = 'Public links cannot be created without remote storage.';
   const hasDirectoryPersistence = services.persistenceMode === 'directory';
   const shareRecordingOptions = Object.values(vm.project.recordings ?? {})
@@ -212,6 +223,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
       label: recording.name,
       segmentCount: recording.segments.length,
     }));
+  const latestShareRecordingId = shareRecordingOptions[0]?.id;
   const imageGenerationState = vm.modelStates.find(
     (model) => model.id === imageGenerationModel.IMAGE_GENERATION_MODEL_ID,
   );
@@ -538,7 +550,21 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   }
 
   const closePresenterViewSession = useCallback(() => {
+    for (const pendingRecording of pendingPresenterRecordingsRef.current.values()) {
+      if (pendingRecording.chunks.length === 0) continue;
+      const audioBlob = new Blob(pendingRecording.chunks, {
+        type: pendingRecording.recording.audio.mimeType,
+      });
+      vm.addTranscriptRecording({
+        ...pendingRecording.recording,
+        audio: {
+          ...pendingRecording.recording.audio,
+          objectUrl: URL.createObjectURL(audioBlob),
+        },
+      });
+    }
     presenterSessionServiceRef.current?.closePresenterWindow();
+    pendingPresenterRecordingsRef.current.clear();
     presenterFullscreenEnteredRef.current = false;
     vm.clearAnimationPreview();
     setAudienceFullscreenPromptOpen(false);
@@ -1113,6 +1139,38 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   useEffect(() => {
     if (!presenterRemoteSession && !presenterSessionId) return undefined;
     return getPresenterSessionService().subscribeToCommands((message) => {
+      const savePresenterRecording = (
+        recording: TranscriptRecording,
+        audioBlob?: Blob,
+      ) => {
+        const editorOwnedRecording = audioBlob
+          ? {
+              ...recording,
+              audio: {
+                ...recording.audio,
+                objectUrl: URL.createObjectURL(audioBlob),
+              },
+            }
+          : recording;
+        const projectWithRecording = {
+          ...vm.project,
+          recordings: {
+            ...(vm.project.recordings ?? {}),
+            [editorOwnedRecording.id]: editorOwnedRecording,
+          },
+          updatedAt: new Date().toISOString(),
+        };
+        vm.addTranscriptRecording(editorOwnedRecording);
+        getPresenterSessionService().publishState(
+          createPresenterStatePayload({
+            activePageId: vm.activePageId,
+            animationPreview: vm.animationPreview,
+            presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
+            project: projectWithRecording,
+          }),
+        );
+      };
+
       if (message.command === 'start-presenting') {
         const firstPageId =
           pageVisibility.getFirstVisiblePage(vm.project)?.id ??
@@ -1160,32 +1218,19 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         return;
       }
       if (message.command === 'save-recording') {
-        const editorOwnedRecording = message.audioBlob
-          ? {
-              ...message.recording,
-              audio: {
-                ...message.recording.audio,
-                objectUrl: URL.createObjectURL(message.audioBlob),
-              },
-            }
-          : message.recording;
-        const projectWithRecording = {
-          ...vm.project,
-          recordings: {
-            ...(vm.project.recordings ?? {}),
-            [editorOwnedRecording.id]: editorOwnedRecording,
-          },
-          updatedAt: new Date().toISOString(),
-        };
-        vm.addTranscriptRecording(editorOwnedRecording);
-        getPresenterSessionService().publishState(
-          createPresenterStatePayload({
-            activePageId: vm.activePageId,
-            animationPreview: vm.animationPreview,
-            presenterMode: presenterSessionId || remotePresenterActive ? 'presenting' : 'ready',
-            project: projectWithRecording,
-          }),
-        );
+        pendingPresenterRecordingsRef.current.delete(message.recording.id);
+        savePresenterRecording(message.recording, message.audioBlob);
+        return;
+      }
+      if (message.command === 'recording-checkpoint') {
+        const pendingRecording = pendingPresenterRecordingsRef.current.get(message.recording.id);
+        pendingPresenterRecordingsRef.current.set(message.recording.id, {
+          chunks: [
+            ...(pendingRecording?.chunks ?? []),
+            ...(message.audioChunk ? [message.audioChunk] : []),
+          ],
+          recording: message.recording,
+        });
         return;
       }
       if (message.command === 'update-stream-peer') {
@@ -1367,23 +1412,29 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   );
 
   useEffect(() => {
-    if (!publicSharingAvailable) {
-      if (!shareMetadata?.shareId) return undefined;
+    if (!shareMetadata?.shareId) return undefined;
+    if (!mirrorHasCurrentProject) {
+      const nextStatus = vm.mirrorState.status === 'failed' ? 'sync-failed' : 'syncing';
+      if (shareMetadata.status === nextStatus) return undefined;
       const timeoutId = window.setTimeout(() => {
-        setShareMetadata((current) => (current ? { ...current, status: 'sync-failed' } : current));
+        setShareMetadata((current) => (current ? { ...current, status: nextStatus } : current));
       }, 0);
       return () => {
         window.clearTimeout(timeoutId);
       };
     }
-    if (!shareMetadata?.shareId) return undefined;
-    if (hasPublishedCurrentProjectShare(shareMetadata, undefined, vm.project)) return undefined;
-    void publishCurrentProjectShare().catch(() => undefined);
+    if (
+      hasPublishedCurrentProjectShare(shareMetadata, latestShareRecordingId, vm.project)
+    ) {
+      return undefined;
+    }
+    void publishCurrentProjectShare(latestShareRecordingId).catch(() => undefined);
     return undefined;
   }, [
     hasPublishedCurrentProjectShare,
+    latestShareRecordingId,
+    mirrorHasCurrentProject,
     publishCurrentProjectShare,
-    publicSharingAvailable,
     shareMetadata,
     vm.mirrorState.status,
     vm.project,

--- a/apps/editor/src/ui/presenter/PresenterView.tsx
+++ b/apps/editor/src/ui/presenter/PresenterView.tsx
@@ -246,7 +246,9 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     { pageId: string; pageIndex: number; pageName: string } | undefined
   >(undefined);
   const recorderRef = useRef<PresenterAudioRecorder | undefined>(undefined);
+  const activeRecordingRef = useRef<TranscriptRecording | undefined>(undefined);
   const recordingStartedAtRef = useRef(0);
+  const recordingStopPromiseRef = useRef<Promise<void> | undefined>(undefined);
   const recordingObjectUrlRef = useRef<string | undefined>(undefined);
   const transcriptChannelRef = useRef<BroadcastChannel | undefined>(undefined);
   const speechTranscriberRef = useRef<PresenterSpeechTranscriber | undefined>(undefined);
@@ -366,6 +368,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
   useEffect(() => {
     return () => {
       void speechTranscriberRef.current?.stop();
+      recorderRef.current?.cancel();
       recorderRef.current?.revokeObjectUrl();
       if (recordingObjectUrlRef.current) URL.revokeObjectURL(recordingObjectUrlRef.current);
     };
@@ -411,17 +414,6 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       window.removeEventListener('message', handleMessage);
     };
   }, [applyTimerCommand, postCommand, resolvedSessionId]);
-
-  useEffect(() => {
-    function handlePageHide() {
-      postCommand({ command: 'close' });
-    }
-
-    window.addEventListener('pagehide', handlePageHide);
-    return () => {
-      window.removeEventListener('pagehide', handlePageHide);
-    };
-  }, [postCommand]);
 
   useEffect(() => {
     if (!remotePanelOpen) return;
@@ -605,6 +597,28 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     [getCurrentTranscriptMarker, refreshTranscriptSegments],
   );
 
+  const postRecordingCheckpoint = useCallback((audioChunk?: Blob) => {
+    const activeRecording = activeRecordingRef.current;
+    if (!activeRecording) return;
+    const now = new Date().toISOString();
+    const recording: TranscriptRecording = {
+      ...activeRecording,
+      updatedAt: now,
+      durationMs: Math.max(0, Date.now() - recordingStartedAtRef.current),
+      audio: {
+        ...activeRecording.audio,
+        ...(audioChunk?.type ? { mimeType: audioChunk.type } : {}),
+      },
+      segments: transcriptSegmentsRef.current,
+    };
+    activeRecordingRef.current = recording;
+    postCommand({
+      ...(audioChunk ? { audioChunk } : {}),
+      command: 'recording-checkpoint',
+      recording,
+    });
+  }, [postCommand]);
+
   const startRecording = useCallback(async () => {
     if (
       recordingStatus === 'recording' ||
@@ -621,10 +635,30 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       fullTranscriptTextRef.current = '';
       transcriptSegmentsRef.current = [];
       slideTranscriptMarkersRef.current = [];
-      const recorder = new PresenterAudioRecorder();
+      const now = new Date().toISOString();
+      activeRecordingRef.current = {
+        id: createTranscriptId('recording'),
+        name: `Presenter recording ${new Date(now).toLocaleString()}`,
+        createdAt: now,
+        updatedAt: now,
+        durationMs: 0,
+        ...(transcriptionLanguageCodeRef.current
+          ? { language: transcriptionLanguageCodeRef.current }
+          : {}),
+        modelPresetId: webSpeechTranscriptionModelId,
+        audio: {
+          mimeType: 'audio/webm',
+          storage: 'inline',
+        },
+        segments: [],
+      };
+      const recorder = new PresenterAudioRecorder({
+        onChunk: (chunk) => postRecordingCheckpoint(chunk.blob),
+        timesliceMs: 250,
+      });
       recorderRef.current = recorder;
-      await recorder.start();
       recordingStartedAtRef.current = Date.now();
+      await recorder.start();
       slideTranscriptMarkersRef.current = [getCurrentTranscriptMarker(0)];
       refreshTranscriptSegments('', false);
       const speechTranscriber = new PresenterSpeechTranscriber({
@@ -636,6 +670,7 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
       } catch (error) {
         recorder.cancel();
         recorderRef.current = undefined;
+        activeRecordingRef.current = undefined;
         throw error;
       }
       speechTranscriberRef.current = speechTranscriber;
@@ -649,55 +684,65 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     }
   }, [
     getCurrentTranscriptMarker,
+    postRecordingCheckpoint,
     publishTranscriptState,
     recordingStatus,
     refreshTranscriptSegments,
     updateLiveTranscript,
   ]);
 
-  const stopRecording = useCallback(async () => {
+  const stopRecording = useCallback(() => {
+    if (recordingStopPromiseRef.current) return recordingStopPromiseRef.current;
     const recorder = recorderRef.current;
-    if (!recorder) return;
-    try {
-      setRecordingStatus('transcribing');
-      await speechTranscriberRef.current?.stop();
-      const finalTranscriptText = speechTranscriberRef.current?.getText();
-      if (finalTranscriptText) {
-        updateLiveTranscript(finalTranscriptText, true);
-      } else {
-        refreshTranscriptSegments(fullTranscriptTextRef.current, true);
+    if (!recorder) return Promise.resolve();
+    const stopPromise = (async () => {
+      try {
+        setRecordingStatus('transcribing');
+        await speechTranscriberRef.current?.stop();
+        const finalTranscriptText = speechTranscriberRef.current?.getText();
+        if (finalTranscriptText) {
+          updateLiveTranscript(finalTranscriptText, true);
+        } else {
+          refreshTranscriptSegments(fullTranscriptTextRef.current, true);
+        }
+        const result = await recorder.stop();
+        const objectUrl = recorder.getObjectUrl() ?? URL.createObjectURL(result.blob);
+        recordingObjectUrlRef.current = objectUrl;
+        const now = new Date().toISOString();
+        const activeRecording = activeRecordingRef.current;
+        const recordingId = activeRecording?.id ?? createTranscriptId('recording');
+        const recording: TranscriptRecording = {
+          ...activeRecording,
+          id: recordingId,
+          name: activeRecording?.name ?? `Presenter recording ${new Date(now).toLocaleString()}`,
+          createdAt: activeRecording?.createdAt ?? now,
+          updatedAt: now,
+          durationMs: result.durationMs,
+          ...(transcriptionLanguageCode ? { language: transcriptionLanguageCode } : {}),
+          modelPresetId: webSpeechTranscriptionModelId,
+          audio: {
+            mimeType: result.mimeType,
+            objectUrl,
+            storage: 'inline',
+          },
+          segments: transcriptSegmentsRef.current,
+        };
+        postCommand({ audioBlob: result.blob, command: 'save-recording', recording });
+        setRecordingStatus('saved');
+        publishTranscriptState('saved');
+      } catch (error) {
+        setRecordingError(error instanceof Error ? error.message : 'Recording could not be saved.');
+        setRecordingStatus('save-failed');
+        publishTranscriptState('save-failed');
+      } finally {
+        recorderRef.current = undefined;
+        activeRecordingRef.current = undefined;
+        speechTranscriberRef.current = undefined;
+        recordingStopPromiseRef.current = undefined;
       }
-      const result = await recorder.stop();
-      const objectUrl = recorder.getObjectUrl() ?? URL.createObjectURL(result.blob);
-      recordingObjectUrlRef.current = objectUrl;
-      const now = new Date().toISOString();
-      const recordingId = createTranscriptId('recording');
-      const recording: TranscriptRecording = {
-        id: recordingId,
-        name: `Presenter recording ${new Date(now).toLocaleString()}`,
-        createdAt: now,
-        updatedAt: now,
-        durationMs: result.durationMs,
-        ...(transcriptionLanguageCode ? { language: transcriptionLanguageCode } : {}),
-        modelPresetId: webSpeechTranscriptionModelId,
-        audio: {
-          mimeType: result.mimeType,
-          objectUrl,
-          storage: 'inline',
-        },
-        segments: transcriptSegmentsRef.current,
-      };
-      postCommand({ audioBlob: result.blob, command: 'save-recording', recording });
-      setRecordingStatus('saved');
-      publishTranscriptState('saved');
-    } catch (error) {
-      setRecordingError(error instanceof Error ? error.message : 'Recording could not be saved.');
-      setRecordingStatus('save-failed');
-      publishTranscriptState('save-failed');
-    } finally {
-      recorderRef.current = undefined;
-      speechTranscriberRef.current = undefined;
-    }
+    })();
+    recordingStopPromiseRef.current = stopPromise;
+    return stopPromise;
   }, [
     postCommand,
     publishTranscriptState,
@@ -705,6 +750,29 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     transcriptionLanguageCode,
     updateLiveTranscript,
   ]);
+
+  const finishPresenterView = useCallback(async (closeWindow: boolean) => {
+    if (!recorderRef.current && !recordingStopPromiseRef.current) {
+      postCommand({ command: 'close' });
+      if (closeWindow) window.close();
+      return;
+    }
+    await stopRecording();
+    postCommand({ command: 'close' });
+    if (closeWindow) window.close();
+  }, [postCommand, stopRecording]);
+
+  useEffect(() => {
+    function handlePageHide() {
+      postRecordingCheckpoint();
+      postCommand({ command: 'close' });
+    }
+
+    window.addEventListener('pagehide', handlePageHide);
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide);
+    };
+  }, [postCommand, postRecordingCheckpoint]);
 
   useEffect(() => {
     const channel = transcriptChannelRef.current;
@@ -893,10 +961,11 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
     if (action === 'fast-forward-movie') pulsePresenterMovieHold('fast-forward');
     if (action === 'jump-movie-start') controlPresenterMovies('start');
     if (action === 'jump-movie-end') controlPresenterMovies('end');
-    if (action === 'quit-presentation') window.close();
+    if (action === 'quit-presentation') void finishPresenterView(true);
   }, [
     activePageIndex,
     controlPresenterMovies,
+    finishPresenterView,
     goToPage,
     pulsePresenterMovieHold,
     postCommand,
@@ -952,6 +1021,11 @@ export function PresenterView({ sessionId = getRouteSessionId() }: PresenterView
         return;
       }
       if (!snapshot) return;
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        executePresenterShortcut('quit-presentation');
+        return;
+      }
       if (event.key === '#') {
         event.preventDefault();
         executePresenterShortcut('open-slide-navigator');

--- a/apps/editor/src/ui/share/PublicDeckViewer.tsx
+++ b/apps/editor/src/ui/share/PublicDeckViewer.tsx
@@ -203,7 +203,9 @@ function formatTranscriptTimestamp(milliseconds: number) {
 }
 
 function getTranscriptRecordings(project: ProjectDocument): TranscriptRecording[] {
-  return Object.values(project.recordings ?? {}).filter((recording) => recording.segments.length > 0);
+  return Object.values(project.recordings ?? {})
+    .filter((recording) => recording.segments.length > 0)
+    .sort((first, second) => Date.parse(second.createdAt) - Date.parse(first.createdAt));
 }
 
 function getTranscriptQuestionContext(

--- a/apps/editor/tests/unit/services/presenterSessionService.test.ts
+++ b/apps/editor/tests/unit/services/presenterSessionService.test.ts
@@ -227,7 +227,7 @@ describe('BrowserPresenterSessionService', () => {
     unsubscribe();
   });
 
-  it('forwards saved presenter recordings from the active presenter session', () => {
+  it('forwards presenter recording checkpoints and final saves from the active session', () => {
     const popup = { location: { href: '' }, postMessage: vi.fn(), closed: false } as unknown as Window;
     const commandHandler = vi.fn();
     const service = new BrowserPresenterSessionService({
@@ -238,6 +238,7 @@ describe('BrowserPresenterSessionService', () => {
     });
     const project = sampleProject.createSampleProject();
     const audioBlob = new Blob(['partial talk audio'], { type: 'audio/webm;codecs=opus' });
+    const audioChunk = new Blob(['checkpoint audio'], { type: 'audio/webm;codecs=opus' });
     const recording = {
       id: 'recording-1',
       name: 'Presenter recording',
@@ -269,6 +270,26 @@ describe('BrowserPresenterSessionService', () => {
       new MessageEvent('message', {
         origin: 'https://localstudio.test',
         data: {
+          audioChunk,
+          command: 'recording-checkpoint',
+          recording,
+          sessionId: 'session-7',
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+      }),
+    );
+
+    expect(commandHandler).toHaveBeenCalledWith({
+      audioChunk,
+      command: 'recording-checkpoint',
+      recording,
+    });
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://localstudio.test',
+        data: {
           audioBlob,
           command: 'save-recording',
           recording,
@@ -284,6 +305,22 @@ describe('BrowserPresenterSessionService', () => {
       command: 'save-recording',
       recording,
     });
+
+    commandHandler.mockClear();
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://localstudio.test',
+        data: {
+          audioChunk: 'not-a-blob',
+          command: 'recording-checkpoint',
+          recording,
+          sessionId: 'session-7',
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+      }),
+    );
+    expect(commandHandler).not.toHaveBeenCalled();
     unsubscribe();
   });
 });

--- a/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.persistence-fixtures.ts
@@ -145,7 +145,11 @@ class RecordingMirrorService implements MirrorService<MinioMirrorConfig> {
       void repository;
       void config;
       void options;
-      return Promise.resolve({ enabled: true, status: 'synced' });
+      return Promise.resolve({
+        enabled: true,
+        status: 'synced',
+        lastSyncedAt: new Date().toISOString(),
+      });
     },
   );
 

--- a/apps/editor/tests/unit/ui/editor/EditorShell.presenter-fullscreen.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.presenter-fullscreen.test.tsx
@@ -7,10 +7,14 @@ import { EditorShell } from '../../../../src/ui/editor/shell/EditorShell';
 import { editorShellTestHarness } from './EditorShell.test-harness';
 
 const {
+  LoadingProjectRepository,
+  RecordingMirrorService,
+  RecordingShareService,
   SavingProjectRepository,
   createAppServices,
   selectImageLayer,
   startFullscreenPresentation,
+  waitForShareButtonReady,
 } = editorShellTestHarness;
 
 describe('EditorShell presenter fullscreen workflows', () => {
@@ -277,6 +281,151 @@ describe('EditorShell presenter fullscreen workflows', () => {
         ],
       });
     });
+  });
+
+  it('finalizes a checkpointed recording when the presenter closes and updates the existing public link', async () => {
+    const popup = {
+      close: vi.fn(),
+      closed: false,
+      location: { href: '' },
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      value: vi.fn(() => popup),
+    });
+    vi.spyOn(BrowserPresenterSessionService.prototype, 'openRemoteControlSession').mockResolvedValue({
+      code: 'peer-published-recording',
+      connectedControllerCount: 0,
+      expiresAt: '2026-08-14T12:00:00.000Z',
+      presenterDeviceId: 'presenter-device-published-recording',
+      presenterLabel: 'MacBook Pro',
+      qrUrl: 'http://localhost:4176/joystick/?peer=peer-published-recording',
+      sessionId: 'remote-session-published-recording',
+      transport: 'peerjs',
+    });
+    const project = sampleProject.createSampleProject();
+    project.recordings = {
+      'recording-old': {
+        id: 'recording-old',
+        name: 'Older presenter recording',
+        createdAt: '2026-08-12T12:00:00.000Z',
+        updatedAt: '2026-08-12T12:00:00.000Z',
+        durationMs: 1200,
+        modelPresetId: 'web-speech-api',
+        audio: {
+          mimeType: 'audio/webm;codecs=opus',
+          objectUrl: 'blob:recording-old',
+          storage: 'inline',
+        },
+        segments: [
+          {
+            id: 'segment-old',
+            text: 'The older public recording.',
+            startMs: 0,
+            endMs: 1200,
+            final: true,
+            pageId: 'page-1',
+            pageIndex: 0,
+            pageName: 'Slide 1',
+          },
+        ],
+      },
+    };
+    const mirrorService = new RecordingMirrorService();
+    const shareService = new RecordingShareService();
+    const repository = new LoadingProjectRepository(project);
+    const services = createAppServices();
+    services.mirrorService = mirrorService;
+    services.shareService = shareService;
+    services.projectRepository = repository;
+    services.persistenceAvailable = true;
+    services.skipStoredProjectLoad = false;
+    render(<EditorShell services={services} />);
+
+    await waitForShareButtonReady();
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+    await waitFor(() => {
+      expect(shareService.updateShare).toHaveBeenCalledWith(
+        'project-project-1',
+        expect.any(Object),
+        expect.any(Object),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close share panel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Presentation play options' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Presenter view' }));
+    const presenterSessionId = new URL(popup.location.href).searchParams.get('presenterSession');
+    const audioBlob = new Blob(['latest audio'], { type: 'audio/webm;codecs=opus' });
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          audioChunk: audioBlob,
+          command: 'recording-checkpoint',
+          recording: {
+            id: 'recording-latest',
+            name: 'Latest presenter recording',
+            createdAt: '2026-08-13T12:00:00.000Z',
+            updatedAt: '2026-08-13T12:00:00.000Z',
+            durationMs: 1800,
+            modelPresetId: 'web-speech-api',
+            audio: {
+              mimeType: 'audio/webm;codecs=opus',
+              storage: 'inline',
+            },
+            segments: [
+              {
+                id: 'segment-latest',
+                text: 'The newest public recording.',
+                startMs: 0,
+                endMs: 1800,
+                final: true,
+                pageId: 'page-1',
+                pageIndex: 0,
+                pageName: 'Slide 1',
+              },
+            ],
+          },
+          sessionId: presenterSessionId,
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+        origin: window.location.origin,
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          command: 'close',
+          sessionId: presenterSessionId,
+          source: 'localstudio-presenter-window',
+          type: 'command',
+        },
+        origin: window.location.origin,
+      }),
+    );
+
+    await waitFor(
+      () => {
+        expect(
+          shareService.updateShare.mock.calls.some(
+            ([shareId, sharedProject]) =>
+              shareId === 'project-project-1' &&
+              Object.keys(sharedProject.recordings ?? {}).join(',') === 'recording-latest',
+          ),
+        ).toBe(true);
+      },
+      { timeout: 3_000 },
+    );
+    expect(repository.savedProjects.at(-1)?.recordings?.['recording-latest']).toBeDefined();
+    expect(new Set(shareService.updateShare.mock.calls.map(([shareId]) => shareId))).toEqual(
+      new Set(['project-project-1']),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+    expect(screen.getByLabelText('Recording for public share')).toHaveValue('recording-latest');
   });
 
   it('hides page insert controls in fullscreen presenter mode and restores a clean editor state on exit', async () => {

--- a/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
+++ b/apps/editor/tests/unit/ui/presenter/PresenterView.test.tsx
@@ -3,6 +3,8 @@ import Konva from 'konva';
 import { StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sampleProject } from '../../../../src/domain/projects/sampleProject';
+import { PresenterAudioRecorder } from '../../../../src/services/transcription/presenterAudioRecorder';
+import { PresenterSpeechTranscriber } from '../../../../src/services/transcription/presenterSpeechTranscriber';
 import { PresenterView } from '../../../../src/ui/presenter/PresenterView';
 
 const remoteStreamPublisherMock = vi.hoisted(() => {
@@ -931,5 +933,52 @@ describe('PresenterView', () => {
       }),
       window.location.origin,
     );
+  });
+
+  it('checkpoints an active recording synchronously before pagehide closes the session', async () => {
+    const postMessage = vi.fn<(message: { command: string }, targetOrigin: string) => void>();
+    const opener = { postMessage };
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: opener,
+    });
+    vi.spyOn(PresenterAudioRecorder.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(PresenterSpeechTranscriber.prototype, 'start').mockImplementation(() => undefined);
+    window.localStorage.setItem('localstudio.presenterWindowIntroDismissed', '1');
+    render(<PresenterView sessionId="session-1" />);
+    const project = sampleProject.createSampleProject();
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: window.location.origin,
+          data: {
+            payload: {
+              activePageId: 'page-1',
+              animationPreview: undefined,
+              project,
+            },
+            sessionId: 'session-1',
+            source: 'localstudio-presenter-main',
+            type: 'state',
+          },
+        }),
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Start recording' }));
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('button', { name: 'Stop recording' })).toBeInTheDocument();
+    postMessage.mockClear();
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(postMessage.mock.calls.map(([message]) => message.command)).toEqual([
+      'recording-checkpoint',
+      'close',
+    ]);
   });
 });

--- a/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
+++ b/apps/editor/tests/unit/ui/share/PublicDeckViewer.test.tsx
@@ -235,6 +235,21 @@ describe('PublicDeckViewer', () => {
         ],
       },
     };
+    const newestRecording = project.recordings.recording1!;
+    project.recordings = {
+      'recording-old': {
+        ...newestRecording,
+        id: 'recording-old',
+        name: 'Older presenter recording',
+        createdAt: '2026-07-17T12:00:00.000Z',
+        updatedAt: '2026-07-17T12:00:00.000Z',
+        audio: {
+          ...newestRecording.audio,
+          objectUrl: 'https://cdn.localstudio.test/recordings/recording-old.webm',
+        },
+      },
+      recording1: newestRecording,
+    };
     const { share, shareService } = createRemoteShare(
       '00000000-0000-4000-8000-000000000207',
       project,
@@ -252,6 +267,10 @@ describe('PublicDeckViewer', () => {
     expect(screen.getByRole('region', { name: 'Presentation playback' })).toBeInTheDocument();
     let audio = document.querySelector('audio');
     expect(audio).toBeInstanceOf(HTMLAudioElement);
+    expect(audio).toHaveAttribute(
+      'src',
+      'https://cdn.localstudio.test/recordings/recording1.webm',
+    );
     expect(screen.getByRole('button', { name: 'Jump to slide 1: Slide 1' })).toHaveStyle({
       '--public-deck-chapter-preview-left': '0px',
       '--public-deck-chapter-preview-x': '0%',

--- a/tests/e2e/editor/coverage-service-contracts.spec.ts
+++ b/tests/e2e/editor/coverage-service-contracts.spec.ts
@@ -650,6 +650,7 @@ test.describe('editor service contracts coverage batch', () => {
         'update-stream-peer',
         'go-to-page',
         'next',
+        'recording-checkpoint',
         'save-recording',
         'close',
         'previous',

--- a/tests/e2e/editor/presenter-recording-transcription.spec.ts
+++ b/tests/e2e/editor/presenter-recording-transcription.spec.ts
@@ -248,6 +248,7 @@ test.describe('editor presenter recording transcription journey', () => {
     const commandNames = await page.evaluate(
       () => window.__LOCALSTUDIO_E2E_PRESENTER__?.commands ?? [],
     );
+    expect(commandNames).toContain('recording-checkpoint');
     expect(commandNames).toContain('save-recording');
     const savedRecordingSegments = await page.evaluate(
       () =>
@@ -268,5 +269,12 @@ test.describe('editor presenter recording transcription journey', () => {
         ).__LOCALSTUDIO_E2E_TRANSCRIPTION_LANGUAGES ?? [],
     );
     expect(transcriptionLanguages).toContain('en-US');
+
+    await page.getByRole('button', { name: 'Start recording' }).click();
+    await expect(page.getByRole('button', { name: 'Stop recording' })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect.poll(async () =>
+      page.evaluate(() => window.__LOCALSTUDIO_E2E_PRESENTER__?.commands.slice(-2) ?? []),
+    ).toEqual(['save-recording', 'close']);
   });
 });

--- a/tests/e2e/editor/service-contracts-presenter-session.spec.ts
+++ b/tests/e2e/editor/service-contracts-presenter-session.spec.ts
@@ -38,6 +38,7 @@ test('executes presenter session service contracts in the browser runtime', asyn
     'update-stream-peer',
     'go-to-page',
     'next',
+    'recording-checkpoint',
     'save-recording',
     'close',
     'previous',

--- a/tests/e2e/public-deck/view-shared-deck.spec.ts
+++ b/tests/e2e/public-deck/view-shared-deck.spec.ts
@@ -70,6 +70,31 @@ test.describe('public deck view journey', () => {
       align: 'center',
     };
     payload.project.recordings = {
+      'e2e-recording-old': {
+        id: 'e2e-recording-old',
+        name: 'Older E2E presenter recording',
+        createdAt: '2026-07-05T12:00:00.000Z',
+        updatedAt: '2026-07-05T12:00:00.000Z',
+        durationMs: 2200,
+        language: 'en',
+        modelPresetId: 'web-speech-api',
+        audio: {
+          mimeType: 'audio/webm;codecs=opus',
+          objectUrl: 'https://cdn.localstudio.test/recordings/e2e-recording-old.webm',
+          storage: 'remote',
+        },
+        segments: [
+          {
+            id: 'old-segment',
+            text: 'This older recording must not play by default.',
+            startMs: 0,
+            endMs: 2200,
+            final: true,
+            pageIndex: 0,
+            pageName: 'Opening',
+          },
+        ],
+      },
       'e2e-recording': {
         id: 'e2e-recording',
         name: 'E2E presenter recording',
@@ -126,6 +151,10 @@ test.describe('public deck view journey', () => {
     const missingShareSrc = encodeURIComponent('http://localhost/missing-share.json');
     await publicDeck.goto(`/editor/?share=e2e-share&src=${shareSrc}`);
     await publicDeck.expectReady(false);
+    await expect(page.locator('audio').first()).toHaveAttribute(
+      'src',
+      'https://cdn.localstudio.test/recordings/e2e-recording.webm',
+    );
     await expect(page.getByText('1 / 3')).toBeVisible();
     await page.getByRole('button', { name: 'Next slide' }).click();
     await expect(page.getByText('2 / 3')).toBeVisible();

--- a/tests/e2e/support/presenter-session-service-contract-scenario.ts
+++ b/tests/e2e/support/presenter-session-service-contract-scenario.ts
@@ -83,6 +83,19 @@ export async function runPresenterSessionServiceContractScenario(
   window.dispatchEvent(
     new MessageEvent('message', {
       data: {
+        audioChunk: new Blob(['checkpoint'], { type: 'audio/webm' }),
+        command: 'recording-checkpoint',
+        recording: { id: 'recording-1', segments: [] },
+        sessionId: opened.sessionId,
+        source: 'localstudio-presenter-window',
+        type: 'command',
+      },
+      origin: new URL(window.location.href).origin,
+    }),
+  );
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: {
         command: 'save-recording',
         recording: { id: 'recording-1', segments: [] },
         sessionId: opened.sessionId,
@@ -106,6 +119,7 @@ export async function runPresenterSessionServiceContractScenario(
     );
   }
   for (const invalidCommand of [
+    { audioChunk: 'invalid', command: 'recording-checkpoint', recording: { id: 'invalid' } },
     { command: 'save-recording' },
     { command: 'update-stream-peer', peerId: 42 },
     { command: 'update-timer', timer: { elapsedMs: '1', paused: false } },


### PR DESCRIPTION
## Summary

- Preserve presenter session state through published audio recording and transcription flows
- Align editor, presenter, and public deck playback behavior for recorded audio
- Add unit and end-to-end coverage for session contracts, fullscreen persistence, recording, and shared decks

## Testing

- Not run (not requested)