### PR TITLE
Corrigir z-index do submenu de alinhamento

### DIFF
--- a/apps/editor/src/ui/styles/floating-toolbar.css
+++ b/apps/editor/src/ui/styles/floating-toolbar.css
@@ -1,5 +1,6 @@
 .floating-toolbar {
   position: absolute;
+  z-index: 20;
   left: 50%;
   top: -48px;
   display: flex;

--- a/tests/e2e/editor/media-workflows.spec.ts
+++ b/tests/e2e/editor/media-workflows.spec.ts
@@ -28,6 +28,23 @@ test.describe('editor media workflow journey', () => {
     await expect(page.getByLabel('Crop top left')).toBeVisible();
     await page.getByRole('button', { name: 'Done' }).click();
 
+    await page.getByRole('button', { name: 'Align' }).click();
+    const alignMenu = page.getByRole('menu');
+    await expect(alignMenu).toBeVisible();
+    await expect
+      .poll(() =>
+        alignMenu.evaluate((menu) => {
+          const bounds = menu.getBoundingClientRect();
+          const topmostElement = document.elementFromPoint(
+            bounds.left + bounds.width / 2,
+            bounds.top + Math.min(50, bounds.height - 1),
+          );
+          return topmostElement !== null && menu.contains(topmostElement);
+        }),
+      )
+      .toBe(true);
+    await page.getByRole('menuitem', { name: 'Center', exact: true }).click();
+
     await editor.openTool('Design');
     await page
       .getByRole('tablist', { name: 'Movie inspector sections' })


### PR DESCRIPTION
## Summary
- Define um `z-index` para manter a barra de ferramentas flutuante acima de outros elementos.
- Adiciona cobertura E2E para verificar a visibilidade e a interação do submenu de alinhamento.

## Testing
- Não executado (não solicitado).