### PR TITLE
Add windowed audience playback mode

### DIFF
--- a/apps/editor/src/ui/editor/shell/AudienceFullscreenPrompt.tsx
+++ b/apps/editor/src/ui/editor/shell/AudienceFullscreenPrompt.tsx
@@ -1,12 +1,18 @@
 interface AudienceFullscreenPromptProps {
   onClose: () => void;
   onEnterFullscreen: () => void;
+  onStartWindowed?: (() => void) | undefined;
+  mode?: 'fullscreen' | 'window';
 }
 
 export function AudienceFullscreenPrompt({
+  mode = 'fullscreen',
   onClose,
   onEnterFullscreen,
+  onStartWindowed,
 }: AudienceFullscreenPromptProps) {
+  const isWindowMode = mode === 'window';
+
   return (
     <div className="audience-fullscreen-backdrop" role="presentation">
       <section
@@ -27,11 +33,16 @@ export function AudienceFullscreenPrompt({
         </button>
         <h2 id="audience-fullscreen-title">Audience Window</h2>
         <p>
-          This window is what your audience sees. Drag it to the screen your audience will be
-          looking at and enter full screen mode.
+          {isWindowMode
+            ? 'This window is what your audience sees. Drag it to the screen your audience will be looking at and start playback in this browser window.'
+            : 'This window is what your audience sees. Drag it to the screen your audience will be looking at and enter full screen mode.'}
         </p>
-        <button className="audience-fullscreen-primary" type="button" onClick={onEnterFullscreen}>
-          Enter full screen mode
+        <button
+          className="audience-fullscreen-primary"
+          type="button"
+          onClick={isWindowMode ? onStartWindowed : onEnterFullscreen}
+        >
+          {isWindowMode ? 'Play in window' : 'Enter full screen mode'}
         </button>
       </section>
     </div>

--- a/apps/editor/src/ui/editor/shell/EditorShell.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react';
 import { localStudioAnalyticsConfig } from '@localstudio/analytics-config/config';
 import type Konva from 'konva';
 import type { AppServices } from '../../../app/composition';
@@ -129,6 +129,11 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const [designFontFocusKey, setDesignFontFocusKey] = useState(0);
   const [speakerNotesOpen, setSpeakerNotesOpen] = useState(false);
   const [audienceFullscreenPromptOpen, setAudienceFullscreenPromptOpen] = useState(false);
+  const [audiencePromptMode, setAudiencePromptMode] = useState<'fullscreen' | 'window'>(
+    'fullscreen',
+  );
+  const [windowedPresentationActive, setWindowedPresentationActive] = useState(false);
+  const [windowedExitHintVisible, setWindowedExitHintVisible] = useState(false);
   const [keyboardShortcutsOpen, setKeyboardShortcutsOpen] = useState(false);
   const [fontReplacementOpen, setFontReplacementOpen] = useState(false);
   const [slideNavigatorOpen, setSlideNavigatorOpen] = useState(false);
@@ -164,6 +169,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const imageExportStageRef = useRef<Konva.Stage>(null);
   const workspaceRef = useRef<HTMLElement>(null);
   const slideFrameRef = useRef<HTMLDivElement>(null);
+  const windowedExitHintTimerRef = useRef<number | undefined>(undefined);
   const presenterSessionServiceRef = useRef<BrowserPresenterSessionService | undefined>(undefined);
   const presenterRemotePanelRef = useRef<HTMLDivElement>(null);
   const aiWorkflowTourRef = useRef<EditorAiWorkflowTourHandle>(null);
@@ -198,6 +204,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   const activePage = vm.project.pages[activePageIndex];
   const visiblePages = pageVisibility.getVisiblePages(vm.project);
   const visiblePageCount = visiblePages.length;
+  const browserPresentationActive = vm.isFullscreen || windowedPresentationActive;
   const activeVisiblePageIndex = Math.max(
     0,
     visiblePages.findIndex((page) => page.id === vm.activePageId),
@@ -627,6 +634,12 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     presenterSessionServiceRef.current?.closePresenterWindow();
     pendingPresenterRecordingsRef.current.clear();
     presenterFullscreenEnteredRef.current = false;
+    setWindowedPresentationActive(false);
+    setWindowedExitHintVisible(false);
+    if (windowedExitHintTimerRef.current !== undefined) {
+      window.clearTimeout(windowedExitHintTimerRef.current);
+      windowedExitHintTimerRef.current = undefined;
+    }
     vm.clearAnimationPreview();
     setAudienceFullscreenPromptOpen(false);
     setPresenterRemoteSession(undefined);
@@ -637,7 +650,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     setPresenterSessionId(undefined);
   }, [vm]);
 
-  const openPresenterView = useCallback(() => {
+  const openPresenterView = useCallback((options?: { audienceMode?: 'fullscreen' | 'window' }) => {
     if (presenterSessionId) return;
     const pageId = vm.activePageId;
     if (!pageId) return;
@@ -677,6 +690,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         );
       });
     presenterFullscreenEnteredRef.current = false;
+    setAudiencePromptMode(options?.audienceMode ?? 'fullscreen');
     setAudienceFullscreenPromptOpen(true);
     vm.playPresentationPreview(pageId);
     window.setTimeout(() => {
@@ -689,6 +703,28 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   function enterAudienceFullscreen() {
     setAudienceFullscreenPromptOpen(false);
     void vm.toggleFullscreen(workspaceRef.current);
+  }
+
+  function startWindowedAudiencePlayback() {
+    setAudienceFullscreenPromptOpen(false);
+    setWindowedPresentationActive(true);
+  }
+
+  const closeWindowedAudiencePlayback = useCallback(() => {
+    closePresenterViewSession();
+  }, [closePresenterViewSession]);
+
+  function handleWorkspacePointerMove(event: MouseEvent<HTMLElement>) {
+    if (!windowedPresentationActive) return;
+    if (event.clientY > 56) return;
+    setWindowedExitHintVisible(true);
+    if (windowedExitHintTimerRef.current !== undefined) {
+      window.clearTimeout(windowedExitHintTimerRef.current);
+    }
+    windowedExitHintTimerRef.current = window.setTimeout(() => {
+      setWindowedExitHintVisible(false);
+      windowedExitHintTimerRef.current = undefined;
+    }, 2200);
   }
 
   const playPresentationPageAt = useCallback(
@@ -773,6 +809,10 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     }
     if (action === 'quit-presentation') {
       setKeyboardShortcutsOpen(false);
+      if (windowedPresentationActive) {
+        closeWindowedAudiencePlayback();
+        return;
+      }
       if (vm.isFullscreen) void vm.toggleFullscreen(workspaceRef.current);
       return;
     }
@@ -975,7 +1015,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
 
       const isPresenterPlayback = vm.animationPreview?.mode === 'presenter';
       const isPreviewNavigationActive =
-        vm.isFullscreen || Boolean(isPresenterPlayback && vm.animationPreview?.playing);
+        browserPresentationActive || Boolean(isPresenterPlayback && vm.animationPreview?.playing);
       if (keyboardShortcutsOpen && event.key === 'Escape') {
         event.preventDefault();
         setKeyboardShortcutsOpen(false);
@@ -1018,6 +1058,10 @@ function EditorDesktopShell({ services }: EditorShellProps) {
         }
         if (event.key === 'Escape') {
           event.preventDefault();
+          if (windowedPresentationActive) {
+            closeWindowedAudiencePlayback();
+            return;
+          }
           if (vm.isFullscreen) void vm.toggleFullscreen(workspaceRef.current);
           return;
         }
@@ -1135,6 +1179,8 @@ function EditorDesktopShell({ services }: EditorShellProps) {
   }, [
     activePageIndex,
     advancePresentationPreviewFromUserAction,
+    browserPresentationActive,
+    closeWindowedAudiencePlayback,
     controlPresentationMovies,
     hasSelection,
     isHistoryReadOnly,
@@ -1148,11 +1194,15 @@ function EditorDesktopShell({ services }: EditorShellProps) {
     slideNavigatorOpen,
     stopPresentationMovieHold,
     vm,
+    windowedPresentationActive,
   ]);
 
   useEffect(() => {
     return () => {
       movieHoldStateRef.current = presentationMovieControls.stopHold(movieHoldStateRef.current);
+      if (windowedExitHintTimerRef.current !== undefined) {
+        window.clearTimeout(windowedExitHintTimerRef.current);
+      }
     };
   }, []);
 
@@ -1559,6 +1609,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             'workspace-column',
             leftPanelOpen ? 'workspace-column-left-panel-open' : '',
             vm.zoomPercent < 100 ? 'workspace-column-zoomed-out' : '',
+            windowedPresentationActive ? 'workspace-column-windowed-presentation' : '',
             presentationCursorHidden ? 'workspace-column-cursor-hidden' : '',
           ]
             .filter(Boolean)
@@ -1566,7 +1617,13 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           aria-label="Canvas workspace"
           data-tour-id="canvas-workspace"
           ref={workspaceRef}
+          onMouseMove={handleWorkspacePointerMove}
         >
+          {windowedPresentationActive && windowedExitHintVisible ? (
+            <div className="windowed-presentation-exit-tooltip" role="tooltip">
+              Press Esc to exit full screen
+            </div>
+          ) : null}
           {keyboardShortcutsOpen ? (
             <KeyboardShortcutsDialog
               onClose={() => setKeyboardShortcutsOpen(false)}
@@ -1608,7 +1665,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
             selection={vm.selection}
             slideFrameRef={slideFrameRef}
             stageRef={stageRef}
-            presentationMode={vm.isFullscreen || vm.animationPreview?.mode === 'presenter'}
+            presentationMode={browserPresentationActive || vm.animationPreview?.mode === 'presenter'}
             readOnly={isHistoryReadOnly}
             zoomPercent={vm.zoomPercent}
             backgroundSelectionMode={vm.backgroundSelectionMode}
@@ -1632,7 +1689,7 @@ function EditorDesktopShell({ services }: EditorShellProps) {
                   }
             }
             onAnimationPreviewAdvance={
-              vm.isFullscreen || vm.animationPreview?.mode === 'presenter'
+              browserPresentationActive || vm.animationPreview?.mode === 'presenter'
                 ? vm.advancePresentationPreview
                 : vm.advanceAnimationPreview
             }
@@ -1754,8 +1811,10 @@ function EditorDesktopShell({ services }: EditorShellProps) {
           ) : null}
           {audienceFullscreenPromptOpen ? (
             <AudienceFullscreenPrompt
+              mode={audiencePromptMode}
               onClose={closePresenterViewSession}
               onEnterFullscreen={enterAudienceFullscreen}
+              onStartWindowed={startWindowedAudiencePlayback}
             />
           ) : null}
           <input

--- a/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorToolbarSurface.tsx
@@ -21,7 +21,7 @@ interface EditorToolbarSurfaceProps {
   onExportPdf: () => void;
   onNewProject: () => void;
   onOpenKeyboardShortcuts: () => void;
-  onOpenPresenterView: () => void;
+  onOpenPresenterView: (options?: { audienceMode?: 'fullscreen' | 'window' }) => void;
   onLocalProjectSetupCancel?: () => void;
   onLocalProjectSetupConfirm?: () => void;
   onShare: () => void;

--- a/apps/editor/src/ui/editor/toolbars/ProjectPlayControl.tsx
+++ b/apps/editor/src/ui/editor/toolbars/ProjectPlayControl.tsx
@@ -6,7 +6,7 @@ export function ProjectPlayControl({
 }: {
   isMenuOpen: boolean;
   onMenuOpenChange: (isOpen: boolean) => void;
-  onOpenPresenterView?: (() => void) | undefined;
+  onOpenPresenterView?: ((options?: { audienceMode?: 'fullscreen' | 'window' }) => void) | undefined;
   onStartPresenterMode?: ((options?: { fromBeginning?: boolean }) => void) | undefined;
 }) {
   function startPresenterMode(options?: { fromBeginning?: boolean }) {
@@ -72,6 +72,20 @@ export function ProjectPlayControl({
               fullscreen
             </span>
             <span>Present in fullscreen</span>
+          </button>
+          <button
+            className="toolbar-dropdown-item project-play-dropdown-item"
+            role="menuitem"
+            type="button"
+            onClick={() => {
+              onMenuOpenChange(false);
+              onOpenPresenterView?.({ audienceMode: 'window' });
+            }}
+          >
+            <span className="material-symbols-outlined" aria-hidden="true">
+              open_in_browser
+            </span>
+            <span>Play in window</span>
           </button>
           <button
             className="toolbar-dropdown-item project-play-dropdown-item"

--- a/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
+++ b/apps/editor/src/ui/editor/toolbars/TopToolbar.tsx
@@ -65,7 +65,7 @@ interface TopToolbarProps {
   onSaveLocal?: (() => void) | undefined;
   onSaveLocalAs?: (() => void) | undefined;
   onProjectNameChange?: ((name: string) => void) | undefined;
-  onOpenPresenterView?: (() => void) | undefined;
+  onOpenPresenterView?: ((options?: { audienceMode?: 'fullscreen' | 'window' }) => void) | undefined;
   onRedo?: (() => void) | undefined;
   onResetZoom?: (() => void) | undefined;
   onShare?: (() => void) | undefined;

--- a/apps/editor/src/ui/styles/canvas-workspace.css
+++ b/apps/editor/src/ui/styles/canvas-workspace.css
@@ -23,7 +23,11 @@
   background-size: 40px 40px;
 }
 
-.workspace-column:fullscreen {
+.workspace-column:fullscreen,
+.workspace-column-windowed-presentation {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
   width: 100vw;
   height: 100vh;
   grid-template-rows: minmax(0, 1fr);
@@ -32,11 +36,13 @@
   overflow: hidden;
 }
 
-.workspace-column:fullscreen .prompt-stack {
+.workspace-column:fullscreen .prompt-stack,
+.workspace-column-windowed-presentation .prompt-stack {
   display: none;
 }
 
-.workspace-column:fullscreen .scrolling-canvas-workspace {
+.workspace-column:fullscreen .scrolling-canvas-workspace,
+.workspace-column-windowed-presentation .scrolling-canvas-workspace {
   width: 100vw;
   height: 100vh;
   display: grid;
@@ -62,16 +68,19 @@
 }
 
 .workspace-column:fullscreen .scroll-page,
+.workspace-column-windowed-presentation .scroll-page,
 .scrolling-canvas-workspace:fullscreen .scroll-page {
   min-height: 100vh;
   align-content: center;
 }
 
-.workspace-column:fullscreen .scroll-page:not(.scroll-page-active) {
+.workspace-column:fullscreen .scroll-page:not(.scroll-page-active),
+.workspace-column-windowed-presentation .scroll-page:not(.scroll-page-active) {
   display: none;
 }
 
-.workspace-column:fullscreen .scroll-page-active {
+.workspace-column:fullscreen .scroll-page-active,
+.workspace-column-windowed-presentation .scroll-page-active {
   width: 100vw;
   display: grid;
   grid-template-rows: minmax(0, 1fr);
@@ -80,26 +89,31 @@
 }
 
 .workspace-column:fullscreen .scroll-page-header,
+.workspace-column-windowed-presentation .scroll-page-header,
 .scrolling-canvas-workspace:fullscreen .scroll-page-header {
   display: none;
 }
 
 .workspace-column:fullscreen .canvas-frame,
 .workspace-column:fullscreen .scroll-page-placeholder,
+.workspace-column-windowed-presentation .canvas-frame,
+.workspace-column-windowed-presentation .scroll-page-placeholder,
 .scrolling-canvas-workspace:fullscreen .canvas-frame,
 .scrolling-canvas-workspace:fullscreen .scroll-page-placeholder {
   width: min(100vw, calc(100vh * 16 / 9));
   max-width: 100vw;
 }
 
-.workspace-column:fullscreen .canvas-frame {
+.workspace-column:fullscreen .canvas-frame,
+.workspace-column-windowed-presentation .canvas-frame {
   border: 0;
   outline: 0;
   box-shadow: none;
   transform: none !important;
 }
 
-.workspace-column:fullscreen .canvas-artboard {
+.workspace-column:fullscreen .canvas-artboard,
+.workspace-column-windowed-presentation .canvas-artboard {
   border-radius: 0;
 }
 
@@ -152,6 +166,17 @@
 .workspace-column-zoomed-out .scrolling-canvas-workspace {
   height: auto;
   overflow: visible;
+}
+
+.workspace-column-windowed-presentation.workspace-column-zoomed-out {
+  grid-template-rows: minmax(0, 1fr);
+  align-content: stretch;
+  overflow: hidden;
+}
+
+.workspace-column-windowed-presentation.workspace-column-zoomed-out .scrolling-canvas-workspace {
+  height: 100vh;
+  overflow: hidden;
 }
 
 .scrolling-canvas-workspace {

--- a/apps/editor/src/ui/styles/presentation-overlays.css
+++ b/apps/editor/src/ui/styles/presentation-overlays.css
@@ -100,6 +100,24 @@
   display: none;
 }
 
+.windowed-presentation-exit-tooltip {
+  position: fixed;
+  top: 14px;
+  left: 50%;
+  z-index: 1010;
+  transform: translateX(-50%);
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 6px;
+  background: rgba(5, 13, 16, 0.9);
+  color: var(--ew-text);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 18px;
+  pointer-events: none;
+}
+
 .workspace-column-cursor-hidden,
 .workspace-column-cursor-hidden * {
   cursor: none !important;

--- a/apps/editor/tests/unit/ui/editor/EditorShell.presenter-fullscreen.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.presenter-fullscreen.test.tsx
@@ -120,6 +120,69 @@ describe('EditorShell presenter fullscreen workflows', () => {
     expect(popupClose).not.toHaveBeenCalled();
   });
 
+  it('opens presenter view with windowed audience playback without requesting fullscreen', async () => {
+    const popupClose = vi.fn();
+    const popup = {
+      close: popupClose,
+      closed: false,
+      location: { href: '' },
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    const openWindow = vi.fn(() => popup);
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      value: openWindow,
+    });
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(HTMLElement.prototype, 'requestFullscreen', {
+      configurable: true,
+      value: requestFullscreen,
+    });
+
+    render(<EditorShell services={createAppServices()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Presentation play options' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Play in window' }));
+
+    expect(openWindow).toHaveBeenCalledTimes(1);
+    expect(popup.location.href).toContain('presenter=1');
+    expect(screen.getByRole('dialog', { name: 'Audience Window' })).toHaveTextContent(
+      'start playback in this browser window',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play in window' }));
+
+    await waitFor(() => {
+      expect(requestFullscreen).not.toHaveBeenCalled();
+      expect(screen.queryByRole('dialog', { name: 'Audience Window' })).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Canvas workspace')).toHaveClass(
+        'workspace-column-windowed-presentation',
+      );
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'presenter',
+      );
+    });
+
+    fireEvent.mouseMove(screen.getByLabelText('Canvas workspace'), { clientY: 12 });
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Press Esc to exit full screen');
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(popupClose).toHaveBeenCalledTimes(1);
+      expect(screen.getByLabelText('Canvas workspace')).not.toHaveClass(
+        'workspace-column-windowed-presentation',
+      );
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Slide canvas')).toHaveAttribute(
+        'data-animation-preview-mode',
+        'idle',
+      );
+    });
+  });
+
   it('stops presenter click navigation when the presenter window closes before audience fullscreen', async () => {
     const project = sampleProject.createSampleProject();
     project.pages = [

--- a/apps/editor/tests/unit/ui/editor/TopToolbar.presentation.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/TopToolbar.presentation.test.tsx
@@ -80,4 +80,22 @@ describe('TopToolbar presentation actions', () => {
 
     expect(onOpenPresenterView).toHaveBeenCalledTimes(1);
   });
+
+  it('opens presenter view in window mode from the play menu', async () => {
+    const user = userEvent.setup();
+    const onOpenPresenterView = vi.fn();
+
+    render(
+      <TopToolbar
+        project={sampleProject.createSampleProject()}
+        language="PT-BR"
+        onOpenPresenterView={onOpenPresenterView}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Presentation play options' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Play in window' }));
+
+    expect(onOpenPresenterView).toHaveBeenCalledWith({ audienceMode: 'window' });
+  });
 });

--- a/tests/e2e/editor/presenter-notes-editor-menu.ts
+++ b/tests/e2e/editor/presenter-notes-editor-menu.ts
@@ -8,6 +8,7 @@ export const presenterNotesEditorMenu = {
     await page.getByRole('button', { name: 'Presentation play options' }).click();
     await expect(page.getByRole('menu', { name: 'Presentation play menu' })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: /Present in fullscreen/i })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: /Play in window/i })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: /Presenter view/i })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: /Play from beginning/i })).toBeVisible();
 

--- a/tests/e2e/editor/presenter-play-in-window.spec.ts
+++ b/tests/e2e/editor/presenter-play-in-window.spec.ts
@@ -1,0 +1,53 @@
+import { EditorAppPage } from '../pages/editor-app.page';
+import { expect, test, withIsolatedDevServer } from '../support/journey-test';
+
+const getServer = withIsolatedDevServer(test);
+
+test.describe('editor presenter play in window', () => {
+  test('opens presenter view and keeps audience playback windowed', async ({ page }) => {
+    const editor = new EditorAppPage(page, getServer().baseURL);
+    await editor.gotoNewProject();
+
+    await page.getByRole('button', { name: 'Presentation play options' }).click();
+    const presenterPagePromise = page.waitForEvent('popup');
+    await page.getByRole('menuitem', { name: 'Play in window' }).click();
+    const presenterPage = await presenterPagePromise;
+
+    await expect(presenterPage.getByLabel('Presenter view')).toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Audience Window' })).toContainText(
+      'start playback in this browser window',
+    );
+    await expect
+      .poll(() => page.evaluate(() => Boolean(document.fullscreenElement)))
+      .toBe(false);
+
+    await page.getByRole('button', { name: 'Play in window' }).click();
+
+    await expect(page.getByRole('dialog', { name: 'Audience Window' })).toBeHidden();
+    await expect(page.getByRole('region', { name: 'Canvas workspace' })).toHaveClass(
+      /workspace-column-windowed-presentation/,
+    );
+    await expect(page.getByTestId('slide-canvas-frame')).toHaveAttribute(
+      'data-animation-preview-mode',
+      'presenter',
+    );
+    await expect
+      .poll(() => page.evaluate(() => Boolean(document.fullscreenElement)))
+      .toBe(false);
+
+    await page.mouse.move(400, 10);
+    await expect(page.getByRole('tooltip')).toHaveText('Press Esc to exit full screen');
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByRole('region', { name: 'Canvas workspace' })).not.toHaveClass(
+      /workspace-column-windowed-presentation/,
+    );
+    await expect(page.getByRole('tooltip')).toBeHidden();
+    await expect(page.getByTestId('slide-canvas-frame')).toHaveAttribute(
+      'data-animation-preview-mode',
+      'idle',
+    );
+    await expect.poll(() => presenterPage.isClosed()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a “Play in window” presentation option alongside fullscreen playback.
- Keep audience playback within the editor window without requesting browser fullscreen.
- Support Escape-to-exit behavior and a temporary exit hint on pointer movement.
- Add unit and end-to-end coverage for the new workflow.

## Testing

- Added unit tests for windowed presenter playback and toolbar behavior.
- Added Playwright coverage for the complete play-in-window flow.
- Extended the presenter menu E2E checks to include the new option.