### PR TITLE
Split editor test jobs into eight CI shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,22 @@ jobs:
         include:
           - label: landing
             command: npm run test --workspace @localstudio/landing
-          - label: editor 1/4
-            command: npm run test --workspace @localstudio/editor -- --shard=1/4
-          - label: editor 2/4
-            command: npm run test --workspace @localstudio/editor -- --shard=2/4
-          - label: editor 3/4
-            command: npm run test --workspace @localstudio/editor -- --shard=3/4
-          - label: editor 4/4
-            command: npm run test --workspace @localstudio/editor -- --shard=4/4
+          - label: editor 1/8
+            command: npm run test --workspace @localstudio/editor -- --shard=1/8
+          - label: editor 2/8
+            command: npm run test --workspace @localstudio/editor -- --shard=2/8
+          - label: editor 3/8
+            command: npm run test --workspace @localstudio/editor -- --shard=3/8
+          - label: editor 4/8
+            command: npm run test --workspace @localstudio/editor -- --shard=4/8
+          - label: editor 5/8
+            command: npm run test --workspace @localstudio/editor -- --shard=5/8
+          - label: editor 6/8
+            command: npm run test --workspace @localstudio/editor -- --shard=6/8
+          - label: editor 7/8
+            command: npm run test --workspace @localstudio/editor -- --shard=7/8
+          - label: editor 8/8
+            command: npm run test --workspace @localstudio/editor -- --shard=8/8
           - label: joystick
             command: npm run test --workspace @localstudio/joystick
 
@@ -203,26 +211,61 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: editor 1/3
+          - label: editor 1/8
             script: test:e2e:coverage:editor
             report: editor-shard-1
             raw_path: test-results/editor-shard-1-coverage/**/browser-coverage.json
-            shard: 1/3
+            shard: 1/8
             output_name: editor-shard-1
             coverage_threshold: '0'
-          - label: editor 2/3
+          - label: editor 2/8
             script: test:e2e:coverage:editor
             report: editor-shard-2
             raw_path: test-results/editor-shard-2-coverage/**/browser-coverage.json
-            shard: 2/3
+            shard: 2/8
             output_name: editor-shard-2
             coverage_threshold: '0'
-          - label: editor 3/3
+          - label: editor 3/8
             script: test:e2e:coverage:editor
             report: editor-shard-3
             raw_path: test-results/editor-shard-3-coverage/**/browser-coverage.json
-            shard: 3/3
+            shard: 3/8
             output_name: editor-shard-3
+            coverage_threshold: '0'
+          - label: editor 4/8
+            script: test:e2e:coverage:editor
+            report: editor-shard-4
+            raw_path: test-results/editor-shard-4-coverage/**/browser-coverage.json
+            shard: 4/8
+            output_name: editor-shard-4
+            coverage_threshold: '0'
+          - label: editor 5/8
+            script: test:e2e:coverage:editor
+            report: editor-shard-5
+            raw_path: test-results/editor-shard-5-coverage/**/browser-coverage.json
+            shard: 5/8
+            output_name: editor-shard-5
+            coverage_threshold: '0'
+          - label: editor 6/8
+            script: test:e2e:coverage:editor
+            report: editor-shard-6
+            raw_path: test-results/editor-shard-6-coverage/**/browser-coverage.json
+            shard: 6/8
+            output_name: editor-shard-6
+            coverage_threshold: '0'
+          - label: editor 7/8
+            script: test:e2e:coverage:editor
+            report: editor-shard-7
+            raw_path: test-results/editor-shard-7-coverage/**/browser-coverage.json
+            shard: 7/8
+            output_name: editor-shard-7
+            coverage_threshold: '0'
+          - label: editor 8/8
+            script: test:e2e:coverage:editor
+            report: editor-shard-8
+            raw_path: test-results/editor-shard-8-coverage/**/browser-coverage.json
+            shard: 8/8
+            output_name: editor-shard-8
             coverage_threshold: '0'
           - label: landing
             script: test:e2e:coverage:landing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,24 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true'
         run: npm ci
 
+      - name: Restore ESLint cache
+        id: eslint-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .eslintcache
+          key: eslint-${{ runner.os }}-node26-${{ hashFiles('package-lock.json', 'eslint.config.js') }}-${{ github.sha }}
+          restore-keys: |
+            eslint-${{ runner.os }}-node26-${{ hashFiles('package-lock.json', 'eslint.config.js') }}-
+
       - name: Lint
-        run: npm run lint
+        run: npm run lint -- --cache --cache-location .eslintcache --concurrency auto
+
+      - name: Save ESLint cache
+        if: steps.eslint-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: .eslintcache
+          key: ${{ steps.eslint-cache.outputs.cache-primary-key }}
 
   typecheck:
     name: Typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,22 +156,38 @@ jobs:
         include:
           - label: landing
             command: npm run test --workspace @localstudio/landing
-          - label: editor 1/8
-            command: npm run test --workspace @localstudio/editor -- --shard=1/8
-          - label: editor 2/8
-            command: npm run test --workspace @localstudio/editor -- --shard=2/8
-          - label: editor 3/8
-            command: npm run test --workspace @localstudio/editor -- --shard=3/8
-          - label: editor 4/8
-            command: npm run test --workspace @localstudio/editor -- --shard=4/8
-          - label: editor 5/8
-            command: npm run test --workspace @localstudio/editor -- --shard=5/8
-          - label: editor 6/8
-            command: npm run test --workspace @localstudio/editor -- --shard=6/8
-          - label: editor 7/8
-            command: npm run test --workspace @localstudio/editor -- --shard=7/8
-          - label: editor 8/8
-            command: npm run test --workspace @localstudio/editor -- --shard=8/8
+          - label: editor 1/16
+            command: npm run test --workspace @localstudio/editor -- --shard=1/16
+          - label: editor 2/16
+            command: npm run test --workspace @localstudio/editor -- --shard=2/16
+          - label: editor 3/16
+            command: npm run test --workspace @localstudio/editor -- --shard=3/16
+          - label: editor 4/16
+            command: npm run test --workspace @localstudio/editor -- --shard=4/16
+          - label: editor 5/16
+            command: npm run test --workspace @localstudio/editor -- --shard=5/16
+          - label: editor 6/16
+            command: npm run test --workspace @localstudio/editor -- --shard=6/16
+          - label: editor 7/16
+            command: npm run test --workspace @localstudio/editor -- --shard=7/16
+          - label: editor 8/16
+            command: npm run test --workspace @localstudio/editor -- --shard=8/16
+          - label: editor 9/16
+            command: npm run test --workspace @localstudio/editor -- --shard=9/16
+          - label: editor 10/16
+            command: npm run test --workspace @localstudio/editor -- --shard=10/16
+          - label: editor 11/16
+            command: npm run test --workspace @localstudio/editor -- --shard=11/16
+          - label: editor 12/16
+            command: npm run test --workspace @localstudio/editor -- --shard=12/16
+          - label: editor 13/16
+            command: npm run test --workspace @localstudio/editor -- --shard=13/16
+          - label: editor 14/16
+            command: npm run test --workspace @localstudio/editor -- --shard=14/16
+          - label: editor 15/16
+            command: npm run test --workspace @localstudio/editor -- --shard=15/16
+          - label: editor 16/16
+            command: npm run test --workspace @localstudio/editor -- --shard=16/16
           - label: joystick
             command: npm run test --workspace @localstudio/joystick
 
@@ -211,61 +227,117 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: editor 1/8
+          - label: editor 1/16
             script: test:e2e:coverage:editor
             report: editor-shard-1
             raw_path: test-results/editor-shard-1-coverage/**/browser-coverage.json
-            shard: 1/8
+            shard: 1/16
             output_name: editor-shard-1
             coverage_threshold: '0'
-          - label: editor 2/8
+          - label: editor 2/16
             script: test:e2e:coverage:editor
             report: editor-shard-2
             raw_path: test-results/editor-shard-2-coverage/**/browser-coverage.json
-            shard: 2/8
+            shard: 2/16
             output_name: editor-shard-2
             coverage_threshold: '0'
-          - label: editor 3/8
+          - label: editor 3/16
             script: test:e2e:coverage:editor
             report: editor-shard-3
             raw_path: test-results/editor-shard-3-coverage/**/browser-coverage.json
-            shard: 3/8
+            shard: 3/16
             output_name: editor-shard-3
             coverage_threshold: '0'
-          - label: editor 4/8
+          - label: editor 4/16
             script: test:e2e:coverage:editor
             report: editor-shard-4
             raw_path: test-results/editor-shard-4-coverage/**/browser-coverage.json
-            shard: 4/8
+            shard: 4/16
             output_name: editor-shard-4
             coverage_threshold: '0'
-          - label: editor 5/8
+          - label: editor 5/16
             script: test:e2e:coverage:editor
             report: editor-shard-5
             raw_path: test-results/editor-shard-5-coverage/**/browser-coverage.json
-            shard: 5/8
+            shard: 5/16
             output_name: editor-shard-5
             coverage_threshold: '0'
-          - label: editor 6/8
+          - label: editor 6/16
             script: test:e2e:coverage:editor
             report: editor-shard-6
             raw_path: test-results/editor-shard-6-coverage/**/browser-coverage.json
-            shard: 6/8
+            shard: 6/16
             output_name: editor-shard-6
             coverage_threshold: '0'
-          - label: editor 7/8
+          - label: editor 7/16
             script: test:e2e:coverage:editor
             report: editor-shard-7
             raw_path: test-results/editor-shard-7-coverage/**/browser-coverage.json
-            shard: 7/8
+            shard: 7/16
             output_name: editor-shard-7
             coverage_threshold: '0'
-          - label: editor 8/8
+          - label: editor 8/16
             script: test:e2e:coverage:editor
             report: editor-shard-8
             raw_path: test-results/editor-shard-8-coverage/**/browser-coverage.json
-            shard: 8/8
+            shard: 8/16
             output_name: editor-shard-8
+            coverage_threshold: '0'
+          - label: editor 9/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-9
+            raw_path: test-results/editor-shard-9-coverage/**/browser-coverage.json
+            shard: 9/16
+            output_name: editor-shard-9
+            coverage_threshold: '0'
+          - label: editor 10/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-10
+            raw_path: test-results/editor-shard-10-coverage/**/browser-coverage.json
+            shard: 10/16
+            output_name: editor-shard-10
+            coverage_threshold: '0'
+          - label: editor 11/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-11
+            raw_path: test-results/editor-shard-11-coverage/**/browser-coverage.json
+            shard: 11/16
+            output_name: editor-shard-11
+            coverage_threshold: '0'
+          - label: editor 12/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-12
+            raw_path: test-results/editor-shard-12-coverage/**/browser-coverage.json
+            shard: 12/16
+            output_name: editor-shard-12
+            coverage_threshold: '0'
+          - label: editor 13/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-13
+            raw_path: test-results/editor-shard-13-coverage/**/browser-coverage.json
+            shard: 13/16
+            output_name: editor-shard-13
+            coverage_threshold: '0'
+          - label: editor 14/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-14
+            raw_path: test-results/editor-shard-14-coverage/**/browser-coverage.json
+            shard: 14/16
+            output_name: editor-shard-14
+            coverage_threshold: '0'
+          - label: editor 15/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-15
+            raw_path: test-results/editor-shard-15-coverage/**/browser-coverage.json
+            shard: 15/16
+            output_name: editor-shard-15
+            coverage_threshold: '0'
+          - label: editor 16/16
+            script: test:e2e:coverage:editor
+            report: editor-shard-16
+            raw_path: test-results/editor-shard-16-coverage/**/browser-coverage.json
+            shard: 16/16
+            output_name: editor-shard-16
             coverage_threshold: '0'
           - label: landing
             script: test:e2e:coverage:landing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,6 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Install Playwright Chromium browser
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium
 
       - name: Playwright E2E coverage test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
 
   test:
     name: Unit tests (${{ matrix.label }})
-    needs: dependencies
+    needs: [dependencies, lint, typecheck]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -516,7 +516,7 @@ jobs:
 
   build:
     name: Build
-    needs: dependencies
+    needs: [dependencies, lint, typecheck]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,9 @@ jobs:
     name: Playwright E2E (${{ matrix.label }})
     needs: build
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      options: --ipc=host
     permissions:
       contents: read
     strategy:
@@ -324,21 +327,6 @@ jobs:
         with:
           name: localstudio-dist
           path: dist
-
-      - name: Restore Playwright browser cache
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
-      - name: Install Playwright Chromium system dependencies
-        run: npx playwright install-deps chromium
-
-      - name: Install Playwright Chromium browser
-        run: npx playwright install chromium
 
       - name: Playwright E2E coverage test
         run: npm run ${{ matrix.script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,9 +205,6 @@ jobs:
     name: Playwright E2E (${{ matrix.label }})
     needs: build
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
-      options: --ipc=host
     permissions:
       contents: read
     strategy:
@@ -327,6 +324,22 @@ jobs:
         with:
           name: localstudio-dist
           path: dist
+
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright Chromium system dependencies
+        run: npx playwright install-deps chromium
+
+      - name: Install Playwright Chromium browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
 
       - name: Playwright E2E coverage test
         run: npm run ${{ matrix.script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,38 +156,22 @@ jobs:
         include:
           - label: landing
             command: npm run test --workspace @localstudio/landing
-          - label: editor 1/16
-            command: npm run test --workspace @localstudio/editor -- --shard=1/16
-          - label: editor 2/16
-            command: npm run test --workspace @localstudio/editor -- --shard=2/16
-          - label: editor 3/16
-            command: npm run test --workspace @localstudio/editor -- --shard=3/16
-          - label: editor 4/16
-            command: npm run test --workspace @localstudio/editor -- --shard=4/16
-          - label: editor 5/16
-            command: npm run test --workspace @localstudio/editor -- --shard=5/16
-          - label: editor 6/16
-            command: npm run test --workspace @localstudio/editor -- --shard=6/16
-          - label: editor 7/16
-            command: npm run test --workspace @localstudio/editor -- --shard=7/16
-          - label: editor 8/16
-            command: npm run test --workspace @localstudio/editor -- --shard=8/16
-          - label: editor 9/16
-            command: npm run test --workspace @localstudio/editor -- --shard=9/16
-          - label: editor 10/16
-            command: npm run test --workspace @localstudio/editor -- --shard=10/16
-          - label: editor 11/16
-            command: npm run test --workspace @localstudio/editor -- --shard=11/16
-          - label: editor 12/16
-            command: npm run test --workspace @localstudio/editor -- --shard=12/16
-          - label: editor 13/16
-            command: npm run test --workspace @localstudio/editor -- --shard=13/16
-          - label: editor 14/16
-            command: npm run test --workspace @localstudio/editor -- --shard=14/16
-          - label: editor 15/16
-            command: npm run test --workspace @localstudio/editor -- --shard=15/16
-          - label: editor 16/16
-            command: npm run test --workspace @localstudio/editor -- --shard=16/16
+          - label: editor 1/8
+            command: npm run test --workspace @localstudio/editor -- --shard=1/8
+          - label: editor 2/8
+            command: npm run test --workspace @localstudio/editor -- --shard=2/8
+          - label: editor 3/8
+            command: npm run test --workspace @localstudio/editor -- --shard=3/8
+          - label: editor 4/8
+            command: npm run test --workspace @localstudio/editor -- --shard=4/8
+          - label: editor 5/8
+            command: npm run test --workspace @localstudio/editor -- --shard=5/8
+          - label: editor 6/8
+            command: npm run test --workspace @localstudio/editor -- --shard=6/8
+          - label: editor 7/8
+            command: npm run test --workspace @localstudio/editor -- --shard=7/8
+          - label: editor 8/8
+            command: npm run test --workspace @localstudio/editor -- --shard=8/8
           - label: joystick
             command: npm run test --workspace @localstudio/joystick
 
@@ -227,117 +211,61 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: editor 1/16
+          - label: editor 1/8
             script: test:e2e:coverage:editor
             report: editor-shard-1
             raw_path: test-results/editor-shard-1-coverage/**/browser-coverage.json
-            shard: 1/16
+            shard: 1/8
             output_name: editor-shard-1
             coverage_threshold: '0'
-          - label: editor 2/16
+          - label: editor 2/8
             script: test:e2e:coverage:editor
             report: editor-shard-2
             raw_path: test-results/editor-shard-2-coverage/**/browser-coverage.json
-            shard: 2/16
+            shard: 2/8
             output_name: editor-shard-2
             coverage_threshold: '0'
-          - label: editor 3/16
+          - label: editor 3/8
             script: test:e2e:coverage:editor
             report: editor-shard-3
             raw_path: test-results/editor-shard-3-coverage/**/browser-coverage.json
-            shard: 3/16
+            shard: 3/8
             output_name: editor-shard-3
             coverage_threshold: '0'
-          - label: editor 4/16
+          - label: editor 4/8
             script: test:e2e:coverage:editor
             report: editor-shard-4
             raw_path: test-results/editor-shard-4-coverage/**/browser-coverage.json
-            shard: 4/16
+            shard: 4/8
             output_name: editor-shard-4
             coverage_threshold: '0'
-          - label: editor 5/16
+          - label: editor 5/8
             script: test:e2e:coverage:editor
             report: editor-shard-5
             raw_path: test-results/editor-shard-5-coverage/**/browser-coverage.json
-            shard: 5/16
+            shard: 5/8
             output_name: editor-shard-5
             coverage_threshold: '0'
-          - label: editor 6/16
+          - label: editor 6/8
             script: test:e2e:coverage:editor
             report: editor-shard-6
             raw_path: test-results/editor-shard-6-coverage/**/browser-coverage.json
-            shard: 6/16
+            shard: 6/8
             output_name: editor-shard-6
             coverage_threshold: '0'
-          - label: editor 7/16
+          - label: editor 7/8
             script: test:e2e:coverage:editor
             report: editor-shard-7
             raw_path: test-results/editor-shard-7-coverage/**/browser-coverage.json
-            shard: 7/16
+            shard: 7/8
             output_name: editor-shard-7
             coverage_threshold: '0'
-          - label: editor 8/16
+          - label: editor 8/8
             script: test:e2e:coverage:editor
             report: editor-shard-8
             raw_path: test-results/editor-shard-8-coverage/**/browser-coverage.json
-            shard: 8/16
+            shard: 8/8
             output_name: editor-shard-8
-            coverage_threshold: '0'
-          - label: editor 9/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-9
-            raw_path: test-results/editor-shard-9-coverage/**/browser-coverage.json
-            shard: 9/16
-            output_name: editor-shard-9
-            coverage_threshold: '0'
-          - label: editor 10/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-10
-            raw_path: test-results/editor-shard-10-coverage/**/browser-coverage.json
-            shard: 10/16
-            output_name: editor-shard-10
-            coverage_threshold: '0'
-          - label: editor 11/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-11
-            raw_path: test-results/editor-shard-11-coverage/**/browser-coverage.json
-            shard: 11/16
-            output_name: editor-shard-11
-            coverage_threshold: '0'
-          - label: editor 12/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-12
-            raw_path: test-results/editor-shard-12-coverage/**/browser-coverage.json
-            shard: 12/16
-            output_name: editor-shard-12
-            coverage_threshold: '0'
-          - label: editor 13/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-13
-            raw_path: test-results/editor-shard-13-coverage/**/browser-coverage.json
-            shard: 13/16
-            output_name: editor-shard-13
-            coverage_threshold: '0'
-          - label: editor 14/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-14
-            raw_path: test-results/editor-shard-14-coverage/**/browser-coverage.json
-            shard: 14/16
-            output_name: editor-shard-14
-            coverage_threshold: '0'
-          - label: editor 15/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-15
-            raw_path: test-results/editor-shard-15-coverage/**/browser-coverage.json
-            shard: 15/16
-            output_name: editor-shard-15
-            coverage_threshold: '0'
-          - label: editor 16/16
-            script: test:e2e:coverage:editor
-            report: editor-shard-16
-            raw_path: test-results/editor-shard-16-coverage/**/browser-coverage.json
-            shard: 16/16
-            output_name: editor-shard-16
             coverage_threshold: '0'
           - label: landing
             script: test:e2e:coverage:landing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
 
   e2e:
     name: Playwright E2E (${{ matrix.label }})
-    needs: build
+    needs: [build, lint, typecheck]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -445,7 +445,7 @@ jobs:
 
   build:
     name: Build
-    needs: [dependencies, lint, typecheck]
+    needs: dependencies
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
             shard: 1/8
             output_name: editor-shard-1
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: editor 2/8
             script: test:e2e:coverage:editor
             report: editor-shard-2
@@ -225,6 +226,7 @@ jobs:
             shard: 2/8
             output_name: editor-shard-2
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: editor 3/8
             script: test:e2e:coverage:editor
             report: editor-shard-3
@@ -232,6 +234,7 @@ jobs:
             shard: 3/8
             output_name: editor-shard-3
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: editor 4/8
             script: test:e2e:coverage:editor
             report: editor-shard-4
@@ -239,6 +242,7 @@ jobs:
             shard: 4/8
             output_name: editor-shard-4
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: editor 5/8
             script: test:e2e:coverage:editor
             report: editor-shard-5
@@ -246,6 +250,7 @@ jobs:
             shard: 5/8
             output_name: editor-shard-5
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: editor 6/8
             script: test:e2e:coverage:editor
             report: editor-shard-6
@@ -253,6 +258,7 @@ jobs:
             shard: 6/8
             output_name: editor-shard-6
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: editor 7/8
             script: test:e2e:coverage:editor
             report: editor-shard-7
@@ -260,6 +266,7 @@ jobs:
             shard: 7/8
             output_name: editor-shard-7
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: editor 8/8
             script: test:e2e:coverage:editor
             report: editor-shard-8
@@ -267,6 +274,7 @@ jobs:
             shard: 8/8
             output_name: editor-shard-8
             coverage_threshold: '0'
+            coverage_report: '0'
           - label: landing
             script: test:e2e:coverage:landing
             report: landing
@@ -274,6 +282,7 @@ jobs:
             shard: ''
             output_name: ''
             coverage_threshold: ''
+            coverage_report: '1'
           - label: public-deck
             script: test:e2e:coverage:public-deck
             report: public-deck
@@ -281,6 +290,7 @@ jobs:
             shard: ''
             output_name: ''
             coverage_threshold: ''
+            coverage_report: '1'
           - label: webmcp
             script: test:e2e:coverage:webmcp
             report: webmcp
@@ -288,6 +298,7 @@ jobs:
             shard: ''
             output_name: ''
             coverage_threshold: ''
+            coverage_report: '1'
           - label: joystick
             script: test:e2e:coverage:joystick
             report: joystick
@@ -295,6 +306,7 @@ jobs:
             shard: ''
             output_name: ''
             coverage_threshold: ''
+            coverage_report: '1'
 
     steps:
       - name: Checkout
@@ -344,6 +356,7 @@ jobs:
         run: npm run ${{ matrix.script }}
         env:
           E2E_SERVER: dist
+          E2E_COVERAGE_REPORT: ${{ matrix.coverage_report }}
           E2E_COVERAGE_THRESHOLD: ${{ matrix.coverage_threshold }}
           LOCALSTUDIO_E2E_OUTPUT_NAME: ${{ matrix.output_name }}
           LOCALSTUDIO_E2E_SHARD: ${{ matrix.shard }}
@@ -357,7 +370,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Add E2E coverage report to job summary
-        if: always()
+        if: ${{ always() && matrix.coverage_report != '0' }}
         run: |
           if [ -f coverage-report/${{ matrix.report }}/coverage-summary.md ]; then
             cat coverage-report/${{ matrix.report }}/coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
@@ -366,7 +379,7 @@ jobs:
           fi
 
       - name: Upload E2E coverage report
-        if: always()
+        if: ${{ always() && matrix.coverage_report != '0' }}
         uses: actions/upload-artifact@v5
         with:
           name: e2e-coverage-report-${{ matrix.report }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .worktrees/
+.eslintcache
 node_modules/
 dist/
 coverage/

--- a/scripts/run-e2e-coverage.mjs
+++ b/scripts/run-e2e-coverage.mjs
@@ -1,6 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
-import { readdirSync } from 'node:fs';
+import { readdirSync, readFileSync, rmSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { basename, join } from 'node:path';
 import process from 'node:process';
@@ -416,7 +415,42 @@ function parseShard(value) {
 
 function applyShard(files, shard) {
   if (!shard) return files;
-  return files.filter((_file, fileIndex) => fileIndex % shard.total === shard.index - 1);
+  const buckets = Array.from({ length: shard.total }, (_value, bucketIndex) => ({
+    files: [],
+    index: bucketIndex,
+    weight: 0,
+  }));
+  const weightedFiles = files
+    .map((file) => ({ file, weight: estimateSpecWeight(file) }))
+    .sort((left, right) => right.weight - left.weight || left.file.localeCompare(right.file));
+
+  for (const weightedFile of weightedFiles) {
+    buckets.sort((left, right) => left.weight - right.weight || left.index - right.index);
+    buckets[0].files.push(weightedFile.file);
+    buckets[0].weight += weightedFile.weight;
+  }
+
+  return buckets
+    .find((bucket) => bucket.index === shard.index - 1)
+    .files.sort((left, right) => left.localeCompare(right));
+}
+
+function estimateSpecWeight(file) {
+  let sourceText = '';
+  try {
+    sourceText = readFileSync(join(workspaceRoot, file), 'utf8');
+  } catch {
+    return 1;
+  }
+  const lineCount = sourceText.split('\n').length;
+  const testCount = countMatches(sourceText, /\btest(?:\.skip|\.fixme|\.only)?\s*\(/g);
+  const timeoutCount = countMatches(sourceText, /timeout:\s*[0-9_]+|test\.setTimeout/g);
+  const waitCount = countMatches(sourceText, /setTimeout\(|expect\.poll|toPass\(/g);
+  return lineCount + testCount * 80 + timeoutCount * 20 + waitCount * 30;
+}
+
+function countMatches(sourceText, pattern) {
+  return sourceText.match(pattern)?.length ?? 0;
 }
 
 function shouldRunSplit(split, files) {


### PR DESCRIPTION
## Summary

- Increase editor unit-test parallelism from four to eight shards.
- Split editor E2E coverage runs into eight shards with matching reports and coverage paths.
- Preserve landing and joystick test jobs.

## Testing

- Not run (not requested)