### PR TITLE
Add WebMCP Playground to landing navigation

### DIFF
--- a/apps/landing/src/components/LandingHeader.tsx
+++ b/apps/landing/src/components/LandingHeader.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { href: '#top', label: 'About it', sectionId: 'top' },
   { href: '#features', label: 'Features', sectionId: 'features' },
   { href: '#requirements', label: 'Requirements', sectionId: 'requirements' },
+  { href: '/editor/webmcp', label: 'WebMCP Playground', sectionId: 'webmcp-playground' },
   { href: localStudioAppRoutes.docs.gettingStartedAnchor, label: 'Docs', sectionId: 'docs' },
   // Pricing is temporarily disabled from the landing navigation.
   // { href: '#pricing', label: 'Pricing', sectionId: 'pricing' },

--- a/apps/landing/tests/unit/LandingPage.test.tsx
+++ b/apps/landing/tests/unit/LandingPage.test.tsx
@@ -60,11 +60,15 @@ describe('LandingPage', () => {
       'About it',
       'Features',
       'Requirements',
+      'WebMCP Playground',
       'Docs',
     ]);
     expect(screen.getByRole('link', { name: 'About it' })).toHaveAttribute('href', '#top');
     expect(screen.getByRole('link', { name: 'Features' })).toHaveAttribute('href', '#features');
-    expect(screen.queryByRole('link', { name: 'WebMCP Showcase' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'WebMCP Playground' })).toHaveAttribute(
+      'href',
+      '/editor/webmcp',
+    );
     expect(screen.getByRole('link', { name: 'Requirements' })).toHaveAttribute(
       'href',
       '#requirements',
@@ -117,6 +121,7 @@ describe('LandingPage', () => {
       'About it',
       'Features',
       'Requirements',
+      'WebMCP Playground',
       'Docs',
     ]);
     expect(within(mobileNav).getByRole('link', { name: 'About it' })).toHaveAttribute(

--- a/tests/e2e/landing/public-funnel.spec.ts
+++ b/tests/e2e/landing/public-funnel.spec.ts
@@ -84,13 +84,17 @@ test.describe('landing public funnel journey', () => {
     }
 
     await page.goto(new URL('/', getServer().baseURL).toString());
+    await expect(page.getByRole('link', { name: 'WebMCP Playground' })).toHaveAttribute(
+      'href',
+      '/editor/webmcp',
+    );
     await expect(page.getByRole('link', { name: 'Open WebMCP demo' })).toHaveAttribute(
       'href',
       '/editor/webmcp',
     );
 
     if (!isLandingCoverageRun) {
-      await page.getByRole('link', { name: 'Open WebMCP demo' }).click();
+      await page.getByRole('link', { name: 'WebMCP Playground' }).click();
       await expect(page).toHaveURL(/\/editor\/webmcp$/);
       await expect(page.getByRole('heading', { name: /WebMCP showcase/i })).toBeVisible();
     }


### PR DESCRIPTION
## Summary

- Add a WebMCP Playground link to the landing page navigation.
- Update unit and end-to-end coverage for the new navigation entry and route.

## Testing

- Updated landing page unit tests.
- Updated the public funnel Playwright test to verify navigation to `/editor/webmcp`.