### PR TITLE
Validate video replacement and load it through an object URL

### DIFF
--- a/apps/editor/src/ui/editor/media/localMediaImportConfig.ts
+++ b/apps/editor/src/ui/editor/media/localMediaImportConfig.ts
@@ -1,6 +1,13 @@
+const supportedVideoExtensions = new Set(['mp4', 'webm']);
+const supportedVideoMimeTypes = new Set(['video/mp4', 'video/webm']);
+
 export const localMediaImportConfig = {
   accept: 'image/*,video/*',
   localVideoExtensions: new Set(['mp4', 'webm', 'mov']),
-  supportedVideoExtensions: new Set(['mp4', 'webm']),
-  supportedVideoMimeTypes: new Set(['video/mp4', 'video/webm']),
+  supportedVideoExtensions,
+  supportedVideoMimeTypes,
+  videoReplaceAccept: [
+    ...supportedVideoMimeTypes,
+    ...[...supportedVideoExtensions].map((extension) => `.${extension}`),
+  ].join(','),
 };

--- a/apps/editor/src/ui/editor/panels/movie-inspector/MovieInspector.tsx
+++ b/apps/editor/src/ui/editor/panels/movie-inspector/MovieInspector.tsx
@@ -1,4 +1,13 @@
-import { FileVideo, FolderOpen, Pause, Play, SkipBack, SkipForward, Volume2, VolumeX } from 'lucide-react';
+import {
+  FileVideo,
+  FolderOpen,
+  Pause,
+  Play,
+  SkipBack,
+  SkipForward,
+  Volume2,
+  VolumeX,
+} from 'lucide-react';
 import { useRef } from 'react';
 import type {
   ElementAnimationBuild,
@@ -7,6 +16,7 @@ import type {
   VideoRepeatMode,
 } from '../../../../domain/documents/model';
 import type { MediaPlaybackPatch } from '../../../../domain/commands/elements/basicCommands';
+import { localMediaImportConfig } from '../../media/localMediaImportConfig';
 
 type ElementAnimationPatch = Omit<ElementAnimationBuild, 'elementId' | 'id'>;
 type MovieStartTrigger = ElementAnimationBuild['trigger'];
@@ -21,7 +31,9 @@ interface MovieInspectorProps {
   assetName?: string | undefined;
   element: VideoElement;
   onReplaceVideoAsset?: ((file: File) => void) | undefined;
-  onSetElementAnimationBuilds?: ((elementIds: string[], patch: ElementAnimationPatch) => void) | undefined;
+  onSetElementAnimationBuilds?:
+    | ((elementIds: string[], patch: ElementAnimationPatch) => void)
+    | undefined;
   onUpdateMedia: (patch: MediaPlaybackPatch) => void;
   page?: ProjectDocument['pages'][number] | undefined;
 }
@@ -73,7 +85,7 @@ export function MovieInspector({
           <input
             ref={replaceVideoInputRef}
             aria-label="Replace video file"
-            accept="video/*"
+            accept={localMediaImportConfig.videoReplaceAccept}
             className="visually-hidden-input"
             type="file"
             onChange={(event) => {
@@ -176,7 +188,10 @@ export function MovieInspector({
               type="range"
               value={trimEndSeconds}
               onChange={(event) => {
-                const nextEnd = Math.max(toTrimSeconds(event.target.value), element.trimStartSeconds);
+                const nextEnd = Math.max(
+                  toTrimSeconds(event.target.value),
+                  element.trimStartSeconds,
+                );
                 onUpdateMedia({ trimEndSeconds: nextEnd });
               }}
             />
@@ -275,7 +290,9 @@ function formatMovieTime(seconds: number) {
   const displaySeconds = (totalSeconds % 60).toString().padStart(2, '0');
   const totalMinutes = Math.floor(totalSeconds / 60);
   const displayMinutes = (totalMinutes % 60).toString().padStart(2, '0');
-  const hours = Math.floor(totalMinutes / 60).toString().padStart(2, '0');
+  const hours = Math.floor(totalMinutes / 60)
+    .toString()
+    .padStart(2, '0');
   return `${hours}:${displayMinutes}:${displaySeconds},${milliseconds}`;
 }
 

--- a/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
+++ b/apps/editor/src/ui/editor/shell/EditorLeftPanelSurface.tsx
@@ -66,6 +66,7 @@ export function EditorLeftPanelSurface({
         isHistoryReadOnly
           ? undefined
           : (elementId, file) => {
+              // replaceVideoAsset never rejects; failures surface via mediaImportProgress.
               void vm.replaceVideoAsset(elementId, file);
             }
       }

--- a/apps/editor/src/ui/editor/state/use-local-media-import.ts
+++ b/apps/editor/src/ui/editor/state/use-local-media-import.ts
@@ -16,6 +16,46 @@ export interface MediaImportProgressState {
   tone: 'loading' | 'error';
 }
 
+const unsupportedVideoFormatProgress: MediaImportProgressState = {
+  detail:
+    'Video import supports MP4 and WebM files. Convert this clip to MP4 or WebM and import it again.',
+  title: 'Unsupported video format',
+  tone: 'error',
+};
+
+const loadingVideoProgress: MediaImportProgressState = {
+  detail: 'Loading video metadata without copying the full file into memory.',
+  title: 'Loading media',
+  tone: 'loading',
+};
+
+function mediaImportFailedProgress(error: unknown): MediaImportProgressState {
+  return {
+    detail: error instanceof Error ? error.message : 'The selected media file could not be loaded.',
+    title: 'Media import failed',
+    tone: 'error',
+  };
+}
+
+/**
+ * Creates an object URL for a video file and reads its dimensions/duration
+ * without ever copying the full file into memory as a data URL. If reading
+ * the metadata fails, the object URL is revoked before the error propagates
+ * so callers never have to manage cleanup on the failure path themselves.
+ */
+async function loadVideoMedia(file: File) {
+  const objectUrl = localMediaFiles.createMediaObjectUrl(file);
+  try {
+    const mediaSize = await localMediaFiles.readVideoSize(objectUrl);
+    return { objectUrl, mediaSize };
+  } catch (error) {
+    if (typeof URL.revokeObjectURL === 'function') {
+      URL.revokeObjectURL(objectUrl);
+    }
+    throw error;
+  }
+}
+
 interface UseLocalMediaImportOptions {
   activePageId: string;
   analyticsService: AppServices['analyticsService'];
@@ -52,39 +92,42 @@ export function useLocalMediaImport({
   async function importImageFile(file: File) {
     const assetType = localMediaFiles.getMediaAssetType(file);
     if (assetType === 'video' && !localMediaFiles.isSupportedLocalVideoFile(file)) {
-      setMediaImportProgress({
-        detail:
-          'Video import supports MP4 and WebM files. Convert this clip to MP4 or WebM and import it again.',
-        title: 'Unsupported video format',
-        tone: 'error',
-      });
+      setMediaImportProgress(unsupportedVideoFormatProgress);
       return;
     }
 
-    setMediaImportProgress({
-      detail:
-        assetType === 'video'
-          ? 'Loading video metadata without copying the full file into memory.'
-          : assetType === 'gif'
-            ? 'Loading animated media from disk.'
-            : 'Loading image from disk.',
-      title: 'Loading media',
-      tone: 'loading',
-    });
+    setMediaImportProgress(
+      assetType === 'video'
+        ? loadingVideoProgress
+        : {
+            detail:
+              assetType === 'gif'
+                ? 'Loading animated media from disk.'
+                : 'Loading image from disk.',
+            title: 'Loading media',
+            tone: 'loading',
+          },
+    );
     await waitForNextPaint();
 
     let imported = false;
     let objectUrl: string | undefined;
     try {
-      objectUrl =
-        assetType === 'video' || assetType === 'gif'
-          ? localMediaFiles.createMediaObjectUrl(file)
-          : undefined;
-      const mediaUrl = objectUrl ?? (await localMediaFiles.readImageFileAsDataUrl(file));
-      const mediaSize =
-        assetType === 'video'
-          ? await localMediaFiles.readVideoSize(mediaUrl)
-          : await localMediaFiles.readImageSize(mediaUrl);
+      let mediaUrl: string;
+      let mediaSize: { height: number; width: number; durationSeconds?: number };
+      if (assetType === 'video') {
+        const loaded = await loadVideoMedia(file);
+        objectUrl = loaded.objectUrl;
+        mediaUrl = loaded.objectUrl;
+        mediaSize = loaded.mediaSize;
+      } else if (assetType === 'gif') {
+        objectUrl = localMediaFiles.createMediaObjectUrl(file);
+        mediaUrl = objectUrl;
+        mediaSize = await localMediaFiles.readImageSize(mediaUrl);
+      } else {
+        mediaUrl = await localMediaFiles.readImageFileAsDataUrl(file);
+        mediaSize = await localMediaFiles.readImageSize(mediaUrl);
+      }
       const videoDurationSeconds =
         assetType === 'video' &&
         'durationSeconds' in mediaSize &&
@@ -278,12 +321,7 @@ export function useLocalMediaImport({
       );
       imported = true;
     } catch (error) {
-      setMediaImportProgress({
-        detail:
-          error instanceof Error ? error.message : 'The selected media file could not be loaded.',
-        title: 'Media import failed',
-        tone: 'error',
-      });
+      setMediaImportProgress(mediaImportFailedProgress(error));
       return;
     } finally {
       if (!imported && objectUrl && typeof URL.revokeObjectURL === 'function') {
@@ -306,31 +344,44 @@ export function useLocalMediaImport({
 
   async function replaceVideoAsset(elementId: string, file: File) {
     if (localMediaFiles.getMediaAssetType(file) !== 'video') return;
-    const dataUrl = await localMediaFiles.readImageFileAsDataUrl(file);
-    const mediaSize = await localMediaFiles.readVideoSize(dataUrl);
-    const videoDurationSeconds = mediaSize.durationSeconds;
-    const assetId = createPrefixedId('asset');
-    const mediaName = file.name.trim() || 'Replacement video';
 
-    commitProject(
-      (currentProject) =>
-        new basicCommands.ReplaceVideoAssetCommand(
-          elementId,
-          {
-            id: assetId,
-            type: 'video',
-            name: mediaName,
-            mimeType: file.type || 'video/mp4',
-            objectUrl: dataUrl,
-          },
-          videoDurationSeconds !== undefined ? { durationSeconds: videoDurationSeconds } : {},
-        ).execute(currentProject),
-      { selectedElementIds: [elementId] },
-    );
-    analyticsService.capture(postHogEvents.localMediaImported, {
-      assetType: 'video',
-      replacedExistingMedia: true,
-    });
+    if (!localMediaFiles.isSupportedLocalVideoFile(file)) {
+      setMediaImportProgress(unsupportedVideoFormatProgress);
+      return;
+    }
+
+    setMediaImportProgress(loadingVideoProgress);
+    await waitForNextPaint();
+
+    try {
+      const { objectUrl, mediaSize } = await loadVideoMedia(file);
+      const videoDurationSeconds = mediaSize.durationSeconds;
+      const assetId = createPrefixedId('asset');
+      const mediaName = file.name.trim() || 'Replacement video';
+
+      commitProject(
+        (currentProject) =>
+          new basicCommands.ReplaceVideoAssetCommand(
+            elementId,
+            {
+              id: assetId,
+              type: 'video',
+              name: mediaName,
+              mimeType: file.type || 'video/mp4',
+              objectUrl,
+            },
+            videoDurationSeconds !== undefined ? { durationSeconds: videoDurationSeconds } : {},
+          ).execute(currentProject),
+        { selectedElementIds: [elementId] },
+      );
+      analyticsService.capture(postHogEvents.localMediaImported, {
+        assetType: 'video',
+        replacedExistingMedia: true,
+      });
+      setMediaImportProgress(undefined);
+    } catch (error) {
+      setMediaImportProgress(mediaImportFailedProgress(error));
+    }
   }
 
   function clearMediaImportProgress() {

--- a/apps/editor/tests/unit/ui/editor/EditorShell.media-fixtures.ts
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.media-fixtures.ts
@@ -70,9 +70,17 @@ class ReadyStockMediaService implements StockMediaService {
     this.downloadedItems.push({ item, sourceUrl });
     return Promise.resolve({
       blob: new Blob(['stock-media'], {
-        type: sourceUrl.endsWith('.mp4') ? 'video/mp4' : item.kind === 'gif' ? 'image/gif' : 'image/jpeg',
+        type: sourceUrl.endsWith('.mp4')
+          ? 'video/mp4'
+          : item.kind === 'gif'
+            ? 'image/gif'
+            : 'image/jpeg',
       }),
-      mimeType: sourceUrl.endsWith('.mp4') ? 'video/mp4' : item.kind === 'gif' ? 'image/gif' : 'image/jpeg',
+      mimeType: sourceUrl.endsWith('.mp4')
+        ? 'video/mp4'
+        : item.kind === 'gif'
+          ? 'image/gif'
+          : 'image/jpeg',
       objectUrl:
         sourceUrl === stockGif.videoUrl
           ? 'blob:giphy-video'
@@ -143,6 +151,21 @@ function mockVideoMetadataLoad() {
     });
 }
 
+function mockVideoMetadataLoadFailure() {
+  const createElement = document.createElement.bind(document);
+  return vi
+    .spyOn(document, 'createElement')
+    .mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+      const element = createElement(tagName, options);
+      if (tagName.toLowerCase() === 'video') {
+        queueMicrotask(() => {
+          element.dispatchEvent(new Event('error'));
+        });
+      }
+      return element;
+    });
+}
+
 function mockControllableVideoMetadataLoad() {
   const createElement = document.createElement.bind(document);
   let videoElement: HTMLElement | undefined;
@@ -153,6 +176,7 @@ function mockControllableVideoMetadataLoad() {
       if (tagName.toLowerCase() === 'video') {
         Object.defineProperty(element, 'videoWidth', { configurable: true, value: 1280 });
         Object.defineProperty(element, 'videoHeight', { configurable: true, value: 720 });
+        Object.defineProperty(element, 'duration', { configurable: true, value: 8.5 });
         videoElement = element;
       }
       return element;
@@ -175,5 +199,6 @@ export const editorShellMediaFixtures = {
   createProjectWithVideo,
   mockControllableVideoMetadataLoad,
   mockVideoMetadataLoad,
+  mockVideoMetadataLoadFailure,
   stockImage,
 };

--- a/apps/editor/tests/unit/ui/editor/EditorShell.video-replace.test.tsx
+++ b/apps/editor/tests/unit/ui/editor/EditorShell.video-replace.test.tsx
@@ -1,0 +1,152 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { EditorShell } from '../../../../src/ui/editor/shell/EditorShell';
+import { editorShellTestHarness } from './EditorShell.test-harness';
+
+const {
+  SavingProjectRepository,
+  createAppServices,
+  createProjectWithVideo,
+  mockControllableVideoMetadataLoad,
+  mockVideoMetadataLoadFailure,
+  openLeftTab,
+} = editorShellTestHarness;
+
+async function openMovieInspector(user: ReturnType<typeof userEvent.setup>) {
+  await openLeftTab(user, 'Layout');
+  fireEvent.click(screen.getByRole('button', { name: 'Demo clip' }));
+}
+
+function getFileInfoSection() {
+  return screen.getByRole('region', { name: 'Movie file info' });
+}
+
+describe('EditorShell video replace workflow', () => {
+  afterEach(() => {
+    window.history.pushState({}, '', '/editor/');
+    vi.restoreAllMocks();
+  });
+
+  it('blocks MOV replacements with a clear unsupported-format message', async () => {
+    // The browser's file-picker `accept` filter is only an OS-level hint, so it
+    // must not be relied on for validation; disable it here to exercise the
+    // app's own format check the way a user bypassing the picker filter would.
+    const user = userEvent.setup({ applyAccept: false });
+    const services = createAppServices({ initialProject: createProjectWithVideo() });
+    const repository = new SavingProjectRepository();
+    services.projectRepository = repository;
+    const createObjectUrl = vi.spyOn(URL, 'createObjectURL');
+    render(<EditorShell services={services} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    await openMovieInspector(user);
+    expect(within(getFileInfoSection()).getByText('Demo clip')).toBeInTheDocument();
+
+    const input = screen.getByLabelText('Replace video file');
+    expect(input).toHaveAttribute('accept', 'video/mp4,video/webm,.mp4,.webm');
+
+    const video = new File(['video-bytes'], 'phone-video.mov', { type: 'video/quicktime' });
+    await user.upload(input, video);
+
+    expect(await screen.findByText('Unsupported video format')).toBeInTheDocument();
+    expect(screen.getByText(/Video import supports MP4 and WebM files/)).toBeInTheDocument();
+    expect(createObjectUrl).not.toHaveBeenCalled();
+    expect(within(getFileInfoSection()).getByText('Demo clip')).toBeInTheDocument();
+    expect(
+      Object.values(repository.savedProjects.at(-1)?.assets ?? {}).some(
+        (asset) => asset.name === 'phone-video.mov',
+      ),
+    ).toBe(false);
+  });
+
+  it('preserves the original asset and revokes the object URL when the video fails to decode', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices({ initialProject: createProjectWithVideo() });
+    const repository = new SavingProjectRepository();
+    services.projectRepository = repository;
+    render(<EditorShell services={services} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    await openMovieInspector(user);
+
+    mockVideoMetadataLoadFailure();
+    const createObjectUrl = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:broken-replacement');
+    const revokeObjectUrl = vi.spyOn(URL, 'revokeObjectURL');
+
+    const video = new File(['video-bytes'], 'broken.mp4', { type: 'video/mp4' });
+    await user.upload(screen.getByLabelText('Replace video file'), video);
+
+    expect(await screen.findByText('Media import failed')).toBeInTheDocument();
+    expect(createObjectUrl).toHaveBeenCalledWith(video);
+    await waitFor(() => {
+      expect(revokeObjectUrl).toHaveBeenCalledWith('blob:broken-replacement');
+    });
+    expect(within(getFileInfoSection()).getByText('Demo clip')).toBeInTheDocument();
+    expect(
+      Object.values(repository.savedProjects.at(-1)?.assets ?? {}).some(
+        (asset) => asset.name === 'broken.mp4',
+      ),
+    ).toBe(false);
+  });
+
+  it('replaces the video with the new file without buffering it as a data URL', async () => {
+    const user = userEvent.setup();
+    const services = createAppServices({ initialProject: createProjectWithVideo() });
+    const repository = new SavingProjectRepository();
+    services.projectRepository = repository;
+    render(<EditorShell services={services} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Persistence disabled' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    await openMovieInspector(user);
+
+    const metadata = mockControllableVideoMetadataLoad();
+    const createObjectUrl = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:replacement-video');
+
+    const video = new File(['video-bytes'], 'replacement.mp4', { type: 'video/mp4' });
+    await user.upload(screen.getByLabelText('Replace video file'), video);
+
+    expect(await screen.findByText('Loading media')).toBeInTheDocument();
+    expect(
+      screen.getByText('Loading video metadata without copying the full file into memory.'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(metadata.hasMetadataTarget()).toBe(true);
+    });
+
+    act(() => {
+      metadata.loadMetadata();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading media')).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const savedProject = repository.savedProjects.at(-1);
+      const videoElement = savedProject?.elements['video-demo'];
+      expect(videoElement?.type).toBe('video');
+      const assetId = videoElement && 'assetId' in videoElement ? videoElement.assetId : undefined;
+      const asset = assetId ? savedProject?.assets[assetId] : undefined;
+      expect(asset?.objectUrl).toBe('blob:replacement-video');
+      expect(asset?.name).toBe('replacement.mp4');
+      expect(
+        videoElement && 'durationSeconds' in videoElement
+          ? videoElement.durationSeconds
+          : undefined,
+      ).toBe(8.5);
+    });
+
+    expect(createObjectUrl).toHaveBeenCalledWith(video);
+    expect(within(getFileInfoSection()).getByText('replacement.mp4')).toBeInTheDocument();
+    metadata.createElementSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #184

## Problem

**Design > Movie > Replace movie file** bypassed the safeguards of the normal **Insert Media** flow: it accepted `video/*`, skipped `isSupportedLocalVideoFile`, read the whole file as a base64 data URL, and let metadata failures reject a promise the UI discarded. Picking a `.mov` silently did nothing.

## Changes

- `replaceVideoAsset` now validates MP4/WebM and shows the existing **Unsupported video format** dialog for anything else.
- Supported replacements load through `URL.createObjectURL`, matching the initial import path.
- Decode failures show **Media import failed**, keep the previous asset, and revoke the temporary object URL. The function never rejects.
- Shared helpers (`loadVideoMedia`, progress state constants) are used by both `importImageFile` and `replaceVideoAsset`, so the two paths cannot drift again.
- The replacement picker `accept` is derived from the supported formats config (`video/mp4,video/webm,.mp4,.webm`).

## Tests

New `EditorShell.video-replace.test.tsx` covers unsupported MOV, decode failure with URL cleanup, successful replacement with a blob URL, and the picker `accept` value. Full `npm test`, `npm run typecheck`, `npm run lint`, and prettier pass.

https://claude.ai/code/session_01TU2Sh4WMQoaPcX97aGozE4
